### PR TITLE
fix(perf): restore direct array member calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/compiler/tests: restore direct `JavaScriptRuntime.Array` call lowering for proven array receivers in hot paths, including `push`, `pop`, `shift`, `unshift`, `slice`, and `splice`; limit `with`-binding fallback emission to callables created inside `with` bodies so unrelated scope-field reads keep their concrete receiver types.
+- runtime/tests/docs/test262: expand ECMA-262 Section 21.4 Date coverage with newly ported test262 cases, implement the covered Date constructor/prototype/static surface, move Date intrinsic descriptor setup into `Date`, normalize local timezone edge cases, and refresh the Section 21.4 support docs.
 
 ## v0.11.9 - 2026-07-04
 

--- a/src/Compiler/IL/LIRToILCompiler.InstanceCalls.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstanceCalls.cs
@@ -25,8 +25,7 @@ internal sealed partial class LIRToILCompiler
                 $"No matching instance method found: {receiverType.FullName}.{instruction.MethodName} with {argCount} argument(s)");
         }
 
-        // Load receiver
-        EmitLoadTemp(instruction.Receiver, ilEncoder, allocation, methodDescriptor);
+        EmitLoadInstanceMethodReceiver(instruction.Receiver, receiverType, ilEncoder, allocation, methodDescriptor);
 
         var parameters = chosen.GetParameters();
         var expectsParamsArray = parameters.Length == 1 && parameters[0].ParameterType == typeof(object[]);
@@ -95,7 +94,7 @@ internal sealed partial class LIRToILCompiler
                 $"No matching instance method found: {receiverType.FullName}.{instruction.MethodName} with {argCount} argument(s)");
         }
 
-        EmitLoadTemp(instruction.Receiver, ilEncoder, allocation, methodDescriptor);
+        EmitLoadInstanceMethodReceiver(instruction.Receiver, receiverType, ilEncoder, allocation, methodDescriptor);
 
         var parameters = chosen.GetParameters();
         var expectsParamsArray = parameters.Length == 1 && parameters[0].ParameterType == typeof(object[]);
@@ -163,6 +162,26 @@ internal sealed partial class LIRToILCompiler
             .ThenBy(x => x.Method.ToString(), StringComparer.Ordinal)
             .Select(x => x.Method)
             .FirstOrDefault();
+    }
+
+    private void EmitLoadInstanceMethodReceiver(
+        TempVariable receiver,
+        Type receiverType,
+        InstructionEncoder ilEncoder,
+        TempLocalAllocation allocation,
+        MethodDescriptor methodDescriptor)
+    {
+        var receiverStorage = GetTempStorage(receiver);
+        if (receiverStorage.Kind == ValueStorageKind.Reference
+            && receiverStorage.ClrType == receiverType)
+        {
+            EmitLoadTemp(receiver, ilEncoder, allocation, methodDescriptor);
+            return;
+        }
+
+        EmitLoadTempAsObject(receiver, ilEncoder, allocation, methodDescriptor);
+        ilEncoder.OpCode(ILOpCode.Castclass);
+        ilEncoder.Token(_typeReferenceRegistry.GetOrAdd(receiverType));
     }
 
     private void EmitObjectArrayFromTemps(

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Arithmetic.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Arithmetic.cs
@@ -38,8 +38,8 @@ internal sealed partial class LIRToILCompiler
                 EmitStoreTemp(concatStrings.Result, ilEncoder, allocation);
                 break;
             case LIRAddDynamic addDynamic:
-                EmitLoadTemp(addDynamic.Left, ilEncoder, allocation, methodDescriptor);
-                EmitLoadTemp(addDynamic.Right, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(addDynamic.Left, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(addDynamic.Right, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsAddObjectObject(ilEncoder);
                 EmitStoreTemp(addDynamic.Result, ilEncoder, allocation);
                 break;
@@ -84,8 +84,8 @@ internal sealed partial class LIRToILCompiler
                 EmitStoreTemp(mulNumber.Result, ilEncoder, allocation);
                 break;
             case LIRMulDynamic mulDynamic:
-                EmitLoadTemp(mulDynamic.Left, ilEncoder, allocation, methodDescriptor);
-                EmitLoadTemp(mulDynamic.Right, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(mulDynamic.Left, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(mulDynamic.Right, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsMultiply(ilEncoder);
                 EmitStoreTemp(mulDynamic.Result, ilEncoder, allocation);
                 break;

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.DynamicOperators.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.DynamicOperators.cs
@@ -18,67 +18,67 @@ internal sealed partial class LIRToILCompiler
         {
             // 'in' operator - calls Operators.In
             case LIRInOperator inOp:
-                EmitLoadTemp(inOp.Left, ilEncoder, allocation, methodDescriptor);
-                EmitLoadTemp(inOp.Right, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(inOp.Left, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(inOp.Right, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsIn(ilEncoder);
                 EmitStoreTemp(inOp.Result, ilEncoder, allocation);
                 return true;
 
             // 'instanceof' operator - calls Operators.InstanceOf
             case LIRInstanceOfOperator instOf:
-                EmitLoadTemp(instOf.Left, ilEncoder, allocation, methodDescriptor);
-                EmitLoadTemp(instOf.Right, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(instOf.Left, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(instOf.Right, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsInstanceOf(ilEncoder);
                 EmitStoreTemp(instOf.Result, ilEncoder, allocation);
                 return true;
 
             case LIRBinaryDynamicOperator binaryDynamic:
-                EmitLoadTemp(binaryDynamic.Left, ilEncoder, allocation, methodDescriptor);
-                EmitLoadTemp(binaryDynamic.Right, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(binaryDynamic.Left, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(binaryDynamic.Right, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsDynamicBinary(binaryDynamic.Operator, ilEncoder);
                 EmitStoreTemp(binaryDynamic.Result, ilEncoder, allocation);
                 return true;
 
             case LIRNegateNumberDynamic negateDynamic:
-                EmitLoadTemp(negateDynamic.Value, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(negateDynamic.Value, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsUnaryMinus(ilEncoder);
                 EmitStoreTemp(negateDynamic.Result, ilEncoder, allocation);
                 return true;
 
             case LIRBitwiseNotDynamic bitwiseNotDynamic:
-                EmitLoadTemp(bitwiseNotDynamic.Value, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(bitwiseNotDynamic.Value, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsBitwiseNot(ilEncoder);
                 EmitStoreTemp(bitwiseNotDynamic.Result, ilEncoder, allocation);
                 return true;
 
             // Dynamic equality - calls Operators.Equal
             case LIREqualDynamic equalDynamic:
-                EmitLoadTemp(equalDynamic.Left, ilEncoder, allocation, methodDescriptor);
-                EmitLoadTemp(equalDynamic.Right, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(equalDynamic.Left, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(equalDynamic.Right, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsEqual(ilEncoder);
                 EmitStoreTemp(equalDynamic.Result, ilEncoder, allocation);
                 return true;
 
             // Dynamic inequality - calls Operators.NotEqual
             case LIRNotEqualDynamic notEqualDynamic:
-                EmitLoadTemp(notEqualDynamic.Left, ilEncoder, allocation, methodDescriptor);
-                EmitLoadTemp(notEqualDynamic.Right, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(notEqualDynamic.Left, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(notEqualDynamic.Right, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsNotEqual(ilEncoder);
                 EmitStoreTemp(notEqualDynamic.Result, ilEncoder, allocation);
                 return true;
 
             // Dynamic strict equality - calls Operators.StrictEqual
             case LIRStrictEqualDynamic strictEqualDynamic:
-                EmitLoadTemp(strictEqualDynamic.Left, ilEncoder, allocation, methodDescriptor);
-                EmitLoadTemp(strictEqualDynamic.Right, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(strictEqualDynamic.Left, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(strictEqualDynamic.Right, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsStrictEqual(ilEncoder);
                 EmitStoreTemp(strictEqualDynamic.Result, ilEncoder, allocation);
                 return true;
 
             // Dynamic strict inequality - calls Operators.StrictNotEqual
             case LIRStrictNotEqualDynamic strictNotEqualDynamic:
-                EmitLoadTemp(strictNotEqualDynamic.Left, ilEncoder, allocation, methodDescriptor);
-                EmitLoadTemp(strictNotEqualDynamic.Right, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(strictNotEqualDynamic.Left, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(strictNotEqualDynamic.Right, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsStrictNotEqual(ilEncoder);
                 EmitStoreTemp(strictNotEqualDynamic.Result, ilEncoder, allocation);
                 return true;

--- a/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
+++ b/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
@@ -390,14 +390,14 @@ internal sealed partial class LIRToILCompiler
 
             case LIRMulDynamic mulDynamic:
                 // Emit inline dynamic multiplication
-                EmitLoadTemp(mulDynamic.Left, ilEncoder, allocation, methodDescriptor);
-                EmitLoadTemp(mulDynamic.Right, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(mulDynamic.Left, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(mulDynamic.Right, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsMultiply(ilEncoder);
                 break;
             case LIRAddDynamic addDynamic:
                 // Emit inline dynamic addition
-                EmitLoadTemp(addDynamic.Left, ilEncoder, allocation, methodDescriptor);
-                EmitLoadTemp(addDynamic.Right, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(addDynamic.Left, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(addDynamic.Right, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsAddObjectObject(ilEncoder);
                 break;
             case LIRAddDynamicDoubleObject addDynamicDoubleObject:
@@ -416,8 +416,8 @@ internal sealed partial class LIRToILCompiler
                 EmitOperatorsAddAndToNumber(addAndToNumber.Left, addAndToNumber.Right, ilEncoder, allocation, methodDescriptor);
                 break;
             case LIRBinaryDynamicOperator binaryDynamic:
-                EmitLoadTemp(binaryDynamic.Left, ilEncoder, allocation, methodDescriptor);
-                EmitLoadTemp(binaryDynamic.Right, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(binaryDynamic.Left, ilEncoder, allocation, methodDescriptor);
+                EmitLoadTempAsObject(binaryDynamic.Right, ilEncoder, allocation, methodDescriptor);
                 EmitOperatorsDynamicBinary(binaryDynamic.Operator, ilEncoder);
                 break;
             case LIRLoadLeafScopeField loadLeafField:

--- a/src/Compiler/IR/LIR/HIRToLIRLower.Utilities.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLower.Utilities.cs
@@ -55,6 +55,11 @@ public sealed partial class HIRToLIRLowerer
             return lexicalValueTemp;
         }
 
+        if (_scope?.MayUseBoundWithObject != true)
+        {
+            return lexicalValueTemp;
+        }
+
         var nameTemp = CreateTempVariable();
         _methodBodyIR.Instructions.Add(new LIRConstString(binding.Name, nameTemp));
         DefineTempStorage(nameTemp, new ValueStorage(ValueStorageKind.Reference, typeof(string)));

--- a/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
@@ -823,9 +823,9 @@ internal static class LIRIntrinsicNormalization
     {
         return argCount switch
         {
-            0 => methodName is "charAt" or "charCodeAt" or "trim" or "trimStart" or "trimLeft" or "trimEnd" or "trimRight" or "toLowerCase" or "toUpperCase" or "split" or "match" or "search",
-            1 => methodName is "charAt" or "charCodeAt" or "substring" or "substr" or "slice" or "indexOf" or "lastIndexOf" or "startsWith" or "endsWith" or "includes" or "split" or "match" or "search",
-            2 => methodName is "substring" or "substr" or "slice" or "indexOf" or "lastIndexOf" or "startsWith" or "endsWith" or "includes" or "replace" or "split",
+            0 => methodName is "charAt" or "charCodeAt" or "trim" or "trimStart" or "trimLeft" or "trimEnd" or "trimRight" or "toLowerCase" or "toUpperCase",
+            1 => methodName is "charAt" or "charCodeAt" or "substring" or "substr" or "slice" or "indexOf" or "lastIndexOf" or "startsWith" or "endsWith" or "includes",
+            2 => methodName is "substring" or "substr" or "slice" or "indexOf" or "lastIndexOf" or "startsWith" or "endsWith" or "includes",
             _ => false
         };
     }

--- a/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
@@ -57,6 +57,7 @@ internal static class LIRIntrinsicNormalization
             || ins is LIRLoadScopeField
             || ins is LIRLoadLeafScopeField
             || ins is LIRLoadParentScopeField
+            || ins is LIRCallIntrinsicStatic
             || ins is LIRCopyTemp))
         {
             switch (instruction)
@@ -110,6 +111,19 @@ internal static class LIRIntrinsicNormalization
                     }
                     break;
 
+                case LIRCallIntrinsicStatic
+                    {
+                        IntrinsicName: nameof(JavaScriptRuntime.ObjectRuntime),
+                        MethodName: nameof(JavaScriptRuntime.ObjectRuntime.RequireObjectCoercible)
+                    } requireObjectCoercible:
+                    if (requireObjectCoercible.Result.Index >= 0
+                        && requireObjectCoercible.Arguments.Count == 1
+                        && knownSpecializedReceiverClrTypes.TryGetValue(requireObjectCoercible.Arguments[0].Index, out var coercedReceiverType))
+                    {
+                        knownSpecializedReceiverClrTypes[requireObjectCoercible.Result.Index] = coercedReceiverType;
+                    }
+                    break;
+
                 case LIRCopyTemp copyTemp:
                     if (copyTemp.Destination.Index >= 0
                         && knownSpecializedReceiverClrTypes.TryGetValue(copyTemp.Source.Index, out var srcClrType))
@@ -129,6 +143,33 @@ internal static class LIRIntrinsicNormalization
         for (int i = 0; i < methodBody.Instructions.Count; i++)
         {
             var instruction = methodBody.Instructions[i];
+
+            if (instruction is LIRCopyTemp copyTemp)
+            {
+                if (copyTemp.Destination.Index >= 0
+                    && knownSpecializedReceiverClrTypes.TryGetValue(copyTemp.Source.Index, out var copiedReceiverType))
+                {
+                    knownSpecializedReceiverClrTypes[copyTemp.Destination.Index] = copiedReceiverType;
+                }
+
+                if (copyTemp.Destination.Index >= 0
+                    && knownConstStrings.TryGetValue(copyTemp.Source.Index, out var copiedConstString))
+                {
+                    knownConstStrings[copyTemp.Destination.Index] = copiedConstString;
+                }
+            }
+
+            if (instruction is LIRCallIntrinsicStatic
+                {
+                    IntrinsicName: nameof(JavaScriptRuntime.ObjectRuntime),
+                    MethodName: nameof(JavaScriptRuntime.ObjectRuntime.RequireObjectCoercible)
+                } requireObjectCoercible
+                && requireObjectCoercible.Result.Index >= 0
+                && requireObjectCoercible.Arguments.Count == 1
+                && knownSpecializedReceiverClrTypes.TryGetValue(requireObjectCoercible.Arguments[0].Index, out var coercedReceiverType))
+            {
+                knownSpecializedReceiverClrTypes[requireObjectCoercible.Result.Index] = coercedReceiverType;
+            }
 
             if (instruction is LIRGetLength getLength)
             {
@@ -286,6 +327,18 @@ internal static class LIRIntrinsicNormalization
 
             if (instruction is LIRCallMember0 callMember0)
             {
+                if (TryNormalizeArrayMemberCall(
+                        methodBody,
+                        i,
+                        callMember0.Receiver,
+                        callMember0.MethodName,
+                        Array.Empty<TempVariable>(),
+                        callMember0.Result,
+                        knownSpecializedReceiverClrTypes))
+                {
+                    continue;
+                }
+
                 if (!knownSpecializedReceiverClrTypes.TryGetValue(callMember0.Receiver.Index, out var receiverType)
                     || receiverType != typeof(string)
                     || !TryResolveSafeStringIntrinsicReturnClrType(methodBody, callMember0.MethodName, Array.Empty<TempVariable>(), out var returnClrType))
@@ -309,6 +362,18 @@ internal static class LIRIntrinsicNormalization
 
             if (instruction is LIRCallMember1 callMember1)
             {
+                if (TryNormalizeArrayMemberCall(
+                        methodBody,
+                        i,
+                        callMember1.Receiver,
+                        callMember1.MethodName,
+                        new[] { callMember1.A0 },
+                        callMember1.Result,
+                        knownSpecializedReceiverClrTypes))
+                {
+                    continue;
+                }
+
                 if (knownSpecializedReceiverClrTypes.TryGetValue(callMember1.Receiver.Index, out var stringReceiverType)
                     && stringReceiverType == typeof(string)
                     && TryResolveSafeStringIntrinsicReturnClrType(methodBody, callMember1.MethodName, new[] { callMember1.A0 }, out var stringReturnClrType))
@@ -346,6 +411,18 @@ internal static class LIRIntrinsicNormalization
 
             if (instruction is LIRCallMember2 callMember2)
             {
+                if (TryNormalizeArrayMemberCall(
+                        methodBody,
+                        i,
+                        callMember2.Receiver,
+                        callMember2.MethodName,
+                        new[] { callMember2.A0, callMember2.A1 },
+                        callMember2.Result,
+                        knownSpecializedReceiverClrTypes))
+                {
+                    continue;
+                }
+
                 if (!knownSpecializedReceiverClrTypes.TryGetValue(callMember2.Receiver.Index, out var receiverType)
                     || receiverType != typeof(string)
                     || !TryResolveSafeStringIntrinsicReturnClrType(methodBody, callMember2.MethodName, new[] { callMember2.A0, callMember2.A1 }, out var returnClrType))
@@ -365,6 +442,18 @@ internal static class LIRIntrinsicNormalization
                 }
 
                 continue;
+            }
+
+            if (instruction is LIRCallMember3 callMember3)
+            {
+                TryNormalizeArrayMemberCall(
+                    methodBody,
+                    i,
+                    callMember3.Receiver,
+                    callMember3.MethodName,
+                    new[] { callMember3.A0, callMember3.A1, callMember3.A2 },
+                    callMember3.Result,
+                    knownSpecializedReceiverClrTypes);
             }
         }
 
@@ -748,31 +837,110 @@ internal static class LIRIntrinsicNormalization
             return;
         }
 
+        ValueStorage storage;
         if (returnClrType == typeof(bool))
         {
-            methodBody.TempStorages[result.Index] = new ValueStorage(ValueStorageKind.UnboxedValue, typeof(bool));
-            return;
+            storage = new ValueStorage(ValueStorageKind.UnboxedValue, typeof(bool));
         }
-
-        if (returnClrType == typeof(double))
+        else if (returnClrType == typeof(double))
         {
-            methodBody.TempStorages[result.Index] = new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double));
-            return;
+            storage = new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double));
         }
-
-        if (returnClrType == typeof(string))
+        else if (returnClrType == typeof(string))
         {
-            methodBody.TempStorages[result.Index] = new ValueStorage(ValueStorageKind.Reference, typeof(string));
-            return;
+            storage = new ValueStorage(ValueStorageKind.Reference, typeof(string));
         }
-
-        if (returnClrType == typeof(JavaScriptRuntime.Array))
+        else if (returnClrType == typeof(JavaScriptRuntime.Array))
         {
-            methodBody.TempStorages[result.Index] = new ValueStorage(ValueStorageKind.Reference, typeof(JavaScriptRuntime.Array));
+            storage = new ValueStorage(ValueStorageKind.Reference, typeof(JavaScriptRuntime.Array));
+        }
+        else
+        {
+            storage = new ValueStorage(ValueStorageKind.Reference, typeof(object));
+        }
+
+        methodBody.TempStorages[result.Index] = storage;
+        ApplySingleAssignmentSlotStorage(methodBody, result, storage);
+    }
+
+    private static void ApplySingleAssignmentSlotStorage(MethodBodyIR methodBody, TempVariable result, ValueStorage storage)
+    {
+        if (result.Index < 0 || result.Index >= methodBody.TempVariableSlots.Count)
+        {
             return;
         }
 
-        methodBody.TempStorages[result.Index] = new ValueStorage(ValueStorageKind.Reference, typeof(object));
+        var slot = methodBody.TempVariableSlots[result.Index];
+        if (slot < 0
+            || slot >= methodBody.VariableStorages.Count
+            || !methodBody.SingleAssignmentSlots.Contains(slot))
+        {
+            return;
+        }
+
+        var current = methodBody.VariableStorages[slot];
+        if (current.Kind == ValueStorageKind.Reference && current.ClrType == typeof(object))
+        {
+            methodBody.VariableStorages[slot] = storage;
+        }
+    }
+
+    private static bool TryNormalizeArrayMemberCall(
+        MethodBodyIR methodBody,
+        int instructionIndex,
+        TempVariable receiver,
+        string methodName,
+        IReadOnlyList<TempVariable> arguments,
+        TempVariable result,
+        IDictionary<int, Type> knownSpecializedReceiverClrTypes)
+    {
+        if (!knownSpecializedReceiverClrTypes.TryGetValue(receiver.Index, out var receiverType)
+            || receiverType != typeof(JavaScriptRuntime.Array)
+            || !TryResolveArrayMemberReturnClrType(methodName, arguments.Count, out var returnClrType))
+        {
+            return false;
+        }
+
+        methodBody.Instructions[instructionIndex] = new LIRCallInstanceMethod(
+            Receiver: receiver,
+            ReceiverClrType: typeof(JavaScriptRuntime.Array),
+            MethodName: methodName,
+            Arguments: arguments,
+            Result: result);
+
+        ApplyResolvedIntrinsicReturnStorage(methodBody, result, returnClrType);
+        if (result.Index >= 0 && IsSpecializedReceiverClrType(returnClrType))
+        {
+            knownSpecializedReceiverClrTypes[result.Index] = returnClrType;
+        }
+
+        return true;
+    }
+
+    private static bool TryResolveArrayMemberReturnClrType(string methodName, int argCount, out Type returnClrType)
+    {
+        returnClrType = typeof(object);
+
+        switch (methodName)
+        {
+            case "push" when argCount is 0 or 1:
+            case "unshift" when argCount is 0 or 1:
+                returnClrType = typeof(double);
+                return true;
+
+            case "pop" when argCount == 0:
+            case "shift" when argCount == 0:
+                returnClrType = typeof(object);
+                return true;
+
+            case "slice" when argCount is >= 0 and <= 2:
+            case "splice" when argCount is >= 0 and <= 3:
+                returnClrType = typeof(JavaScriptRuntime.Array);
+                return true;
+
+            default:
+                return false;
+        }
     }
 
     private static bool IsNumericDouble(MethodBodyIR methodBody, TempVariable temp)

--- a/src/Compiler/SymbolTable/Scope.cs
+++ b/src/Compiler/SymbolTable/Scope.cs
@@ -162,6 +162,12 @@ public class Scope
     public bool HasParameterExpressions { get; set; }
 
     /// <summary>
+    /// True when this callable value can be created inside a <c>with</c> statement and therefore
+    /// may need captured-with-object identifier resolution when invoked later.
+    /// </summary>
+    public bool MayUseBoundWithObject { get; set; }
+
+    /// <summary>
     /// True when this block scope is the hoisting target for <c>var</c> declarations.
     /// Used for synthetic function-body scopes created when parameter expressions require
     /// separate parameter/body environments.

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.cs
@@ -35,6 +35,7 @@ namespace Jroc.SymbolTables
         private int _closureCounter = 0;
         private string? _currentAssignmentTarget = null;
         private string _currentModulePath = string.Empty;
+        private int _activeWithDepth;
 
         private static BindingInfo? TryResolveBinding(Scope scope, string name)
         {
@@ -879,6 +880,7 @@ namespace Jroc.SymbolTables
                             // Create a pseudo-scope for the method if we compile methods as functions later
                             var mname = (mdef.Key as Identifier)?.Name ?? $"Method_L{mdef.Location.Start.Line}C{mdef.Location.Start.Column}";
                             var methodScope = new Scope(mname, ScopeKind.Function, classScope, mfunc);
+                            methodScope.MayUseBoundWithObject = _activeWithDepth > 0;
 
                             // Class methods can be async/generators; propagate these flags so type generation
                             // and IL lowering can emit the correct state-machine fields.
@@ -1019,7 +1021,7 @@ namespace Jroc.SymbolTables
                         {
                             var mname = (mdef.Key as Identifier)?.Name ?? $"Method_L{mdef.Location.Start.Line}C{mdef.Location.Start.Column}";
                             var methodScope = new Scope(mname, ScopeKind.Function, classExprScope, mfunc);
-
+                            methodScope.MayUseBoundWithObject = _activeWithDepth > 0;
                             methodScope.IsAsync = mfunc.Async;
                             if (mfunc.Async)
                             {
@@ -1174,6 +1176,7 @@ namespace Jroc.SymbolTables
                     }
                     // Create the scope (constructor links it to the parent); no manual add to avoid duplicates
                     var funcExprScope = new Scope(funcExprName, ScopeKind.Function, currentScope, funcExpr);
+                    funcExprScope.MayUseBoundWithObject = _activeWithDepth > 0;
                     funcExprScope.IsAsync = funcExpr.Async;
                     if (funcExpr.Async)
                     {
@@ -1469,6 +1472,7 @@ namespace Jroc.SymbolTables
                     var col1Based = arrowFunc.Location.Start.Column + 1;
                     var arrowName = $"ArrowFunction_L{arrowFunc.Location.Start.Line}C{col1Based}";
                     var arrowScope = new Scope(arrowName, ScopeKind.Function, currentScope, arrowFunc);
+                    arrowScope.MayUseBoundWithObject = _activeWithDepth > 0;
                     arrowScope.IsAsync = arrowFunc.Async;
                     if (arrowFunc.Async)
                     {
@@ -1843,6 +1847,18 @@ namespace Jroc.SymbolTables
                     if (tryStmt.Finalizer != null)
                     {
                         BuildScopeRecursive(globalScope, tryStmt.Finalizer, currentScope);
+                    }
+                    break;
+                case WithStatement withStmt:
+                    BuildScopeRecursive(globalScope, withStmt.Object, currentScope);
+                    _activeWithDepth++;
+                    try
+                    {
+                        BuildScopeRecursive(globalScope, withStmt.Body, currentScope);
+                    }
+                    finally
+                    {
+                        _activeWithDepth--;
                     }
                     break;
                 default:

--- a/src/JavaScriptRuntime/String.cs
+++ b/src/JavaScriptRuntime/String.cs
@@ -1165,7 +1165,11 @@ namespace JavaScriptRuntime
         {
             input ??= string.Empty;
 
-            if (double.IsNaN(index) || double.IsInfinity(index))
+            if (double.IsNaN(index))
+            {
+                index = 0d;
+            }
+            else if (double.IsInfinity(index))
             {
                 return double.NaN;
             }

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x560e
+				// Method begins at RVA 0x5198
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5629
+						// Method begins at RVA 0x51b3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5632
+						// Method begins at RVA 0x51bc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x563b
+						// Method begins at RVA 0x51c5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5644
+						// Method begins at RVA 0x51ce
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x564d
+						// Method begins at RVA 0x51d7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -146,7 +146,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5656
+						// Method begins at RVA 0x51e0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -164,7 +164,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5620
+					// Method begins at RVA 0x51aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5617
+				// Method begins at RVA 0x51a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -532,7 +532,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x565f
+				// Method begins at RVA 0x51e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -641,7 +641,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5668
+				// Method begins at RVA 0x51f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -669,65 +669,49 @@
 			)
 			// Method begins at RVA 0x2b30
 			// Header size: 12
-			// Code size: 111 (0x6f)
+			// Code size: 81 (0x51)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] object[]
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0006: stloc.0
-			IL_0007: ldstr "path"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
+			IL_000d: ldstr "resolve"
+			IL_0012: ldc.i4.6
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
 			IL_001a: ldarg.0
 			IL_001b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::__dirname
-			IL_0020: stloc.1
-			IL_0021: ldstr "__dirname"
-			IL_0026: ldloc.1
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_002c: stloc.1
-			IL_002d: ldc.i4.6
-			IL_002e: newarr [System.Runtime]System.Object
-			IL_0033: dup
-			IL_0034: ldc.i4.0
-			IL_0035: ldloc.1
-			IL_0036: stelem.ref
-			IL_0037: dup
-			IL_0038: ldc.i4.1
-			IL_0039: ldstr ".."
-			IL_003e: stelem.ref
-			IL_003f: dup
-			IL_0040: ldc.i4.2
-			IL_0041: ldstr ".."
-			IL_0046: stelem.ref
-			IL_0047: dup
-			IL_0048: ldc.i4.3
-			IL_0049: ldstr "tests"
-			IL_004e: stelem.ref
-			IL_004f: dup
-			IL_0050: ldc.i4.4
-			IL_0051: ldstr "test262"
-			IL_0056: stelem.ref
-			IL_0057: dup
-			IL_0058: ldc.i4.5
-			IL_0059: ldstr "test262.pin.json"
-			IL_005e: stelem.ref
-			IL_005f: stloc.2
-			IL_0060: ldloc.0
-			IL_0061: ldstr "resolve"
-			IL_0066: ldloc.2
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_006c: stloc.0
-			IL_006d: ldloc.0
-			IL_006e: ret
+			IL_0020: stelem.ref
+			IL_0021: dup
+			IL_0022: ldc.i4.1
+			IL_0023: ldstr ".."
+			IL_0028: stelem.ref
+			IL_0029: dup
+			IL_002a: ldc.i4.2
+			IL_002b: ldstr ".."
+			IL_0030: stelem.ref
+			IL_0031: dup
+			IL_0032: ldc.i4.3
+			IL_0033: ldstr "tests"
+			IL_0038: stelem.ref
+			IL_0039: dup
+			IL_003a: ldc.i4.4
+			IL_003b: ldstr "test262"
+			IL_0040: stelem.ref
+			IL_0041: dup
+			IL_0042: ldc.i4.5
+			IL_0043: ldstr "test262.pin.json"
+			IL_0048: stelem.ref
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_004e: stloc.0
+			IL_004f: ldloc.0
+			IL_0050: ret
 		} // end of method defaultPinPath::__js_call__
 
 	} // end of class defaultPinPath
@@ -747,7 +731,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x567a
+					// Method begins at RVA 0x5204
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -765,7 +749,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5671
+				// Method begins at RVA 0x51fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -792,9 +776,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2bac
+			// Method begins at RVA 0x2b90
 			// Header size: 12
-			// Code size: 154 (0x9a)
+			// Code size: 126 (0x7e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/Scope/Block_L80C14,
@@ -818,56 +802,44 @@
 
 			IL_001c: ldarg.0
 			IL_001d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0022: stloc.2
-			IL_0023: ldstr "path"
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0027: stloc.2
 			IL_0028: ldloc.2
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_002e: stloc.2
-			IL_002f: ldloc.2
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0035: stloc.2
-			IL_0036: ldloc.2
-			IL_0037: ldstr "isAbsolute"
-			IL_003c: ldarg.2
-			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0042: stloc.2
-			IL_0043: ldloc.2
-			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0049: stloc.1
-			IL_004a: ldloc.1
-			IL_004b: brfalse IL_0052
+			IL_0029: ldstr "isAbsolute"
+			IL_002e: ldarg.2
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0034: stloc.2
+			IL_0035: ldloc.2
+			IL_0036: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_003b: stloc.1
+			IL_003c: ldloc.1
+			IL_003d: brfalse IL_0044
 
-			IL_0050: ldarg.2
-			IL_0051: ret
+			IL_0042: ldarg.2
+			IL_0043: ret
 
-			IL_0052: ldarg.0
-			IL_0053: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0058: stloc.2
-			IL_0059: ldstr "path"
-			IL_005e: ldloc.2
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0064: stloc.2
-			IL_0065: ldloc.2
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006b: stloc.2
-			IL_006c: ldstr "process"
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0076: stloc.3
-			IL_0077: ldloc.3
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007d: stloc.3
-			IL_007e: ldloc.3
-			IL_007f: ldstr "cwd"
-			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0089: stloc.3
-			IL_008a: ldloc.2
-			IL_008b: ldstr "resolve"
-			IL_0090: ldloc.3
-			IL_0091: ldarg.2
-			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0097: stloc.3
-			IL_0098: ldloc.3
-			IL_0099: ret
+			IL_0044: ldarg.0
+			IL_0045: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_004f: stloc.2
+			IL_0050: ldstr "process"
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_005a: stloc.3
+			IL_005b: ldloc.3
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0061: stloc.3
+			IL_0062: ldloc.3
+			IL_0063: ldstr "cwd"
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_006d: stloc.3
+			IL_006e: ldloc.2
+			IL_006f: ldstr "resolve"
+			IL_0074: ldloc.3
+			IL_0075: ldarg.2
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_007b: stloc.3
+			IL_007c: ldloc.3
+			IL_007d: ret
 		} // end of method resolvePathFromCwd::__js_call__
 
 	} // end of class resolvePathFromCwd
@@ -883,7 +855,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5683
+				// Method begins at RVA 0x520d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -907,7 +879,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c54
+			// Method begins at RVA 0x2c1c
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -946,7 +918,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x568c
+				// Method begins at RVA 0x5216
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -973,63 +945,57 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2c8c
+			// Method begins at RVA 0x2c54
 			// Header size: 12
-			// Code size: 123 (0x7b)
+			// Code size: 109 (0x6d)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object[],
+				[0] object[],
+				[1] object,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
-			IL_0006: stloc.0
-			IL_0007: ldstr "toPortablePath"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0026: stloc.0
-			IL_0027: ldloc.0
-			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002d: stloc.0
-			IL_002e: ldstr "^\\/+"
-			IL_0033: ldstr ""
-			IL_0038: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_003d: stloc.2
-			IL_003e: ldloc.0
-			IL_003f: ldstr "replace"
-			IL_0044: ldloc.2
-			IL_0045: ldstr ""
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004f: stloc.0
-			IL_0050: ldloc.0
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.0
-			IL_0057: ldstr "\\/+$"
-			IL_005c: ldstr ""
-			IL_0061: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0066: stloc.2
-			IL_0067: ldloc.0
-			IL_0068: ldstr "replace"
-			IL_006d: ldloc.2
-			IL_006e: ldstr ""
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0078: stloc.0
-			IL_0079: ldloc.0
-			IL_007a: ret
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.0
+			IL_000b: ldarg.0
+			IL_000c: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
+			IL_0011: ldloc.0
+			IL_0012: ldarg.2
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0018: stloc.1
+			IL_0019: ldloc.1
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001f: stloc.1
+			IL_0020: ldstr "^\\/+"
+			IL_0025: ldstr ""
+			IL_002a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_002f: stloc.2
+			IL_0030: ldloc.1
+			IL_0031: ldstr "replace"
+			IL_0036: ldloc.2
+			IL_0037: ldstr ""
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0041: stloc.1
+			IL_0042: ldloc.1
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0048: stloc.1
+			IL_0049: ldstr "\\/+$"
+			IL_004e: ldstr ""
+			IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0058: stloc.2
+			IL_0059: ldloc.1
+			IL_005a: ldstr "replace"
+			IL_005f: ldloc.2
+			IL_0060: ldstr ""
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_006a: stloc.1
+			IL_006b: ldloc.1
+			IL_006c: ret
 		} // end of method normalizeSpecPath::__js_call__
 
 	} // end of class normalizeSpecPath
@@ -1049,7 +1015,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x569e
+					// Method begins at RVA 0x5228
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1067,7 +1033,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5695
+				// Method begins at RVA 0x521f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1092,7 +1058,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d14
+			// Method begins at RVA 0x2cd0
 			// Header size: 12
 			// Code size: 188 (0xbc)
 			.maxstack 8
@@ -1201,7 +1167,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x56b0
+					// Method begins at RVA 0x523a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1219,7 +1185,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56a7
+				// Method begins at RVA 0x5231
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1247,7 +1213,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x56cb
+						// Method begins at RVA 0x5255
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1265,7 +1231,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x56c2
+					// Method begins at RVA 0x524c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1283,7 +1249,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56b9
+				// Method begins at RVA 0x5243
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1308,7 +1274,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ddc
+			// Method begins at RVA 0x2d98
 			// Header size: 12
 			// Code size: 501 (0x1f5)
 			.maxstack 8
@@ -1545,7 +1511,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56d4
+				// Method begins at RVA 0x525e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1573,7 +1539,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x56ef
+						// Method begins at RVA 0x5279
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1591,7 +1557,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x56e6
+					// Method begins at RVA 0x5270
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1609,7 +1575,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56dd
+				// Method begins at RVA 0x5267
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1636,9 +1602,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2ffc
+			// Method begins at RVA 0x2fb8
 			// Header size: 12
-			// Code size: 244 (0xf4)
+			// Code size: 226 (0xe2)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
@@ -1648,119 +1614,113 @@
 				[4] class Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/Scope_ForOf_L116C7/Block_L116C29,
 				[5] class Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/Scope_ForOf_L116C7/Block_L116C29/Block_L117C42,
 				[6] object,
-				[7] object,
-				[8] object[],
+				[7] object[],
+				[8] object,
 				[9] bool
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_0006: stloc.s 7
-			IL_0008: ldstr "ensureStringArray"
-			IL_000d: ldloc.s 7
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 7
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.s 8
-			IL_0022: ldloc.s 7
-			IL_0024: ldloc.s 8
-			IL_0026: ldarg.2
-			IL_0027: ldstr "excludedFromMvp"
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0031: pop
-			IL_0032: ldarg.2
-			IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_0038: stloc.0
-			IL_0039: ldc.i4.0
-			IL_003a: stloc.1
-			IL_003b: ldc.i4.0
-			IL_003c: stloc.2
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 7
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_0012: ldloc.s 7
+			IL_0014: ldarg.2
+			IL_0015: ldstr "excludedFromMvp"
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_001f: pop
+			IL_0020: ldarg.2
+			IL_0021: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_0026: stloc.0
+			IL_0027: ldc.i4.0
+			IL_0028: stloc.1
+			IL_0029: ldc.i4.0
+			IL_002a: stloc.2
 			.try
 			{
-				// loop start (head: IL_003d)
-					IL_003d: ldloc.0
-					IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_0043: stloc.s 7
-					IL_0045: ldloc.s 7
-					IL_0047: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_004c: stloc.s 9
-					IL_004e: ldloc.s 9
-					IL_0050: brtrue IL_00d8
+				// loop start (head: IL_002b)
+					IL_002b: ldloc.0
+					IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_0031: stloc.s 8
+					IL_0033: ldloc.s 8
+					IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_003a: stloc.s 9
+					IL_003c: ldloc.s 9
+					IL_003e: brtrue IL_00c6
 
-					IL_0055: ldloc.s 7
-					IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_005c: stloc.s 7
-					IL_005e: ldloc.s 7
-					IL_0060: stloc.3
-					IL_0061: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/Scope_ForOf_L116C7/Block_L116C29::.ctor()
-					IL_0066: stloc.s 4
-					IL_0068: ldloc.3
-					IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_006e: stloc.s 7
-					IL_0070: ldloc.s 7
-					IL_0072: ldstr "startsWith"
-					IL_0077: ldstr "frontmatter:"
-					IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0081: stloc.s 7
-					IL_0083: ldloc.s 7
-					IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_008a: stloc.s 9
-					IL_008c: ldloc.s 9
-					IL_008e: brfalse IL_00c6
+					IL_0043: ldloc.s 8
+					IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_004a: stloc.s 8
+					IL_004c: ldloc.s 8
+					IL_004e: stloc.3
+					IL_004f: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/Scope_ForOf_L116C7/Block_L116C29::.ctor()
+					IL_0054: stloc.s 4
+					IL_0056: ldloc.3
+					IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_005c: stloc.s 8
+					IL_005e: ldloc.s 8
+					IL_0060: ldstr "startsWith"
+					IL_0065: ldstr "frontmatter:"
+					IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_006f: stloc.s 8
+					IL_0071: ldloc.s 8
+					IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0078: stloc.s 9
+					IL_007a: ldloc.s 9
+					IL_007c: brfalse IL_00b4
 
-					IL_0093: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/Scope_ForOf_L116C7/Block_L116C29/Block_L117C42::.ctor()
-					IL_0098: stloc.s 5
-					IL_009a: ldstr "Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification."
-					IL_009f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_00a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_00a9: stloc.s 7
-					IL_00ab: ldloc.s 7
-					IL_00ad: stloc.s 6
-					IL_00af: ldloc.s 6
-					IL_00b1: isinst [System.Runtime]System.Exception
-					IL_00b6: dup
-					IL_00b7: brtrue IL_00c5
+					IL_0081: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/Scope_ForOf_L116C7/Block_L116C29/Block_L117C42::.ctor()
+					IL_0086: stloc.s 5
+					IL_0088: ldstr "Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification."
+					IL_008d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0092: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0097: stloc.s 8
+					IL_0099: ldloc.s 8
+					IL_009b: stloc.s 6
+					IL_009d: ldloc.s 6
+					IL_009f: isinst [System.Runtime]System.Exception
+					IL_00a4: dup
+					IL_00a5: brtrue IL_00b3
 
-					IL_00bc: pop
-					IL_00bd: ldloc.s 6
-					IL_00bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-					IL_00c4: throw
+					IL_00aa: pop
+					IL_00ab: ldloc.s 6
+					IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_00b2: throw
 
-					IL_00c5: throw
+					IL_00b3: throw
 
-					IL_00c6: br IL_003d
+					IL_00b4: br IL_002b
 				// end loop
-				IL_00cb: ldloc.0
-				IL_00cc: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_00d1: ldc.i4.1
-				IL_00d2: stloc.2
-				IL_00d3: leave IL_00f2
+				IL_00b9: ldloc.0
+				IL_00ba: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_00bf: ldc.i4.1
+				IL_00c0: stloc.2
+				IL_00c1: leave IL_00e0
 
-				IL_00d8: ldc.i4.1
-				IL_00d9: stloc.1
-				IL_00da: leave IL_00f2
+				IL_00c6: ldc.i4.1
+				IL_00c7: stloc.1
+				IL_00c8: leave IL_00e0
 			} // end .try
 			finally
 			{
-				IL_00df: ldloc.1
-				IL_00e0: brtrue IL_00f1
+				IL_00cd: ldloc.1
+				IL_00ce: brtrue IL_00df
 
-				IL_00e5: ldloc.2
-				IL_00e6: brtrue IL_00f1
+				IL_00d3: ldloc.2
+				IL_00d4: brtrue IL_00df
 
-				IL_00eb: ldloc.0
-				IL_00ec: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_00d9: ldloc.0
+				IL_00da: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_00f1: endfinally
+				IL_00df: endfinally
 			} // end handler
 
-			IL_00f2: ldnull
-			IL_00f3: ret
+			IL_00e0: ldnull
+			IL_00e1: ret
 		} // end of method validateExcludedFromMvp::__js_call__
 
 	} // end of class validateExcludedFromMvp
@@ -1780,7 +1740,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5701
+					// Method begins at RVA 0x528b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1800,7 +1760,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x570a
+					// Method begins at RVA 0x5294
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1820,7 +1780,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5713
+					// Method begins at RVA 0x529d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1838,7 +1798,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56f8
+				// Method begins at RVA 0x5282
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1865,9 +1825,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x310c
+			// Method begins at RVA 0x30b8
 			// Header size: 12
-			// Code size: 1496 (0x5d8)
+			// Code size: 1272 (0x4f8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262Bootstrap/validatePin/Scope/Block_L124C39,
@@ -2005,440 +1965,376 @@
 			IL_012a: ldarg.0
 			IL_012b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
 			IL_0130: stloc.s 11
-			IL_0132: ldstr "ensureString"
-			IL_0137: ldloc.s 11
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_013e: stloc.s 11
-			IL_0140: ldc.i4.1
-			IL_0141: newarr [System.Runtime]System.Object
-			IL_0146: dup
-			IL_0147: ldc.i4.0
-			IL_0148: ldarg.0
-			IL_0149: stelem.ref
-			IL_014a: stloc.s 13
-			IL_014c: ldarg.2
-			IL_014d: ldstr "upstream"
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0157: ldstr "owner"
-			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0161: stloc.s 14
-			IL_0163: ldloc.s 11
-			IL_0165: ldloc.s 13
-			IL_0167: ldloc.s 14
-			IL_0169: ldstr "upstream.owner"
-			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0173: pop
-			IL_0174: ldarg.0
-			IL_0175: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_017a: stloc.s 14
-			IL_017c: ldstr "ensureString"
-			IL_0181: ldloc.s 14
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0188: stloc.s 14
-			IL_018a: ldc.i4.1
-			IL_018b: newarr [System.Runtime]System.Object
-			IL_0190: dup
-			IL_0191: ldc.i4.0
-			IL_0192: ldarg.0
-			IL_0193: stelem.ref
-			IL_0194: stloc.s 13
-			IL_0196: ldarg.2
-			IL_0197: ldstr "upstream"
-			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a1: ldstr "repo"
-			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ab: stloc.s 11
-			IL_01ad: ldloc.s 14
-			IL_01af: ldloc.s 13
-			IL_01b1: ldloc.s 11
-			IL_01b3: ldstr "upstream.repo"
-			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01bd: pop
-			IL_01be: ldarg.0
-			IL_01bf: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_01c4: stloc.s 11
-			IL_01c6: ldstr "ensureString"
-			IL_01cb: ldloc.s 11
-			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01d2: stloc.s 11
-			IL_01d4: ldc.i4.1
-			IL_01d5: newarr [System.Runtime]System.Object
-			IL_01da: dup
-			IL_01db: ldc.i4.0
-			IL_01dc: ldarg.0
-			IL_01dd: stelem.ref
-			IL_01de: stloc.s 13
-			IL_01e0: ldarg.2
-			IL_01e1: ldstr "upstream"
-			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01eb: ldstr "cloneUrl"
-			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f5: stloc.s 14
-			IL_01f7: ldloc.s 11
-			IL_01f9: ldloc.s 13
-			IL_01fb: ldloc.s 14
-			IL_01fd: ldstr "upstream.cloneUrl"
-			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0207: pop
-			IL_0208: ldarg.0
-			IL_0209: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_020e: stloc.s 14
-			IL_0210: ldstr "ensureString"
-			IL_0215: ldloc.s 14
-			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_021c: stloc.s 14
-			IL_021e: ldc.i4.1
-			IL_021f: newarr [System.Runtime]System.Object
-			IL_0224: dup
-			IL_0225: ldc.i4.0
-			IL_0226: ldarg.0
-			IL_0227: stelem.ref
-			IL_0228: stloc.s 13
-			IL_022a: ldarg.2
-			IL_022b: ldstr "upstream"
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0235: ldstr "commit"
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023f: stloc.s 11
-			IL_0241: ldloc.s 14
-			IL_0243: ldloc.s 13
+			IL_0132: ldc.i4.1
+			IL_0133: newarr [System.Runtime]System.Object
+			IL_0138: dup
+			IL_0139: ldc.i4.0
+			IL_013a: ldarg.0
+			IL_013b: stelem.ref
+			IL_013c: stloc.s 13
+			IL_013e: ldarg.2
+			IL_013f: ldstr "upstream"
+			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0149: ldstr "owner"
+			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0153: stloc.s 14
+			IL_0155: ldloc.s 11
+			IL_0157: ldloc.s 13
+			IL_0159: ldloc.s 14
+			IL_015b: ldstr "upstream.owner"
+			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0165: pop
+			IL_0166: ldarg.0
+			IL_0167: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_016c: stloc.s 14
+			IL_016e: ldc.i4.1
+			IL_016f: newarr [System.Runtime]System.Object
+			IL_0174: dup
+			IL_0175: ldc.i4.0
+			IL_0176: ldarg.0
+			IL_0177: stelem.ref
+			IL_0178: stloc.s 13
+			IL_017a: ldarg.2
+			IL_017b: ldstr "upstream"
+			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0185: ldstr "repo"
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_018f: stloc.s 11
+			IL_0191: ldloc.s 14
+			IL_0193: ldloc.s 13
+			IL_0195: ldloc.s 11
+			IL_0197: ldstr "upstream.repo"
+			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01a1: pop
+			IL_01a2: ldarg.0
+			IL_01a3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_01a8: stloc.s 11
+			IL_01aa: ldc.i4.1
+			IL_01ab: newarr [System.Runtime]System.Object
+			IL_01b0: dup
+			IL_01b1: ldc.i4.0
+			IL_01b2: ldarg.0
+			IL_01b3: stelem.ref
+			IL_01b4: stloc.s 13
+			IL_01b6: ldarg.2
+			IL_01b7: ldstr "upstream"
+			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01c1: ldstr "cloneUrl"
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01cb: stloc.s 14
+			IL_01cd: ldloc.s 11
+			IL_01cf: ldloc.s 13
+			IL_01d1: ldloc.s 14
+			IL_01d3: ldstr "upstream.cloneUrl"
+			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01dd: pop
+			IL_01de: ldarg.0
+			IL_01df: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_01e4: stloc.s 14
+			IL_01e6: ldc.i4.1
+			IL_01e7: newarr [System.Runtime]System.Object
+			IL_01ec: dup
+			IL_01ed: ldc.i4.0
+			IL_01ee: ldarg.0
+			IL_01ef: stelem.ref
+			IL_01f0: stloc.s 13
+			IL_01f2: ldarg.2
+			IL_01f3: ldstr "upstream"
+			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01fd: ldstr "commit"
+			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0207: stloc.s 11
+			IL_0209: ldloc.s 14
+			IL_020b: ldloc.s 13
+			IL_020d: ldloc.s 11
+			IL_020f: ldstr "upstream.commit"
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0219: pop
+			IL_021a: ldarg.0
+			IL_021b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_0220: stloc.s 11
+			IL_0222: ldc.i4.1
+			IL_0223: newarr [System.Runtime]System.Object
+			IL_0228: dup
+			IL_0229: ldc.i4.0
+			IL_022a: ldarg.0
+			IL_022b: stelem.ref
+			IL_022c: stloc.s 13
+			IL_022e: ldarg.2
+			IL_022f: ldstr "upstream"
+			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0239: ldstr "packageVersion"
+			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0243: stloc.s 14
 			IL_0245: ldloc.s 11
-			IL_0247: ldstr "upstream.commit"
-			IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0251: pop
-			IL_0252: ldarg.0
-			IL_0253: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_0258: stloc.s 11
-			IL_025a: ldstr "ensureString"
-			IL_025f: ldloc.s 11
-			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0266: stloc.s 11
-			IL_0268: ldc.i4.1
-			IL_0269: newarr [System.Runtime]System.Object
-			IL_026e: dup
-			IL_026f: ldc.i4.0
-			IL_0270: ldarg.0
-			IL_0271: stelem.ref
-			IL_0272: stloc.s 13
-			IL_0274: ldarg.2
-			IL_0275: ldstr "upstream"
-			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_027f: ldstr "packageVersion"
-			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0289: stloc.s 14
-			IL_028b: ldloc.s 11
-			IL_028d: ldloc.s 13
-			IL_028f: ldloc.s 14
-			IL_0291: ldstr "upstream.packageVersion"
-			IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_029b: pop
-			IL_029c: ldarg.0
-			IL_029d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_02a2: stloc.s 14
-			IL_02a4: ldstr "ensureString"
-			IL_02a9: ldloc.s 14
-			IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02b0: stloc.s 14
-			IL_02b2: ldc.i4.1
-			IL_02b3: newarr [System.Runtime]System.Object
-			IL_02b8: dup
-			IL_02b9: ldc.i4.0
+			IL_0247: ldloc.s 13
+			IL_0249: ldloc.s 14
+			IL_024b: ldstr "upstream.packageVersion"
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0255: pop
+			IL_0256: ldarg.0
+			IL_0257: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_025c: stloc.s 14
+			IL_025e: ldc.i4.1
+			IL_025f: newarr [System.Runtime]System.Object
+			IL_0264: dup
+			IL_0265: ldc.i4.0
+			IL_0266: ldarg.0
+			IL_0267: stelem.ref
+			IL_0268: stloc.s 13
+			IL_026a: ldarg.2
+			IL_026b: ldstr "localOverrideEnvVar"
+			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0275: stloc.s 11
+			IL_0277: ldloc.s 14
+			IL_0279: ldloc.s 13
+			IL_027b: ldloc.s 11
+			IL_027d: ldstr "localOverrideEnvVar"
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0287: pop
+			IL_0288: ldarg.0
+			IL_0289: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_028e: stloc.s 11
+			IL_0290: ldc.i4.1
+			IL_0291: newarr [System.Runtime]System.Object
+			IL_0296: dup
+			IL_0297: ldc.i4.0
+			IL_0298: ldarg.0
+			IL_0299: stelem.ref
+			IL_029a: stloc.s 13
+			IL_029c: ldarg.2
+			IL_029d: ldstr "managedRoot"
+			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02a7: stloc.s 14
+			IL_02a9: ldloc.s 11
+			IL_02ab: ldloc.s 13
+			IL_02ad: ldloc.s 14
+			IL_02af: ldstr "managedRoot"
+			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02b9: pop
 			IL_02ba: ldarg.0
-			IL_02bb: stelem.ref
-			IL_02bc: stloc.s 13
-			IL_02be: ldarg.2
-			IL_02bf: ldstr "localOverrideEnvVar"
-			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02c9: stloc.s 11
-			IL_02cb: ldloc.s 14
-			IL_02cd: ldloc.s 13
-			IL_02cf: ldloc.s 11
-			IL_02d1: ldstr "localOverrideEnvVar"
-			IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02db: pop
-			IL_02dc: ldarg.0
-			IL_02dd: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_02e2: stloc.s 11
-			IL_02e4: ldstr "ensureString"
-			IL_02e9: ldloc.s 11
-			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02f0: stloc.s 11
-			IL_02f2: ldc.i4.1
-			IL_02f3: newarr [System.Runtime]System.Object
-			IL_02f8: dup
-			IL_02f9: ldc.i4.0
-			IL_02fa: ldarg.0
-			IL_02fb: stelem.ref
-			IL_02fc: stloc.s 13
-			IL_02fe: ldarg.2
-			IL_02ff: ldstr "managedRoot"
-			IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0309: stloc.s 14
-			IL_030b: ldloc.s 11
-			IL_030d: ldloc.s 13
-			IL_030f: ldloc.s 14
-			IL_0311: ldstr "managedRoot"
-			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_031b: pop
-			IL_031c: ldarg.0
-			IL_031d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_0322: stloc.s 14
-			IL_0324: ldstr "ensureString"
-			IL_0329: ldloc.s 14
-			IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0330: stloc.s 14
-			IL_0332: ldc.i4.1
-			IL_0333: newarr [System.Runtime]System.Object
-			IL_0338: dup
-			IL_0339: ldc.i4.0
-			IL_033a: ldarg.0
-			IL_033b: stelem.ref
-			IL_033c: stloc.s 13
-			IL_033e: ldarg.2
-			IL_033f: ldstr "lineEndings"
-			IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0349: stloc.s 11
-			IL_034b: ldloc.s 14
-			IL_034d: ldloc.s 13
-			IL_034f: ldloc.s 11
-			IL_0351: ldstr "lineEndings"
-			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_035b: pop
-			IL_035c: ldarg.0
-			IL_035d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_0362: stloc.s 11
-			IL_0364: ldstr "ensureString"
-			IL_0369: ldloc.s 11
-			IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0370: stloc.s 11
-			IL_0372: ldc.i4.1
-			IL_0373: newarr [System.Runtime]System.Object
-			IL_0378: dup
-			IL_0379: ldc.i4.0
-			IL_037a: ldarg.0
-			IL_037b: stelem.ref
-			IL_037c: stloc.s 13
-			IL_037e: ldarg.2
-			IL_037f: ldstr "updateStrategy"
-			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0389: stloc.s 14
-			IL_038b: ldloc.s 11
-			IL_038d: ldloc.s 13
-			IL_038f: ldloc.s 14
-			IL_0391: ldstr "updateStrategy"
-			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_039b: pop
-			IL_039c: ldarg.0
-			IL_039d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_03a2: stloc.s 14
-			IL_03a4: ldstr "ensureStringArray"
-			IL_03a9: ldloc.s 14
-			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03b0: stloc.s 14
-			IL_03b2: ldc.i4.1
-			IL_03b3: newarr [System.Runtime]System.Object
-			IL_03b8: dup
-			IL_03b9: ldc.i4.0
-			IL_03ba: ldarg.0
-			IL_03bb: stelem.ref
-			IL_03bc: stloc.s 13
-			IL_03be: ldarg.2
-			IL_03bf: ldstr "includeFiles"
-			IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03c9: stloc.s 11
-			IL_03cb: ldloc.s 14
-			IL_03cd: ldloc.s 13
-			IL_03cf: ldloc.s 11
-			IL_03d1: ldstr "includeFiles"
-			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03db: pop
-			IL_03dc: ldarg.0
-			IL_03dd: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_03e2: stloc.s 11
-			IL_03e4: ldstr "ensureStringArray"
-			IL_03e9: ldloc.s 11
-			IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03f0: stloc.s 11
-			IL_03f2: ldc.i4.1
-			IL_03f3: newarr [System.Runtime]System.Object
-			IL_03f8: dup
-			IL_03f9: ldc.i4.0
-			IL_03fa: ldarg.0
-			IL_03fb: stelem.ref
-			IL_03fc: stloc.s 13
-			IL_03fe: ldarg.2
-			IL_03ff: ldstr "includeDirectories"
-			IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0409: stloc.s 14
+			IL_02bb: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_02c0: stloc.s 14
+			IL_02c2: ldc.i4.1
+			IL_02c3: newarr [System.Runtime]System.Object
+			IL_02c8: dup
+			IL_02c9: ldc.i4.0
+			IL_02ca: ldarg.0
+			IL_02cb: stelem.ref
+			IL_02cc: stloc.s 13
+			IL_02ce: ldarg.2
+			IL_02cf: ldstr "lineEndings"
+			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d9: stloc.s 11
+			IL_02db: ldloc.s 14
+			IL_02dd: ldloc.s 13
+			IL_02df: ldloc.s 11
+			IL_02e1: ldstr "lineEndings"
+			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02eb: pop
+			IL_02ec: ldarg.0
+			IL_02ed: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_02f2: stloc.s 11
+			IL_02f4: ldc.i4.1
+			IL_02f5: newarr [System.Runtime]System.Object
+			IL_02fa: dup
+			IL_02fb: ldc.i4.0
+			IL_02fc: ldarg.0
+			IL_02fd: stelem.ref
+			IL_02fe: stloc.s 13
+			IL_0300: ldarg.2
+			IL_0301: ldstr "updateStrategy"
+			IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_030b: stloc.s 14
+			IL_030d: ldloc.s 11
+			IL_030f: ldloc.s 13
+			IL_0311: ldloc.s 14
+			IL_0313: ldstr "updateStrategy"
+			IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_031d: pop
+			IL_031e: ldarg.0
+			IL_031f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_0324: stloc.s 14
+			IL_0326: ldc.i4.1
+			IL_0327: newarr [System.Runtime]System.Object
+			IL_032c: dup
+			IL_032d: ldc.i4.0
+			IL_032e: ldarg.0
+			IL_032f: stelem.ref
+			IL_0330: stloc.s 13
+			IL_0332: ldarg.2
+			IL_0333: ldstr "includeFiles"
+			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_033d: stloc.s 11
+			IL_033f: ldloc.s 14
+			IL_0341: ldloc.s 13
+			IL_0343: ldloc.s 11
+			IL_0345: ldstr "includeFiles"
+			IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_034f: pop
+			IL_0350: ldarg.0
+			IL_0351: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_0356: stloc.s 11
+			IL_0358: ldc.i4.1
+			IL_0359: newarr [System.Runtime]System.Object
+			IL_035e: dup
+			IL_035f: ldc.i4.0
+			IL_0360: ldarg.0
+			IL_0361: stelem.ref
+			IL_0362: stloc.s 13
+			IL_0364: ldarg.2
+			IL_0365: ldstr "includeDirectories"
+			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_036f: stloc.s 14
+			IL_0371: ldloc.s 11
+			IL_0373: ldloc.s 13
+			IL_0375: ldloc.s 14
+			IL_0377: ldstr "includeDirectories"
+			IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0381: pop
+			IL_0382: ldarg.0
+			IL_0383: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_0388: stloc.s 14
+			IL_038a: ldc.i4.1
+			IL_038b: newarr [System.Runtime]System.Object
+			IL_0390: dup
+			IL_0391: ldc.i4.0
+			IL_0392: ldarg.0
+			IL_0393: stelem.ref
+			IL_0394: stloc.s 13
+			IL_0396: ldarg.2
+			IL_0397: ldstr "requiredFiles"
+			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a1: stloc.s 11
+			IL_03a3: ldloc.s 14
+			IL_03a5: ldloc.s 13
+			IL_03a7: ldloc.s 11
+			IL_03a9: ldstr "requiredFiles"
+			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03b3: pop
+			IL_03b4: ldarg.0
+			IL_03b5: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_03ba: stloc.s 11
+			IL_03bc: ldc.i4.1
+			IL_03bd: newarr [System.Runtime]System.Object
+			IL_03c2: dup
+			IL_03c3: ldc.i4.0
+			IL_03c4: ldarg.0
+			IL_03c5: stelem.ref
+			IL_03c6: stloc.s 13
+			IL_03c8: ldarg.2
+			IL_03c9: ldstr "requiredDirectories"
+			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d3: stloc.s 14
+			IL_03d5: ldloc.s 11
+			IL_03d7: ldloc.s 13
+			IL_03d9: ldloc.s 14
+			IL_03db: ldstr "requiredDirectories"
+			IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03e5: pop
+			IL_03e6: ldarg.0
+			IL_03e7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_03ec: stloc.s 14
+			IL_03ee: ldc.i4.1
+			IL_03ef: newarr [System.Runtime]System.Object
+			IL_03f4: dup
+			IL_03f5: ldc.i4.0
+			IL_03f6: ldarg.0
+			IL_03f7: stelem.ref
+			IL_03f8: stloc.s 13
+			IL_03fa: ldarg.2
+			IL_03fb: ldstr "defaultHarnessFiles"
+			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0405: stloc.s 11
+			IL_0407: ldloc.s 14
+			IL_0409: ldloc.s 13
 			IL_040b: ldloc.s 11
-			IL_040d: ldloc.s 13
-			IL_040f: ldloc.s 14
-			IL_0411: ldstr "includeDirectories"
-			IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_041b: pop
-			IL_041c: ldarg.0
-			IL_041d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_0422: stloc.s 14
-			IL_0424: ldstr "ensureStringArray"
-			IL_0429: ldloc.s 14
-			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0430: stloc.s 14
-			IL_0432: ldc.i4.1
-			IL_0433: newarr [System.Runtime]System.Object
-			IL_0438: dup
-			IL_0439: ldc.i4.0
-			IL_043a: ldarg.0
-			IL_043b: stelem.ref
-			IL_043c: stloc.s 13
-			IL_043e: ldarg.2
-			IL_043f: ldstr "requiredFiles"
-			IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0449: stloc.s 11
-			IL_044b: ldloc.s 14
-			IL_044d: ldloc.s 13
-			IL_044f: ldloc.s 11
-			IL_0451: ldstr "requiredFiles"
-			IL_0456: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_045b: pop
-			IL_045c: ldarg.0
-			IL_045d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_0462: stloc.s 11
-			IL_0464: ldstr "ensureStringArray"
-			IL_0469: ldloc.s 11
-			IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0470: stloc.s 11
-			IL_0472: ldc.i4.1
-			IL_0473: newarr [System.Runtime]System.Object
-			IL_0478: dup
-			IL_0479: ldc.i4.0
-			IL_047a: ldarg.0
-			IL_047b: stelem.ref
-			IL_047c: stloc.s 13
-			IL_047e: ldarg.2
-			IL_047f: ldstr "requiredDirectories"
-			IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0489: stloc.s 14
-			IL_048b: ldloc.s 11
-			IL_048d: ldloc.s 13
-			IL_048f: ldloc.s 14
-			IL_0491: ldstr "requiredDirectories"
-			IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_049b: pop
-			IL_049c: ldarg.0
-			IL_049d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_04a2: stloc.s 14
-			IL_04a4: ldstr "ensureStringArray"
-			IL_04a9: ldloc.s 14
-			IL_04ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_04b0: stloc.s 14
-			IL_04b2: ldc.i4.1
-			IL_04b3: newarr [System.Runtime]System.Object
-			IL_04b8: dup
-			IL_04b9: ldc.i4.0
-			IL_04ba: ldarg.0
-			IL_04bb: stelem.ref
-			IL_04bc: stloc.s 13
-			IL_04be: ldarg.2
-			IL_04bf: ldstr "defaultHarnessFiles"
-			IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04c9: stloc.s 11
-			IL_04cb: ldloc.s 14
-			IL_04cd: ldloc.s 13
-			IL_04cf: ldloc.s 11
-			IL_04d1: ldstr "defaultHarnessFiles"
-			IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04db: pop
-			IL_04dc: ldarg.0
-			IL_04dd: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateExcludedFromMvp
-			IL_04e2: stloc.s 11
-			IL_04e4: ldstr "validateExcludedFromMvp"
-			IL_04e9: ldloc.s 11
-			IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_04f0: stloc.s 11
-			IL_04f2: ldc.i4.1
-			IL_04f3: newarr [System.Runtime]System.Object
-			IL_04f8: dup
-			IL_04f9: ldc.i4.0
-			IL_04fa: ldarg.0
-			IL_04fb: stelem.ref
-			IL_04fc: stloc.s 13
-			IL_04fe: ldloc.s 11
-			IL_0500: ldloc.s 13
-			IL_0502: ldarg.2
-			IL_0503: ldstr "excludedFromMvp"
-			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_050d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0512: pop
-			IL_0513: ldarg.0
-			IL_0514: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_0519: stloc.s 11
-			IL_051b: ldstr "ensureStringArray"
-			IL_0520: ldloc.s 11
-			IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0527: stloc.s 11
-			IL_0529: ldc.i4.1
-			IL_052a: newarr [System.Runtime]System.Object
-			IL_052f: dup
-			IL_0530: ldc.i4.0
-			IL_0531: ldarg.0
-			IL_0532: stelem.ref
-			IL_0533: stloc.s 13
-			IL_0535: ldarg.2
-			IL_0536: ldstr "attributionFiles"
-			IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0540: stloc.s 14
-			IL_0542: ldloc.s 11
-			IL_0544: ldloc.s 13
-			IL_0546: ldloc.s 14
-			IL_0548: ldstr "attributionFiles"
-			IL_054d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0552: pop
-			IL_0553: ldstr "^[0-9a-f]{40}$"
-			IL_0558: ldstr "i"
-			IL_055d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0562: stloc.s 15
-			IL_0564: ldloc.s 15
-			IL_0566: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_056b: stloc.s 14
-			IL_056d: ldloc.s 14
-			IL_056f: ldstr "test"
-			IL_0574: ldarg.2
-			IL_0575: ldstr "upstream"
-			IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_057f: ldstr "commit"
-			IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0589: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_058e: stloc.s 14
-			IL_0590: ldloc.s 14
-			IL_0592: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0597: ldc.i4.0
-			IL_0598: ceq
-			IL_059a: stloc.s 6
-			IL_059c: ldloc.s 6
-			IL_059e: brfalse IL_05d6
+			IL_040d: ldstr "defaultHarnessFiles"
+			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0417: pop
+			IL_0418: ldarg.0
+			IL_0419: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateExcludedFromMvp
+			IL_041e: stloc.s 11
+			IL_0420: ldc.i4.1
+			IL_0421: newarr [System.Runtime]System.Object
+			IL_0426: dup
+			IL_0427: ldc.i4.0
+			IL_0428: ldarg.0
+			IL_0429: stelem.ref
+			IL_042a: stloc.s 13
+			IL_042c: ldloc.s 11
+			IL_042e: ldloc.s 13
+			IL_0430: ldarg.2
+			IL_0431: ldstr "excludedFromMvp"
+			IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0440: pop
+			IL_0441: ldarg.0
+			IL_0442: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_0447: stloc.s 11
+			IL_0449: ldc.i4.1
+			IL_044a: newarr [System.Runtime]System.Object
+			IL_044f: dup
+			IL_0450: ldc.i4.0
+			IL_0451: ldarg.0
+			IL_0452: stelem.ref
+			IL_0453: stloc.s 13
+			IL_0455: ldarg.2
+			IL_0456: ldstr "attributionFiles"
+			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0460: stloc.s 14
+			IL_0462: ldloc.s 11
+			IL_0464: ldloc.s 13
+			IL_0466: ldloc.s 14
+			IL_0468: ldstr "attributionFiles"
+			IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0472: pop
+			IL_0473: ldstr "^[0-9a-f]{40}$"
+			IL_0478: ldstr "i"
+			IL_047d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0482: stloc.s 15
+			IL_0484: ldloc.s 15
+			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_048b: stloc.s 14
+			IL_048d: ldloc.s 14
+			IL_048f: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			IL_0494: ldarg.2
+			IL_0495: ldstr "upstream"
+			IL_049a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_049f: ldstr "commit"
+			IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_04ae: stloc.s 14
+			IL_04b0: ldloc.s 14
+			IL_04b2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04b7: ldc.i4.0
+			IL_04b8: ceq
+			IL_04ba: stloc.s 6
+			IL_04bc: ldloc.s 6
+			IL_04be: brfalse IL_04f6
 
-			IL_05a3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validatePin/Scope/Block_L149C52::.ctor()
-			IL_05a8: stloc.s 4
-			IL_05aa: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
-			IL_05af: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_05b9: stloc.s 14
-			IL_05bb: ldloc.s 14
-			IL_05bd: stloc.s 5
-			IL_05bf: ldloc.s 5
-			IL_05c1: isinst [System.Runtime]System.Exception
-			IL_05c6: dup
-			IL_05c7: brtrue IL_05d5
+			IL_04c3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validatePin/Scope/Block_L149C52::.ctor()
+			IL_04c8: stloc.s 4
+			IL_04ca: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
+			IL_04cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_04d9: stloc.s 14
+			IL_04db: ldloc.s 14
+			IL_04dd: stloc.s 5
+			IL_04df: ldloc.s 5
+			IL_04e1: isinst [System.Runtime]System.Exception
+			IL_04e6: dup
+			IL_04e7: brtrue IL_04f5
 
-			IL_05cc: pop
-			IL_05cd: ldloc.s 5
-			IL_05cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_05d4: throw
+			IL_04ec: pop
+			IL_04ed: ldloc.s 5
+			IL_04ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_04f4: throw
 
-			IL_05d5: throw
+			IL_04f5: throw
 
-			IL_05d6: ldnull
-			IL_05d7: ret
+			IL_04f6: ldnull
+			IL_04f7: ret
 		} // end of method validatePin::__js_call__
 
 	} // end of class validatePin
@@ -2454,7 +2350,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x571c
+				// Method begins at RVA 0x52a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2481,9 +2377,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x36f0
+			// Method begins at RVA 0x35bc
 			// Header size: 12
-			// Code size: 94 (0x5e)
+			// Code size: 66 (0x42)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2493,46 +2389,34 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0006: stloc.2
-			IL_0007: ldstr "fs"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.2
 			IL_000c: ldloc.2
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.2
-			IL_0013: ldloc.2
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.2
-			IL_001a: ldloc.2
-			IL_001b: ldstr "readFileSync"
-			IL_0020: ldarg.2
-			IL_0021: ldstr "utf8"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: stloc.0
-			IL_002e: ldloc.0
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_0034: stloc.2
-			IL_0035: ldloc.2
-			IL_0036: stloc.1
+			IL_000d: ldstr "readFileSync"
+			IL_0012: ldarg.2
+			IL_0013: ldstr "utf8"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_001d: stloc.2
+			IL_001e: ldloc.2
+			IL_001f: stloc.0
+			IL_0020: ldloc.0
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_0026: stloc.2
+			IL_0027: ldloc.2
+			IL_0028: stloc.1
+			IL_0029: ldarg.0
+			IL_002a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validatePin
+			IL_002f: ldc.i4.1
+			IL_0030: newarr [System.Runtime]System.Object
+			IL_0035: dup
+			IL_0036: ldc.i4.0
 			IL_0037: ldarg.0
-			IL_0038: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validatePin
-			IL_003d: stloc.2
-			IL_003e: ldstr "validatePin"
-			IL_0043: ldloc.2
-			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0049: stloc.2
-			IL_004a: ldloc.2
-			IL_004b: ldc.i4.1
-			IL_004c: newarr [System.Runtime]System.Object
-			IL_0051: dup
-			IL_0052: ldc.i4.0
-			IL_0053: ldarg.0
-			IL_0054: stelem.ref
-			IL_0055: ldloc.1
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_005b: pop
-			IL_005c: ldloc.1
-			IL_005d: ret
+			IL_0038: stelem.ref
+			IL_0039: ldloc.1
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003f: pop
+			IL_0040: ldloc.1
+			IL_0041: ret
 		} // end of method loadPin::__js_call__
 
 	} // end of class loadPin
@@ -2548,7 +2432,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5725
+				// Method begins at RVA 0x52af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2576,9 +2460,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x375c
+			// Method begins at RVA 0x360c
 			// Header size: 12
-			// Code size: 116 (0x74)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2588,48 +2472,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0006: stloc.1
-			IL_0007: ldstr "path"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.1
 			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "dirname"
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_000d: ldstr "dirname"
+			IL_0012: ldarg.2
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0018: stloc.1
+			IL_0019: ldloc.1
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0026: stloc.1
-			IL_0027: ldloc.1
-			IL_0028: stloc.0
-			IL_0029: ldarg.0
-			IL_002a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_002f: stloc.1
-			IL_0030: ldstr "path"
-			IL_0035: ldloc.1
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003b: stloc.1
-			IL_003c: ldloc.1
-			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0042: stloc.1
-			IL_0043: ldarg.3
-			IL_0044: ldstr "managedRoot"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004e: stloc.2
-			IL_004f: ldloc.1
-			IL_0050: ldstr "resolve"
-			IL_0055: ldloc.0
+			IL_0027: ldarg.3
+			IL_0028: ldstr "managedRoot"
+			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0032: stloc.2
+			IL_0033: ldloc.1
+			IL_0034: ldstr "resolve"
+			IL_0039: ldloc.0
+			IL_003a: ldloc.2
+			IL_003b: ldarg.3
+			IL_003c: ldstr "upstream"
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0046: ldstr "commit"
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0055: stloc.2
 			IL_0056: ldloc.2
-			IL_0057: ldarg.3
-			IL_0058: ldstr "upstream"
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0062: ldstr "commit"
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0071: stloc.2
-			IL_0072: ldloc.2
-			IL_0073: ret
+			IL_0057: ret
 		} // end of method resolveManagedCheckoutRoot::__js_call__
 
 	} // end of class resolveManagedCheckoutRoot
@@ -2645,7 +2517,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x572e
+				// Method begins at RVA 0x52b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2672,9 +2544,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x37dc
+			// Method begins at RVA 0x3670
 			// Header size: 12
-			// Code size: 144 (0x90)
+			// Code size: 116 (0x74)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2684,64 +2556,52 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0006: stloc.0
-			IL_0007: ldstr "path"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "posix"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0025: stloc.0
-			IL_0026: ldarg.0
-			IL_0027: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-			IL_002c: stloc.1
-			IL_002d: ldstr "normalizeSpecPath"
-			IL_0032: ldloc.1
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0038: stloc.1
-			IL_0039: ldc.i4.1
-			IL_003a: newarr [System.Runtime]System.Object
-			IL_003f: dup
-			IL_0040: ldc.i4.0
-			IL_0041: ldarg.0
-			IL_0042: stelem.ref
-			IL_0043: stloc.2
-			IL_0044: ldloc.1
-			IL_0045: ldloc.2
-			IL_0046: ldarg.2
-			IL_0047: ldstr "managedRoot"
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0056: stloc.1
-			IL_0057: ldloc.0
-			IL_0058: ldstr "join"
-			IL_005d: ldloc.1
-			IL_005e: ldarg.2
-			IL_005f: ldstr "upstream"
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0069: ldstr "commit"
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0078: stloc.1
-			IL_0079: ldc.i4.1
-			IL_007a: newarr [System.Runtime]System.Object
-			IL_007f: dup
-			IL_0080: ldc.i4.0
-			IL_0081: ldarg.0
-			IL_0082: stelem.ref
-			IL_0083: stloc.2
-			IL_0084: ldnull
-			IL_0085: ldloc.1
-			IL_0086: tail.
-			IL_0088: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-			IL_008d: ret
+			IL_0006: ldstr "posix"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+			IL_001c: stloc.1
+			IL_001d: ldc.i4.1
+			IL_001e: newarr [System.Runtime]System.Object
+			IL_0023: dup
+			IL_0024: ldc.i4.0
+			IL_0025: ldarg.0
+			IL_0026: stelem.ref
+			IL_0027: stloc.2
+			IL_0028: ldloc.1
+			IL_0029: ldloc.2
+			IL_002a: ldarg.2
+			IL_002b: ldstr "managedRoot"
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003a: stloc.1
+			IL_003b: ldloc.0
+			IL_003c: ldstr "join"
+			IL_0041: ldloc.1
+			IL_0042: ldarg.2
+			IL_0043: ldstr "upstream"
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_004d: ldstr "commit"
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_005c: stloc.1
+			IL_005d: ldc.i4.1
+			IL_005e: newarr [System.Runtime]System.Object
+			IL_0063: dup
+			IL_0064: ldc.i4.0
+			IL_0065: ldarg.0
+			IL_0066: stelem.ref
+			IL_0067: stloc.2
+			IL_0068: ldnull
+			IL_0069: ldloc.1
+			IL_006a: tail.
+			IL_006c: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_0071: ret
 
-			IL_008e: ldnull
-			IL_008f: ret
+			IL_0072: ldnull
+			IL_0073: ret
 		} // end of method resolveManagedCheckoutLabel::__js_call__
 
 	} // end of class resolveManagedCheckoutLabel
@@ -2761,7 +2621,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5740
+					// Method begins at RVA 0x52ca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2779,7 +2639,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5737
+				// Method begins at RVA 0x52c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2807,9 +2667,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3878
+			// Method begins at RVA 0x36f0
 			// Header size: 12
-			// Code size: 266 (0x10a)
+			// Code size: 252 (0xfc)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2899,33 +2759,27 @@
 
 			IL_00c3: ldarg.0
 			IL_00c4: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
-			IL_00c9: stloc.3
-			IL_00ca: ldstr "resolvePathFromCwd"
-			IL_00cf: ldloc.3
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00d5: stloc.3
-			IL_00d6: ldloc.3
-			IL_00d7: ldc.i4.1
-			IL_00d8: newarr [System.Runtime]System.Object
-			IL_00dd: dup
-			IL_00de: ldc.i4.0
-			IL_00df: ldarg.0
-			IL_00e0: stelem.ref
-			IL_00e1: ldloc.0
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00e7: stloc.3
-			IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00ed: dup
-			IL_00ee: ldstr "source"
-			IL_00f3: ldloc.2
-			IL_00f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00f9: dup
-			IL_00fa: ldstr "rootPath"
-			IL_00ff: ldloc.3
-			IL_0100: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0105: stloc.s 9
-			IL_0107: ldloc.s 9
-			IL_0109: ret
+			IL_00c9: ldc.i4.1
+			IL_00ca: newarr [System.Runtime]System.Object
+			IL_00cf: dup
+			IL_00d0: ldc.i4.0
+			IL_00d1: ldarg.0
+			IL_00d2: stelem.ref
+			IL_00d3: ldloc.0
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00d9: stloc.3
+			IL_00da: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00df: dup
+			IL_00e0: ldstr "source"
+			IL_00e5: ldloc.2
+			IL_00e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00eb: dup
+			IL_00ec: ldstr "rootPath"
+			IL_00f1: ldloc.3
+			IL_00f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00f7: stloc.s 9
+			IL_00f9: ldloc.s 9
+			IL_00fb: ret
 		} // end of method resolveOverrideRoot::__js_call__
 
 	} // end of class resolveOverrideRoot
@@ -2945,7 +2799,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5752
+					// Method begins at RVA 0x52dc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2963,7 +2817,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5749
+				// Method begins at RVA 0x52d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2991,9 +2845,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3990
+			// Method begins at RVA 0x37f8
 			// Header size: 12
-			// Code size: 1155 (0x483)
+			// Code size: 1109 (0x455)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3077,321 +2931,307 @@
 			IL_00b2: ldarg.0
 			IL_00b3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
 			IL_00b8: stloc.s 8
-			IL_00ba: ldstr "toPortablePath"
-			IL_00bf: ldloc.s 8
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c6: stloc.s 8
-			IL_00c8: ldc.i4.1
-			IL_00c9: newarr [System.Runtime]System.Object
-			IL_00ce: dup
-			IL_00cf: ldc.i4.0
-			IL_00d0: ldarg.0
-			IL_00d1: stelem.ref
-			IL_00d2: stloc.s 9
-			IL_00d4: ldloc.s 8
-			IL_00d6: ldloc.s 9
-			IL_00d8: ldarg.2
-			IL_00d9: ldstr "managedRoot"
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00e8: stloc.s 8
-			IL_00ea: ldloc.s 8
-			IL_00ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00ba: ldc.i4.1
+			IL_00bb: newarr [System.Runtime]System.Object
+			IL_00c0: dup
+			IL_00c1: ldc.i4.0
+			IL_00c2: ldarg.0
+			IL_00c3: stelem.ref
+			IL_00c4: stloc.s 9
+			IL_00c6: ldloc.s 8
+			IL_00c8: ldloc.s 9
+			IL_00ca: ldarg.2
+			IL_00cb: ldstr "managedRoot"
+			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00da: stloc.s 8
+			IL_00dc: ldloc.s 8
+			IL_00de: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00e3: stloc.s 10
+			IL_00e5: ldstr "managedRoot "
+			IL_00ea: ldloc.s 10
+			IL_00ec: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00f1: stloc.s 10
-			IL_00f3: ldstr "managedRoot "
-			IL_00f8: ldloc.s 10
-			IL_00fa: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00ff: stloc.s 10
-			IL_0101: ldarg.0
-			IL_0102: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutLabel
-			IL_0107: stloc.s 8
-			IL_0109: ldstr "resolveManagedCheckoutLabel"
-			IL_010e: ldloc.s 8
-			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0115: stloc.s 8
-			IL_0117: ldc.i4.1
-			IL_0118: newarr [System.Runtime]System.Object
-			IL_011d: dup
-			IL_011e: ldc.i4.0
-			IL_011f: ldarg.0
-			IL_0120: stelem.ref
-			IL_0121: stloc.s 9
-			IL_0123: ldloc.s 8
-			IL_0125: ldloc.s 9
-			IL_0127: ldarg.2
-			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_012d: stloc.s 8
-			IL_012f: ldloc.s 8
+			IL_00f3: ldc.i4.1
+			IL_00f4: newarr [System.Runtime]System.Object
+			IL_00f9: dup
+			IL_00fa: ldc.i4.0
+			IL_00fb: ldarg.0
+			IL_00fc: stelem.ref
+			IL_00fd: stloc.s 9
+			IL_00ff: ldarg.0
+			IL_0100: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutLabel
+			IL_0105: ldloc.s 9
+			IL_0107: ldarg.2
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_010d: stloc.s 8
+			IL_010f: ldloc.s 8
+			IL_0111: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0116: stloc.s 11
+			IL_0118: ldstr "checkoutDir "
+			IL_011d: ldloc.s 11
+			IL_011f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0124: stloc.s 11
+			IL_0126: ldarg.2
+			IL_0127: ldstr "localOverrideEnvVar"
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0131: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0136: stloc.s 11
-			IL_0138: ldstr "checkoutDir "
-			IL_013d: ldloc.s 11
+			IL_0136: stloc.s 12
+			IL_0138: ldstr "overrideEnv "
+			IL_013d: ldloc.s 12
 			IL_013f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0144: stloc.s 11
+			IL_0144: stloc.s 12
 			IL_0146: ldarg.2
-			IL_0147: ldstr "localOverrideEnvVar"
+			IL_0147: ldstr "lineEndings"
 			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0151: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0156: stloc.s 12
-			IL_0158: ldstr "overrideEnv "
-			IL_015d: ldloc.s 12
+			IL_0156: stloc.s 13
+			IL_0158: ldstr "lineEndings "
+			IL_015d: ldloc.s 13
 			IL_015f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0164: stloc.s 12
+			IL_0164: stloc.s 13
 			IL_0166: ldarg.2
-			IL_0167: ldstr "lineEndings"
+			IL_0167: ldstr "updateStrategy"
 			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0171: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0176: stloc.s 13
-			IL_0178: ldstr "lineEndings "
-			IL_017d: ldloc.s 13
+			IL_0176: stloc.s 14
+			IL_0178: ldstr "updateStrategy "
+			IL_017d: ldloc.s 14
 			IL_017f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0184: stloc.s 13
+			IL_0184: stloc.s 14
 			IL_0186: ldarg.2
-			IL_0187: ldstr "updateStrategy"
+			IL_0187: ldstr "includeFiles"
 			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0191: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0196: stloc.s 14
-			IL_0198: ldstr "updateStrategy "
-			IL_019d: ldloc.s 14
-			IL_019f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01a4: stloc.s 14
-			IL_01a6: ldarg.2
-			IL_01a7: ldstr "includeFiles"
-			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b6: stloc.s 8
-			IL_01b8: ldloc.s 8
-			IL_01ba: ldstr "join"
-			IL_01bf: ldstr ", "
-			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01c9: stloc.s 8
-			IL_01cb: ldloc.s 8
-			IL_01cd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01d2: stloc.s 15
-			IL_01d4: ldstr "includeFiles "
-			IL_01d9: ldloc.s 15
-			IL_01db: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01e0: stloc.s 15
-			IL_01e2: ldarg.2
-			IL_01e3: ldstr "includeDirectories"
-			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f2: stloc.s 8
-			IL_01f4: ldloc.s 8
-			IL_01f6: ldstr "join"
-			IL_01fb: ldstr ", "
-			IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0205: stloc.s 8
-			IL_0207: ldloc.s 8
-			IL_0209: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_020e: stloc.s 16
-			IL_0210: ldstr "includeDirectories "
-			IL_0215: ldloc.s 16
-			IL_0217: call string [System.Runtime]System.String::Concat(string, string)
-			IL_021c: stloc.s 16
-			IL_021e: ldarg.2
-			IL_021f: ldstr "requiredFiles"
-			IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_022e: stloc.s 8
-			IL_0230: ldloc.s 8
-			IL_0232: ldstr "join"
-			IL_0237: ldstr ", "
-			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0241: stloc.s 8
-			IL_0243: ldloc.s 8
-			IL_0245: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_024a: stloc.s 17
-			IL_024c: ldstr "requiredFiles "
-			IL_0251: ldloc.s 17
-			IL_0253: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0258: stloc.s 17
-			IL_025a: ldarg.2
-			IL_025b: ldstr "requiredDirectories"
-			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_026a: stloc.s 8
-			IL_026c: ldloc.s 8
-			IL_026e: ldstr "join"
-			IL_0273: ldstr ", "
-			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_027d: stloc.s 8
-			IL_027f: ldloc.s 8
-			IL_0281: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0286: stloc.s 18
-			IL_0288: ldstr "requiredDirectories "
-			IL_028d: ldloc.s 18
-			IL_028f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0294: stloc.s 18
-			IL_0296: ldarg.2
-			IL_0297: ldstr "defaultHarnessFiles"
-			IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a6: stloc.s 8
-			IL_02a8: ldloc.s 8
-			IL_02aa: ldstr "join"
-			IL_02af: ldstr ", "
-			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02b9: stloc.s 8
-			IL_02bb: ldloc.s 8
-			IL_02bd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02c2: stloc.s 19
-			IL_02c4: ldstr "defaultHarnessFiles "
-			IL_02c9: ldloc.s 19
-			IL_02cb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02d0: stloc.s 19
-			IL_02d2: ldarg.2
-			IL_02d3: ldstr "excludedFromMvp"
-			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e2: stloc.s 8
-			IL_02e4: ldloc.s 8
-			IL_02e6: ldstr "join"
-			IL_02eb: ldstr "; "
-			IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02f5: stloc.s 8
-			IL_02f7: ldloc.s 8
-			IL_02f9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02fe: stloc.s 20
-			IL_0300: ldstr "excludedFromMvp "
-			IL_0305: ldloc.s 20
-			IL_0307: call string [System.Runtime]System.String::Concat(string, string)
-			IL_030c: stloc.s 20
-			IL_030e: ldarg.2
-			IL_030f: ldstr "attributionFiles"
-			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_031e: stloc.s 8
-			IL_0320: ldloc.s 8
-			IL_0322: ldstr "join"
-			IL_0327: ldstr ", "
-			IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0331: stloc.s 8
-			IL_0333: ldloc.s 8
-			IL_0335: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_033a: stloc.s 21
-			IL_033c: ldstr "attributionFiles "
-			IL_0341: ldloc.s 21
-			IL_0343: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0348: stloc.s 21
-			IL_034a: ldc.i4.s 16
-			IL_034c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0196: stloc.s 8
+			IL_0198: ldloc.s 8
+			IL_019a: ldstr "join"
+			IL_019f: ldstr ", "
+			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01a9: stloc.s 8
+			IL_01ab: ldloc.s 8
+			IL_01ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01b2: stloc.s 15
+			IL_01b4: ldstr "includeFiles "
+			IL_01b9: ldloc.s 15
+			IL_01bb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01c0: stloc.s 15
+			IL_01c2: ldarg.2
+			IL_01c3: ldstr "includeDirectories"
+			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01d2: stloc.s 8
+			IL_01d4: ldloc.s 8
+			IL_01d6: ldstr "join"
+			IL_01db: ldstr ", "
+			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01e5: stloc.s 8
+			IL_01e7: ldloc.s 8
+			IL_01e9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ee: stloc.s 16
+			IL_01f0: ldstr "includeDirectories "
+			IL_01f5: ldloc.s 16
+			IL_01f7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01fc: stloc.s 16
+			IL_01fe: ldarg.2
+			IL_01ff: ldstr "requiredFiles"
+			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_020e: stloc.s 8
+			IL_0210: ldloc.s 8
+			IL_0212: ldstr "join"
+			IL_0217: ldstr ", "
+			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0221: stloc.s 8
+			IL_0223: ldloc.s 8
+			IL_0225: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_022a: stloc.s 17
+			IL_022c: ldstr "requiredFiles "
+			IL_0231: ldloc.s 17
+			IL_0233: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0238: stloc.s 17
+			IL_023a: ldarg.2
+			IL_023b: ldstr "requiredDirectories"
+			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_024a: stloc.s 8
+			IL_024c: ldloc.s 8
+			IL_024e: ldstr "join"
+			IL_0253: ldstr ", "
+			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_025d: stloc.s 8
+			IL_025f: ldloc.s 8
+			IL_0261: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0266: stloc.s 18
+			IL_0268: ldstr "requiredDirectories "
+			IL_026d: ldloc.s 18
+			IL_026f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0274: stloc.s 18
+			IL_0276: ldarg.2
+			IL_0277: ldstr "defaultHarnessFiles"
+			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0286: stloc.s 8
+			IL_0288: ldloc.s 8
+			IL_028a: ldstr "join"
+			IL_028f: ldstr ", "
+			IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0299: stloc.s 8
+			IL_029b: ldloc.s 8
+			IL_029d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02a2: stloc.s 19
+			IL_02a4: ldstr "defaultHarnessFiles "
+			IL_02a9: ldloc.s 19
+			IL_02ab: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02b0: stloc.s 19
+			IL_02b2: ldarg.2
+			IL_02b3: ldstr "excludedFromMvp"
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c2: stloc.s 8
+			IL_02c4: ldloc.s 8
+			IL_02c6: ldstr "join"
+			IL_02cb: ldstr "; "
+			IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02d5: stloc.s 8
+			IL_02d7: ldloc.s 8
+			IL_02d9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02de: stloc.s 20
+			IL_02e0: ldstr "excludedFromMvp "
+			IL_02e5: ldloc.s 20
+			IL_02e7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02ec: stloc.s 20
+			IL_02ee: ldarg.2
+			IL_02ef: ldstr "attributionFiles"
+			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02fe: stloc.s 8
+			IL_0300: ldloc.s 8
+			IL_0302: ldstr "join"
+			IL_0307: ldstr ", "
+			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0311: stloc.s 8
+			IL_0313: ldloc.s 8
+			IL_0315: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_031a: stloc.s 21
+			IL_031c: ldstr "attributionFiles "
+			IL_0321: ldloc.s 21
+			IL_0323: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0328: stloc.s 21
+			IL_032a: ldc.i4.s 16
+			IL_032c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0331: dup
+			IL_0332: ldloc.s 4
+			IL_0334: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0339: dup
+			IL_033a: ldloc.s 5
+			IL_033c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0341: dup
+			IL_0342: ldloc.s 6
+			IL_0344: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0349: dup
+			IL_034a: ldloc.s 7
+			IL_034c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0351: dup
-			IL_0352: ldloc.s 4
+			IL_0352: ldloc.s 10
 			IL_0354: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0359: dup
-			IL_035a: ldloc.s 5
+			IL_035a: ldloc.s 11
 			IL_035c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0361: dup
-			IL_0362: ldloc.s 6
+			IL_0362: ldloc.s 12
 			IL_0364: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0369: dup
-			IL_036a: ldloc.s 7
+			IL_036a: ldloc.s 13
 			IL_036c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0371: dup
-			IL_0372: ldloc.s 10
+			IL_0372: ldloc.s 14
 			IL_0374: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0379: dup
-			IL_037a: ldloc.s 11
+			IL_037a: ldloc.s 15
 			IL_037c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0381: dup
-			IL_0382: ldloc.s 12
+			IL_0382: ldloc.s 16
 			IL_0384: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0389: dup
-			IL_038a: ldloc.s 13
+			IL_038a: ldloc.s 17
 			IL_038c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0391: dup
-			IL_0392: ldloc.s 14
+			IL_0392: ldloc.s 18
 			IL_0394: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0399: dup
-			IL_039a: ldloc.s 15
+			IL_039a: ldloc.s 19
 			IL_039c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_03a1: dup
-			IL_03a2: ldloc.s 16
+			IL_03a2: ldloc.s 20
 			IL_03a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_03a9: dup
-			IL_03aa: ldloc.s 17
+			IL_03aa: ldloc.s 21
 			IL_03ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03b1: dup
-			IL_03b2: ldloc.s 18
-			IL_03b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03b9: dup
-			IL_03ba: ldloc.s 19
-			IL_03bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03c1: dup
-			IL_03c2: ldloc.s 20
-			IL_03c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03c9: dup
-			IL_03ca: ldloc.s 21
-			IL_03cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03d1: stloc.s 22
-			IL_03d3: ldloc.s 22
-			IL_03d5: stloc.1
-			IL_03d6: ldarg.3
-			IL_03d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03dc: stloc.3
-			IL_03dd: ldloc.3
-			IL_03de: brfalse IL_046a
+			IL_03b1: stloc.s 22
+			IL_03b3: ldloc.s 22
+			IL_03b5: stloc.1
+			IL_03b6: ldarg.3
+			IL_03b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03bc: stloc.3
+			IL_03bd: ldloc.3
+			IL_03be: brfalse IL_043c
 
-			IL_03e3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/describePlan/Scope/Block_L202C16::.ctor()
-			IL_03e8: stloc.2
-			IL_03e9: ldarg.3
-			IL_03ea: ldstr "source"
-			IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03f9: stloc.s 21
-			IL_03fb: ldstr "overrideSource "
-			IL_0400: ldloc.s 21
-			IL_0402: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0407: stloc.s 21
-			IL_0409: ldloc.1
-			IL_040a: ldloc.s 21
-			IL_040c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0411: pop
-			IL_0412: ldarg.0
-			IL_0413: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
-			IL_0418: stloc.s 8
-			IL_041a: ldstr "toPortablePath"
-			IL_041f: ldloc.s 8
-			IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0426: stloc.s 8
-			IL_0428: ldc.i4.1
-			IL_0429: newarr [System.Runtime]System.Object
-			IL_042e: dup
-			IL_042f: ldc.i4.0
-			IL_0430: ldarg.0
-			IL_0431: stelem.ref
-			IL_0432: stloc.s 9
-			IL_0434: ldloc.s 8
-			IL_0436: ldloc.s 9
-			IL_0438: ldarg.3
-			IL_0439: ldstr "rootPath"
-			IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0448: stloc.s 8
-			IL_044a: ldloc.s 8
-			IL_044c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0451: stloc.s 21
-			IL_0453: ldstr "overrideRoot "
-			IL_0458: ldloc.s 21
-			IL_045a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_045f: stloc.s 21
-			IL_0461: ldloc.1
-			IL_0462: ldloc.s 21
-			IL_0464: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0469: pop
+			IL_03c3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/describePlan/Scope/Block_L202C16::.ctor()
+			IL_03c8: stloc.2
+			IL_03c9: ldarg.3
+			IL_03ca: ldstr "source"
+			IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03d9: stloc.s 21
+			IL_03db: ldstr "overrideSource "
+			IL_03e0: ldloc.s 21
+			IL_03e2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03e7: stloc.s 21
+			IL_03e9: ldloc.1
+			IL_03ea: ldloc.s 21
+			IL_03ec: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03f1: pop
+			IL_03f2: ldarg.0
+			IL_03f3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
+			IL_03f8: stloc.s 8
+			IL_03fa: ldc.i4.1
+			IL_03fb: newarr [System.Runtime]System.Object
+			IL_0400: dup
+			IL_0401: ldc.i4.0
+			IL_0402: ldarg.0
+			IL_0403: stelem.ref
+			IL_0404: stloc.s 9
+			IL_0406: ldloc.s 8
+			IL_0408: ldloc.s 9
+			IL_040a: ldarg.3
+			IL_040b: ldstr "rootPath"
+			IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_041a: stloc.s 8
+			IL_041c: ldloc.s 8
+			IL_041e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0423: stloc.s 21
+			IL_0425: ldstr "overrideRoot "
+			IL_042a: ldloc.s 21
+			IL_042c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0431: stloc.s 21
+			IL_0433: ldloc.1
+			IL_0434: ldloc.s 21
+			IL_0436: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_043b: pop
 
-			IL_046a: ldloc.1
-			IL_046b: ldc.i4.1
-			IL_046c: newarr [System.Runtime]System.Object
-			IL_0471: dup
-			IL_0472: ldc.i4.0
-			IL_0473: ldstr "\n"
-			IL_0478: stelem.ref
-			IL_0479: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_047e: stloc.s 21
-			IL_0480: ldloc.s 21
-			IL_0482: ret
+			IL_043c: ldloc.1
+			IL_043d: ldc.i4.1
+			IL_043e: newarr [System.Runtime]System.Object
+			IL_0443: dup
+			IL_0444: ldc.i4.0
+			IL_0445: ldstr "\n"
+			IL_044a: stelem.ref
+			IL_044b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0450: stloc.s 21
+			IL_0452: ldloc.s 21
+			IL_0454: ret
 		} // end of method describePlan::__js_call__
 
 	} // end of class describePlan
@@ -3407,7 +3247,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x575b
+				// Method begins at RVA 0x52e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3434,9 +3274,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3e20
+			// Method begins at RVA 0x3c5c
 			// Header size: 12
-			// Code size: 58 (0x3a)
+			// Code size: 44 (0x2c)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -3444,26 +3284,20 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0006: stloc.0
-			IL_0007: ldstr "fs"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "mkdirSync"
-			IL_0020: ldarg.2
-			IL_0021: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0026: dup
-			IL_0027: ldstr "recursive"
-			IL_002c: ldc.i4.1
-			IL_002d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0037: pop
-			IL_0038: ldnull
-			IL_0039: ret
+			IL_000d: ldstr "mkdirSync"
+			IL_0012: ldarg.2
+			IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0018: dup
+			IL_0019: ldstr "recursive"
+			IL_001e: ldc.i4.1
+			IL_001f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0029: pop
+			IL_002a: ldnull
+			IL_002b: ret
 		} // end of method ensureDir::__js_call__
 
 	} // end of class ensureDir
@@ -3483,7 +3317,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x576d
+					// Method begins at RVA 0x52f7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3501,7 +3335,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5764
+				// Method begins at RVA 0x52ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3528,9 +3362,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3e68
+			// Method begins at RVA 0x3c94
 			// Header size: 12
-			// Code size: 133 (0x85)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262Bootstrap/removeDir/Scope/Block_L215C37,
@@ -3540,58 +3374,46 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0006: stloc.1
-			IL_0007: ldstr "fs"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.1
 			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "existsSync"
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0026: stloc.1
-			IL_0027: ldloc.1
-			IL_0028: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_002d: ldc.i4.0
-			IL_002e: ceq
-			IL_0030: stloc.2
-			IL_0031: ldloc.2
-			IL_0032: brfalse IL_003f
+			IL_000d: ldstr "existsSync"
+			IL_0012: ldarg.2
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0018: stloc.1
+			IL_0019: ldloc.1
+			IL_001a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_001f: ldc.i4.0
+			IL_0020: ceq
+			IL_0022: stloc.2
+			IL_0023: ldloc.2
+			IL_0024: brfalse IL_0031
 
-			IL_0037: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/removeDir/Scope/Block_L215C37::.ctor()
-			IL_003c: stloc.0
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0029: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/removeDir/Scope/Block_L215C37::.ctor()
+			IL_002e: stloc.0
+			IL_002f: ldnull
+			IL_0030: ret
 
-			IL_003f: ldarg.0
-			IL_0040: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0045: stloc.1
-			IL_0046: ldstr "fs"
-			IL_004b: ldloc.1
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0051: stloc.1
-			IL_0052: ldloc.1
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0058: stloc.1
-			IL_0059: ldloc.1
-			IL_005a: ldstr "rmSync"
-			IL_005f: ldarg.2
-			IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0065: dup
-			IL_0066: ldstr "recursive"
-			IL_006b: ldc.i4.1
-			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0071: dup
-			IL_0072: ldstr "force"
-			IL_0077: ldc.i4.1
-			IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0082: pop
-			IL_0083: ldnull
-			IL_0084: ret
+			IL_0031: ldarg.0
+			IL_0032: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003c: stloc.1
+			IL_003d: ldloc.1
+			IL_003e: ldstr "rmSync"
+			IL_0043: ldarg.2
+			IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0049: dup
+			IL_004a: ldstr "recursive"
+			IL_004f: ldc.i4.1
+			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0055: dup
+			IL_0056: ldstr "force"
+			IL_005b: ldc.i4.1
+			IL_005c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0066: pop
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method removeDir::__js_call__
 
 	} // end of class removeDir
@@ -3611,7 +3433,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x577f
+					// Method begins at RVA 0x5309
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3631,7 +3453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5788
+					// Method begins at RVA 0x5312
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3649,7 +3471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5776
+				// Method begins at RVA 0x5300
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3677,9 +3499,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3efc
+			// Method begins at RVA 0x3d0c
 			// Header size: 12
-			// Code size: 705 (0x2c1)
+			// Code size: 687 (0x2af)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3696,258 +3518,252 @@
 				[11] bool,
 				[12] object,
 				[13] object,
-				[14] object,
-				[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[16] string,
+				[14] string,
+				[15] object,
+				[16] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[17] string
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
-			IL_0006: stloc.s 9
-			IL_0008: ldstr "childProcess"
-			IL_000d: ldloc.s 9
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 9
-			IL_0016: ldloc.s 9
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001d: stloc.s 9
-			IL_001f: ldc.r8 4
-			IL_0028: ldc.r8 1024
-			IL_0031: mul
-			IL_0032: stloc.s 10
-			IL_0034: ldloc.s 10
-			IL_0036: ldc.r8 1024
-			IL_003f: mul
-			IL_0040: stloc.s 10
-			IL_0042: ldloc.s 9
-			IL_0044: ldstr "spawnSync"
-			IL_0049: ldstr "git"
-			IL_004e: ldarg.2
-			IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0054: dup
-			IL_0055: ldstr "cwd"
-			IL_005a: ldarg.3
-			IL_005b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0060: dup
-			IL_0061: ldstr "encoding"
-			IL_0066: ldstr "utf8"
-			IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0070: dup
-			IL_0071: ldstr "maxBuffer"
-			IL_0076: ldloc.s 10
-			IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_007d: dup
-			IL_007e: ldstr "shell"
-			IL_0083: ldc.i4.0
-			IL_0084: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_008e: stloc.s 9
-			IL_0090: ldloc.s 9
-			IL_0092: stloc.0
-			IL_0093: ldloc.0
-			IL_0094: ldstr "error"
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00a3: stloc.s 11
-			IL_00a5: ldloc.s 11
-			IL_00a7: brfalse IL_00d3
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.s 9
+			IL_000d: ldc.r8 4
+			IL_0016: ldc.r8 1024
+			IL_001f: mul
+			IL_0020: stloc.s 10
+			IL_0022: ldloc.s 10
+			IL_0024: ldc.r8 1024
+			IL_002d: mul
+			IL_002e: stloc.s 10
+			IL_0030: ldloc.s 9
+			IL_0032: ldstr "spawnSync"
+			IL_0037: ldstr "git"
+			IL_003c: ldarg.2
+			IL_003d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0042: dup
+			IL_0043: ldstr "cwd"
+			IL_0048: ldarg.3
+			IL_0049: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_004e: dup
+			IL_004f: ldstr "encoding"
+			IL_0054: ldstr "utf8"
+			IL_0059: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_005e: dup
+			IL_005f: ldstr "maxBuffer"
+			IL_0064: ldloc.s 10
+			IL_0066: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_006b: dup
+			IL_006c: ldstr "shell"
+			IL_0071: ldc.i4.0
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_007c: stloc.s 9
+			IL_007e: ldloc.s 9
+			IL_0080: stloc.0
+			IL_0081: ldloc.0
+			IL_0082: ldstr "error"
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0091: stloc.s 11
+			IL_0093: ldloc.s 11
+			IL_0095: brfalse IL_00c1
 
-			IL_00ac: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/runGit/Scope/Block_L230C20::.ctor()
-			IL_00b1: stloc.1
-			IL_00b2: ldloc.0
-			IL_00b3: ldstr "error"
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00bd: stloc.2
-			IL_00be: ldloc.2
-			IL_00bf: isinst [System.Runtime]System.Exception
-			IL_00c4: dup
-			IL_00c5: brtrue IL_00d2
+			IL_009a: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/runGit/Scope/Block_L230C20::.ctor()
+			IL_009f: stloc.1
+			IL_00a0: ldloc.0
+			IL_00a1: ldstr "error"
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ab: stloc.2
+			IL_00ac: ldloc.2
+			IL_00ad: isinst [System.Runtime]System.Exception
+			IL_00b2: dup
+			IL_00b3: brtrue IL_00c0
 
-			IL_00ca: pop
-			IL_00cb: ldloc.2
-			IL_00cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00d1: throw
+			IL_00b8: pop
+			IL_00b9: ldloc.2
+			IL_00ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00bf: throw
 
-			IL_00d2: throw
+			IL_00c0: throw
 
-			IL_00d3: ldloc.0
-			IL_00d4: ldstr "status"
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00de: stloc.s 9
-			IL_00e0: ldloc.s 9
-			IL_00e2: ldc.r8 0.0
-			IL_00eb: box [System.Runtime]System.Double
-			IL_00f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00f5: stloc.s 11
-			IL_00f7: ldloc.s 11
-			IL_00f9: brfalse IL_029b
+			IL_00c1: ldloc.0
+			IL_00c2: ldstr "status"
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00cc: stloc.s 9
+			IL_00ce: ldloc.s 9
+			IL_00d0: ldc.r8 0.0
+			IL_00d9: box [System.Runtime]System.Double
+			IL_00de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_00e3: stloc.s 11
+			IL_00e5: ldloc.s 11
+			IL_00e7: brfalse IL_0289
 
-			IL_00fe: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/runGit/Scope/Block_L234C27::.ctor()
-			IL_0103: stloc.3
-			IL_0104: ldloc.0
-			IL_0105: ldstr "stderr"
-			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_010f: stloc.s 9
-			IL_0111: ldloc.s 9
-			IL_0113: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0118: stloc.s 11
-			IL_011a: ldloc.s 11
-			IL_011c: brtrue IL_012d
+			IL_00ec: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/runGit/Scope/Block_L234C27::.ctor()
+			IL_00f1: stloc.3
+			IL_00f2: ldloc.0
+			IL_00f3: ldstr "stderr"
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00fd: stloc.s 9
+			IL_00ff: ldloc.s 9
+			IL_0101: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0106: stloc.s 11
+			IL_0108: ldloc.s 11
+			IL_010a: brtrue IL_011b
 
-			IL_0121: ldstr ""
-			IL_0126: stloc.s 13
-			IL_0128: br IL_0131
+			IL_010f: ldstr ""
+			IL_0114: stloc.s 13
+			IL_0116: br IL_011f
 
-			IL_012d: ldloc.s 9
-			IL_012f: stloc.s 13
+			IL_011b: ldloc.s 9
+			IL_011d: stloc.s 13
 
-			IL_0131: ldloc.s 13
-			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0138: stloc.s 9
-			IL_013a: ldloc.s 9
-			IL_013c: ldstr "trim"
-			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0146: stloc.s 9
-			IL_0148: ldloc.s 9
-			IL_014a: stloc.s 4
-			IL_014c: ldloc.0
-			IL_014d: ldstr "stdout"
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0157: stloc.s 9
-			IL_0159: ldloc.s 9
-			IL_015b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0160: stloc.s 11
-			IL_0162: ldloc.s 11
-			IL_0164: brtrue IL_0175
+			IL_011f: ldloc.s 13
+			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0126: stloc.s 9
+			IL_0128: ldloc.s 9
+			IL_012a: castclass [System.Runtime]System.String
+			IL_012f: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0134: stloc.s 14
+			IL_0136: ldloc.s 14
+			IL_0138: stloc.s 4
+			IL_013a: ldloc.0
+			IL_013b: ldstr "stdout"
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0145: stloc.s 9
+			IL_0147: ldloc.s 9
+			IL_0149: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_014e: stloc.s 11
+			IL_0150: ldloc.s 11
+			IL_0152: brtrue IL_0163
 
-			IL_0169: ldstr ""
-			IL_016e: stloc.s 14
-			IL_0170: br IL_0179
+			IL_0157: ldstr ""
+			IL_015c: stloc.s 15
+			IL_015e: br IL_0167
 
-			IL_0175: ldloc.s 9
-			IL_0177: stloc.s 14
+			IL_0163: ldloc.s 9
+			IL_0165: stloc.s 15
 
-			IL_0179: ldloc.s 14
-			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0180: stloc.s 9
-			IL_0182: ldloc.s 9
-			IL_0184: ldstr "trim"
-			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_018e: stloc.s 9
-			IL_0190: ldloc.s 9
-			IL_0192: stloc.s 5
-			IL_0194: ldc.i4.2
-			IL_0195: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_019a: dup
-			IL_019b: ldloc.s 4
-			IL_019d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01a2: dup
-			IL_01a3: ldloc.s 5
-			IL_01a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01aa: stloc.s 15
-			IL_01ac: ldstr "Boolean"
-			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01b6: stloc.s 9
-			IL_01b8: ldloc.s 15
-			IL_01ba: ldc.i4.1
-			IL_01bb: newarr [System.Runtime]System.Object
-			IL_01c0: dup
-			IL_01c1: ldc.i4.0
-			IL_01c2: ldloc.s 9
-			IL_01c4: stelem.ref
-			IL_01c5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::'filter'(object[])
-			IL_01ca: stloc.s 15
-			IL_01cc: ldloc.s 15
-			IL_01ce: ldc.i4.1
-			IL_01cf: newarr [System.Runtime]System.Object
-			IL_01d4: dup
-			IL_01d5: ldc.i4.0
-			IL_01d6: ldstr "\n"
-			IL_01db: stelem.ref
-			IL_01dc: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01e1: stloc.s 16
-			IL_01e3: ldloc.s 16
-			IL_01e5: stloc.s 6
-			IL_01e7: ldarg.2
-			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ed: stloc.s 9
-			IL_01ef: ldloc.s 9
-			IL_01f1: ldstr "join"
-			IL_01f6: ldstr " "
-			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0200: stloc.s 9
-			IL_0202: ldloc.s 9
-			IL_0204: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0209: stloc.s 16
-			IL_020b: ldstr "git "
-			IL_0210: ldloc.s 16
-			IL_0212: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0217: stloc.s 16
-			IL_0219: ldloc.s 16
-			IL_021b: ldstr " failed"
-			IL_0220: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0225: stloc.s 16
-			IL_0227: ldloc.s 6
-			IL_0229: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_022e: stloc.s 11
-			IL_0230: ldloc.s 11
-			IL_0232: brfalse IL_0257
+			IL_0167: ldloc.s 15
+			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016e: stloc.s 9
+			IL_0170: ldloc.s 9
+			IL_0172: castclass [System.Runtime]System.String
+			IL_0177: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_017c: stloc.s 14
+			IL_017e: ldloc.s 14
+			IL_0180: stloc.s 5
+			IL_0182: ldc.i4.2
+			IL_0183: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0188: dup
+			IL_0189: ldloc.s 4
+			IL_018b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0190: dup
+			IL_0191: ldloc.s 5
+			IL_0193: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0198: stloc.s 16
+			IL_019a: ldstr "Boolean"
+			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01a4: stloc.s 9
+			IL_01a6: ldloc.s 16
+			IL_01a8: ldc.i4.1
+			IL_01a9: newarr [System.Runtime]System.Object
+			IL_01ae: dup
+			IL_01af: ldc.i4.0
+			IL_01b0: ldloc.s 9
+			IL_01b2: stelem.ref
+			IL_01b3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::'filter'(object[])
+			IL_01b8: stloc.s 16
+			IL_01ba: ldloc.s 16
+			IL_01bc: ldc.i4.1
+			IL_01bd: newarr [System.Runtime]System.Object
+			IL_01c2: dup
+			IL_01c3: ldc.i4.0
+			IL_01c4: ldstr "\n"
+			IL_01c9: stelem.ref
+			IL_01ca: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_01cf: stloc.s 14
+			IL_01d1: ldloc.s 14
+			IL_01d3: stloc.s 6
+			IL_01d5: ldarg.2
+			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01db: stloc.s 9
+			IL_01dd: ldloc.s 9
+			IL_01df: ldstr "join"
+			IL_01e4: ldstr " "
+			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01ee: stloc.s 9
+			IL_01f0: ldloc.s 9
+			IL_01f2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01f7: stloc.s 14
+			IL_01f9: ldstr "git "
+			IL_01fe: ldloc.s 14
+			IL_0200: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0205: stloc.s 14
+			IL_0207: ldloc.s 14
+			IL_0209: ldstr " failed"
+			IL_020e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0213: stloc.s 14
+			IL_0215: ldloc.s 6
+			IL_0217: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_021c: stloc.s 11
+			IL_021e: ldloc.s 11
+			IL_0220: brfalse IL_0245
 
-			IL_0237: ldloc.s 6
-			IL_0239: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_023e: stloc.s 17
-			IL_0240: ldstr ":\n"
-			IL_0245: ldloc.s 17
-			IL_0247: call string [System.Runtime]System.String::Concat(string, string)
-			IL_024c: stloc.s 17
-			IL_024e: ldloc.s 17
-			IL_0250: stloc.s 7
-			IL_0252: br IL_025e
+			IL_0225: ldloc.s 6
+			IL_0227: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_022c: stloc.s 17
+			IL_022e: ldstr ":\n"
+			IL_0233: ldloc.s 17
+			IL_0235: call string [System.Runtime]System.String::Concat(string, string)
+			IL_023a: stloc.s 17
+			IL_023c: ldloc.s 17
+			IL_023e: stloc.s 7
+			IL_0240: br IL_024c
 
-			IL_0257: ldstr "."
-			IL_025c: stloc.s 7
+			IL_0245: ldstr "."
+			IL_024a: stloc.s 7
 
-			IL_025e: ldloc.s 7
-			IL_0260: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0265: stloc.s 17
-			IL_0267: ldloc.s 16
-			IL_0269: ldloc.s 17
-			IL_026b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0270: stloc.s 17
-			IL_0272: ldloc.s 17
-			IL_0274: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0279: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_027e: stloc.s 9
-			IL_0280: ldloc.s 9
-			IL_0282: stloc.s 8
-			IL_0284: ldloc.s 8
-			IL_0286: isinst [System.Runtime]System.Exception
-			IL_028b: dup
-			IL_028c: brtrue IL_029a
+			IL_024c: ldloc.s 7
+			IL_024e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0253: stloc.s 17
+			IL_0255: ldloc.s 14
+			IL_0257: ldloc.s 17
+			IL_0259: call string [System.Runtime]System.String::Concat(string, string)
+			IL_025e: stloc.s 17
+			IL_0260: ldloc.s 17
+			IL_0262: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0267: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_026c: stloc.s 9
+			IL_026e: ldloc.s 9
+			IL_0270: stloc.s 8
+			IL_0272: ldloc.s 8
+			IL_0274: isinst [System.Runtime]System.Exception
+			IL_0279: dup
+			IL_027a: brtrue IL_0288
 
-			IL_0291: pop
-			IL_0292: ldloc.s 8
-			IL_0294: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0299: throw
+			IL_027f: pop
+			IL_0280: ldloc.s 8
+			IL_0282: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0287: throw
 
-			IL_029a: throw
+			IL_0288: throw
 
-			IL_029b: ldloc.0
-			IL_029c: ldstr "stdout"
-			IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a6: stloc.s 9
-			IL_02a8: ldloc.s 9
-			IL_02aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02af: stloc.s 11
-			IL_02b1: ldloc.s 11
-			IL_02b3: brtrue IL_02be
+			IL_0289: ldloc.0
+			IL_028a: ldstr "stdout"
+			IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0294: stloc.s 9
+			IL_0296: ldloc.s 9
+			IL_0298: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_029d: stloc.s 11
+			IL_029f: ldloc.s 11
+			IL_02a1: brtrue IL_02ac
 
-			IL_02b8: ldstr ""
-			IL_02bd: ret
+			IL_02a6: ldstr ""
+			IL_02ab: ret
 
-			IL_02be: ldloc.s 9
-			IL_02c0: ret
+			IL_02ac: ldloc.s 9
+			IL_02ae: ret
 		} // end of method runGit::__js_call__
 
 	} // end of class runGit
@@ -3963,7 +3779,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5791
+				// Method begins at RVA 0x531b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3987,7 +3803,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x57a3
+					// Method begins at RVA 0x532d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4005,7 +3821,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x579a
+				// Method begins at RVA 0x5324
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4029,7 +3845,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x57b5
+					// Method begins at RVA 0x533f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4047,7 +3863,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x57ac
+				// Method begins at RVA 0x5336
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4074,9 +3890,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x41cc
+			// Method begins at RVA 0x3fc8
 			// Header size: 12
-			// Code size: 451 (0x1c3)
+			// Code size: 415 (0x19f)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -4118,7 +3934,7 @@
 					IL_0026: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_002b: stloc.s 13
 					IL_002d: ldloc.s 13
-					IL_002f: brtrue IL_00a5
+					IL_002f: brtrue IL_0093
 
 					IL_0034: ldloc.s 12
 					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -4129,163 +3945,151 @@
 					IL_0046: stloc.s 5
 					IL_0048: ldarg.0
 					IL_0049: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_004e: stloc.s 12
-					IL_0050: ldstr "normalizeSpecPath"
-					IL_0055: ldloc.s 12
-					IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_005c: stloc.s 12
-					IL_005e: ldloc.s 12
-					IL_0060: ldc.i4.1
-					IL_0061: newarr [System.Runtime]System.Object
-					IL_0066: dup
-					IL_0067: ldc.i4.0
-					IL_0068: ldarg.0
-					IL_0069: stelem.ref
-					IL_006a: ldloc.s 4
-					IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0071: stloc.s 12
-					IL_0073: ldloc.s 12
-					IL_0075: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_007a: stloc.s 14
-					IL_007c: ldstr "/"
-					IL_0081: ldloc.s 14
-					IL_0083: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0088: stloc.s 14
-					IL_008a: ldloc.0
-					IL_008b: ldloc.s 14
-					IL_008d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0092: pop
-					IL_0093: br IL_001c
+					IL_004e: ldc.i4.1
+					IL_004f: newarr [System.Runtime]System.Object
+					IL_0054: dup
+					IL_0055: ldc.i4.0
+					IL_0056: ldarg.0
+					IL_0057: stelem.ref
+					IL_0058: ldloc.s 4
+					IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_005f: stloc.s 12
+					IL_0061: ldloc.s 12
+					IL_0063: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0068: stloc.s 14
+					IL_006a: ldstr "/"
+					IL_006f: ldloc.s 14
+					IL_0071: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0076: stloc.s 14
+					IL_0078: ldloc.0
+					IL_0079: ldloc.s 14
+					IL_007b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0080: pop
+					IL_0081: br IL_001c
 				// end loop
-				IL_0098: ldloc.1
-				IL_0099: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_009e: ldc.i4.1
-				IL_009f: stloc.3
-				IL_00a0: leave IL_00bf
+				IL_0086: ldloc.1
+				IL_0087: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_008c: ldc.i4.1
+				IL_008d: stloc.3
+				IL_008e: leave IL_00ad
 
-				IL_00a5: ldc.i4.1
-				IL_00a6: stloc.2
-				IL_00a7: leave IL_00bf
+				IL_0093: ldc.i4.1
+				IL_0094: stloc.2
+				IL_0095: leave IL_00ad
 			} // end .try
 			finally
 			{
-				IL_00ac: ldloc.2
-				IL_00ad: brtrue IL_00be
+				IL_009a: ldloc.2
+				IL_009b: brtrue IL_00ac
 
-				IL_00b2: ldloc.3
-				IL_00b3: brtrue IL_00be
+				IL_00a0: ldloc.3
+				IL_00a1: brtrue IL_00ac
 
-				IL_00b8: ldloc.1
-				IL_00b9: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_00a6: ldloc.1
+				IL_00a7: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_00be: endfinally
+				IL_00ac: endfinally
 			} // end handler
 
-			IL_00bf: ldarg.2
-			IL_00c0: ldstr "includeDirectories"
-			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ca: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_00cf: stloc.s 6
-			IL_00d1: ldc.i4.0
-			IL_00d2: stloc.s 7
-			IL_00d4: ldc.i4.0
-			IL_00d5: stloc.s 8
+			IL_00ad: ldarg.2
+			IL_00ae: ldstr "includeDirectories"
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_00bd: stloc.s 6
+			IL_00bf: ldc.i4.0
+			IL_00c0: stloc.s 7
+			IL_00c2: ldc.i4.0
+			IL_00c3: stloc.s 8
 			.try
 			{
-				// loop start (head: IL_00d7)
-					IL_00d7: ldloc.s 6
-					IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_00de: stloc.s 12
-					IL_00e0: ldloc.s 12
-					IL_00e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_00e7: stloc.s 13
-					IL_00e9: ldloc.s 13
-					IL_00eb: brtrue IL_01a3
+				// loop start (head: IL_00c5)
+					IL_00c5: ldloc.s 6
+					IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_00cc: stloc.s 12
+					IL_00ce: ldloc.s 12
+					IL_00d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_00d5: stloc.s 13
+					IL_00d7: ldloc.s 13
+					IL_00d9: brtrue IL_017f
 
-					IL_00f0: ldloc.s 12
-					IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_00f7: stloc.s 12
-					IL_00f9: ldloc.s 12
-					IL_00fb: stloc.s 9
-					IL_00fd: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/Scope_ForOf_L251C7/Block_L251C54::.ctor()
-					IL_0102: stloc.s 10
-					IL_0104: ldarg.0
-					IL_0105: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_010a: stloc.s 12
-					IL_010c: ldstr "normalizeSpecPath"
-					IL_0111: ldloc.s 12
-					IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0118: stloc.s 12
-					IL_011a: ldloc.s 12
-					IL_011c: ldc.i4.1
-					IL_011d: newarr [System.Runtime]System.Object
-					IL_0122: dup
-					IL_0123: ldc.i4.0
-					IL_0124: ldarg.0
-					IL_0125: stelem.ref
-					IL_0126: ldloc.s 9
-					IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_012d: stloc.s 12
-					IL_012f: ldloc.s 12
-					IL_0131: stloc.s 11
-					IL_0133: ldloc.s 11
-					IL_0135: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_013a: stloc.s 14
-					IL_013c: ldstr "/"
-					IL_0141: ldloc.s 14
-					IL_0143: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0148: stloc.s 14
-					IL_014a: ldloc.s 14
-					IL_014c: ldstr "/"
-					IL_0151: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0156: stloc.s 14
-					IL_0158: ldloc.0
-					IL_0159: ldloc.s 14
-					IL_015b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0160: pop
-					IL_0161: ldloc.s 11
-					IL_0163: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0168: stloc.s 14
-					IL_016a: ldstr "/"
-					IL_016f: ldloc.s 14
-					IL_0171: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0176: stloc.s 14
-					IL_0178: ldloc.s 14
-					IL_017a: ldstr "/**"
-					IL_017f: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0184: stloc.s 14
-					IL_0186: ldloc.0
-					IL_0187: ldloc.s 14
-					IL_0189: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_018e: pop
-					IL_018f: br IL_00d7
+					IL_00de: ldloc.s 12
+					IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_00e5: stloc.s 12
+					IL_00e7: ldloc.s 12
+					IL_00e9: stloc.s 9
+					IL_00eb: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/Scope_ForOf_L251C7/Block_L251C54::.ctor()
+					IL_00f0: stloc.s 10
+					IL_00f2: ldarg.0
+					IL_00f3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_00f8: ldc.i4.1
+					IL_00f9: newarr [System.Runtime]System.Object
+					IL_00fe: dup
+					IL_00ff: ldc.i4.0
+					IL_0100: ldarg.0
+					IL_0101: stelem.ref
+					IL_0102: ldloc.s 9
+					IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0109: stloc.s 12
+					IL_010b: ldloc.s 12
+					IL_010d: stloc.s 11
+					IL_010f: ldloc.s 11
+					IL_0111: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0116: stloc.s 14
+					IL_0118: ldstr "/"
+					IL_011d: ldloc.s 14
+					IL_011f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0124: stloc.s 14
+					IL_0126: ldloc.s 14
+					IL_0128: ldstr "/"
+					IL_012d: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0132: stloc.s 14
+					IL_0134: ldloc.0
+					IL_0135: ldloc.s 14
+					IL_0137: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_013c: pop
+					IL_013d: ldloc.s 11
+					IL_013f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0144: stloc.s 14
+					IL_0146: ldstr "/"
+					IL_014b: ldloc.s 14
+					IL_014d: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0152: stloc.s 14
+					IL_0154: ldloc.s 14
+					IL_0156: ldstr "/**"
+					IL_015b: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0160: stloc.s 14
+					IL_0162: ldloc.0
+					IL_0163: ldloc.s 14
+					IL_0165: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_016a: pop
+					IL_016b: br IL_00c5
 				// end loop
-				IL_0194: ldloc.s 6
-				IL_0196: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_019b: ldc.i4.1
-				IL_019c: stloc.s 8
-				IL_019e: leave IL_01c1
+				IL_0170: ldloc.s 6
+				IL_0172: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0177: ldc.i4.1
+				IL_0178: stloc.s 8
+				IL_017a: leave IL_019d
 
-				IL_01a3: ldc.i4.1
-				IL_01a4: stloc.s 7
-				IL_01a6: leave IL_01c1
+				IL_017f: ldc.i4.1
+				IL_0180: stloc.s 7
+				IL_0182: leave IL_019d
 			} // end .try
 			finally
 			{
-				IL_01ab: ldloc.s 7
-				IL_01ad: brtrue IL_01c0
+				IL_0187: ldloc.s 7
+				IL_0189: brtrue IL_019c
 
-				IL_01b2: ldloc.s 8
-				IL_01b4: brtrue IL_01c0
+				IL_018e: ldloc.s 8
+				IL_0190: brtrue IL_019c
 
-				IL_01b9: ldloc.s 6
-				IL_01bb: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_0195: ldloc.s 6
+				IL_0197: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_01c0: endfinally
+				IL_019c: endfinally
 			} // end handler
 
-			IL_01c1: ldloc.0
-			IL_01c2: ret
+			IL_019d: ldloc.0
+			IL_019e: ret
 		} // end of method buildSparsePatterns::__js_call__
 
 	} // end of class buildSparsePatterns
@@ -4309,7 +4113,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5806
+						// Method begins at RVA 0x5390
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4329,7 +4133,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x580f
+						// Method begins at RVA 0x5399
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4347,7 +4151,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x57fd
+					// Method begins at RVA 0x5387
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4367,7 +4171,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5818
+					// Method begins at RVA 0x53a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4385,7 +4189,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x57be
+				// Method begins at RVA 0x5348
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4413,7 +4217,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x57d9
+						// Method begins at RVA 0x5363
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4431,7 +4235,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x57d0
+					// Method begins at RVA 0x535a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4449,7 +4253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x57c7
+				// Method begins at RVA 0x5351
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4477,7 +4281,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x57f4
+						// Method begins at RVA 0x537e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4495,7 +4299,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x57eb
+					// Method begins at RVA 0x5375
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4513,7 +4317,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x57e2
+				// Method begins at RVA 0x536c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4541,9 +4345,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x43b8
+			// Method begins at RVA 0x4190
 			// Header size: 12
-			// Code size: 1801 (0x709)
+			// Code size: 1621 (0x655)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -4613,7 +4417,7 @@
 					IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_0033: stloc.s 25
 					IL_0035: ldloc.s 25
-					IL_0037: brtrue IL_01da
+					IL_0037: brtrue IL_0192
 
 					IL_003c: ldloc.s 24
 					IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -4624,626 +4428,566 @@
 					IL_004e: stloc.s 6
 					IL_0050: ldarg.0
 					IL_0051: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_0056: stloc.s 24
-					IL_0058: ldstr "path"
-					IL_005d: ldloc.s 24
-					IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0064: stloc.s 24
-					IL_0066: ldloc.s 24
-					IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_006d: stloc.s 24
-					IL_006f: ldc.i4.1
-					IL_0070: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_0075: dup
-					IL_0076: ldarg.2
-					IL_0077: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_007c: stloc.s 26
-					IL_007e: ldarg.0
-					IL_007f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_0084: stloc.s 27
-					IL_0086: ldstr "normalizeSpecPath"
-					IL_008b: ldloc.s 27
-					IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0092: stloc.s 27
-					IL_0094: ldloc.s 27
-					IL_0096: ldc.i4.1
-					IL_0097: newarr [System.Runtime]System.Object
-					IL_009c: dup
-					IL_009d: ldc.i4.0
-					IL_009e: ldarg.0
-					IL_009f: stelem.ref
-					IL_00a0: ldloc.s 5
-					IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_00a7: stloc.s 27
-					IL_00a9: ldloc.s 27
-					IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_00b0: stloc.s 27
-					IL_00b2: ldloc.s 27
-					IL_00b4: ldstr "split"
-					IL_00b9: ldstr "/"
-					IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00c3: stloc.s 27
-					IL_00c5: ldloc.s 26
-					IL_00c7: ldloc.s 27
-					IL_00c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_00ce: ldloc.s 26
-					IL_00d0: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_00d5: stloc.s 28
-					IL_00d7: ldloc.s 24
-					IL_00d9: ldstr "join"
-					IL_00de: ldloc.s 28
-					IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-					IL_00e5: stloc.s 24
-					IL_00e7: ldloc.s 24
-					IL_00e9: stloc.s 7
-					IL_00eb: ldarg.0
-					IL_00ec: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_00f1: stloc.s 24
-					IL_00f3: ldstr "fs"
-					IL_00f8: ldloc.s 24
-					IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_00ff: stloc.s 24
-					IL_0101: ldloc.s 24
-					IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0108: stloc.s 24
-					IL_010a: ldloc.s 24
-					IL_010c: ldstr "existsSync"
-					IL_0111: ldloc.s 7
-					IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0118: stloc.s 24
-					IL_011a: ldloc.s 24
-					IL_011c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0121: ldc.i4.0
-					IL_0122: ceq
-					IL_0124: stloc.s 25
-					IL_0126: ldloc.s 25
-					IL_0128: box [System.Runtime]System.Boolean
-					IL_012d: stloc.s 29
-					IL_012f: ldloc.s 29
-					IL_0131: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0136: stloc.s 25
-					IL_0138: ldloc.s 25
-					IL_013a: brtrue IL_01a3
+					IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_005b: stloc.s 24
+					IL_005d: ldc.i4.1
+					IL_005e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_0063: dup
+					IL_0064: ldarg.2
+					IL_0065: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_006a: stloc.s 26
+					IL_006c: ldarg.0
+					IL_006d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_0072: ldc.i4.1
+					IL_0073: newarr [System.Runtime]System.Object
+					IL_0078: dup
+					IL_0079: ldc.i4.0
+					IL_007a: ldarg.0
+					IL_007b: stelem.ref
+					IL_007c: ldloc.s 5
+					IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0083: stloc.s 27
+					IL_0085: ldloc.s 27
+					IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_008c: stloc.s 27
+					IL_008e: ldloc.s 27
+					IL_0090: ldstr "split"
+					IL_0095: ldstr "/"
+					IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_009f: stloc.s 27
+					IL_00a1: ldloc.s 26
+					IL_00a3: ldloc.s 27
+					IL_00a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_00aa: ldloc.s 26
+					IL_00ac: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_00b1: stloc.s 28
+					IL_00b3: ldloc.s 24
+					IL_00b5: ldstr "join"
+					IL_00ba: ldloc.s 28
+					IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_00c1: stloc.s 24
+					IL_00c3: ldloc.s 24
+					IL_00c5: stloc.s 7
+					IL_00c7: ldarg.0
+					IL_00c8: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_00d2: stloc.s 24
+					IL_00d4: ldloc.s 24
+					IL_00d6: ldstr "existsSync"
+					IL_00db: ldloc.s 7
+					IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_00e2: stloc.s 24
+					IL_00e4: ldloc.s 24
+					IL_00e6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_00eb: ldc.i4.0
+					IL_00ec: ceq
+					IL_00ee: stloc.s 25
+					IL_00f0: ldloc.s 25
+					IL_00f2: box [System.Runtime]System.Boolean
+					IL_00f7: stloc.s 29
+					IL_00f9: ldloc.s 29
+					IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0100: stloc.s 25
+					IL_0102: ldloc.s 25
+					IL_0104: brtrue IL_015b
 
-					IL_013f: ldarg.0
-					IL_0140: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_0145: stloc.s 24
-					IL_0147: ldstr "fs"
-					IL_014c: ldloc.s 24
-					IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0153: stloc.s 24
-					IL_0155: ldloc.s 24
-					IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_015c: stloc.s 24
-					IL_015e: ldloc.s 24
-					IL_0160: ldstr "statSync"
-					IL_0165: ldloc.s 7
-					IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_016c: stloc.s 24
-					IL_016e: ldloc.s 24
-					IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0175: stloc.s 24
-					IL_0177: ldloc.s 24
-					IL_0179: ldstr "isFile"
-					IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_0183: stloc.s 24
-					IL_0185: ldloc.s 24
-					IL_0187: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_018c: ldc.i4.0
-					IL_018d: ceq
-					IL_018f: stloc.s 25
-					IL_0191: ldloc.s 25
-					IL_0193: box [System.Runtime]System.Boolean
-					IL_0198: stloc.s 30
-					IL_019a: ldloc.s 30
-					IL_019c: stloc.s 32
-					IL_019e: br IL_01a7
+					IL_0109: ldarg.0
+					IL_010a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0114: stloc.s 24
+					IL_0116: ldloc.s 24
+					IL_0118: ldstr "statSync"
+					IL_011d: ldloc.s 7
+					IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0124: stloc.s 24
+					IL_0126: ldloc.s 24
+					IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_012d: stloc.s 24
+					IL_012f: ldloc.s 24
+					IL_0131: ldstr "isFile"
+					IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_013b: stloc.s 24
+					IL_013d: ldloc.s 24
+					IL_013f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0144: ldc.i4.0
+					IL_0145: ceq
+					IL_0147: stloc.s 25
+					IL_0149: ldloc.s 25
+					IL_014b: box [System.Runtime]System.Boolean
+					IL_0150: stloc.s 30
+					IL_0152: ldloc.s 30
+					IL_0154: stloc.s 32
+					IL_0156: br IL_015f
 
-					IL_01a3: ldloc.s 29
-					IL_01a5: stloc.s 32
+					IL_015b: ldloc.s 29
+					IL_015d: stloc.s 32
 
-					IL_01a7: ldloc.s 32
-					IL_01a9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01ae: stloc.s 25
-					IL_01b0: ldloc.s 25
-					IL_01b2: brfalse IL_01c7
+					IL_015f: ldloc.s 32
+					IL_0161: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0166: stloc.s 25
+					IL_0168: ldloc.s 25
+					IL_016a: brfalse IL_017f
 
-					IL_01b7: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L264C7/Block_L264C44/Block_L266C69::.ctor()
-					IL_01bc: stloc.s 8
-					IL_01be: ldloc.0
-					IL_01bf: ldloc.s 5
-					IL_01c1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01c6: pop
+					IL_016f: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L264C7/Block_L264C44/Block_L266C69::.ctor()
+					IL_0174: stloc.s 8
+					IL_0176: ldloc.0
+					IL_0177: ldloc.s 5
+					IL_0179: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_017e: pop
 
-					IL_01c7: br IL_0024
+					IL_017f: br IL_0024
 				// end loop
-				IL_01cc: ldloc.2
-				IL_01cd: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_01d2: ldc.i4.1
-				IL_01d3: stloc.s 4
-				IL_01d5: leave IL_01f5
+				IL_0184: ldloc.2
+				IL_0185: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_018a: ldc.i4.1
+				IL_018b: stloc.s 4
+				IL_018d: leave IL_01ad
 
-				IL_01da: ldc.i4.1
-				IL_01db: stloc.3
-				IL_01dc: leave IL_01f5
+				IL_0192: ldc.i4.1
+				IL_0193: stloc.3
+				IL_0194: leave IL_01ad
 			} // end .try
 			finally
 			{
-				IL_01e1: ldloc.3
-				IL_01e2: brtrue IL_01f4
+				IL_0199: ldloc.3
+				IL_019a: brtrue IL_01ac
 
-				IL_01e7: ldloc.s 4
-				IL_01e9: brtrue IL_01f4
+				IL_019f: ldloc.s 4
+				IL_01a1: brtrue IL_01ac
 
-				IL_01ee: ldloc.2
-				IL_01ef: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_01a6: ldloc.2
+				IL_01a7: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_01f4: endfinally
+				IL_01ac: endfinally
 			} // end handler
 
-			IL_01f5: ldarg.3
-			IL_01f6: ldstr "requiredDirectories"
-			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0200: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_0205: stloc.s 9
-			IL_0207: ldc.i4.0
-			IL_0208: stloc.s 10
-			IL_020a: ldc.i4.0
-			IL_020b: stloc.s 11
+			IL_01ad: ldarg.3
+			IL_01ae: ldstr "requiredDirectories"
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01b8: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_01bd: stloc.s 9
+			IL_01bf: ldc.i4.0
+			IL_01c0: stloc.s 10
+			IL_01c2: ldc.i4.0
+			IL_01c3: stloc.s 11
 			.try
 			{
-				// loop start (head: IL_020d)
-					IL_020d: ldloc.s 9
-					IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_0214: stloc.s 24
-					IL_0216: ldloc.s 24
-					IL_0218: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_021d: stloc.s 25
-					IL_021f: ldloc.s 25
-					IL_0221: brtrue IL_03c5
+				// loop start (head: IL_01c5)
+					IL_01c5: ldloc.s 9
+					IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_01cc: stloc.s 24
+					IL_01ce: ldloc.s 24
+					IL_01d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_01d5: stloc.s 25
+					IL_01d7: ldloc.s 25
+					IL_01d9: brtrue IL_0335
 
-					IL_0226: ldloc.s 24
-					IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_022d: stloc.s 24
-					IL_022f: ldloc.s 24
-					IL_0231: stloc.s 12
-					IL_0233: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55::.ctor()
-					IL_0238: stloc.s 13
-					IL_023a: ldarg.0
-					IL_023b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_0240: stloc.s 24
-					IL_0242: ldstr "path"
-					IL_0247: ldloc.s 24
-					IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_024e: stloc.s 24
-					IL_0250: ldloc.s 24
-					IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0257: stloc.s 24
-					IL_0259: ldc.i4.1
-					IL_025a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_025f: dup
-					IL_0260: ldarg.2
-					IL_0261: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_0266: stloc.s 26
-					IL_0268: ldarg.0
-					IL_0269: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_026e: stloc.s 27
-					IL_0270: ldstr "normalizeSpecPath"
-					IL_0275: ldloc.s 27
-					IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_027c: stloc.s 27
-					IL_027e: ldloc.s 27
-					IL_0280: ldc.i4.1
-					IL_0281: newarr [System.Runtime]System.Object
-					IL_0286: dup
-					IL_0287: ldc.i4.0
-					IL_0288: ldarg.0
-					IL_0289: stelem.ref
-					IL_028a: ldloc.s 12
-					IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0291: stloc.s 27
-					IL_0293: ldloc.s 27
-					IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_029a: stloc.s 27
-					IL_029c: ldloc.s 27
-					IL_029e: ldstr "split"
-					IL_02a3: ldstr "/"
-					IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_02ad: stloc.s 27
-					IL_02af: ldloc.s 26
-					IL_02b1: ldloc.s 27
-					IL_02b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_02b8: ldloc.s 26
-					IL_02ba: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_02bf: stloc.s 28
-					IL_02c1: ldloc.s 24
-					IL_02c3: ldstr "join"
-					IL_02c8: ldloc.s 28
-					IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_01de: ldloc.s 24
+					IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_01e5: stloc.s 24
+					IL_01e7: ldloc.s 24
+					IL_01e9: stloc.s 12
+					IL_01eb: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55::.ctor()
+					IL_01f0: stloc.s 13
+					IL_01f2: ldarg.0
+					IL_01f3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01fd: stloc.s 24
+					IL_01ff: ldc.i4.1
+					IL_0200: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_0205: dup
+					IL_0206: ldarg.2
+					IL_0207: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_020c: stloc.s 26
+					IL_020e: ldarg.0
+					IL_020f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_0214: ldc.i4.1
+					IL_0215: newarr [System.Runtime]System.Object
+					IL_021a: dup
+					IL_021b: ldc.i4.0
+					IL_021c: ldarg.0
+					IL_021d: stelem.ref
+					IL_021e: ldloc.s 12
+					IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0225: stloc.s 27
+					IL_0227: ldloc.s 27
+					IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_022e: stloc.s 27
+					IL_0230: ldloc.s 27
+					IL_0232: ldstr "split"
+					IL_0237: ldstr "/"
+					IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0241: stloc.s 27
+					IL_0243: ldloc.s 26
+					IL_0245: ldloc.s 27
+					IL_0247: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_024c: ldloc.s 26
+					IL_024e: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_0253: stloc.s 28
+					IL_0255: ldloc.s 24
+					IL_0257: ldstr "join"
+					IL_025c: ldloc.s 28
+					IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_0263: stloc.s 24
+					IL_0265: ldloc.s 24
+					IL_0267: stloc.s 14
+					IL_0269: ldarg.0
+					IL_026a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0274: stloc.s 24
+					IL_0276: ldloc.s 24
+					IL_0278: ldstr "existsSync"
+					IL_027d: ldloc.s 14
+					IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0284: stloc.s 24
+					IL_0286: ldloc.s 24
+					IL_0288: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_028d: ldc.i4.0
+					IL_028e: ceq
+					IL_0290: stloc.s 25
+					IL_0292: ldloc.s 25
+					IL_0294: box [System.Runtime]System.Boolean
+					IL_0299: stloc.s 29
+					IL_029b: ldloc.s 29
+					IL_029d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02a2: stloc.s 25
+					IL_02a4: ldloc.s 25
+					IL_02a6: brtrue IL_02fd
+
+					IL_02ab: ldarg.0
+					IL_02ac: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02b6: stloc.s 24
+					IL_02b8: ldloc.s 24
+					IL_02ba: ldstr "statSync"
+					IL_02bf: ldloc.s 14
+					IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_02c6: stloc.s 24
+					IL_02c8: ldloc.s 24
+					IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_02cf: stloc.s 24
 					IL_02d1: ldloc.s 24
-					IL_02d3: stloc.s 14
-					IL_02d5: ldarg.0
-					IL_02d6: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_02db: stloc.s 24
-					IL_02dd: ldstr "fs"
-					IL_02e2: ldloc.s 24
-					IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_02e9: stloc.s 24
-					IL_02eb: ldloc.s 24
-					IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02f2: stloc.s 24
-					IL_02f4: ldloc.s 24
-					IL_02f6: ldstr "existsSync"
-					IL_02fb: ldloc.s 14
-					IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0302: stloc.s 24
-					IL_0304: ldloc.s 24
-					IL_0306: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_030b: ldc.i4.0
-					IL_030c: ceq
-					IL_030e: stloc.s 25
-					IL_0310: ldloc.s 25
-					IL_0312: box [System.Runtime]System.Boolean
-					IL_0317: stloc.s 29
-					IL_0319: ldloc.s 29
-					IL_031b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0320: stloc.s 25
-					IL_0322: ldloc.s 25
-					IL_0324: brtrue IL_038d
+					IL_02d3: ldstr "isDirectory"
+					IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02dd: stloc.s 24
+					IL_02df: ldloc.s 24
+					IL_02e1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_02e6: ldc.i4.0
+					IL_02e7: ceq
+					IL_02e9: stloc.s 25
+					IL_02eb: ldloc.s 25
+					IL_02ed: box [System.Runtime]System.Boolean
+					IL_02f2: stloc.s 30
+					IL_02f4: ldloc.s 30
+					IL_02f6: stloc.s 33
+					IL_02f8: br IL_0301
 
-					IL_0329: ldarg.0
-					IL_032a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_032f: stloc.s 24
-					IL_0331: ldstr "fs"
-					IL_0336: ldloc.s 24
-					IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_033d: stloc.s 24
-					IL_033f: ldloc.s 24
-					IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0346: stloc.s 24
-					IL_0348: ldloc.s 24
-					IL_034a: ldstr "statSync"
-					IL_034f: ldloc.s 14
-					IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0356: stloc.s 24
-					IL_0358: ldloc.s 24
-					IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_035f: stloc.s 24
-					IL_0361: ldloc.s 24
-					IL_0363: ldstr "isDirectory"
-					IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_036d: stloc.s 24
-					IL_036f: ldloc.s 24
-					IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0376: ldc.i4.0
-					IL_0377: ceq
-					IL_0379: stloc.s 25
-					IL_037b: ldloc.s 25
-					IL_037d: box [System.Runtime]System.Boolean
-					IL_0382: stloc.s 30
-					IL_0384: ldloc.s 30
-					IL_0386: stloc.s 33
-					IL_0388: br IL_0391
+					IL_02fd: ldloc.s 29
+					IL_02ff: stloc.s 33
 
-					IL_038d: ldloc.s 29
-					IL_038f: stloc.s 33
+					IL_0301: ldloc.s 33
+					IL_0303: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0308: stloc.s 25
+					IL_030a: ldloc.s 25
+					IL_030c: brfalse IL_0321
 
-					IL_0391: ldloc.s 33
-					IL_0393: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0398: stloc.s 25
-					IL_039a: ldloc.s 25
-					IL_039c: brfalse IL_03b1
+					IL_0311: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55/Block_L273C74::.ctor()
+					IL_0316: stloc.s 15
+					IL_0318: ldloc.1
+					IL_0319: ldloc.s 12
+					IL_031b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0320: pop
 
-					IL_03a1: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55/Block_L273C74::.ctor()
-					IL_03a6: stloc.s 15
-					IL_03a8: ldloc.1
-					IL_03a9: ldloc.s 12
-					IL_03ab: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_03b0: pop
-
-					IL_03b1: br IL_020d
+					IL_0321: br IL_01c5
 				// end loop
-				IL_03b6: ldloc.s 9
-				IL_03b8: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_03bd: ldc.i4.1
-				IL_03be: stloc.s 11
-				IL_03c0: leave IL_03e3
+				IL_0326: ldloc.s 9
+				IL_0328: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_032d: ldc.i4.1
+				IL_032e: stloc.s 11
+				IL_0330: leave IL_0353
 
-				IL_03c5: ldc.i4.1
-				IL_03c6: stloc.s 10
-				IL_03c8: leave IL_03e3
+				IL_0335: ldc.i4.1
+				IL_0336: stloc.s 10
+				IL_0338: leave IL_0353
 			} // end .try
 			finally
 			{
-				IL_03cd: ldloc.s 10
-				IL_03cf: brtrue IL_03e2
+				IL_033d: ldloc.s 10
+				IL_033f: brtrue IL_0352
 
-				IL_03d4: ldloc.s 11
-				IL_03d6: brtrue IL_03e2
+				IL_0344: ldloc.s 11
+				IL_0346: brtrue IL_0352
 
-				IL_03db: ldloc.s 9
-				IL_03dd: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_034b: ldloc.s 9
+				IL_034d: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_03e2: endfinally
+				IL_0352: endfinally
 			} // end handler
 
-			IL_03e3: ldloc.0
-			IL_03e4: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_03e9: conv.r8
-			IL_03ea: ldc.r8 0.0
-			IL_03f3: cgt
-			IL_03f5: box [System.Runtime]System.Boolean
-			IL_03fa: stloc.s 29
-			IL_03fc: ldloc.s 29
-			IL_03fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0403: stloc.s 25
-			IL_0405: ldloc.s 25
-			IL_0407: brtrue IL_042a
+			IL_0353: ldloc.0
+			IL_0354: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0359: conv.r8
+			IL_035a: ldc.r8 0.0
+			IL_0363: cgt
+			IL_0365: box [System.Runtime]System.Boolean
+			IL_036a: stloc.s 29
+			IL_036c: ldloc.s 29
+			IL_036e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0373: stloc.s 25
+			IL_0375: ldloc.s 25
+			IL_0377: brtrue IL_039a
 
-			IL_040c: ldloc.1
-			IL_040d: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0412: conv.r8
-			IL_0413: ldc.r8 0.0
-			IL_041c: cgt
-			IL_041e: box [System.Runtime]System.Boolean
-			IL_0423: stloc.s 34
-			IL_0425: br IL_042e
+			IL_037c: ldloc.1
+			IL_037d: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0382: conv.r8
+			IL_0383: ldc.r8 0.0
+			IL_038c: cgt
+			IL_038e: box [System.Runtime]System.Boolean
+			IL_0393: stloc.s 34
+			IL_0395: br IL_039e
 
-			IL_042a: ldloc.s 29
-			IL_042c: stloc.s 34
+			IL_039a: ldloc.s 29
+			IL_039c: stloc.s 34
 
-			IL_042e: ldloc.s 34
-			IL_0430: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0435: stloc.s 25
-			IL_0437: ldloc.s 25
-			IL_0439: brfalse IL_0531
+			IL_039e: ldloc.s 34
+			IL_03a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03a5: stloc.s 25
+			IL_03a7: ldloc.s 25
+			IL_03a9: brfalse IL_04a1
 
-			IL_043e: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64::.ctor()
-			IL_0443: stloc.s 16
-			IL_0445: ldc.i4.0
-			IL_0446: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_044b: stloc.s 17
-			IL_044d: ldloc.0
-			IL_044e: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0453: conv.r8
-			IL_0454: ldc.r8 0.0
-			IL_045d: cgt
-			IL_045f: brfalse IL_04a2
+			IL_03ae: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64::.ctor()
+			IL_03b3: stloc.s 16
+			IL_03b5: ldc.i4.0
+			IL_03b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_03bb: stloc.s 17
+			IL_03bd: ldloc.0
+			IL_03be: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_03c3: conv.r8
+			IL_03c4: ldc.r8 0.0
+			IL_03cd: cgt
+			IL_03cf: brfalse IL_0412
 
-			IL_0464: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L280C33::.ctor()
-			IL_0469: stloc.s 18
-			IL_046b: ldloc.0
-			IL_046c: ldc.i4.1
-			IL_046d: newarr [System.Runtime]System.Object
-			IL_0472: dup
-			IL_0473: ldc.i4.0
-			IL_0474: ldstr ", "
-			IL_0479: stelem.ref
-			IL_047a: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_047f: stloc.s 35
-			IL_0481: ldloc.s 35
-			IL_0483: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0488: stloc.s 35
-			IL_048a: ldstr "missing files: "
-			IL_048f: ldloc.s 35
-			IL_0491: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0496: stloc.s 35
-			IL_0498: ldloc.s 17
-			IL_049a: ldloc.s 35
-			IL_049c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_04a1: pop
+			IL_03d4: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L280C33::.ctor()
+			IL_03d9: stloc.s 18
+			IL_03db: ldloc.0
+			IL_03dc: ldc.i4.1
+			IL_03dd: newarr [System.Runtime]System.Object
+			IL_03e2: dup
+			IL_03e3: ldc.i4.0
+			IL_03e4: ldstr ", "
+			IL_03e9: stelem.ref
+			IL_03ea: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_03ef: stloc.s 35
+			IL_03f1: ldloc.s 35
+			IL_03f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03f8: stloc.s 35
+			IL_03fa: ldstr "missing files: "
+			IL_03ff: ldloc.s 35
+			IL_0401: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0406: stloc.s 35
+			IL_0408: ldloc.s 17
+			IL_040a: ldloc.s 35
+			IL_040c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0411: pop
 
-			IL_04a2: ldloc.1
-			IL_04a3: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_04a8: conv.r8
-			IL_04a9: ldc.r8 0.0
-			IL_04b2: cgt
-			IL_04b4: brfalse IL_04f7
+			IL_0412: ldloc.1
+			IL_0413: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0418: conv.r8
+			IL_0419: ldc.r8 0.0
+			IL_0422: cgt
+			IL_0424: brfalse IL_0467
 
-			IL_04b9: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L283C39::.ctor()
-			IL_04be: stloc.s 19
-			IL_04c0: ldloc.1
-			IL_04c1: ldc.i4.1
-			IL_04c2: newarr [System.Runtime]System.Object
-			IL_04c7: dup
-			IL_04c8: ldc.i4.0
-			IL_04c9: ldstr ", "
-			IL_04ce: stelem.ref
-			IL_04cf: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_04d4: stloc.s 35
-			IL_04d6: ldloc.s 35
-			IL_04d8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04dd: stloc.s 35
-			IL_04df: ldstr "missing directories: "
-			IL_04e4: ldloc.s 35
-			IL_04e6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04eb: stloc.s 35
-			IL_04ed: ldloc.s 17
-			IL_04ef: ldloc.s 35
-			IL_04f1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_04f6: pop
+			IL_0429: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L283C39::.ctor()
+			IL_042e: stloc.s 19
+			IL_0430: ldloc.1
+			IL_0431: ldc.i4.1
+			IL_0432: newarr [System.Runtime]System.Object
+			IL_0437: dup
+			IL_0438: ldc.i4.0
+			IL_0439: ldstr ", "
+			IL_043e: stelem.ref
+			IL_043f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0444: stloc.s 35
+			IL_0446: ldloc.s 35
+			IL_0448: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_044d: stloc.s 35
+			IL_044f: ldstr "missing directories: "
+			IL_0454: ldloc.s 35
+			IL_0456: call string [System.Runtime]System.String::Concat(string, string)
+			IL_045b: stloc.s 35
+			IL_045d: ldloc.s 17
+			IL_045f: ldloc.s 35
+			IL_0461: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0466: pop
 
-			IL_04f7: ldloc.s 17
-			IL_04f9: ldc.i4.1
-			IL_04fa: newarr [System.Runtime]System.Object
-			IL_04ff: dup
-			IL_0500: ldc.i4.0
-			IL_0501: ldstr "; "
-			IL_0506: stelem.ref
-			IL_0507: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_050c: stloc.s 35
-			IL_050e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0513: dup
-			IL_0514: ldstr "ok"
-			IL_0519: ldc.i4.0
-			IL_051a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_051f: dup
-			IL_0520: ldstr "message"
-			IL_0525: ldloc.s 35
-			IL_0527: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_052c: stloc.s 36
-			IL_052e: ldloc.s 36
-			IL_0530: ret
+			IL_0467: ldloc.s 17
+			IL_0469: ldc.i4.1
+			IL_046a: newarr [System.Runtime]System.Object
+			IL_046f: dup
+			IL_0470: ldc.i4.0
+			IL_0471: ldstr "; "
+			IL_0476: stelem.ref
+			IL_0477: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_047c: stloc.s 35
+			IL_047e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0483: dup
+			IL_0484: ldstr "ok"
+			IL_0489: ldc.i4.0
+			IL_048a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_048f: dup
+			IL_0490: ldstr "message"
+			IL_0495: ldloc.s 35
+			IL_0497: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_049c: stloc.s 36
+			IL_049e: ldloc.s 36
+			IL_04a0: ret
 
-			IL_0531: ldarg.0
-			IL_0532: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0537: stloc.s 24
-			IL_0539: ldstr "path"
-			IL_053e: ldloc.s 24
-			IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0545: stloc.s 24
-			IL_0547: ldloc.s 24
-			IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_054e: stloc.s 24
-			IL_0550: ldloc.s 24
-			IL_0552: ldstr "join"
-			IL_0557: ldarg.2
-			IL_0558: ldstr "package.json"
-			IL_055d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0562: stloc.s 24
-			IL_0564: ldloc.s 24
-			IL_0566: stloc.s 20
-			IL_0568: ldarg.0
-			IL_0569: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_056e: stloc.s 24
-			IL_0570: ldstr "fs"
-			IL_0575: ldloc.s 24
-			IL_0577: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_057c: stloc.s 24
-			IL_057e: ldloc.s 24
-			IL_0580: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0585: stloc.s 24
-			IL_0587: ldloc.s 24
-			IL_0589: ldstr "readFileSync"
-			IL_058e: ldloc.s 20
-			IL_0590: ldstr "utf8"
-			IL_0595: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_059a: stloc.s 24
-			IL_059c: ldloc.s 24
-			IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_05a3: stloc.s 24
-			IL_05a5: ldloc.s 24
-			IL_05a7: stloc.s 21
-			IL_05a9: ldloc.s 21
-			IL_05ab: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_05b0: ldc.i4.0
-			IL_05b1: ceq
-			IL_05b3: stloc.s 25
-			IL_05b5: ldloc.s 25
-			IL_05b7: box [System.Runtime]System.Boolean
-			IL_05bc: stloc.s 29
-			IL_05be: ldloc.s 29
-			IL_05c0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05c5: stloc.s 25
-			IL_05c7: ldloc.s 25
-			IL_05c9: brtrue IL_060c
+			IL_04a1: ldarg.0
+			IL_04a2: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04ac: stloc.s 24
+			IL_04ae: ldloc.s 24
+			IL_04b0: ldstr "join"
+			IL_04b5: ldarg.2
+			IL_04b6: ldstr "package.json"
+			IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04c0: stloc.s 24
+			IL_04c2: ldloc.s 24
+			IL_04c4: stloc.s 20
+			IL_04c6: ldarg.0
+			IL_04c7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04d1: stloc.s 24
+			IL_04d3: ldloc.s 24
+			IL_04d5: ldstr "readFileSync"
+			IL_04da: ldloc.s 20
+			IL_04dc: ldstr "utf8"
+			IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04e6: stloc.s 24
+			IL_04e8: ldloc.s 24
+			IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_04ef: stloc.s 24
+			IL_04f1: ldloc.s 24
+			IL_04f3: stloc.s 21
+			IL_04f5: ldloc.s 21
+			IL_04f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04fc: ldc.i4.0
+			IL_04fd: ceq
+			IL_04ff: stloc.s 25
+			IL_0501: ldloc.s 25
+			IL_0503: box [System.Runtime]System.Boolean
+			IL_0508: stloc.s 29
+			IL_050a: ldloc.s 29
+			IL_050c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0511: stloc.s 25
+			IL_0513: ldloc.s 25
+			IL_0515: brtrue IL_0558
+
+			IL_051a: ldloc.s 21
+			IL_051c: ldstr "version"
+			IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0526: stloc.s 24
+			IL_0528: ldloc.s 24
+			IL_052a: ldarg.3
+			IL_052b: ldstr "upstream"
+			IL_0530: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0535: ldstr "packageVersion"
+			IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_053f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0544: stloc.s 25
+			IL_0546: ldloc.s 25
+			IL_0548: box [System.Runtime]System.Boolean
+			IL_054d: stloc.s 30
+			IL_054f: ldloc.s 30
+			IL_0551: stloc.s 37
+			IL_0553: br IL_055c
+
+			IL_0558: ldloc.s 29
+			IL_055a: stloc.s 37
+
+			IL_055c: ldloc.s 37
+			IL_055e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0563: stloc.s 25
+			IL_0565: ldloc.s 25
+			IL_0567: brfalse IL_0633
+
+			IL_056c: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L291C75::.ctor()
+			IL_0571: stloc.s 22
+			IL_0573: ldarg.3
+			IL_0574: ldstr "upstream"
+			IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_057e: ldstr "packageVersion"
+			IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0588: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_058d: stloc.s 35
+			IL_058f: ldstr "package.json version mismatch: expected "
+			IL_0594: ldloc.s 35
+			IL_0596: call string [System.Runtime]System.String::Concat(string, string)
+			IL_059b: stloc.s 35
+			IL_059d: ldloc.s 35
+			IL_059f: ldstr ", got "
+			IL_05a4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05a9: stloc.s 35
+			IL_05ab: ldloc.s 21
+			IL_05ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05b2: stloc.s 25
+			IL_05b4: ldloc.s 25
+			IL_05b6: brfalse IL_05ce
+
+			IL_05bb: ldloc.s 21
+			IL_05bd: ldstr "version"
+			IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05c7: stloc.s 38
+			IL_05c9: br IL_05d2
 
 			IL_05ce: ldloc.s 21
-			IL_05d0: ldstr "version"
-			IL_05d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05da: stloc.s 24
-			IL_05dc: ldloc.s 24
-			IL_05de: ldarg.3
-			IL_05df: ldstr "upstream"
-			IL_05e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05e9: ldstr "packageVersion"
-			IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_05f8: stloc.s 25
-			IL_05fa: ldloc.s 25
-			IL_05fc: box [System.Runtime]System.Boolean
-			IL_0601: stloc.s 30
-			IL_0603: ldloc.s 30
-			IL_0605: stloc.s 37
-			IL_0607: br IL_0610
+			IL_05d0: stloc.s 38
 
-			IL_060c: ldloc.s 29
-			IL_060e: stloc.s 37
+			IL_05d2: ldloc.s 38
+			IL_05d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05d9: stloc.s 25
+			IL_05db: ldloc.s 25
+			IL_05dd: brfalse IL_05f5
 
-			IL_0610: ldloc.s 37
-			IL_0612: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0617: stloc.s 25
-			IL_0619: ldloc.s 25
-			IL_061b: brfalse IL_06e7
+			IL_05e2: ldloc.s 21
+			IL_05e4: ldstr "version"
+			IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05ee: stloc.s 23
+			IL_05f0: br IL_05fc
 
-			IL_0620: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L291C75::.ctor()
-			IL_0625: stloc.s 22
-			IL_0627: ldarg.3
-			IL_0628: ldstr "upstream"
-			IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0632: ldstr "packageVersion"
-			IL_0637: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_063c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0641: stloc.s 35
-			IL_0643: ldstr "package.json version mismatch: expected "
-			IL_0648: ldloc.s 35
-			IL_064a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_064f: stloc.s 35
-			IL_0651: ldloc.s 35
-			IL_0653: ldstr ", got "
-			IL_0658: call string [System.Runtime]System.String::Concat(string, string)
-			IL_065d: stloc.s 35
-			IL_065f: ldloc.s 21
-			IL_0661: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0666: stloc.s 25
-			IL_0668: ldloc.s 25
-			IL_066a: brfalse IL_0682
+			IL_05f5: ldstr "<missing>"
+			IL_05fa: stloc.s 23
 
-			IL_066f: ldloc.s 21
-			IL_0671: ldstr "version"
-			IL_0676: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_067b: stloc.s 38
-			IL_067d: br IL_0686
+			IL_05fc: ldloc.s 23
+			IL_05fe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0603: stloc.s 39
+			IL_0605: ldloc.s 35
+			IL_0607: ldloc.s 39
+			IL_0609: call string [System.Runtime]System.String::Concat(string, string)
+			IL_060e: stloc.s 39
+			IL_0610: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0615: dup
+			IL_0616: ldstr "ok"
+			IL_061b: ldc.i4.0
+			IL_061c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0621: dup
+			IL_0622: ldstr "message"
+			IL_0627: ldloc.s 39
+			IL_0629: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_062e: stloc.s 36
+			IL_0630: ldloc.s 36
+			IL_0632: ret
 
-			IL_0682: ldloc.s 21
-			IL_0684: stloc.s 38
-
-			IL_0686: ldloc.s 38
-			IL_0688: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_068d: stloc.s 25
-			IL_068f: ldloc.s 25
-			IL_0691: brfalse IL_06a9
-
-			IL_0696: ldloc.s 21
-			IL_0698: ldstr "version"
-			IL_069d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06a2: stloc.s 23
-			IL_06a4: br IL_06b0
-
-			IL_06a9: ldstr "<missing>"
-			IL_06ae: stloc.s 23
-
-			IL_06b0: ldloc.s 23
-			IL_06b2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06b7: stloc.s 39
-			IL_06b9: ldloc.s 35
-			IL_06bb: ldloc.s 39
-			IL_06bd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06c2: stloc.s 39
-			IL_06c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_06c9: dup
-			IL_06ca: ldstr "ok"
-			IL_06cf: ldc.i4.0
-			IL_06d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_06d5: dup
-			IL_06d6: ldstr "message"
-			IL_06db: ldloc.s 39
-			IL_06dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06e2: stloc.s 36
-			IL_06e4: ldloc.s 36
-			IL_06e6: ret
-
-			IL_06e7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_06ec: dup
-			IL_06ed: ldstr "ok"
-			IL_06f2: ldc.i4.1
-			IL_06f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_06f8: dup
-			IL_06f9: ldstr "message"
-			IL_06fe: ldstr ""
-			IL_0703: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0708: ret
+			IL_0633: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0638: dup
+			IL_0639: ldstr "ok"
+			IL_063e: ldc.i4.1
+			IL_063f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0644: dup
+			IL_0645: ldstr "message"
+			IL_064a: ldstr ""
+			IL_064f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0654: ret
 		} // end of method validateResolvedRoot::__js_call__
 
 	} // end of class validateResolvedRoot
@@ -5267,7 +5011,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5833
+						// Method begins at RVA 0x53bd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5285,7 +5029,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x582a
+					// Method begins at RVA 0x53b4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5305,7 +5049,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x583c
+					// Method begins at RVA 0x53c6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5323,7 +5067,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5821
+				// Method begins at RVA 0x53ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5352,9 +5096,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4b04
+			// Method begins at RVA 0x4828
 			// Header size: 12
-			// Code size: 1259 (0x4eb)
+			// Code size: 1057 (0x421)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14,
@@ -5364,11 +5108,11 @@
 				[4] class Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L322C22,
 				[5] object,
 				[6] bool,
-				[7] object,
-				[8] object[],
+				[7] object[],
+				[8] object,
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[10] object,
-				[11] object[],
+				[10] object[],
+				[11] object,
 				[12] string
 			)
 
@@ -5378,465 +5122,403 @@
 			IL_0008: ceq
 			IL_000a: stloc.s 6
 			IL_000c: ldloc.s 6
-			IL_000e: brfalse IL_0098
+			IL_000e: brfalse IL_0086
 
 			IL_0013: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14::.ctor()
 			IL_0018: stloc.0
-			IL_0019: ldarg.0
-			IL_001a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
-			IL_001f: stloc.s 7
-			IL_0021: ldstr "validateResolvedRoot"
-			IL_0026: ldloc.s 7
-			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_002d: stloc.s 7
-			IL_002f: ldc.i4.1
-			IL_0030: newarr [System.Runtime]System.Object
-			IL_0035: dup
-			IL_0036: ldc.i4.0
-			IL_0037: ldarg.0
-			IL_0038: stelem.ref
-			IL_0039: stloc.s 8
-			IL_003b: ldloc.s 7
-			IL_003d: ldloc.s 8
-			IL_003f: ldarg.2
-			IL_0040: ldarg.3
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0046: stloc.s 7
-			IL_0048: ldloc.s 7
-			IL_004a: stloc.1
-			IL_004b: ldloc.1
-			IL_004c: ldstr "ok"
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0056: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_005b: stloc.s 6
-			IL_005d: ldloc.s 6
-			IL_005f: brfalse IL_0098
+			IL_0019: ldc.i4.1
+			IL_001a: newarr [System.Runtime]System.Object
+			IL_001f: dup
+			IL_0020: ldc.i4.0
+			IL_0021: ldarg.0
+			IL_0022: stelem.ref
+			IL_0023: stloc.s 7
+			IL_0025: ldarg.0
+			IL_0026: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+			IL_002b: ldloc.s 7
+			IL_002d: ldarg.2
+			IL_002e: ldarg.3
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
+			IL_0038: stloc.1
+			IL_0039: ldloc.1
+			IL_003a: ldstr "ok"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0049: stloc.s 6
+			IL_004b: ldloc.s 6
+			IL_004d: brfalse IL_0086
 
-			IL_0064: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14/Block_L304C20::.ctor()
-			IL_0069: stloc.2
-			IL_006a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_006f: dup
-			IL_0070: ldstr "source"
-			IL_0075: ldstr "managed-cache"
-			IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_007f: dup
-			IL_0080: ldstr "rootPath"
-			IL_0085: ldarg.2
-			IL_0086: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_008b: dup
-			IL_008c: ldstr "reused"
-			IL_0091: ldc.i4.1
-			IL_0092: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0097: ret
+			IL_0052: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14/Block_L304C20::.ctor()
+			IL_0057: stloc.2
+			IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_005d: dup
+			IL_005e: ldstr "source"
+			IL_0063: ldstr "managed-cache"
+			IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_006d: dup
+			IL_006e: ldstr "rootPath"
+			IL_0073: ldarg.2
+			IL_0074: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0079: dup
+			IL_007a: ldstr "reused"
+			IL_007f: ldc.i4.1
+			IL_0080: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0085: ret
 
-			IL_0098: ldarg.0
-			IL_0099: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::removeDir
-			IL_009e: stloc.s 7
-			IL_00a0: ldstr "removeDir"
-			IL_00a5: ldloc.s 7
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ac: stloc.s 7
-			IL_00ae: ldc.i4.1
-			IL_00af: newarr [System.Runtime]System.Object
-			IL_00b4: dup
-			IL_00b5: ldc.i4.0
-			IL_00b6: ldarg.0
-			IL_00b7: stelem.ref
-			IL_00b8: stloc.s 8
-			IL_00ba: ldloc.s 7
-			IL_00bc: ldloc.s 8
-			IL_00be: ldarg.2
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00c4: pop
-			IL_00c5: ldarg.0
-			IL_00c6: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureDir
-			IL_00cb: stloc.s 7
-			IL_00cd: ldstr "ensureDir"
-			IL_00d2: ldloc.s 7
-			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00d9: stloc.s 7
-			IL_00db: ldc.i4.1
-			IL_00dc: newarr [System.Runtime]System.Object
-			IL_00e1: dup
-			IL_00e2: ldc.i4.0
-			IL_00e3: ldarg.0
-			IL_00e4: stelem.ref
-			IL_00e5: stloc.s 8
-			IL_00e7: ldloc.s 7
-			IL_00e9: ldloc.s 8
-			IL_00eb: ldarg.2
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00f1: pop
-			IL_00f2: ldarg.0
-			IL_00f3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_00f8: stloc.s 7
-			IL_00fa: ldstr "runGit"
-			IL_00ff: ldloc.s 7
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0106: stloc.s 7
-			IL_0108: ldc.i4.1
-			IL_0109: newarr [System.Runtime]System.Object
-			IL_010e: dup
-			IL_010f: ldc.i4.0
-			IL_0110: ldarg.0
-			IL_0111: stelem.ref
-			IL_0112: stloc.s 8
-			IL_0114: ldc.i4.1
-			IL_0115: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_011a: dup
-			IL_011b: ldstr "init"
-			IL_0120: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0125: stloc.s 9
-			IL_0127: ldloc.s 7
-			IL_0129: ldloc.s 8
-			IL_012b: ldloc.s 9
-			IL_012d: ldarg.2
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0133: pop
-			IL_0134: ldarg.0
-			IL_0135: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_013a: stloc.s 7
-			IL_013c: ldstr "runGit"
-			IL_0141: ldloc.s 7
-			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0148: stloc.s 7
-			IL_014a: ldc.i4.1
-			IL_014b: newarr [System.Runtime]System.Object
-			IL_0150: dup
-			IL_0151: ldc.i4.0
-			IL_0152: ldarg.0
-			IL_0153: stelem.ref
-			IL_0154: stloc.s 8
-			IL_0156: ldc.i4.3
-			IL_0157: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_015c: dup
-			IL_015d: ldstr "config"
-			IL_0162: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0167: dup
-			IL_0168: ldstr "core.autocrlf"
-			IL_016d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0172: dup
-			IL_0173: ldstr "false"
-			IL_0178: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_017d: stloc.s 9
-			IL_017f: ldloc.s 7
-			IL_0181: ldloc.s 8
-			IL_0183: ldloc.s 9
-			IL_0185: ldarg.2
-			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_018b: pop
-			IL_018c: ldarg.0
-			IL_018d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_0192: stloc.s 7
-			IL_0194: ldstr "runGit"
-			IL_0199: ldloc.s 7
-			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01a0: stloc.s 7
-			IL_01a2: ldc.i4.1
-			IL_01a3: newarr [System.Runtime]System.Object
-			IL_01a8: dup
-			IL_01a9: ldc.i4.0
-			IL_01aa: ldarg.0
-			IL_01ab: stelem.ref
-			IL_01ac: stloc.s 8
-			IL_01ae: ldc.i4.3
-			IL_01af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0086: ldc.i4.1
+			IL_0087: newarr [System.Runtime]System.Object
+			IL_008c: dup
+			IL_008d: ldc.i4.0
+			IL_008e: ldarg.0
+			IL_008f: stelem.ref
+			IL_0090: stloc.s 7
+			IL_0092: ldarg.0
+			IL_0093: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::removeDir
+			IL_0098: ldloc.s 7
+			IL_009a: ldarg.2
+			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00a0: pop
+			IL_00a1: ldc.i4.1
+			IL_00a2: newarr [System.Runtime]System.Object
+			IL_00a7: dup
+			IL_00a8: ldc.i4.0
+			IL_00a9: ldarg.0
+			IL_00aa: stelem.ref
+			IL_00ab: stloc.s 7
+			IL_00ad: ldarg.0
+			IL_00ae: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureDir
+			IL_00b3: ldloc.s 7
+			IL_00b5: ldarg.2
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00bb: pop
+			IL_00bc: ldarg.0
+			IL_00bd: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_00c2: stloc.s 8
+			IL_00c4: ldc.i4.1
+			IL_00c5: newarr [System.Runtime]System.Object
+			IL_00ca: dup
+			IL_00cb: ldc.i4.0
+			IL_00cc: ldarg.0
+			IL_00cd: stelem.ref
+			IL_00ce: stloc.s 7
+			IL_00d0: ldc.i4.1
+			IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00d6: dup
+			IL_00d7: ldstr "init"
+			IL_00dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00e1: stloc.s 9
+			IL_00e3: ldloc.s 8
+			IL_00e5: ldloc.s 7
+			IL_00e7: ldloc.s 9
+			IL_00e9: ldarg.2
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_00ef: pop
+			IL_00f0: ldarg.0
+			IL_00f1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_00f6: stloc.s 8
+			IL_00f8: ldc.i4.1
+			IL_00f9: newarr [System.Runtime]System.Object
+			IL_00fe: dup
+			IL_00ff: ldc.i4.0
+			IL_0100: ldarg.0
+			IL_0101: stelem.ref
+			IL_0102: stloc.s 7
+			IL_0104: ldc.i4.3
+			IL_0105: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_010a: dup
+			IL_010b: ldstr "config"
+			IL_0110: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0115: dup
+			IL_0116: ldstr "core.autocrlf"
+			IL_011b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0120: dup
+			IL_0121: ldstr "false"
+			IL_0126: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_012b: stloc.s 9
+			IL_012d: ldloc.s 8
+			IL_012f: ldloc.s 7
+			IL_0131: ldloc.s 9
+			IL_0133: ldarg.2
+			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0139: pop
+			IL_013a: ldarg.0
+			IL_013b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_0140: stloc.s 8
+			IL_0142: ldc.i4.1
+			IL_0143: newarr [System.Runtime]System.Object
+			IL_0148: dup
+			IL_0149: ldc.i4.0
+			IL_014a: ldarg.0
+			IL_014b: stelem.ref
+			IL_014c: stloc.s 7
+			IL_014e: ldc.i4.3
+			IL_014f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0154: dup
+			IL_0155: ldstr "config"
+			IL_015a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_015f: dup
+			IL_0160: ldstr "core.eol"
+			IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_016a: dup
+			IL_016b: ldstr "lf"
+			IL_0170: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0175: stloc.s 9
+			IL_0177: ldloc.s 8
+			IL_0179: ldloc.s 7
+			IL_017b: ldloc.s 9
+			IL_017d: ldarg.2
+			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0183: pop
+			IL_0184: ldarg.0
+			IL_0185: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_018a: stloc.s 8
+			IL_018c: ldc.i4.1
+			IL_018d: newarr [System.Runtime]System.Object
+			IL_0192: dup
+			IL_0193: ldc.i4.0
+			IL_0194: ldarg.0
+			IL_0195: stelem.ref
+			IL_0196: stloc.s 7
+			IL_0198: ldc.i4.4
+			IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_019e: dup
+			IL_019f: ldstr "remote"
+			IL_01a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01a9: dup
+			IL_01aa: ldstr "add"
+			IL_01af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_01b4: dup
-			IL_01b5: ldstr "config"
+			IL_01b5: ldstr "origin"
 			IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_01bf: dup
-			IL_01c0: ldstr "core.eol"
-			IL_01c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01ca: dup
-			IL_01cb: ldstr "lf"
-			IL_01d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01d5: stloc.s 9
-			IL_01d7: ldloc.s 7
-			IL_01d9: ldloc.s 8
-			IL_01db: ldloc.s 9
-			IL_01dd: ldarg.2
-			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01e3: pop
-			IL_01e4: ldarg.0
-			IL_01e5: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_01ea: stloc.s 7
-			IL_01ec: ldstr "runGit"
-			IL_01f1: ldloc.s 7
-			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01f8: stloc.s 7
-			IL_01fa: ldc.i4.1
-			IL_01fb: newarr [System.Runtime]System.Object
-			IL_0200: dup
-			IL_0201: ldc.i4.0
-			IL_0202: ldarg.0
-			IL_0203: stelem.ref
-			IL_0204: stloc.s 8
-			IL_0206: ldc.i4.4
-			IL_0207: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_020c: dup
-			IL_020d: ldstr "remote"
-			IL_0212: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0217: dup
-			IL_0218: ldstr "add"
-			IL_021d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0222: dup
-			IL_0223: ldstr "origin"
-			IL_0228: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_022d: dup
-			IL_022e: ldarg.3
-			IL_022f: ldstr "upstream"
-			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0239: ldstr "cloneUrl"
-			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0243: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0248: stloc.s 9
-			IL_024a: ldloc.s 7
-			IL_024c: ldloc.s 8
-			IL_024e: ldloc.s 9
-			IL_0250: ldarg.2
-			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0256: pop
-			IL_0257: ldarg.0
-			IL_0258: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_025d: stloc.s 7
-			IL_025f: ldstr "runGit"
-			IL_0264: ldloc.s 7
-			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_026b: stloc.s 7
-			IL_026d: ldc.i4.1
-			IL_026e: newarr [System.Runtime]System.Object
-			IL_0273: dup
-			IL_0274: ldc.i4.0
-			IL_0275: ldarg.0
-			IL_0276: stelem.ref
-			IL_0277: stloc.s 8
-			IL_0279: ldc.i4.3
-			IL_027a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_027f: dup
-			IL_0280: ldstr "sparse-checkout"
-			IL_0285: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_028a: dup
-			IL_028b: ldstr "init"
-			IL_0290: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0295: dup
-			IL_0296: ldstr "--no-cone"
-			IL_029b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02a0: stloc.s 9
+			IL_01c0: ldarg.3
+			IL_01c1: ldstr "upstream"
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01cb: ldstr "cloneUrl"
+			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01da: stloc.s 9
+			IL_01dc: ldloc.s 8
+			IL_01de: ldloc.s 7
+			IL_01e0: ldloc.s 9
+			IL_01e2: ldarg.2
+			IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01e8: pop
+			IL_01e9: ldarg.0
+			IL_01ea: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_01ef: stloc.s 8
+			IL_01f1: ldc.i4.1
+			IL_01f2: newarr [System.Runtime]System.Object
+			IL_01f7: dup
+			IL_01f8: ldc.i4.0
+			IL_01f9: ldarg.0
+			IL_01fa: stelem.ref
+			IL_01fb: stloc.s 7
+			IL_01fd: ldc.i4.3
+			IL_01fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0203: dup
+			IL_0204: ldstr "sparse-checkout"
+			IL_0209: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_020e: dup
+			IL_020f: ldstr "init"
+			IL_0214: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0219: dup
+			IL_021a: ldstr "--no-cone"
+			IL_021f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0224: stloc.s 9
+			IL_0226: ldloc.s 8
+			IL_0228: ldloc.s 7
+			IL_022a: ldloc.s 9
+			IL_022c: ldarg.2
+			IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0232: pop
+			IL_0233: ldarg.0
+			IL_0234: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_0239: stloc.s 8
+			IL_023b: ldc.i4.1
+			IL_023c: newarr [System.Runtime]System.Object
+			IL_0241: dup
+			IL_0242: ldc.i4.0
+			IL_0243: ldarg.0
+			IL_0244: stelem.ref
+			IL_0245: stloc.s 7
+			IL_0247: ldc.i4.3
+			IL_0248: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_024d: dup
+			IL_024e: ldstr "sparse-checkout"
+			IL_0253: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0258: dup
+			IL_0259: ldstr "set"
+			IL_025e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0263: dup
+			IL_0264: ldstr "--no-cone"
+			IL_0269: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_026e: stloc.s 9
+			IL_0270: ldc.i4.1
+			IL_0271: newarr [System.Runtime]System.Object
+			IL_0276: dup
+			IL_0277: ldc.i4.0
+			IL_0278: ldarg.0
+			IL_0279: stelem.ref
+			IL_027a: stloc.s 10
+			IL_027c: ldarg.0
+			IL_027d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
+			IL_0282: ldloc.s 10
+			IL_0284: ldarg.3
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_028a: stloc.s 11
+			IL_028c: ldloc.s 9
+			IL_028e: ldc.i4.1
+			IL_028f: newarr [System.Runtime]System.Object
+			IL_0294: dup
+			IL_0295: ldc.i4.0
+			IL_0296: ldloc.s 11
+			IL_0298: stelem.ref
+			IL_0299: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
+			IL_029e: stloc.s 9
+			IL_02a0: ldloc.s 8
 			IL_02a2: ldloc.s 7
-			IL_02a4: ldloc.s 8
-			IL_02a6: ldloc.s 9
-			IL_02a8: ldarg.2
-			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02ae: pop
-			IL_02af: ldarg.0
-			IL_02b0: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_02b5: stloc.s 7
-			IL_02b7: ldstr "runGit"
-			IL_02bc: ldloc.s 7
-			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02c3: stloc.s 7
-			IL_02c5: ldc.i4.1
-			IL_02c6: newarr [System.Runtime]System.Object
-			IL_02cb: dup
-			IL_02cc: ldc.i4.0
-			IL_02cd: ldarg.0
-			IL_02ce: stelem.ref
-			IL_02cf: stloc.s 8
-			IL_02d1: ldc.i4.3
-			IL_02d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02d7: dup
-			IL_02d8: ldstr "sparse-checkout"
-			IL_02dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02e2: dup
-			IL_02e3: ldstr "set"
-			IL_02e8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02ed: dup
-			IL_02ee: ldstr "--no-cone"
-			IL_02f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02f8: stloc.s 9
-			IL_02fa: ldarg.0
-			IL_02fb: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
-			IL_0300: stloc.s 10
-			IL_0302: ldstr "buildSparsePatterns"
-			IL_0307: ldloc.s 10
-			IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_030e: stloc.s 10
-			IL_0310: ldc.i4.1
-			IL_0311: newarr [System.Runtime]System.Object
-			IL_0316: dup
-			IL_0317: ldc.i4.0
-			IL_0318: ldarg.0
-			IL_0319: stelem.ref
-			IL_031a: stloc.s 11
-			IL_031c: ldloc.s 10
-			IL_031e: ldloc.s 11
-			IL_0320: ldarg.3
-			IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0326: stloc.s 10
-			IL_0328: ldloc.s 9
-			IL_032a: ldc.i4.1
-			IL_032b: newarr [System.Runtime]System.Object
-			IL_0330: dup
-			IL_0331: ldc.i4.0
-			IL_0332: ldloc.s 10
-			IL_0334: stelem.ref
-			IL_0335: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
-			IL_033a: stloc.s 9
-			IL_033c: ldloc.s 7
-			IL_033e: ldloc.s 8
-			IL_0340: ldloc.s 9
-			IL_0342: ldarg.2
-			IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0348: pop
-			IL_0349: ldarg.0
-			IL_034a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_034f: stloc.s 7
-			IL_0351: ldstr "runGit"
-			IL_0356: ldloc.s 7
-			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_035d: stloc.s 7
-			IL_035f: ldc.i4.1
-			IL_0360: newarr [System.Runtime]System.Object
-			IL_0365: dup
-			IL_0366: ldc.i4.0
-			IL_0367: ldarg.0
-			IL_0368: stelem.ref
-			IL_0369: stloc.s 8
-			IL_036b: ldc.i4.5
-			IL_036c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0371: dup
-			IL_0372: ldstr "fetch"
-			IL_0377: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_037c: dup
-			IL_037d: ldstr "--depth"
-			IL_0382: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0387: dup
-			IL_0388: ldstr "1"
-			IL_038d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0392: dup
-			IL_0393: ldstr "origin"
-			IL_0398: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_039d: dup
-			IL_039e: ldarg.3
-			IL_039f: ldstr "upstream"
-			IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03a9: ldstr "commit"
-			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03b8: stloc.s 9
-			IL_03ba: ldloc.s 7
-			IL_03bc: ldloc.s 8
-			IL_03be: ldloc.s 9
-			IL_03c0: ldarg.2
-			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03c6: pop
-			IL_03c7: ldarg.0
-			IL_03c8: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_03cd: stloc.s 7
-			IL_03cf: ldstr "runGit"
-			IL_03d4: ldloc.s 7
-			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03db: stloc.s 7
-			IL_03dd: ldc.i4.1
-			IL_03de: newarr [System.Runtime]System.Object
+			IL_02a4: ldloc.s 9
+			IL_02a6: ldarg.2
+			IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02ac: pop
+			IL_02ad: ldarg.0
+			IL_02ae: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_02b3: stloc.s 8
+			IL_02b5: ldc.i4.1
+			IL_02b6: newarr [System.Runtime]System.Object
+			IL_02bb: dup
+			IL_02bc: ldc.i4.0
+			IL_02bd: ldarg.0
+			IL_02be: stelem.ref
+			IL_02bf: stloc.s 7
+			IL_02c1: ldc.i4.5
+			IL_02c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02c7: dup
+			IL_02c8: ldstr "fetch"
+			IL_02cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02d2: dup
+			IL_02d3: ldstr "--depth"
+			IL_02d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02dd: dup
+			IL_02de: ldstr "1"
+			IL_02e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02e8: dup
+			IL_02e9: ldstr "origin"
+			IL_02ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02f3: dup
+			IL_02f4: ldarg.3
+			IL_02f5: ldstr "upstream"
+			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ff: ldstr "commit"
+			IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0309: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_030e: stloc.s 9
+			IL_0310: ldloc.s 8
+			IL_0312: ldloc.s 7
+			IL_0314: ldloc.s 9
+			IL_0316: ldarg.2
+			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_031c: pop
+			IL_031d: ldarg.0
+			IL_031e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_0323: stloc.s 8
+			IL_0325: ldc.i4.1
+			IL_0326: newarr [System.Runtime]System.Object
+			IL_032b: dup
+			IL_032c: ldc.i4.0
+			IL_032d: ldarg.0
+			IL_032e: stelem.ref
+			IL_032f: stloc.s 7
+			IL_0331: ldc.i4.3
+			IL_0332: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0337: dup
+			IL_0338: ldstr "checkout"
+			IL_033d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0342: dup
+			IL_0343: ldstr "--detach"
+			IL_0348: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_034d: dup
+			IL_034e: ldstr "FETCH_HEAD"
+			IL_0353: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0358: stloc.s 9
+			IL_035a: ldloc.s 8
+			IL_035c: ldloc.s 7
+			IL_035e: ldloc.s 9
+			IL_0360: ldarg.2
+			IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0366: pop
+			IL_0367: ldc.i4.1
+			IL_0368: newarr [System.Runtime]System.Object
+			IL_036d: dup
+			IL_036e: ldc.i4.0
+			IL_036f: ldarg.0
+			IL_0370: stelem.ref
+			IL_0371: stloc.s 7
+			IL_0373: ldarg.0
+			IL_0374: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+			IL_0379: ldloc.s 7
+			IL_037b: ldarg.2
+			IL_037c: ldarg.3
+			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0382: stloc.s 8
+			IL_0384: ldloc.s 8
+			IL_0386: stloc.3
+			IL_0387: ldloc.3
+			IL_0388: ldstr "ok"
+			IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0392: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0397: ldc.i4.0
+			IL_0398: ceq
+			IL_039a: stloc.s 6
+			IL_039c: ldloc.s 6
+			IL_039e: brfalse IL_03f3
+
+			IL_03a3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L322C22::.ctor()
+			IL_03a8: stloc.s 4
+			IL_03aa: ldloc.3
+			IL_03ab: ldstr "message"
+			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03ba: stloc.s 12
+			IL_03bc: ldstr "Pinned test262 checkout is incomplete after bootstrap: "
+			IL_03c1: ldloc.s 12
+			IL_03c3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03c8: stloc.s 12
+			IL_03ca: ldloc.s 12
+			IL_03cc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03d6: stloc.s 8
+			IL_03d8: ldloc.s 8
+			IL_03da: stloc.s 5
+			IL_03dc: ldloc.s 5
+			IL_03de: isinst [System.Runtime]System.Exception
 			IL_03e3: dup
-			IL_03e4: ldc.i4.0
-			IL_03e5: ldarg.0
-			IL_03e6: stelem.ref
-			IL_03e7: stloc.s 8
-			IL_03e9: ldc.i4.3
-			IL_03ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_03ef: dup
-			IL_03f0: ldstr "checkout"
-			IL_03f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03fa: dup
-			IL_03fb: ldstr "--detach"
-			IL_0400: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0405: dup
-			IL_0406: ldstr "FETCH_HEAD"
-			IL_040b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0410: stloc.s 9
-			IL_0412: ldloc.s 7
-			IL_0414: ldloc.s 8
-			IL_0416: ldloc.s 9
-			IL_0418: ldarg.2
-			IL_0419: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_041e: pop
-			IL_041f: ldarg.0
-			IL_0420: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
-			IL_0425: stloc.s 7
-			IL_0427: ldstr "validateResolvedRoot"
-			IL_042c: ldloc.s 7
-			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0433: stloc.s 7
-			IL_0435: ldc.i4.1
-			IL_0436: newarr [System.Runtime]System.Object
-			IL_043b: dup
-			IL_043c: ldc.i4.0
-			IL_043d: ldarg.0
-			IL_043e: stelem.ref
-			IL_043f: stloc.s 8
-			IL_0441: ldloc.s 7
-			IL_0443: ldloc.s 8
-			IL_0445: ldarg.2
-			IL_0446: ldarg.3
-			IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_044c: stloc.s 7
-			IL_044e: ldloc.s 7
-			IL_0450: stloc.3
-			IL_0451: ldloc.3
-			IL_0452: ldstr "ok"
-			IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_045c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0461: ldc.i4.0
-			IL_0462: ceq
-			IL_0464: stloc.s 6
-			IL_0466: ldloc.s 6
-			IL_0468: brfalse IL_04bd
+			IL_03e4: brtrue IL_03f2
 
-			IL_046d: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L322C22::.ctor()
-			IL_0472: stloc.s 4
-			IL_0474: ldloc.3
-			IL_0475: ldstr "message"
-			IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_047f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0484: stloc.s 12
-			IL_0486: ldstr "Pinned test262 checkout is incomplete after bootstrap: "
-			IL_048b: ldloc.s 12
-			IL_048d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0492: stloc.s 12
-			IL_0494: ldloc.s 12
-			IL_0496: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_049b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_04a0: stloc.s 7
-			IL_04a2: ldloc.s 7
-			IL_04a4: stloc.s 5
-			IL_04a6: ldloc.s 5
-			IL_04a8: isinst [System.Runtime]System.Exception
-			IL_04ad: dup
-			IL_04ae: brtrue IL_04bc
+			IL_03e9: pop
+			IL_03ea: ldloc.s 5
+			IL_03ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03f1: throw
 
-			IL_04b3: pop
-			IL_04b4: ldloc.s 5
-			IL_04b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_04bb: throw
+			IL_03f2: throw
 
-			IL_04bc: throw
-
-			IL_04bd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04c2: dup
-			IL_04c3: ldstr "source"
-			IL_04c8: ldstr "managed-cache"
-			IL_04cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04d2: dup
-			IL_04d3: ldstr "rootPath"
-			IL_04d8: ldarg.2
-			IL_04d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04de: dup
-			IL_04df: ldstr "reused"
-			IL_04e4: ldc.i4.0
-			IL_04e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_04ea: ret
+			IL_03f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03f8: dup
+			IL_03f9: ldstr "source"
+			IL_03fe: ldstr "managed-cache"
+			IL_0403: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0408: dup
+			IL_0409: ldstr "rootPath"
+			IL_040e: ldarg.2
+			IL_040f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0414: dup
+			IL_0415: ldstr "reused"
+			IL_041a: ldc.i4.0
+			IL_041b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0420: ret
 		} // end of method ensureManagedCheckout::__js_call__
 
 	} // end of class ensureManagedCheckout
@@ -5860,7 +5542,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5857
+						// Method begins at RVA 0x53e1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5878,7 +5560,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x584e
+					// Method begins at RVA 0x53d8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5896,7 +5578,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5845
+				// Method begins at RVA 0x53cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5925,9 +5607,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4ffc
+			// Method begins at RVA 0x4c58
 			// Header size: 12
-			// Code size: 439 (0x1b7)
+			// Code size: 389 (0x185)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5935,181 +5617,165 @@
 				[2] object,
 				[3] class Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16/Block_L333C24,
 				[4] object,
-				[5] object,
-				[6] object[],
+				[5] object[],
+				[6] object,
 				[7] bool,
 				[8] object,
 				[9] string,
 				[10] string
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
-			IL_0006: stloc.s 5
-			IL_0008: ldstr "resolveOverrideRoot"
-			IL_000d: ldloc.s 5
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 5
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.s 6
-			IL_0022: ldloc.s 5
-			IL_0024: ldloc.s 6
-			IL_0026: ldarg.s args
-			IL_0028: ldarg.3
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_002e: stloc.s 5
-			IL_0030: ldloc.s 5
-			IL_0032: stloc.0
-			IL_0033: ldloc.0
-			IL_0034: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0039: stloc.s 7
-			IL_003b: ldloc.s 7
-			IL_003d: brfalse IL_0164
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 5
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
+			IL_0012: ldloc.s 5
+			IL_0014: ldarg.s args
+			IL_0016: ldarg.3
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_001c: stloc.s 6
+			IL_001e: ldloc.s 6
+			IL_0020: stloc.0
+			IL_0021: ldloc.0
+			IL_0022: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0027: stloc.s 7
+			IL_0029: ldloc.s 7
+			IL_002b: brfalse IL_0144
 
-			IL_0042: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16::.ctor()
-			IL_0047: stloc.1
-			IL_0048: ldarg.0
-			IL_0049: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
-			IL_004e: stloc.s 5
-			IL_0050: ldstr "validateResolvedRoot"
-			IL_0055: ldloc.s 5
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_005c: stloc.s 5
-			IL_005e: ldc.i4.1
-			IL_005f: newarr [System.Runtime]System.Object
-			IL_0064: dup
-			IL_0065: ldc.i4.0
-			IL_0066: ldarg.0
-			IL_0067: stelem.ref
-			IL_0068: stloc.s 6
-			IL_006a: ldloc.0
-			IL_006b: ldstr "rootPath"
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0075: stloc.s 8
-			IL_0077: ldloc.s 5
-			IL_0079: ldloc.s 6
-			IL_007b: ldloc.s 8
-			IL_007d: ldarg.3
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0083: stloc.s 8
-			IL_0085: ldloc.s 8
-			IL_0087: stloc.2
-			IL_0088: ldloc.2
-			IL_0089: ldstr "ok"
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0093: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0098: ldc.i4.0
-			IL_0099: ceq
-			IL_009b: stloc.s 7
-			IL_009d: ldloc.s 7
-			IL_009f: brfalse IL_011e
+			IL_0030: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16::.ctor()
+			IL_0035: stloc.1
+			IL_0036: ldarg.0
+			IL_0037: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+			IL_003c: stloc.s 6
+			IL_003e: ldc.i4.1
+			IL_003f: newarr [System.Runtime]System.Object
+			IL_0044: dup
+			IL_0045: ldc.i4.0
+			IL_0046: ldarg.0
+			IL_0047: stelem.ref
+			IL_0048: stloc.s 5
+			IL_004a: ldloc.0
+			IL_004b: ldstr "rootPath"
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0055: stloc.s 8
+			IL_0057: ldloc.s 6
+			IL_0059: ldloc.s 5
+			IL_005b: ldloc.s 8
+			IL_005d: ldarg.3
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0063: stloc.s 8
+			IL_0065: ldloc.s 8
+			IL_0067: stloc.2
+			IL_0068: ldloc.2
+			IL_0069: ldstr "ok"
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0078: ldc.i4.0
+			IL_0079: ceq
+			IL_007b: stloc.s 7
+			IL_007d: ldloc.s 7
+			IL_007f: brfalse IL_00fe
 
-			IL_00a4: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16/Block_L333C24::.ctor()
-			IL_00a9: stloc.3
-			IL_00aa: ldloc.0
-			IL_00ab: ldstr "rootPath"
-			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00ba: stloc.s 9
-			IL_00bc: ldstr "Override test262 root '"
-			IL_00c1: ldloc.s 9
-			IL_00c3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00c8: stloc.s 9
+			IL_0084: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16/Block_L333C24::.ctor()
+			IL_0089: stloc.3
+			IL_008a: ldloc.0
+			IL_008b: ldstr "rootPath"
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0095: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_009a: stloc.s 9
+			IL_009c: ldstr "Override test262 root '"
+			IL_00a1: ldloc.s 9
+			IL_00a3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00a8: stloc.s 9
+			IL_00aa: ldloc.s 9
+			IL_00ac: ldstr "' is invalid: "
+			IL_00b1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00b6: stloc.s 9
+			IL_00b8: ldloc.2
+			IL_00b9: ldstr "message"
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00c8: stloc.s 10
 			IL_00ca: ldloc.s 9
-			IL_00cc: ldstr "' is invalid: "
-			IL_00d1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00d6: stloc.s 9
-			IL_00d8: ldloc.2
-			IL_00d9: ldstr "message"
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00e8: stloc.s 10
-			IL_00ea: ldloc.s 9
-			IL_00ec: ldloc.s 10
-			IL_00ee: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00f3: stloc.s 10
-			IL_00f5: ldloc.s 10
-			IL_00f7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0101: stloc.s 8
-			IL_0103: ldloc.s 8
-			IL_0105: stloc.s 4
-			IL_0107: ldloc.s 4
-			IL_0109: isinst [System.Runtime]System.Exception
-			IL_010e: dup
-			IL_010f: brtrue IL_011d
+			IL_00cc: ldloc.s 10
+			IL_00ce: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00d3: stloc.s 10
+			IL_00d5: ldloc.s 10
+			IL_00d7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00e1: stloc.s 8
+			IL_00e3: ldloc.s 8
+			IL_00e5: stloc.s 4
+			IL_00e7: ldloc.s 4
+			IL_00e9: isinst [System.Runtime]System.Exception
+			IL_00ee: dup
+			IL_00ef: brtrue IL_00fd
 
-			IL_0114: pop
-			IL_0115: ldloc.s 4
-			IL_0117: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_011c: throw
+			IL_00f4: pop
+			IL_00f5: ldloc.s 4
+			IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00fc: throw
 
-			IL_011d: throw
+			IL_00fd: throw
 
-			IL_011e: ldloc.0
-			IL_011f: ldstr "source"
-			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0129: stloc.s 8
-			IL_012b: ldloc.0
-			IL_012c: ldstr "rootPath"
-			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0136: stloc.s 5
-			IL_0138: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_013d: dup
-			IL_013e: ldstr "source"
-			IL_0143: ldloc.s 8
-			IL_0145: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00fe: ldloc.0
+			IL_00ff: ldstr "source"
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0109: stloc.s 8
+			IL_010b: ldloc.0
+			IL_010c: ldstr "rootPath"
+			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0116: stloc.s 6
+			IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_011d: dup
+			IL_011e: ldstr "source"
+			IL_0123: ldloc.s 8
+			IL_0125: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_012a: dup
+			IL_012b: ldstr "rootPath"
+			IL_0130: ldloc.s 6
+			IL_0132: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0137: dup
+			IL_0138: ldstr "reused"
+			IL_013d: ldc.i4.1
+			IL_013e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0143: ret
+
+			IL_0144: ldc.i4.1
+			IL_0145: newarr [System.Runtime]System.Object
 			IL_014a: dup
-			IL_014b: ldstr "rootPath"
-			IL_0150: ldloc.s 5
-			IL_0152: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0157: dup
-			IL_0158: ldstr "reused"
-			IL_015d: ldc.i4.1
-			IL_015e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0163: ret
+			IL_014b: ldc.i4.0
+			IL_014c: ldarg.0
+			IL_014d: stelem.ref
+			IL_014e: stloc.s 5
+			IL_0150: ldarg.0
+			IL_0151: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
+			IL_0156: ldloc.s 5
+			IL_0158: ldarg.2
+			IL_0159: ldarg.3
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_015f: stloc.s 6
+			IL_0161: ldarg.s args
+			IL_0163: ldstr "force"
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_016d: stloc.s 8
+			IL_016f: ldarg.0
+			IL_0170: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0175: ldnull
+			IL_0176: ldloc.s 6
+			IL_0178: ldarg.3
+			IL_0179: ldloc.s 8
+			IL_017b: tail.
+			IL_017d: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_0182: ret
 
-			IL_0164: ldarg.0
-			IL_0165: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
-			IL_016a: stloc.s 5
-			IL_016c: ldstr "resolveManagedCheckoutRoot"
-			IL_0171: ldloc.s 5
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0178: stloc.s 5
-			IL_017a: ldc.i4.1
-			IL_017b: newarr [System.Runtime]System.Object
-			IL_0180: dup
-			IL_0181: ldc.i4.0
-			IL_0182: ldarg.0
-			IL_0183: stelem.ref
-			IL_0184: stloc.s 6
-			IL_0186: ldloc.s 5
-			IL_0188: ldloc.s 6
-			IL_018a: ldarg.2
-			IL_018b: ldarg.3
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0191: stloc.s 5
-			IL_0193: ldarg.s args
-			IL_0195: ldstr "force"
-			IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_019f: stloc.s 8
-			IL_01a1: ldarg.0
-			IL_01a2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_01a7: ldnull
-			IL_01a8: ldloc.s 5
-			IL_01aa: ldarg.3
-			IL_01ab: ldloc.s 8
-			IL_01ad: tail.
-			IL_01af: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-			IL_01b4: ret
-
-			IL_01b5: ldnull
-			IL_01b6: ret
+			IL_0183: ldnull
+			IL_0184: ret
 		} // end of method resolveBootstrapRoot::__js_call__
 
 	} // end of class resolveBootstrapRoot
@@ -6129,7 +5795,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5869
+					// Method begins at RVA 0x53f3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6147,7 +5813,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5860
+				// Method begins at RVA 0x53ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6176,9 +5842,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x51c0
+			// Method begins at RVA 0x4dec
 			// Header size: 12
-			// Code size: 435 (0x1b3)
+			// Code size: 421 (0x1a5)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/Scope/Block_L344C21,
@@ -6255,94 +5921,90 @@
 			IL_00a2: ldarg.0
 			IL_00a3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
 			IL_00a8: stloc.s 6
-			IL_00aa: ldstr "toPortablePath"
-			IL_00af: ldloc.s 6
-			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00b6: stloc.s 6
-			IL_00b8: ldc.i4.1
-			IL_00b9: newarr [System.Runtime]System.Object
-			IL_00be: dup
-			IL_00bf: ldc.i4.0
-			IL_00c0: ldarg.0
-			IL_00c1: stelem.ref
-			IL_00c2: stloc.s 7
-			IL_00c4: ldloc.s 6
-			IL_00c6: ldloc.s 7
-			IL_00c8: ldarg.2
-			IL_00c9: ldstr "rootPath"
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00d8: stloc.s 6
-			IL_00da: ldloc.s 6
-			IL_00dc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00aa: ldc.i4.1
+			IL_00ab: newarr [System.Runtime]System.Object
+			IL_00b0: dup
+			IL_00b1: ldc.i4.0
+			IL_00b2: ldarg.0
+			IL_00b3: stelem.ref
+			IL_00b4: stloc.s 7
+			IL_00b6: ldloc.s 6
+			IL_00b8: ldloc.s 7
+			IL_00ba: ldarg.2
+			IL_00bb: ldstr "rootPath"
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00ca: stloc.s 6
+			IL_00cc: ldloc.s 6
+			IL_00ce: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00d3: stloc.s 8
+			IL_00d5: ldstr "root "
+			IL_00da: ldloc.s 8
+			IL_00dc: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00e1: stloc.s 8
-			IL_00e3: ldstr "root "
-			IL_00e8: ldloc.s 8
-			IL_00ea: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00ef: stloc.s 8
-			IL_00f1: ldarg.3
-			IL_00f2: ldstr "upstream"
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00fc: ldstr "commit"
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0106: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00e3: ldarg.3
+			IL_00e4: ldstr "upstream"
+			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ee: ldstr "commit"
+			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00fd: stloc.s 9
+			IL_00ff: ldstr "commit "
+			IL_0104: ldloc.s 9
+			IL_0106: call string [System.Runtime]System.String::Concat(string, string)
 			IL_010b: stloc.s 9
-			IL_010d: ldstr "commit "
-			IL_0112: ldloc.s 9
-			IL_0114: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0119: stloc.s 9
-			IL_011b: ldarg.3
-			IL_011c: ldstr "upstream"
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0126: ldstr "packageVersion"
-			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0130: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_010d: ldarg.3
+			IL_010e: ldstr "upstream"
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0118: ldstr "packageVersion"
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0122: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0127: stloc.s 10
+			IL_0129: ldstr "packageVersion "
+			IL_012e: ldloc.s 10
+			IL_0130: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0135: stloc.s 10
-			IL_0137: ldstr "packageVersion "
-			IL_013c: ldloc.s 10
-			IL_013e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0143: stloc.s 10
-			IL_0145: ldloc.2
-			IL_0146: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0137: ldloc.2
+			IL_0138: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_013d: stloc.s 11
+			IL_013f: ldstr "status "
+			IL_0144: ldloc.s 11
+			IL_0146: call string [System.Runtime]System.String::Concat(string, string)
 			IL_014b: stloc.s 11
-			IL_014d: ldstr "status "
-			IL_0152: ldloc.s 11
-			IL_0154: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0159: stloc.s 11
-			IL_015b: ldc.i4.5
-			IL_015c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0161: dup
-			IL_0162: ldloc.s 5
-			IL_0164: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0169: dup
-			IL_016a: ldloc.s 8
-			IL_016c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0171: dup
-			IL_0172: ldloc.s 9
-			IL_0174: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0179: dup
-			IL_017a: ldloc.s 10
-			IL_017c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0181: dup
-			IL_0182: ldloc.s 11
-			IL_0184: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0189: stloc.s 12
-			IL_018b: ldloc.s 12
-			IL_018d: ldc.i4.1
-			IL_018e: newarr [System.Runtime]System.Object
-			IL_0193: dup
-			IL_0194: ldc.i4.0
-			IL_0195: ldstr "\n"
-			IL_019a: stelem.ref
-			IL_019b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01a0: stloc.s 11
-			IL_01a2: ldloc.s 4
-			IL_01a4: ldstr "log"
-			IL_01a9: ldloc.s 11
-			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01b0: pop
-			IL_01b1: ldnull
-			IL_01b2: ret
+			IL_014d: ldc.i4.5
+			IL_014e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0153: dup
+			IL_0154: ldloc.s 5
+			IL_0156: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_015b: dup
+			IL_015c: ldloc.s 8
+			IL_015e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0163: dup
+			IL_0164: ldloc.s 9
+			IL_0166: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_016b: dup
+			IL_016c: ldloc.s 10
+			IL_016e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0173: dup
+			IL_0174: ldloc.s 11
+			IL_0176: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_017b: stloc.s 12
+			IL_017d: ldloc.s 12
+			IL_017f: ldc.i4.1
+			IL_0180: newarr [System.Runtime]System.Object
+			IL_0185: dup
+			IL_0186: ldc.i4.0
+			IL_0187: ldstr "\n"
+			IL_018c: stelem.ref
+			IL_018d: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0192: stloc.s 11
+			IL_0194: ldloc.s 4
+			IL_0196: ldstr "log"
+			IL_019b: ldloc.s 11
+			IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01a2: pop
+			IL_01a3: ldnull
+			IL_01a4: ret
 		} // end of method printResolvedRoot::__js_call__
 
 	} // end of class printResolvedRoot
@@ -6362,7 +6024,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x587b
+					// Method begins at RVA 0x5405
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6382,7 +6044,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5884
+					// Method begins at RVA 0x540e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6400,7 +6062,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5872
+				// Method begins at RVA 0x53fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6426,9 +6088,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x5380
+			// Method begins at RVA 0x4fa0
 			// Header size: 12
-			// Code size: 633 (0x279)
+			// Code size: 483 (0x1e3)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6450,250 +6112,202 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::parseArgs
 			IL_0006: stloc.s 7
-			IL_0008: ldstr "parseArgs"
-			IL_000d: ldloc.s 7
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 7
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.s 8
-			IL_0022: ldstr "process"
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0008: ldc.i4.1
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: stloc.s 8
+			IL_0014: ldstr "process"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_001e: stloc.s 9
+			IL_0020: ldloc.s 9
+			IL_0022: ldstr "argv"
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_002c: stloc.s 9
 			IL_002e: ldloc.s 9
-			IL_0030: ldstr "argv"
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003a: stloc.s 9
-			IL_003c: ldloc.s 9
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0043: stloc.s 9
-			IL_0045: ldloc.s 9
-			IL_0047: ldstr "slice"
-			IL_004c: ldc.r8 2
-			IL_0055: box [System.Runtime]System.Double
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005f: stloc.s 9
-			IL_0061: ldloc.s 7
-			IL_0063: ldloc.s 8
-			IL_0065: ldloc.s 9
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_006c: stloc.s 9
-			IL_006e: ldloc.s 9
-			IL_0070: stloc.0
-			IL_0071: ldloc.0
-			IL_0072: ldstr "help"
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0081: stloc.s 10
-			IL_0083: ldloc.s 10
-			IL_0085: brfalse IL_00ba
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0035: stloc.s 9
+			IL_0037: ldloc.s 9
+			IL_0039: ldstr "slice"
+			IL_003e: ldc.r8 2
+			IL_0047: box [System.Runtime]System.Double
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0051: stloc.s 9
+			IL_0053: ldloc.s 7
+			IL_0055: ldloc.s 8
+			IL_0057: ldloc.s 9
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_005e: stloc.s 9
+			IL_0060: ldloc.s 9
+			IL_0062: stloc.0
+			IL_0063: ldloc.0
+			IL_0064: ldstr "help"
+			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_006e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0073: stloc.s 10
+			IL_0075: ldloc.s 10
+			IL_0077: brfalse IL_009a
 
-			IL_008a: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L363C17::.ctor()
-			IL_008f: stloc.1
+			IL_007c: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L363C17::.ctor()
+			IL_0081: stloc.1
+			IL_0082: ldarg.0
+			IL_0083: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printHelp
+			IL_0088: ldc.i4.1
+			IL_0089: newarr [System.Runtime]System.Object
+			IL_008e: dup
+			IL_008f: ldc.i4.0
 			IL_0090: ldarg.0
-			IL_0091: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printHelp
-			IL_0096: stloc.s 9
-			IL_0098: ldstr "printHelp"
-			IL_009d: ldloc.s 9
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a4: stloc.s 9
-			IL_00a6: ldloc.s 9
-			IL_00a8: ldc.i4.1
-			IL_00a9: newarr [System.Runtime]System.Object
-			IL_00ae: dup
-			IL_00af: ldc.i4.0
-			IL_00b0: ldarg.0
-			IL_00b1: stelem.ref
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00b7: pop
-			IL_00b8: ldnull
-			IL_00b9: ret
+			IL_0091: stelem.ref
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0097: pop
+			IL_0098: ldnull
+			IL_0099: ret
 
-			IL_00ba: ldarg.0
-			IL_00bb: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
-			IL_00c0: stloc.s 9
-			IL_00c2: ldstr "resolvePathFromCwd"
-			IL_00c7: ldloc.s 9
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ce: stloc.s 9
-			IL_00d0: ldc.i4.1
-			IL_00d1: newarr [System.Runtime]System.Object
-			IL_00d6: dup
-			IL_00d7: ldc.i4.0
-			IL_00d8: ldarg.0
-			IL_00d9: stelem.ref
-			IL_00da: stloc.s 8
-			IL_00dc: ldloc.0
-			IL_00dd: ldstr "pin"
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e7: stloc.s 7
-			IL_00e9: ldloc.s 7
-			IL_00eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00f0: stloc.s 10
-			IL_00f2: ldloc.s 10
-			IL_00f4: brtrue IL_012b
+			IL_009a: ldarg.0
+			IL_009b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
+			IL_00a0: stloc.s 9
+			IL_00a2: ldc.i4.1
+			IL_00a3: newarr [System.Runtime]System.Object
+			IL_00a8: dup
+			IL_00a9: ldc.i4.0
+			IL_00aa: ldarg.0
+			IL_00ab: stelem.ref
+			IL_00ac: stloc.s 8
+			IL_00ae: ldloc.0
+			IL_00af: ldstr "pin"
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b9: stloc.s 7
+			IL_00bb: ldloc.s 7
+			IL_00bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00c2: stloc.s 10
+			IL_00c4: ldloc.s 10
+			IL_00c6: brtrue IL_00eb
 
-			IL_00f9: ldarg.0
-			IL_00fa: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
-			IL_00ff: stloc.s 11
-			IL_0101: ldstr "defaultPinPath"
-			IL_0106: ldloc.s 11
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_010d: stloc.s 11
-			IL_010f: ldloc.s 11
-			IL_0111: ldc.i4.1
-			IL_0112: newarr [System.Runtime]System.Object
-			IL_0117: dup
-			IL_0118: ldc.i4.0
-			IL_0119: ldarg.0
-			IL_011a: stelem.ref
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0120: stloc.s 11
-			IL_0122: ldloc.s 11
-			IL_0124: stloc.s 13
-			IL_0126: br IL_012f
+			IL_00cb: ldarg.0
+			IL_00cc: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
+			IL_00d1: ldc.i4.1
+			IL_00d2: newarr [System.Runtime]System.Object
+			IL_00d7: dup
+			IL_00d8: ldc.i4.0
+			IL_00d9: ldarg.0
+			IL_00da: stelem.ref
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00e0: stloc.s 11
+			IL_00e2: ldloc.s 11
+			IL_00e4: stloc.s 13
+			IL_00e6: br IL_00ef
 
-			IL_012b: ldloc.s 7
-			IL_012d: stloc.s 13
+			IL_00eb: ldloc.s 7
+			IL_00ed: stloc.s 13
 
-			IL_012f: ldloc.s 9
-			IL_0131: ldloc.s 8
-			IL_0133: ldloc.s 13
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_013a: stloc.s 9
-			IL_013c: ldloc.s 9
-			IL_013e: stloc.2
-			IL_013f: ldarg.0
-			IL_0140: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
-			IL_0145: stloc.s 9
-			IL_0147: ldstr "loadPin"
-			IL_014c: ldloc.s 9
-			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0153: stloc.s 9
-			IL_0155: ldloc.s 9
-			IL_0157: ldc.i4.1
-			IL_0158: newarr [System.Runtime]System.Object
-			IL_015d: dup
-			IL_015e: ldc.i4.0
-			IL_015f: ldarg.0
-			IL_0160: stelem.ref
-			IL_0161: ldloc.2
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0167: stloc.s 9
-			IL_0169: ldloc.s 9
-			IL_016b: stloc.3
+			IL_00ef: ldloc.s 9
+			IL_00f1: ldloc.s 8
+			IL_00f3: ldloc.s 13
+			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00fa: stloc.s 9
+			IL_00fc: ldloc.s 9
+			IL_00fe: stloc.2
+			IL_00ff: ldarg.0
+			IL_0100: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
+			IL_0105: ldc.i4.1
+			IL_0106: newarr [System.Runtime]System.Object
+			IL_010b: dup
+			IL_010c: ldc.i4.0
+			IL_010d: ldarg.0
+			IL_010e: stelem.ref
+			IL_010f: ldloc.2
+			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0115: stloc.s 9
+			IL_0117: ldloc.s 9
+			IL_0119: stloc.3
+			IL_011a: ldarg.0
+			IL_011b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
+			IL_0120: ldc.i4.1
+			IL_0121: newarr [System.Runtime]System.Object
+			IL_0126: dup
+			IL_0127: ldc.i4.0
+			IL_0128: ldarg.0
+			IL_0129: stelem.ref
+			IL_012a: ldloc.0
+			IL_012b: ldloc.3
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0131: stloc.s 9
+			IL_0133: ldloc.s 9
+			IL_0135: stloc.s 4
+			IL_0137: ldloc.0
+			IL_0138: ldstr "describe"
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0142: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0147: stloc.s 10
+			IL_0149: ldloc.s 10
+			IL_014b: brfalse IL_0197
+
+			IL_0150: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L372C21::.ctor()
+			IL_0155: stloc.s 5
+			IL_0157: ldstr "console"
+			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0161: stloc.s 9
+			IL_0163: ldloc.s 9
+			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016a: stloc.s 9
 			IL_016c: ldarg.0
-			IL_016d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
-			IL_0172: stloc.s 9
-			IL_0174: ldstr "resolveOverrideRoot"
-			IL_0179: ldloc.s 9
-			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0180: stloc.s 9
-			IL_0182: ldloc.s 9
-			IL_0184: ldc.i4.1
-			IL_0185: newarr [System.Runtime]System.Object
-			IL_018a: dup
-			IL_018b: ldc.i4.0
-			IL_018c: ldarg.0
-			IL_018d: stelem.ref
-			IL_018e: ldloc.0
-			IL_018f: ldloc.3
-			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0195: stloc.s 9
-			IL_0197: ldloc.s 9
-			IL_0199: stloc.s 4
-			IL_019b: ldloc.0
-			IL_019c: ldstr "describe"
-			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01ab: stloc.s 10
-			IL_01ad: ldloc.s 10
-			IL_01af: brfalse IL_020d
+			IL_016d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
+			IL_0172: ldc.i4.1
+			IL_0173: newarr [System.Runtime]System.Object
+			IL_0178: dup
+			IL_0179: ldc.i4.0
+			IL_017a: ldarg.0
+			IL_017b: stelem.ref
+			IL_017c: ldloc.3
+			IL_017d: ldloc.s 4
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0184: stloc.s 7
+			IL_0186: ldloc.s 9
+			IL_0188: ldstr "log"
+			IL_018d: ldloc.s 7
+			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0194: pop
+			IL_0195: ldnull
+			IL_0196: ret
 
-			IL_01b4: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L372C21::.ctor()
-			IL_01b9: stloc.s 5
-			IL_01bb: ldstr "console"
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01c5: stloc.s 9
-			IL_01c7: ldloc.s 9
-			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ce: stloc.s 9
-			IL_01d0: ldarg.0
-			IL_01d1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
-			IL_01d6: stloc.s 7
-			IL_01d8: ldstr "describePlan"
-			IL_01dd: ldloc.s 7
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01e4: stloc.s 7
-			IL_01e6: ldloc.s 7
-			IL_01e8: ldc.i4.1
-			IL_01e9: newarr [System.Runtime]System.Object
-			IL_01ee: dup
-			IL_01ef: ldc.i4.0
-			IL_01f0: ldarg.0
-			IL_01f1: stelem.ref
-			IL_01f2: ldloc.3
-			IL_01f3: ldloc.s 4
-			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01fa: stloc.s 7
-			IL_01fc: ldloc.s 9
-			IL_01fe: ldstr "log"
-			IL_0203: ldloc.s 7
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_020a: pop
-			IL_020b: ldnull
-			IL_020c: ret
-
-			IL_020d: ldarg.0
-			IL_020e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
-			IL_0213: stloc.s 7
-			IL_0215: ldstr "resolveBootstrapRoot"
-			IL_021a: ldloc.s 7
-			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0221: stloc.s 7
-			IL_0223: ldloc.s 7
-			IL_0225: ldc.i4.1
-			IL_0226: newarr [System.Runtime]System.Object
-			IL_022b: dup
-			IL_022c: ldc.i4.0
-			IL_022d: ldarg.0
-			IL_022e: stelem.ref
-			IL_022f: ldloc.2
-			IL_0230: ldloc.3
-			IL_0231: ldloc.0
-			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0237: stloc.s 7
-			IL_0239: ldloc.s 7
-			IL_023b: stloc.s 6
-			IL_023d: ldarg.0
-			IL_023e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printResolvedRoot
-			IL_0243: stloc.s 7
-			IL_0245: ldstr "printResolvedRoot"
-			IL_024a: ldloc.s 7
-			IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0251: stloc.s 7
-			IL_0253: ldc.i4.1
-			IL_0254: newarr [System.Runtime]System.Object
-			IL_0259: dup
-			IL_025a: ldc.i4.0
-			IL_025b: ldarg.0
-			IL_025c: stelem.ref
-			IL_025d: stloc.s 8
-			IL_025f: ldloc.s 7
-			IL_0261: ldloc.s 8
-			IL_0263: ldloc.s 6
-			IL_0265: ldloc.3
-			IL_0266: ldloc.0
-			IL_0267: ldstr "printRoot"
-			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0276: pop
-			IL_0277: ldnull
-			IL_0278: ret
+			IL_0197: ldarg.0
+			IL_0198: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
+			IL_019d: ldc.i4.1
+			IL_019e: newarr [System.Runtime]System.Object
+			IL_01a3: dup
+			IL_01a4: ldc.i4.0
+			IL_01a5: ldarg.0
+			IL_01a6: stelem.ref
+			IL_01a7: ldloc.2
+			IL_01a8: ldloc.3
+			IL_01a9: ldloc.0
+			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_01af: stloc.s 7
+			IL_01b1: ldloc.s 7
+			IL_01b3: stloc.s 6
+			IL_01b5: ldarg.0
+			IL_01b6: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printResolvedRoot
+			IL_01bb: stloc.s 7
+			IL_01bd: ldc.i4.1
+			IL_01be: newarr [System.Runtime]System.Object
+			IL_01c3: dup
+			IL_01c4: ldc.i4.0
+			IL_01c5: ldarg.0
+			IL_01c6: stelem.ref
+			IL_01c7: stloc.s 8
+			IL_01c9: ldloc.s 7
+			IL_01cb: ldloc.s 8
+			IL_01cd: ldloc.s 6
+			IL_01cf: ldloc.3
+			IL_01d0: ldloc.0
+			IL_01d1: ldstr "printRoot"
+			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_01e0: pop
+			IL_01e1: ldnull
+			IL_01e2: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -6729,7 +6343,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5896
+					// Method begins at RVA 0x5420
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6749,7 +6363,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x589f
+					// Method begins at RVA 0x5429
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6767,7 +6381,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x588d
+				// Method begins at RVA 0x5417
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6815,7 +6429,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5605
+			// Method begins at RVA 0x518f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -7563,7 +7177,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x58a8
+		// Method begins at RVA 0x5432
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7078
+				// Method begins at RVA 0x69ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x708a
+					// Method begins at RVA 0x69c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -153,7 +153,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7093
+					// Method begins at RVA 0x69c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -173,7 +173,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x709c
+					// Method begins at RVA 0x69d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7081
+				// Method begins at RVA 0x69b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x70ae
+					// Method begins at RVA 0x69e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -321,7 +321,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x70a5
+				// Method begins at RVA 0x69db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -350,7 +350,7 @@
 			)
 			// Method begins at RVA 0x2a78
 			// Header size: 12
-			// Code size: 180 (0xb4)
+			// Code size: 156 (0x9c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262MetadataParser/formatNegative/Scope/Block_L30C17,
@@ -376,63 +376,55 @@
 			IL_001c: ldarg.0
 			IL_001d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
 			IL_0022: stloc.2
-			IL_0023: ldstr "formatScalar"
-			IL_0028: ldloc.2
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_002e: stloc.2
-			IL_002f: ldc.i4.1
-			IL_0030: newarr [System.Runtime]System.Object
-			IL_0035: dup
-			IL_0036: ldc.i4.0
-			IL_0037: ldarg.0
-			IL_0038: stelem.ref
-			IL_0039: stloc.3
-			IL_003a: ldloc.2
-			IL_003b: ldloc.3
-			IL_003c: ldarg.2
-			IL_003d: ldstr "phase"
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_004c: stloc.2
-			IL_004d: ldstr "{ phase: "
-			IL_0052: ldloc.2
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0058: stloc.s 4
-			IL_005a: ldloc.s 4
-			IL_005c: ldstr ", type: "
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0066: stloc.s 4
-			IL_0068: ldarg.0
-			IL_0069: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_006e: stloc.2
-			IL_006f: ldstr "formatScalar"
-			IL_0074: ldloc.2
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_007a: stloc.2
-			IL_007b: ldc.i4.1
-			IL_007c: newarr [System.Runtime]System.Object
-			IL_0081: dup
-			IL_0082: ldc.i4.0
-			IL_0083: ldarg.0
-			IL_0084: stelem.ref
-			IL_0085: stloc.3
-			IL_0086: ldloc.2
-			IL_0087: ldloc.3
-			IL_0088: ldarg.2
-			IL_0089: ldstr "type"
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0098: stloc.2
+			IL_0023: ldc.i4.1
+			IL_0024: newarr [System.Runtime]System.Object
+			IL_0029: dup
+			IL_002a: ldc.i4.0
+			IL_002b: ldarg.0
+			IL_002c: stelem.ref
+			IL_002d: stloc.3
+			IL_002e: ldloc.2
+			IL_002f: ldloc.3
+			IL_0030: ldarg.2
+			IL_0031: ldstr "phase"
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0040: stloc.2
+			IL_0041: ldstr "{ phase: "
+			IL_0046: ldloc.2
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004c: stloc.s 4
+			IL_004e: ldloc.s 4
+			IL_0050: ldstr ", type: "
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_005a: stloc.s 4
+			IL_005c: ldarg.0
+			IL_005d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0062: stloc.2
+			IL_0063: ldc.i4.1
+			IL_0064: newarr [System.Runtime]System.Object
+			IL_0069: dup
+			IL_006a: ldc.i4.0
+			IL_006b: ldarg.0
+			IL_006c: stelem.ref
+			IL_006d: stloc.3
+			IL_006e: ldloc.2
+			IL_006f: ldloc.3
+			IL_0070: ldarg.2
+			IL_0071: ldstr "type"
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0080: stloc.2
+			IL_0081: ldloc.s 4
+			IL_0083: ldloc.2
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0089: stloc.s 4
+			IL_008b: ldloc.s 4
+			IL_008d: ldstr " }"
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0097: stloc.s 4
 			IL_0099: ldloc.s 4
-			IL_009b: ldloc.2
-			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a1: stloc.s 4
-			IL_00a3: ldloc.s 4
-			IL_00a5: ldstr " }"
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00af: stloc.s 4
-			IL_00b1: ldloc.s 4
-			IL_00b3: ret
+			IL_009b: ret
 		} // end of method formatNegative::__js_call__
 
 	} // end of class formatNegative
@@ -452,7 +444,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x70c0
+					// Method begins at RVA 0x69f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -470,7 +462,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x70b7
+				// Method begins at RVA 0x69ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -497,9 +489,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1f 00 00 02
 			)
-			// Method begins at RVA 0x2b38
+			// Method begins at RVA 0x2b20
 			// Header size: 12
-			// Code size: 253 (0xfd)
+			// Code size: 217 (0xd9)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262MetadataParser/formatIssue/Scope/Block_L40C14,
@@ -525,92 +517,80 @@
 			IL_001c: ldarg.0
 			IL_001d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
 			IL_0022: stloc.2
-			IL_0023: ldstr "formatScalar"
-			IL_0028: ldloc.2
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_002e: stloc.2
-			IL_002f: ldc.i4.1
-			IL_0030: newarr [System.Runtime]System.Object
-			IL_0035: dup
-			IL_0036: ldc.i4.0
-			IL_0037: ldarg.0
-			IL_0038: stelem.ref
-			IL_0039: stloc.3
-			IL_003a: ldloc.2
-			IL_003b: ldloc.3
-			IL_003c: ldarg.2
-			IL_003d: ldstr "code"
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_004c: stloc.2
-			IL_004d: ldstr "{ code: "
-			IL_0052: ldloc.2
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0058: stloc.s 4
-			IL_005a: ldloc.s 4
-			IL_005c: ldstr ", source: "
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0066: stloc.s 4
-			IL_0068: ldarg.0
-			IL_0069: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_006e: stloc.2
-			IL_006f: ldstr "formatScalar"
-			IL_0074: ldloc.2
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_007a: stloc.2
-			IL_007b: ldc.i4.1
-			IL_007c: newarr [System.Runtime]System.Object
-			IL_0081: dup
-			IL_0082: ldc.i4.0
-			IL_0083: ldarg.0
-			IL_0084: stelem.ref
-			IL_0085: stloc.3
-			IL_0086: ldloc.2
-			IL_0087: ldloc.3
-			IL_0088: ldarg.2
-			IL_0089: ldstr "source"
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0098: stloc.2
-			IL_0099: ldloc.s 4
-			IL_009b: ldloc.2
-			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a1: stloc.s 4
-			IL_00a3: ldloc.s 4
-			IL_00a5: ldstr ", reason: "
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00af: stloc.s 4
-			IL_00b1: ldarg.0
-			IL_00b2: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_00b7: stloc.2
-			IL_00b8: ldstr "formatScalar"
-			IL_00bd: ldloc.2
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c3: stloc.2
-			IL_00c4: ldc.i4.1
-			IL_00c5: newarr [System.Runtime]System.Object
-			IL_00ca: dup
-			IL_00cb: ldc.i4.0
-			IL_00cc: ldarg.0
-			IL_00cd: stelem.ref
-			IL_00ce: stloc.3
-			IL_00cf: ldloc.2
-			IL_00d0: ldloc.3
-			IL_00d1: ldarg.2
-			IL_00d2: ldstr "reason"
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00e1: stloc.2
-			IL_00e2: ldloc.s 4
-			IL_00e4: ldloc.2
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00ea: stloc.s 4
-			IL_00ec: ldloc.s 4
-			IL_00ee: ldstr " }"
-			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00f8: stloc.s 4
-			IL_00fa: ldloc.s 4
-			IL_00fc: ret
+			IL_0023: ldc.i4.1
+			IL_0024: newarr [System.Runtime]System.Object
+			IL_0029: dup
+			IL_002a: ldc.i4.0
+			IL_002b: ldarg.0
+			IL_002c: stelem.ref
+			IL_002d: stloc.3
+			IL_002e: ldloc.2
+			IL_002f: ldloc.3
+			IL_0030: ldarg.2
+			IL_0031: ldstr "code"
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0040: stloc.2
+			IL_0041: ldstr "{ code: "
+			IL_0046: ldloc.2
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004c: stloc.s 4
+			IL_004e: ldloc.s 4
+			IL_0050: ldstr ", source: "
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_005a: stloc.s 4
+			IL_005c: ldarg.0
+			IL_005d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0062: stloc.2
+			IL_0063: ldc.i4.1
+			IL_0064: newarr [System.Runtime]System.Object
+			IL_0069: dup
+			IL_006a: ldc.i4.0
+			IL_006b: ldarg.0
+			IL_006c: stelem.ref
+			IL_006d: stloc.3
+			IL_006e: ldloc.2
+			IL_006f: ldloc.3
+			IL_0070: ldarg.2
+			IL_0071: ldstr "source"
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0080: stloc.2
+			IL_0081: ldloc.s 4
+			IL_0083: ldloc.2
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0089: stloc.s 4
+			IL_008b: ldloc.s 4
+			IL_008d: ldstr ", reason: "
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0097: stloc.s 4
+			IL_0099: ldarg.0
+			IL_009a: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_009f: stloc.2
+			IL_00a0: ldc.i4.1
+			IL_00a1: newarr [System.Runtime]System.Object
+			IL_00a6: dup
+			IL_00a7: ldc.i4.0
+			IL_00a8: ldarg.0
+			IL_00a9: stelem.ref
+			IL_00aa: stloc.3
+			IL_00ab: ldloc.2
+			IL_00ac: ldloc.3
+			IL_00ad: ldarg.2
+			IL_00ae: ldstr "reason"
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00bd: stloc.2
+			IL_00be: ldloc.s 4
+			IL_00c0: ldloc.2
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00c6: stloc.s 4
+			IL_00c8: ldloc.s 4
+			IL_00ca: ldstr " }"
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00d4: stloc.s 4
+			IL_00d6: ldloc.s 4
+			IL_00d8: ret
 		} // end of method formatIssue::__js_call__
 
 	} // end of class formatIssue
@@ -626,7 +606,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x70c9
+				// Method begins at RVA 0x69ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -654,14 +634,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1f 00 00 02
 			)
-			// Method begins at RVA 0x2c44
+			// Method begins at RVA 0x2c08
 			// Header size: 12
-			// Code size: 5476 (0x1564)
+			// Code size: 4838 (0x12e6)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] object[],
+				[1] object[],
+				[2] object,
 				[3] object
 			)
 
@@ -671,2012 +651,1798 @@
 			IL_000b: ldloc.0
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
-			IL_0012: ldarg.0
-			IL_0013: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0018: stloc.1
-			IL_0019: ldstr "formatScalar"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: ldc.i4.1
-			IL_0026: newarr [System.Runtime]System.Object
-			IL_002b: dup
-			IL_002c: ldc.i4.0
-			IL_002d: ldarg.0
-			IL_002e: stelem.ref
-			IL_002f: stloc.2
-			IL_0030: ldloc.1
-			IL_0031: ldloc.2
-			IL_0032: ldarg.2
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0038: stloc.1
-			IL_0039: ldstr "name: "
-			IL_003e: ldloc.1
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0044: stloc.3
-			IL_0045: ldloc.0
-			IL_0046: ldstr "log"
-			IL_004b: ldloc.3
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0051: pop
-			IL_0052: ldstr "console"
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_005c: stloc.0
-			IL_005d: ldloc.0
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0063: stloc.0
-			IL_0064: ldarg.0
-			IL_0065: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_006a: stloc.1
-			IL_006b: ldstr "formatScalar"
-			IL_0070: ldloc.1
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0076: stloc.1
-			IL_0077: ldc.i4.1
-			IL_0078: newarr [System.Runtime]System.Object
-			IL_007d: dup
-			IL_007e: ldc.i4.0
-			IL_007f: ldarg.0
-			IL_0080: stelem.ref
-			IL_0081: stloc.2
-			IL_0082: ldloc.1
-			IL_0083: ldloc.2
-			IL_0084: ldarg.3
-			IL_0085: ldstr "filePath"
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0094: stloc.1
-			IL_0095: ldstr "filePath: "
-			IL_009a: ldloc.1
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a0: stloc.3
-			IL_00a1: ldloc.0
-			IL_00a2: ldstr "log"
-			IL_00a7: ldloc.3
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ad: pop
-			IL_00ae: ldstr "console"
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b8: stloc.0
-			IL_00b9: ldloc.0
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00bf: stloc.0
-			IL_00c0: ldarg.0
-			IL_00c1: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_00c6: stloc.1
-			IL_00c7: ldstr "formatScalar"
-			IL_00cc: ldloc.1
-			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00d2: stloc.1
-			IL_00d3: ldc.i4.1
-			IL_00d4: newarr [System.Runtime]System.Object
-			IL_00d9: dup
-			IL_00da: ldc.i4.0
-			IL_00db: ldarg.0
-			IL_00dc: stelem.ref
-			IL_00dd: stloc.2
-			IL_00de: ldloc.1
-			IL_00df: ldloc.2
-			IL_00e0: ldarg.3
-			IL_00e1: ldstr "fileName"
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00f0: stloc.1
-			IL_00f1: ldstr "fileName: "
-			IL_00f6: ldloc.1
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00fc: stloc.3
-			IL_00fd: ldloc.0
-			IL_00fe: ldstr "log"
-			IL_0103: ldloc.3
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0109: pop
-			IL_010a: ldstr "console"
-			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0114: stloc.0
-			IL_0115: ldloc.0
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011b: stloc.0
-			IL_011c: ldarg.0
-			IL_011d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0122: stloc.1
-			IL_0123: ldstr "formatScalar"
-			IL_0128: ldloc.1
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_012e: stloc.1
-			IL_012f: ldc.i4.1
-			IL_0130: newarr [System.Runtime]System.Object
-			IL_0135: dup
-			IL_0136: ldc.i4.0
-			IL_0137: ldarg.0
-			IL_0138: stelem.ref
-			IL_0139: stloc.2
-			IL_013a: ldloc.1
-			IL_013b: ldloc.2
-			IL_013c: ldarg.3
-			IL_013d: ldstr "hasFrontmatter"
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_014c: stloc.1
-			IL_014d: ldstr "hasFrontmatter: "
-			IL_0152: ldloc.1
-			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0158: stloc.3
-			IL_0159: ldloc.0
-			IL_015a: ldstr "log"
-			IL_015f: ldloc.3
-			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0165: pop
-			IL_0166: ldstr "console"
-			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0170: stloc.0
-			IL_0171: ldloc.0
-			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0177: stloc.0
-			IL_0178: ldarg.0
-			IL_0179: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_017e: stloc.1
-			IL_017f: ldstr "formatScalar"
-			IL_0184: ldloc.1
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_018a: stloc.1
-			IL_018b: ldc.i4.1
-			IL_018c: newarr [System.Runtime]System.Object
-			IL_0191: dup
-			IL_0192: ldc.i4.0
-			IL_0193: ldarg.0
-			IL_0194: stelem.ref
-			IL_0195: stloc.2
-			IL_0196: ldloc.1
-			IL_0197: ldloc.2
-			IL_0198: ldarg.3
-			IL_0199: ldstr "unknownKeys"
-			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a3: ldstr "length"
-			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01b2: stloc.1
-			IL_01b3: ldstr "unknownKeys.length: "
-			IL_01b8: ldloc.1
-			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01be: stloc.3
-			IL_01bf: ldloc.0
-			IL_01c0: ldstr "log"
-			IL_01c5: ldloc.3
-			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01cb: pop
-			IL_01cc: ldstr "console"
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01d6: stloc.0
-			IL_01d7: ldloc.0
-			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01dd: stloc.0
-			IL_01de: ldarg.0
-			IL_01df: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_01e4: stloc.1
-			IL_01e5: ldstr "formatScalar"
-			IL_01ea: ldloc.1
-			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01f0: stloc.1
-			IL_01f1: ldc.i4.1
-			IL_01f2: newarr [System.Runtime]System.Object
-			IL_01f7: dup
-			IL_01f8: ldc.i4.0
-			IL_01f9: ldarg.0
-			IL_01fa: stelem.ref
-			IL_01fb: stloc.2
-			IL_01fc: ldloc.1
-			IL_01fd: ldloc.2
-			IL_01fe: ldarg.3
-			IL_01ff: ldstr "unknownKeys"
-			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0209: ldc.r8 0.0
-			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_021c: stloc.1
-			IL_021d: ldstr "unknownKeys[0]: "
-			IL_0222: ldloc.1
-			IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0228: stloc.3
-			IL_0229: ldloc.0
-			IL_022a: ldstr "log"
-			IL_022f: ldloc.3
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0235: pop
-			IL_0236: ldstr "console"
-			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0240: stloc.0
-			IL_0241: ldloc.0
-			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0247: stloc.0
-			IL_0248: ldarg.0
-			IL_0249: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_024e: stloc.1
-			IL_024f: ldstr "formatScalar"
-			IL_0254: ldloc.1
-			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_025a: stloc.1
-			IL_025b: ldc.i4.1
-			IL_025c: newarr [System.Runtime]System.Object
-			IL_0261: dup
-			IL_0262: ldc.i4.0
-			IL_0263: ldarg.0
-			IL_0264: stelem.ref
-			IL_0265: stloc.2
-			IL_0266: ldloc.1
-			IL_0267: ldloc.2
-			IL_0268: ldarg.3
-			IL_0269: ldstr "description"
-			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0278: stloc.1
-			IL_0279: ldstr "description: "
-			IL_027e: ldloc.1
-			IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0284: stloc.3
-			IL_0285: ldloc.0
-			IL_0286: ldstr "log"
-			IL_028b: ldloc.3
-			IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0291: pop
-			IL_0292: ldstr "console"
-			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_029c: stloc.0
-			IL_029d: ldloc.0
-			IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a3: stloc.0
-			IL_02a4: ldarg.0
-			IL_02a5: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_02aa: stloc.1
-			IL_02ab: ldstr "formatScalar"
-			IL_02b0: ldloc.1
-			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02b6: stloc.1
-			IL_02b7: ldc.i4.1
-			IL_02b8: newarr [System.Runtime]System.Object
-			IL_02bd: dup
-			IL_02be: ldc.i4.0
-			IL_02bf: ldarg.0
-			IL_02c0: stelem.ref
-			IL_02c1: stloc.2
-			IL_02c2: ldloc.1
-			IL_02c3: ldloc.2
-			IL_02c4: ldarg.3
-			IL_02c5: ldstr "info"
-			IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_02d4: stloc.1
-			IL_02d5: ldstr "info: "
-			IL_02da: ldloc.1
-			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02e0: stloc.3
-			IL_02e1: ldloc.0
-			IL_02e2: ldstr "log"
-			IL_02e7: ldloc.3
-			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02ed: pop
-			IL_02ee: ldstr "console"
-			IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02f8: stloc.0
-			IL_02f9: ldloc.0
-			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ff: stloc.0
-			IL_0300: ldarg.0
-			IL_0301: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0306: stloc.1
-			IL_0307: ldstr "formatScalar"
-			IL_030c: ldloc.1
-			IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0312: stloc.1
-			IL_0313: ldc.i4.1
-			IL_0314: newarr [System.Runtime]System.Object
-			IL_0319: dup
-			IL_031a: ldc.i4.0
-			IL_031b: ldarg.0
-			IL_031c: stelem.ref
-			IL_031d: stloc.2
-			IL_031e: ldloc.1
-			IL_031f: ldloc.2
-			IL_0320: ldarg.3
-			IL_0321: ldstr "esid"
-			IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0330: stloc.1
-			IL_0331: ldstr "esid: "
-			IL_0336: ldloc.1
-			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_033c: stloc.3
-			IL_033d: ldloc.0
-			IL_033e: ldstr "log"
-			IL_0343: ldloc.3
-			IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0349: pop
-			IL_034a: ldstr "console"
-			IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0354: stloc.0
-			IL_0355: ldloc.0
-			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_035b: stloc.0
-			IL_035c: ldarg.0
-			IL_035d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0362: stloc.1
-			IL_0363: ldstr "formatScalar"
-			IL_0368: ldloc.1
-			IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_036e: stloc.1
-			IL_036f: ldc.i4.1
-			IL_0370: newarr [System.Runtime]System.Object
-			IL_0375: dup
-			IL_0376: ldc.i4.0
-			IL_0377: ldarg.0
-			IL_0378: stelem.ref
-			IL_0379: stloc.2
-			IL_037a: ldloc.1
-			IL_037b: ldloc.2
-			IL_037c: ldarg.3
-			IL_037d: ldstr "es5id"
-			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_038c: stloc.1
-			IL_038d: ldstr "es5id: "
-			IL_0392: ldloc.1
-			IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0398: stloc.3
-			IL_0399: ldloc.0
-			IL_039a: ldstr "log"
-			IL_039f: ldloc.3
-			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03a5: pop
-			IL_03a6: ldstr "console"
-			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03b0: stloc.0
-			IL_03b1: ldloc.0
-			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b7: stloc.0
-			IL_03b8: ldarg.0
-			IL_03b9: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_03be: stloc.1
-			IL_03bf: ldstr "formatScalar"
-			IL_03c4: ldloc.1
-			IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03ca: stloc.1
-			IL_03cb: ldc.i4.1
-			IL_03cc: newarr [System.Runtime]System.Object
-			IL_03d1: dup
-			IL_03d2: ldc.i4.0
-			IL_03d3: ldarg.0
-			IL_03d4: stelem.ref
-			IL_03d5: stloc.2
-			IL_03d6: ldloc.1
-			IL_03d7: ldloc.2
-			IL_03d8: ldarg.3
-			IL_03d9: ldstr "includes"
-			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e3: ldstr "length"
-			IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_03f2: stloc.1
-			IL_03f3: ldstr "includes.length: "
-			IL_03f8: ldloc.1
-			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03fe: stloc.3
-			IL_03ff: ldloc.0
-			IL_0400: ldstr "log"
-			IL_0405: ldloc.3
-			IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_040b: pop
-			IL_040c: ldstr "console"
-			IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0416: stloc.0
-			IL_0417: ldloc.0
-			IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_041d: stloc.0
-			IL_041e: ldarg.0
-			IL_041f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0424: stloc.1
-			IL_0425: ldstr "formatScalar"
-			IL_042a: ldloc.1
-			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0430: stloc.1
-			IL_0431: ldc.i4.1
-			IL_0432: newarr [System.Runtime]System.Object
-			IL_0437: dup
-			IL_0438: ldc.i4.0
-			IL_0439: ldarg.0
-			IL_043a: stelem.ref
-			IL_043b: stloc.2
-			IL_043c: ldloc.1
-			IL_043d: ldloc.2
-			IL_043e: ldarg.3
-			IL_043f: ldstr "includes"
-			IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0449: ldc.r8 0.0
-			IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_045c: stloc.1
-			IL_045d: ldstr "includes[0]: "
-			IL_0462: ldloc.1
-			IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0468: stloc.3
-			IL_0469: ldloc.0
-			IL_046a: ldstr "log"
-			IL_046f: ldloc.3
-			IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0475: pop
-			IL_0476: ldstr "console"
-			IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0480: stloc.0
-			IL_0481: ldloc.0
-			IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0487: stloc.0
-			IL_0488: ldarg.0
-			IL_0489: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_048e: stloc.1
-			IL_048f: ldstr "formatScalar"
-			IL_0494: ldloc.1
-			IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_049a: stloc.1
-			IL_049b: ldc.i4.1
-			IL_049c: newarr [System.Runtime]System.Object
-			IL_04a1: dup
-			IL_04a2: ldc.i4.0
-			IL_04a3: ldarg.0
-			IL_04a4: stelem.ref
-			IL_04a5: stloc.2
-			IL_04a6: ldloc.1
-			IL_04a7: ldloc.2
-			IL_04a8: ldarg.3
-			IL_04a9: ldstr "includes"
-			IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04b3: ldc.r8 1
-			IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_04c6: stloc.1
-			IL_04c7: ldstr "includes[1]: "
-			IL_04cc: ldloc.1
-			IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04d2: stloc.3
-			IL_04d3: ldloc.0
-			IL_04d4: ldstr "log"
-			IL_04d9: ldloc.3
-			IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_04df: pop
-			IL_04e0: ldstr "console"
-			IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04ea: stloc.0
-			IL_04eb: ldloc.0
-			IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04f1: stloc.0
-			IL_04f2: ldarg.0
-			IL_04f3: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_04f8: stloc.1
-			IL_04f9: ldstr "formatScalar"
-			IL_04fe: ldloc.1
-			IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0504: stloc.1
-			IL_0505: ldc.i4.1
-			IL_0506: newarr [System.Runtime]System.Object
-			IL_050b: dup
-			IL_050c: ldc.i4.0
-			IL_050d: ldarg.0
-			IL_050e: stelem.ref
-			IL_050f: stloc.2
-			IL_0510: ldloc.1
-			IL_0511: ldloc.2
-			IL_0512: ldarg.3
-			IL_0513: ldstr "flags"
-			IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_051d: ldstr "length"
-			IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_052c: stloc.1
-			IL_052d: ldstr "flags.length: "
-			IL_0532: ldloc.1
-			IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0538: stloc.3
-			IL_0539: ldloc.0
-			IL_053a: ldstr "log"
-			IL_053f: ldloc.3
-			IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0545: pop
-			IL_0546: ldstr "console"
-			IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0550: stloc.0
-			IL_0551: ldloc.0
-			IL_0552: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0557: stloc.0
-			IL_0558: ldarg.0
-			IL_0559: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_055e: stloc.1
-			IL_055f: ldstr "formatScalar"
-			IL_0564: ldloc.1
-			IL_0565: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_056a: stloc.1
-			IL_056b: ldc.i4.1
-			IL_056c: newarr [System.Runtime]System.Object
-			IL_0571: dup
-			IL_0572: ldc.i4.0
-			IL_0573: ldarg.0
-			IL_0574: stelem.ref
-			IL_0575: stloc.2
-			IL_0576: ldloc.1
-			IL_0577: ldloc.2
-			IL_0578: ldarg.3
-			IL_0579: ldstr "flags"
-			IL_057e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0583: ldc.r8 0.0
-			IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0591: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0596: stloc.1
-			IL_0597: ldstr "flags[0]: "
-			IL_059c: ldloc.1
-			IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05a2: stloc.3
-			IL_05a3: ldloc.0
-			IL_05a4: ldstr "log"
-			IL_05a9: ldloc.3
-			IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05af: pop
-			IL_05b0: ldstr "console"
-			IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05ba: stloc.0
-			IL_05bb: ldloc.0
-			IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05c1: stloc.0
-			IL_05c2: ldarg.0
-			IL_05c3: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_05c8: stloc.1
-			IL_05c9: ldstr "formatScalar"
-			IL_05ce: ldloc.1
-			IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_05d4: stloc.1
-			IL_05d5: ldc.i4.1
-			IL_05d6: newarr [System.Runtime]System.Object
-			IL_05db: dup
-			IL_05dc: ldc.i4.0
-			IL_05dd: ldarg.0
-			IL_05de: stelem.ref
-			IL_05df: stloc.2
-			IL_05e0: ldloc.1
-			IL_05e1: ldloc.2
-			IL_05e2: ldarg.3
-			IL_05e3: ldstr "flags"
-			IL_05e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05ed: ldc.r8 1
-			IL_05f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_05fb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0600: stloc.1
-			IL_0601: ldstr "flags[1]: "
-			IL_0606: ldloc.1
-			IL_0607: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_060c: stloc.3
-			IL_060d: ldloc.0
-			IL_060e: ldstr "log"
-			IL_0613: ldloc.3
-			IL_0614: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0619: pop
-			IL_061a: ldstr "console"
-			IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0624: stloc.0
-			IL_0625: ldloc.0
-			IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_062b: stloc.0
-			IL_062c: ldarg.0
-			IL_062d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0632: stloc.1
-			IL_0633: ldstr "formatScalar"
-			IL_0638: ldloc.1
-			IL_0639: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_063e: stloc.1
-			IL_063f: ldc.i4.1
-			IL_0640: newarr [System.Runtime]System.Object
-			IL_0645: dup
-			IL_0646: ldc.i4.0
-			IL_0647: ldarg.0
-			IL_0648: stelem.ref
-			IL_0649: stloc.2
-			IL_064a: ldloc.1
-			IL_064b: ldloc.2
-			IL_064c: ldarg.3
-			IL_064d: ldstr "flags"
-			IL_0652: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0657: ldc.r8 2
-			IL_0660: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0665: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_066a: stloc.1
-			IL_066b: ldstr "flags[2]: "
-			IL_0670: ldloc.1
-			IL_0671: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0676: stloc.3
-			IL_0677: ldloc.0
-			IL_0678: ldstr "log"
-			IL_067d: ldloc.3
-			IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0683: pop
-			IL_0684: ldstr "console"
-			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_068e: stloc.0
-			IL_068f: ldloc.0
-			IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0695: stloc.0
-			IL_0696: ldarg.0
-			IL_0697: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_069c: stloc.1
-			IL_069d: ldstr "formatScalar"
-			IL_06a2: ldloc.1
-			IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06a8: stloc.1
-			IL_06a9: ldc.i4.1
-			IL_06aa: newarr [System.Runtime]System.Object
-			IL_06af: dup
-			IL_06b0: ldc.i4.0
-			IL_06b1: ldarg.0
-			IL_06b2: stelem.ref
-			IL_06b3: stloc.2
-			IL_06b4: ldloc.1
-			IL_06b5: ldloc.2
-			IL_06b6: ldarg.3
-			IL_06b7: ldstr "features"
-			IL_06bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06c1: ldstr "length"
-			IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_06d0: stloc.1
-			IL_06d1: ldstr "features.length: "
-			IL_06d6: ldloc.1
-			IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06dc: stloc.3
-			IL_06dd: ldloc.0
-			IL_06de: ldstr "log"
-			IL_06e3: ldloc.3
-			IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_06e9: pop
-			IL_06ea: ldstr "console"
-			IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06f4: stloc.0
-			IL_06f5: ldloc.0
-			IL_06f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06fb: stloc.0
-			IL_06fc: ldarg.0
-			IL_06fd: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0702: stloc.1
-			IL_0703: ldstr "formatScalar"
-			IL_0708: ldloc.1
-			IL_0709: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_070e: stloc.1
-			IL_070f: ldc.i4.1
-			IL_0710: newarr [System.Runtime]System.Object
-			IL_0715: dup
-			IL_0716: ldc.i4.0
-			IL_0717: ldarg.0
-			IL_0718: stelem.ref
-			IL_0719: stloc.2
-			IL_071a: ldloc.1
-			IL_071b: ldloc.2
-			IL_071c: ldarg.3
-			IL_071d: ldstr "features"
-			IL_0722: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0727: ldc.r8 0.0
-			IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0735: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_073a: stloc.1
-			IL_073b: ldstr "features[0]: "
-			IL_0740: ldloc.1
-			IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0746: stloc.3
-			IL_0747: ldloc.0
-			IL_0748: ldstr "log"
-			IL_074d: ldloc.3
-			IL_074e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0753: pop
-			IL_0754: ldstr "console"
-			IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_075e: stloc.0
-			IL_075f: ldloc.0
-			IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0765: stloc.0
-			IL_0766: ldarg.0
-			IL_0767: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_076c: stloc.1
-			IL_076d: ldstr "formatScalar"
-			IL_0772: ldloc.1
-			IL_0773: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0778: stloc.1
-			IL_0779: ldc.i4.1
-			IL_077a: newarr [System.Runtime]System.Object
-			IL_077f: dup
-			IL_0780: ldc.i4.0
-			IL_0781: ldarg.0
-			IL_0782: stelem.ref
-			IL_0783: stloc.2
-			IL_0784: ldloc.1
-			IL_0785: ldloc.2
-			IL_0786: ldarg.3
-			IL_0787: ldstr "features"
-			IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0791: ldc.r8 1
-			IL_079a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_079f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_07a4: stloc.1
-			IL_07a5: ldstr "features[1]: "
-			IL_07aa: ldloc.1
-			IL_07ab: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_07b0: stloc.3
-			IL_07b1: ldloc.0
-			IL_07b2: ldstr "log"
-			IL_07b7: ldloc.3
-			IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_07bd: pop
-			IL_07be: ldstr "console"
-			IL_07c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07c8: stloc.0
-			IL_07c9: ldloc.0
-			IL_07ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07cf: stloc.0
-			IL_07d0: ldarg.0
-			IL_07d1: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_07d6: stloc.1
-			IL_07d7: ldstr "formatScalar"
-			IL_07dc: ldloc.1
-			IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_07e2: stloc.1
-			IL_07e3: ldc.i4.1
-			IL_07e4: newarr [System.Runtime]System.Object
-			IL_07e9: dup
-			IL_07ea: ldc.i4.0
-			IL_07eb: ldarg.0
-			IL_07ec: stelem.ref
-			IL_07ed: stloc.2
-			IL_07ee: ldloc.1
-			IL_07ef: ldloc.2
-			IL_07f0: ldarg.3
-			IL_07f1: ldstr "locale"
-			IL_07f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07fb: ldstr "length"
-			IL_0800: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_080a: stloc.1
-			IL_080b: ldstr "locale.length: "
-			IL_0810: ldloc.1
-			IL_0811: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0816: stloc.3
-			IL_0817: ldloc.0
-			IL_0818: ldstr "log"
-			IL_081d: ldloc.3
-			IL_081e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0823: pop
-			IL_0824: ldstr "console"
-			IL_0829: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_082e: stloc.0
+			IL_0012: ldc.i4.1
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldarg.0
+			IL_001b: stelem.ref
+			IL_001c: stloc.1
+			IL_001d: ldarg.0
+			IL_001e: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0023: ldloc.1
+			IL_0024: ldarg.2
+			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_002a: stloc.2
+			IL_002b: ldstr "name: "
+			IL_0030: ldloc.2
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0036: stloc.3
+			IL_0037: ldloc.0
+			IL_0038: ldstr "log"
+			IL_003d: ldloc.3
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0043: pop
+			IL_0044: ldstr "console"
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_004e: stloc.0
+			IL_004f: ldloc.0
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0055: stloc.0
+			IL_0056: ldarg.0
+			IL_0057: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_005c: stloc.2
+			IL_005d: ldc.i4.1
+			IL_005e: newarr [System.Runtime]System.Object
+			IL_0063: dup
+			IL_0064: ldc.i4.0
+			IL_0065: ldarg.0
+			IL_0066: stelem.ref
+			IL_0067: stloc.1
+			IL_0068: ldloc.2
+			IL_0069: ldloc.1
+			IL_006a: ldarg.3
+			IL_006b: ldstr "filePath"
+			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_007a: stloc.2
+			IL_007b: ldstr "filePath: "
+			IL_0080: ldloc.2
+			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0086: stloc.3
+			IL_0087: ldloc.0
+			IL_0088: ldstr "log"
+			IL_008d: ldloc.3
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0093: pop
+			IL_0094: ldstr "console"
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_009e: stloc.0
+			IL_009f: ldloc.0
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a5: stloc.0
+			IL_00a6: ldarg.0
+			IL_00a7: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_00ac: stloc.2
+			IL_00ad: ldc.i4.1
+			IL_00ae: newarr [System.Runtime]System.Object
+			IL_00b3: dup
+			IL_00b4: ldc.i4.0
+			IL_00b5: ldarg.0
+			IL_00b6: stelem.ref
+			IL_00b7: stloc.1
+			IL_00b8: ldloc.2
+			IL_00b9: ldloc.1
+			IL_00ba: ldarg.3
+			IL_00bb: ldstr "fileName"
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00ca: stloc.2
+			IL_00cb: ldstr "fileName: "
+			IL_00d0: ldloc.2
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00d6: stloc.3
+			IL_00d7: ldloc.0
+			IL_00d8: ldstr "log"
+			IL_00dd: ldloc.3
+			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e3: pop
+			IL_00e4: ldstr "console"
+			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ee: stloc.0
+			IL_00ef: ldloc.0
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f5: stloc.0
+			IL_00f6: ldarg.0
+			IL_00f7: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_00fc: stloc.2
+			IL_00fd: ldc.i4.1
+			IL_00fe: newarr [System.Runtime]System.Object
+			IL_0103: dup
+			IL_0104: ldc.i4.0
+			IL_0105: ldarg.0
+			IL_0106: stelem.ref
+			IL_0107: stloc.1
+			IL_0108: ldloc.2
+			IL_0109: ldloc.1
+			IL_010a: ldarg.3
+			IL_010b: ldstr "hasFrontmatter"
+			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_011a: stloc.2
+			IL_011b: ldstr "hasFrontmatter: "
+			IL_0120: ldloc.2
+			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0126: stloc.3
+			IL_0127: ldloc.0
+			IL_0128: ldstr "log"
+			IL_012d: ldloc.3
+			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0133: pop
+			IL_0134: ldstr "console"
+			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_013e: stloc.0
+			IL_013f: ldloc.0
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0145: stloc.0
+			IL_0146: ldarg.0
+			IL_0147: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_014c: stloc.2
+			IL_014d: ldc.i4.1
+			IL_014e: newarr [System.Runtime]System.Object
+			IL_0153: dup
+			IL_0154: ldc.i4.0
+			IL_0155: ldarg.0
+			IL_0156: stelem.ref
+			IL_0157: stloc.1
+			IL_0158: ldloc.2
+			IL_0159: ldloc.1
+			IL_015a: ldarg.3
+			IL_015b: ldstr "unknownKeys"
+			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0165: ldstr "length"
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0174: stloc.2
+			IL_0175: ldstr "unknownKeys.length: "
+			IL_017a: ldloc.2
+			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0180: stloc.3
+			IL_0181: ldloc.0
+			IL_0182: ldstr "log"
+			IL_0187: ldloc.3
+			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_018d: pop
+			IL_018e: ldstr "console"
+			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0198: stloc.0
+			IL_0199: ldloc.0
+			IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_019f: stloc.0
+			IL_01a0: ldarg.0
+			IL_01a1: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_01a6: stloc.2
+			IL_01a7: ldc.i4.1
+			IL_01a8: newarr [System.Runtime]System.Object
+			IL_01ad: dup
+			IL_01ae: ldc.i4.0
+			IL_01af: ldarg.0
+			IL_01b0: stelem.ref
+			IL_01b1: stloc.1
+			IL_01b2: ldloc.2
+			IL_01b3: ldloc.1
+			IL_01b4: ldarg.3
+			IL_01b5: ldstr "unknownKeys"
+			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01bf: ldc.r8 0.0
+			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_01d2: stloc.2
+			IL_01d3: ldstr "unknownKeys[0]: "
+			IL_01d8: ldloc.2
+			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01de: stloc.3
+			IL_01df: ldloc.0
+			IL_01e0: ldstr "log"
+			IL_01e5: ldloc.3
+			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01eb: pop
+			IL_01ec: ldstr "console"
+			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01f6: stloc.0
+			IL_01f7: ldloc.0
+			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01fd: stloc.0
+			IL_01fe: ldarg.0
+			IL_01ff: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0204: stloc.2
+			IL_0205: ldc.i4.1
+			IL_0206: newarr [System.Runtime]System.Object
+			IL_020b: dup
+			IL_020c: ldc.i4.0
+			IL_020d: ldarg.0
+			IL_020e: stelem.ref
+			IL_020f: stloc.1
+			IL_0210: ldloc.2
+			IL_0211: ldloc.1
+			IL_0212: ldarg.3
+			IL_0213: ldstr "description"
+			IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0222: stloc.2
+			IL_0223: ldstr "description: "
+			IL_0228: ldloc.2
+			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_022e: stloc.3
+			IL_022f: ldloc.0
+			IL_0230: ldstr "log"
+			IL_0235: ldloc.3
+			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_023b: pop
+			IL_023c: ldstr "console"
+			IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0246: stloc.0
+			IL_0247: ldloc.0
+			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_024d: stloc.0
+			IL_024e: ldarg.0
+			IL_024f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0254: stloc.2
+			IL_0255: ldc.i4.1
+			IL_0256: newarr [System.Runtime]System.Object
+			IL_025b: dup
+			IL_025c: ldc.i4.0
+			IL_025d: ldarg.0
+			IL_025e: stelem.ref
+			IL_025f: stloc.1
+			IL_0260: ldloc.2
+			IL_0261: ldloc.1
+			IL_0262: ldarg.3
+			IL_0263: ldstr "info"
+			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0272: stloc.2
+			IL_0273: ldstr "info: "
+			IL_0278: ldloc.2
+			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_027e: stloc.3
+			IL_027f: ldloc.0
+			IL_0280: ldstr "log"
+			IL_0285: ldloc.3
+			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_028b: pop
+			IL_028c: ldstr "console"
+			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0296: stloc.0
+			IL_0297: ldloc.0
+			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_029d: stloc.0
+			IL_029e: ldarg.0
+			IL_029f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_02a4: stloc.2
+			IL_02a5: ldc.i4.1
+			IL_02a6: newarr [System.Runtime]System.Object
+			IL_02ab: dup
+			IL_02ac: ldc.i4.0
+			IL_02ad: ldarg.0
+			IL_02ae: stelem.ref
+			IL_02af: stloc.1
+			IL_02b0: ldloc.2
+			IL_02b1: ldloc.1
+			IL_02b2: ldarg.3
+			IL_02b3: ldstr "esid"
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_02c2: stloc.2
+			IL_02c3: ldstr "esid: "
+			IL_02c8: ldloc.2
+			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ce: stloc.3
+			IL_02cf: ldloc.0
+			IL_02d0: ldstr "log"
+			IL_02d5: ldloc.3
+			IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02db: pop
+			IL_02dc: ldstr "console"
+			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02e6: stloc.0
+			IL_02e7: ldloc.0
+			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ed: stloc.0
+			IL_02ee: ldarg.0
+			IL_02ef: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_02f4: stloc.2
+			IL_02f5: ldc.i4.1
+			IL_02f6: newarr [System.Runtime]System.Object
+			IL_02fb: dup
+			IL_02fc: ldc.i4.0
+			IL_02fd: ldarg.0
+			IL_02fe: stelem.ref
+			IL_02ff: stloc.1
+			IL_0300: ldloc.2
+			IL_0301: ldloc.1
+			IL_0302: ldarg.3
+			IL_0303: ldstr "es5id"
+			IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0312: stloc.2
+			IL_0313: ldstr "es5id: "
+			IL_0318: ldloc.2
+			IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_031e: stloc.3
+			IL_031f: ldloc.0
+			IL_0320: ldstr "log"
+			IL_0325: ldloc.3
+			IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_032b: pop
+			IL_032c: ldstr "console"
+			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0336: stloc.0
+			IL_0337: ldloc.0
+			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_033d: stloc.0
+			IL_033e: ldarg.0
+			IL_033f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0344: stloc.2
+			IL_0345: ldc.i4.1
+			IL_0346: newarr [System.Runtime]System.Object
+			IL_034b: dup
+			IL_034c: ldc.i4.0
+			IL_034d: ldarg.0
+			IL_034e: stelem.ref
+			IL_034f: stloc.1
+			IL_0350: ldloc.2
+			IL_0351: ldloc.1
+			IL_0352: ldarg.3
+			IL_0353: ldstr "includes"
+			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_035d: ldstr "length"
+			IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_036c: stloc.2
+			IL_036d: ldstr "includes.length: "
+			IL_0372: ldloc.2
+			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0378: stloc.3
+			IL_0379: ldloc.0
+			IL_037a: ldstr "log"
+			IL_037f: ldloc.3
+			IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0385: pop
+			IL_0386: ldstr "console"
+			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0390: stloc.0
+			IL_0391: ldloc.0
+			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0397: stloc.0
+			IL_0398: ldarg.0
+			IL_0399: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_039e: stloc.2
+			IL_039f: ldc.i4.1
+			IL_03a0: newarr [System.Runtime]System.Object
+			IL_03a5: dup
+			IL_03a6: ldc.i4.0
+			IL_03a7: ldarg.0
+			IL_03a8: stelem.ref
+			IL_03a9: stloc.1
+			IL_03aa: ldloc.2
+			IL_03ab: ldloc.1
+			IL_03ac: ldarg.3
+			IL_03ad: ldstr "includes"
+			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03b7: ldc.r8 0.0
+			IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_03ca: stloc.2
+			IL_03cb: ldstr "includes[0]: "
+			IL_03d0: ldloc.2
+			IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_03d6: stloc.3
+			IL_03d7: ldloc.0
+			IL_03d8: ldstr "log"
+			IL_03dd: ldloc.3
+			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03e3: pop
+			IL_03e4: ldstr "console"
+			IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03ee: stloc.0
+			IL_03ef: ldloc.0
+			IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03f5: stloc.0
+			IL_03f6: ldarg.0
+			IL_03f7: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_03fc: stloc.2
+			IL_03fd: ldc.i4.1
+			IL_03fe: newarr [System.Runtime]System.Object
+			IL_0403: dup
+			IL_0404: ldc.i4.0
+			IL_0405: ldarg.0
+			IL_0406: stelem.ref
+			IL_0407: stloc.1
+			IL_0408: ldloc.2
+			IL_0409: ldloc.1
+			IL_040a: ldarg.3
+			IL_040b: ldstr "includes"
+			IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0415: ldc.r8 1
+			IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0428: stloc.2
+			IL_0429: ldstr "includes[1]: "
+			IL_042e: ldloc.2
+			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0434: stloc.3
+			IL_0435: ldloc.0
+			IL_0436: ldstr "log"
+			IL_043b: ldloc.3
+			IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0441: pop
+			IL_0442: ldstr "console"
+			IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_044c: stloc.0
+			IL_044d: ldloc.0
+			IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0453: stloc.0
+			IL_0454: ldarg.0
+			IL_0455: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_045a: stloc.2
+			IL_045b: ldc.i4.1
+			IL_045c: newarr [System.Runtime]System.Object
+			IL_0461: dup
+			IL_0462: ldc.i4.0
+			IL_0463: ldarg.0
+			IL_0464: stelem.ref
+			IL_0465: stloc.1
+			IL_0466: ldloc.2
+			IL_0467: ldloc.1
+			IL_0468: ldarg.3
+			IL_0469: ldstr "flags"
+			IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0473: ldstr "length"
+			IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0482: stloc.2
+			IL_0483: ldstr "flags.length: "
+			IL_0488: ldloc.2
+			IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_048e: stloc.3
+			IL_048f: ldloc.0
+			IL_0490: ldstr "log"
+			IL_0495: ldloc.3
+			IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_049b: pop
+			IL_049c: ldstr "console"
+			IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04a6: stloc.0
+			IL_04a7: ldloc.0
+			IL_04a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04ad: stloc.0
+			IL_04ae: ldarg.0
+			IL_04af: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_04b4: stloc.2
+			IL_04b5: ldc.i4.1
+			IL_04b6: newarr [System.Runtime]System.Object
+			IL_04bb: dup
+			IL_04bc: ldc.i4.0
+			IL_04bd: ldarg.0
+			IL_04be: stelem.ref
+			IL_04bf: stloc.1
+			IL_04c0: ldloc.2
+			IL_04c1: ldloc.1
+			IL_04c2: ldarg.3
+			IL_04c3: ldstr "flags"
+			IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04cd: ldc.r8 0.0
+			IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_04e0: stloc.2
+			IL_04e1: ldstr "flags[0]: "
+			IL_04e6: ldloc.2
+			IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04ec: stloc.3
+			IL_04ed: ldloc.0
+			IL_04ee: ldstr "log"
+			IL_04f3: ldloc.3
+			IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_04f9: pop
+			IL_04fa: ldstr "console"
+			IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0504: stloc.0
+			IL_0505: ldloc.0
+			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_050b: stloc.0
+			IL_050c: ldarg.0
+			IL_050d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0512: stloc.2
+			IL_0513: ldc.i4.1
+			IL_0514: newarr [System.Runtime]System.Object
+			IL_0519: dup
+			IL_051a: ldc.i4.0
+			IL_051b: ldarg.0
+			IL_051c: stelem.ref
+			IL_051d: stloc.1
+			IL_051e: ldloc.2
+			IL_051f: ldloc.1
+			IL_0520: ldarg.3
+			IL_0521: ldstr "flags"
+			IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_052b: ldc.r8 1
+			IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0539: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_053e: stloc.2
+			IL_053f: ldstr "flags[1]: "
+			IL_0544: ldloc.2
+			IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_054a: stloc.3
+			IL_054b: ldloc.0
+			IL_054c: ldstr "log"
+			IL_0551: ldloc.3
+			IL_0552: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0557: pop
+			IL_0558: ldstr "console"
+			IL_055d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0562: stloc.0
+			IL_0563: ldloc.0
+			IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0569: stloc.0
+			IL_056a: ldarg.0
+			IL_056b: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0570: stloc.2
+			IL_0571: ldc.i4.1
+			IL_0572: newarr [System.Runtime]System.Object
+			IL_0577: dup
+			IL_0578: ldc.i4.0
+			IL_0579: ldarg.0
+			IL_057a: stelem.ref
+			IL_057b: stloc.1
+			IL_057c: ldloc.2
+			IL_057d: ldloc.1
+			IL_057e: ldarg.3
+			IL_057f: ldstr "flags"
+			IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0589: ldc.r8 2
+			IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_059c: stloc.2
+			IL_059d: ldstr "flags[2]: "
+			IL_05a2: ldloc.2
+			IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05a8: stloc.3
+			IL_05a9: ldloc.0
+			IL_05aa: ldstr "log"
+			IL_05af: ldloc.3
+			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05b5: pop
+			IL_05b6: ldstr "console"
+			IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05c0: stloc.0
+			IL_05c1: ldloc.0
+			IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05c7: stloc.0
+			IL_05c8: ldarg.0
+			IL_05c9: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_05ce: stloc.2
+			IL_05cf: ldc.i4.1
+			IL_05d0: newarr [System.Runtime]System.Object
+			IL_05d5: dup
+			IL_05d6: ldc.i4.0
+			IL_05d7: ldarg.0
+			IL_05d8: stelem.ref
+			IL_05d9: stloc.1
+			IL_05da: ldloc.2
+			IL_05db: ldloc.1
+			IL_05dc: ldarg.3
+			IL_05dd: ldstr "features"
+			IL_05e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05e7: ldstr "length"
+			IL_05ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_05f6: stloc.2
+			IL_05f7: ldstr "features.length: "
+			IL_05fc: ldloc.2
+			IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0602: stloc.3
+			IL_0603: ldloc.0
+			IL_0604: ldstr "log"
+			IL_0609: ldloc.3
+			IL_060a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_060f: pop
+			IL_0610: ldstr "console"
+			IL_0615: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_061a: stloc.0
+			IL_061b: ldloc.0
+			IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0621: stloc.0
+			IL_0622: ldarg.0
+			IL_0623: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0628: stloc.2
+			IL_0629: ldc.i4.1
+			IL_062a: newarr [System.Runtime]System.Object
+			IL_062f: dup
+			IL_0630: ldc.i4.0
+			IL_0631: ldarg.0
+			IL_0632: stelem.ref
+			IL_0633: stloc.1
+			IL_0634: ldloc.2
+			IL_0635: ldloc.1
+			IL_0636: ldarg.3
+			IL_0637: ldstr "features"
+			IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0641: ldc.r8 0.0
+			IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0654: stloc.2
+			IL_0655: ldstr "features[0]: "
+			IL_065a: ldloc.2
+			IL_065b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0660: stloc.3
+			IL_0661: ldloc.0
+			IL_0662: ldstr "log"
+			IL_0667: ldloc.3
+			IL_0668: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_066d: pop
+			IL_066e: ldstr "console"
+			IL_0673: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0678: stloc.0
+			IL_0679: ldloc.0
+			IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_067f: stloc.0
+			IL_0680: ldarg.0
+			IL_0681: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0686: stloc.2
+			IL_0687: ldc.i4.1
+			IL_0688: newarr [System.Runtime]System.Object
+			IL_068d: dup
+			IL_068e: ldc.i4.0
+			IL_068f: ldarg.0
+			IL_0690: stelem.ref
+			IL_0691: stloc.1
+			IL_0692: ldloc.2
+			IL_0693: ldloc.1
+			IL_0694: ldarg.3
+			IL_0695: ldstr "features"
+			IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_069f: ldc.r8 1
+			IL_06a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_06b2: stloc.2
+			IL_06b3: ldstr "features[1]: "
+			IL_06b8: ldloc.2
+			IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_06be: stloc.3
+			IL_06bf: ldloc.0
+			IL_06c0: ldstr "log"
+			IL_06c5: ldloc.3
+			IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_06cb: pop
+			IL_06cc: ldstr "console"
+			IL_06d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06d6: stloc.0
+			IL_06d7: ldloc.0
+			IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06dd: stloc.0
+			IL_06de: ldarg.0
+			IL_06df: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_06e4: stloc.2
+			IL_06e5: ldc.i4.1
+			IL_06e6: newarr [System.Runtime]System.Object
+			IL_06eb: dup
+			IL_06ec: ldc.i4.0
+			IL_06ed: ldarg.0
+			IL_06ee: stelem.ref
+			IL_06ef: stloc.1
+			IL_06f0: ldloc.2
+			IL_06f1: ldloc.1
+			IL_06f2: ldarg.3
+			IL_06f3: ldstr "locale"
+			IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06fd: ldstr "length"
+			IL_0702: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_070c: stloc.2
+			IL_070d: ldstr "locale.length: "
+			IL_0712: ldloc.2
+			IL_0713: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0718: stloc.3
+			IL_0719: ldloc.0
+			IL_071a: ldstr "log"
+			IL_071f: ldloc.3
+			IL_0720: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0725: pop
+			IL_0726: ldstr "console"
+			IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0730: stloc.0
+			IL_0731: ldloc.0
+			IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0737: stloc.0
+			IL_0738: ldarg.0
+			IL_0739: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_073e: stloc.2
+			IL_073f: ldc.i4.1
+			IL_0740: newarr [System.Runtime]System.Object
+			IL_0745: dup
+			IL_0746: ldc.i4.0
+			IL_0747: ldarg.0
+			IL_0748: stelem.ref
+			IL_0749: stloc.1
+			IL_074a: ldloc.2
+			IL_074b: ldloc.1
+			IL_074c: ldarg.3
+			IL_074d: ldstr "locale"
+			IL_0752: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0757: ldc.r8 0.0
+			IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0765: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_076a: stloc.2
+			IL_076b: ldstr "locale[0]: "
+			IL_0770: ldloc.2
+			IL_0771: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0776: stloc.3
+			IL_0777: ldloc.0
+			IL_0778: ldstr "log"
+			IL_077d: ldloc.3
+			IL_077e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0783: pop
+			IL_0784: ldstr "console"
+			IL_0789: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_078e: stloc.0
+			IL_078f: ldloc.0
+			IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0795: stloc.0
+			IL_0796: ldarg.0
+			IL_0797: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_079c: stloc.2
+			IL_079d: ldc.i4.1
+			IL_079e: newarr [System.Runtime]System.Object
+			IL_07a3: dup
+			IL_07a4: ldc.i4.0
+			IL_07a5: ldarg.0
+			IL_07a6: stelem.ref
+			IL_07a7: stloc.1
+			IL_07a8: ldloc.2
+			IL_07a9: ldloc.1
+			IL_07aa: ldarg.3
+			IL_07ab: ldstr "defines"
+			IL_07b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07b5: ldstr "length"
+			IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_07c4: stloc.2
+			IL_07c5: ldstr "defines.length: "
+			IL_07ca: ldloc.2
+			IL_07cb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_07d0: stloc.3
+			IL_07d1: ldloc.0
+			IL_07d2: ldstr "log"
+			IL_07d7: ldloc.3
+			IL_07d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_07dd: pop
+			IL_07de: ldstr "console"
+			IL_07e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07e8: stloc.0
+			IL_07e9: ldloc.0
+			IL_07ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07ef: stloc.0
+			IL_07f0: ldarg.0
+			IL_07f1: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_07f6: stloc.2
+			IL_07f7: ldc.i4.1
+			IL_07f8: newarr [System.Runtime]System.Object
+			IL_07fd: dup
+			IL_07fe: ldc.i4.0
+			IL_07ff: ldarg.0
+			IL_0800: stelem.ref
+			IL_0801: stloc.1
+			IL_0802: ldloc.2
+			IL_0803: ldloc.1
+			IL_0804: ldarg.3
+			IL_0805: ldstr "defines"
+			IL_080a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_080f: ldc.r8 0.0
+			IL_0818: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_081d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0822: stloc.2
+			IL_0823: ldstr "defines[0]: "
+			IL_0828: ldloc.2
+			IL_0829: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_082e: stloc.3
 			IL_082f: ldloc.0
-			IL_0830: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0835: stloc.0
-			IL_0836: ldarg.0
-			IL_0837: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_083c: stloc.1
-			IL_083d: ldstr "formatScalar"
-			IL_0842: ldloc.1
-			IL_0843: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0848: stloc.1
-			IL_0849: ldc.i4.1
-			IL_084a: newarr [System.Runtime]System.Object
-			IL_084f: dup
-			IL_0850: ldc.i4.0
-			IL_0851: ldarg.0
-			IL_0852: stelem.ref
-			IL_0853: stloc.2
-			IL_0854: ldloc.1
-			IL_0855: ldloc.2
-			IL_0856: ldarg.3
-			IL_0857: ldstr "locale"
-			IL_085c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0861: ldc.r8 0.0
-			IL_086a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_086f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0874: stloc.1
-			IL_0875: ldstr "locale[0]: "
-			IL_087a: ldloc.1
-			IL_087b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0880: stloc.3
-			IL_0881: ldloc.0
-			IL_0882: ldstr "log"
-			IL_0887: ldloc.3
-			IL_0888: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_088d: pop
-			IL_088e: ldstr "console"
-			IL_0893: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0898: stloc.0
-			IL_0899: ldloc.0
-			IL_089a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_089f: stloc.0
-			IL_08a0: ldarg.0
-			IL_08a1: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_08a6: stloc.1
-			IL_08a7: ldstr "formatScalar"
-			IL_08ac: ldloc.1
-			IL_08ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_08b2: stloc.1
-			IL_08b3: ldc.i4.1
-			IL_08b4: newarr [System.Runtime]System.Object
-			IL_08b9: dup
-			IL_08ba: ldc.i4.0
-			IL_08bb: ldarg.0
-			IL_08bc: stelem.ref
-			IL_08bd: stloc.2
-			IL_08be: ldloc.1
-			IL_08bf: ldloc.2
-			IL_08c0: ldarg.3
-			IL_08c1: ldstr "defines"
-			IL_08c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08cb: ldstr "length"
-			IL_08d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_08da: stloc.1
-			IL_08db: ldstr "defines.length: "
-			IL_08e0: ldloc.1
-			IL_08e1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_08e6: stloc.3
-			IL_08e7: ldloc.0
-			IL_08e8: ldstr "log"
-			IL_08ed: ldloc.3
-			IL_08ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_08f3: pop
-			IL_08f4: ldstr "console"
-			IL_08f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_08fe: stloc.0
-			IL_08ff: ldloc.0
-			IL_0900: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0905: stloc.0
-			IL_0906: ldarg.0
-			IL_0907: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_090c: stloc.1
-			IL_090d: ldstr "formatScalar"
-			IL_0912: ldloc.1
-			IL_0913: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0918: stloc.1
-			IL_0919: ldc.i4.1
-			IL_091a: newarr [System.Runtime]System.Object
-			IL_091f: dup
-			IL_0920: ldc.i4.0
-			IL_0921: ldarg.0
-			IL_0922: stelem.ref
-			IL_0923: stloc.2
-			IL_0924: ldloc.1
-			IL_0925: ldloc.2
-			IL_0926: ldarg.3
-			IL_0927: ldstr "defines"
-			IL_092c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0931: ldc.r8 0.0
-			IL_093a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_093f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0944: stloc.1
-			IL_0945: ldstr "defines[0]: "
-			IL_094a: ldloc.1
-			IL_094b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0950: stloc.3
-			IL_0951: ldloc.0
-			IL_0952: ldstr "log"
-			IL_0957: ldloc.3
-			IL_0958: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_095d: pop
-			IL_095e: ldstr "console"
-			IL_0963: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0968: stloc.0
-			IL_0969: ldloc.0
-			IL_096a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_096f: stloc.0
-			IL_0970: ldarg.0
-			IL_0971: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatNegative
-			IL_0976: stloc.1
-			IL_0977: ldstr "formatNegative"
-			IL_097c: ldloc.1
-			IL_097d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0982: stloc.1
-			IL_0983: ldc.i4.1
-			IL_0984: newarr [System.Runtime]System.Object
-			IL_0989: dup
-			IL_098a: ldc.i4.0
-			IL_098b: ldarg.0
-			IL_098c: stelem.ref
-			IL_098d: stloc.2
-			IL_098e: ldloc.1
-			IL_098f: ldloc.2
-			IL_0990: ldarg.3
-			IL_0991: ldstr "negative"
-			IL_0996: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_099b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_09a0: stloc.1
-			IL_09a1: ldstr "negative: "
-			IL_09a6: ldloc.1
-			IL_09a7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_09ac: stloc.3
-			IL_09ad: ldloc.0
-			IL_09ae: ldstr "log"
-			IL_09b3: ldloc.3
-			IL_09b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_09b9: pop
-			IL_09ba: ldstr "console"
-			IL_09bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09c4: stloc.0
-			IL_09c5: ldloc.0
-			IL_09c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09cb: stloc.0
-			IL_09cc: ldarg.0
-			IL_09cd: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_09d2: stloc.1
-			IL_09d3: ldstr "formatScalar"
-			IL_09d8: ldloc.1
-			IL_09d9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_09de: stloc.1
-			IL_09df: ldc.i4.1
-			IL_09e0: newarr [System.Runtime]System.Object
-			IL_09e5: dup
-			IL_09e6: ldc.i4.0
-			IL_09e7: ldarg.0
-			IL_09e8: stelem.ref
-			IL_09e9: stloc.2
-			IL_09ea: ldloc.1
-			IL_09eb: ldloc.2
-			IL_09ec: ldarg.3
-			IL_09ed: ldstr "execution"
-			IL_09f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09f7: ldstr "sourceType"
-			IL_09fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a01: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0a06: stloc.1
-			IL_0a07: ldstr "execution.sourceType: "
-			IL_0a0c: ldloc.1
-			IL_0a0d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0a12: stloc.3
-			IL_0a13: ldloc.0
-			IL_0a14: ldstr "log"
-			IL_0a19: ldloc.3
-			IL_0a1a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0a1f: pop
-			IL_0a20: ldstr "console"
-			IL_0a25: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a2a: stloc.0
-			IL_0a2b: ldloc.0
-			IL_0a2c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a31: stloc.0
-			IL_0a32: ldarg.0
-			IL_0a33: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0a38: stloc.1
-			IL_0a39: ldstr "formatScalar"
-			IL_0a3e: ldloc.1
-			IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0a44: stloc.1
-			IL_0a45: ldc.i4.1
-			IL_0a46: newarr [System.Runtime]System.Object
-			IL_0a4b: dup
-			IL_0a4c: ldc.i4.0
-			IL_0a4d: ldarg.0
-			IL_0a4e: stelem.ref
-			IL_0a4f: stloc.2
-			IL_0a50: ldloc.1
-			IL_0a51: ldloc.2
-			IL_0a52: ldarg.3
-			IL_0a53: ldstr "execution"
-			IL_0a58: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a5d: ldstr "strictMode"
-			IL_0a62: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a67: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0a6c: stloc.1
-			IL_0a6d: ldstr "execution.strictMode: "
-			IL_0a72: ldloc.1
-			IL_0a73: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0a78: stloc.3
-			IL_0a79: ldloc.0
-			IL_0a7a: ldstr "log"
-			IL_0a7f: ldloc.3
-			IL_0a80: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0a85: pop
-			IL_0a86: ldstr "console"
-			IL_0a8b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a90: stloc.0
-			IL_0a91: ldloc.0
-			IL_0a92: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a97: stloc.0
-			IL_0a98: ldarg.0
-			IL_0a99: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0a9e: stloc.1
-			IL_0a9f: ldstr "formatScalar"
-			IL_0aa4: ldloc.1
-			IL_0aa5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0aaa: stloc.1
-			IL_0aab: ldc.i4.1
-			IL_0aac: newarr [System.Runtime]System.Object
-			IL_0ab1: dup
-			IL_0ab2: ldc.i4.0
-			IL_0ab3: ldarg.0
-			IL_0ab4: stelem.ref
-			IL_0ab5: stloc.2
-			IL_0ab6: ldloc.1
-			IL_0ab7: ldloc.2
-			IL_0ab8: ldarg.3
-			IL_0ab9: ldstr "execution"
-			IL_0abe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ac3: ldstr "defaultHarnessIncludes"
-			IL_0ac8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0acd: ldstr "length"
-			IL_0ad2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ad7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0adc: stloc.1
-			IL_0add: ldstr "execution.defaultHarnessIncludes.length: "
-			IL_0ae2: ldloc.1
-			IL_0ae3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0ae8: stloc.3
-			IL_0ae9: ldloc.0
-			IL_0aea: ldstr "log"
-			IL_0aef: ldloc.3
-			IL_0af0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0af5: pop
-			IL_0af6: ldstr "console"
-			IL_0afb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b00: stloc.0
-			IL_0b01: ldloc.0
-			IL_0b02: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b07: stloc.0
-			IL_0b08: ldarg.0
-			IL_0b09: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0b0e: stloc.1
-			IL_0b0f: ldstr "formatScalar"
-			IL_0b14: ldloc.1
-			IL_0b15: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0b1a: stloc.1
-			IL_0b1b: ldc.i4.1
-			IL_0b1c: newarr [System.Runtime]System.Object
-			IL_0b21: dup
-			IL_0b22: ldc.i4.0
-			IL_0b23: ldarg.0
-			IL_0b24: stelem.ref
-			IL_0b25: stloc.2
-			IL_0b26: ldloc.1
-			IL_0b27: ldloc.2
-			IL_0b28: ldarg.3
-			IL_0b29: ldstr "execution"
-			IL_0b2e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b33: ldstr "defaultHarnessIncludes"
-			IL_0b38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b3d: ldc.r8 0.0
-			IL_0b46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0b4b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0b50: stloc.1
-			IL_0b51: ldstr "execution.defaultHarnessIncludes[0]: "
-			IL_0b56: ldloc.1
-			IL_0b57: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0b5c: stloc.3
-			IL_0b5d: ldloc.0
-			IL_0b5e: ldstr "log"
-			IL_0b63: ldloc.3
-			IL_0b64: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0b69: pop
-			IL_0b6a: ldstr "console"
-			IL_0b6f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b74: stloc.0
-			IL_0b75: ldloc.0
-			IL_0b76: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b7b: stloc.0
-			IL_0b7c: ldarg.0
-			IL_0b7d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0b82: stloc.1
-			IL_0b83: ldstr "formatScalar"
-			IL_0b88: ldloc.1
-			IL_0b89: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0b8e: stloc.1
-			IL_0b8f: ldc.i4.1
-			IL_0b90: newarr [System.Runtime]System.Object
-			IL_0b95: dup
-			IL_0b96: ldc.i4.0
-			IL_0b97: ldarg.0
-			IL_0b98: stelem.ref
-			IL_0b99: stloc.2
-			IL_0b9a: ldloc.1
-			IL_0b9b: ldloc.2
-			IL_0b9c: ldarg.3
-			IL_0b9d: ldstr "execution"
-			IL_0ba2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ba7: ldstr "defaultHarnessIncludes"
-			IL_0bac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bb1: ldc.r8 1
-			IL_0bba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0bbf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0bc4: stloc.1
-			IL_0bc5: ldstr "execution.defaultHarnessIncludes[1]: "
-			IL_0bca: ldloc.1
-			IL_0bcb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0bd0: stloc.3
-			IL_0bd1: ldloc.0
-			IL_0bd2: ldstr "log"
-			IL_0bd7: ldloc.3
-			IL_0bd8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0bdd: pop
-			IL_0bde: ldstr "console"
-			IL_0be3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0be8: stloc.0
-			IL_0be9: ldloc.0
-			IL_0bea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0bef: stloc.0
-			IL_0bf0: ldarg.0
-			IL_0bf1: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0bf6: stloc.1
-			IL_0bf7: ldstr "formatScalar"
-			IL_0bfc: ldloc.1
-			IL_0bfd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0c02: stloc.1
-			IL_0c03: ldc.i4.1
-			IL_0c04: newarr [System.Runtime]System.Object
-			IL_0c09: dup
-			IL_0c0a: ldc.i4.0
-			IL_0c0b: ldarg.0
-			IL_0c0c: stelem.ref
-			IL_0c0d: stloc.2
-			IL_0c0e: ldloc.1
-			IL_0c0f: ldloc.2
-			IL_0c10: ldarg.3
-			IL_0c11: ldstr "execution"
-			IL_0c16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c1b: ldstr "harnessIncludes"
-			IL_0c20: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c25: ldstr "length"
-			IL_0c2a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c2f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0c34: stloc.1
-			IL_0c35: ldstr "execution.harnessIncludes.length: "
-			IL_0c3a: ldloc.1
-			IL_0c3b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0c40: stloc.3
-			IL_0c41: ldloc.0
-			IL_0c42: ldstr "log"
-			IL_0c47: ldloc.3
-			IL_0c48: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0c4d: pop
-			IL_0c4e: ldstr "console"
-			IL_0c53: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0c58: stloc.0
-			IL_0c59: ldloc.0
-			IL_0c5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0c5f: stloc.0
-			IL_0c60: ldarg.0
-			IL_0c61: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0c66: stloc.1
-			IL_0c67: ldstr "formatScalar"
-			IL_0c6c: ldloc.1
-			IL_0c6d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0c72: stloc.1
-			IL_0c73: ldc.i4.1
-			IL_0c74: newarr [System.Runtime]System.Object
-			IL_0c79: dup
-			IL_0c7a: ldc.i4.0
-			IL_0c7b: ldarg.0
-			IL_0c7c: stelem.ref
-			IL_0c7d: stloc.2
-			IL_0c7e: ldloc.1
-			IL_0c7f: ldloc.2
-			IL_0c80: ldarg.3
-			IL_0c81: ldstr "execution"
-			IL_0c86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c8b: ldstr "harnessIncludes"
-			IL_0c90: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c95: ldc.r8 0.0
-			IL_0c9e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0ca3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0ca8: stloc.1
-			IL_0ca9: ldstr "execution.harnessIncludes[0]: "
-			IL_0cae: ldloc.1
-			IL_0caf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0cb4: stloc.3
-			IL_0cb5: ldloc.0
-			IL_0cb6: ldstr "log"
-			IL_0cbb: ldloc.3
-			IL_0cbc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0cc1: pop
-			IL_0cc2: ldstr "console"
-			IL_0cc7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ccc: stloc.0
-			IL_0ccd: ldloc.0
-			IL_0cce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0cd3: stloc.0
-			IL_0cd4: ldarg.0
-			IL_0cd5: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0cda: stloc.1
-			IL_0cdb: ldstr "formatScalar"
-			IL_0ce0: ldloc.1
-			IL_0ce1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0ce6: stloc.1
-			IL_0ce7: ldc.i4.1
-			IL_0ce8: newarr [System.Runtime]System.Object
-			IL_0ced: dup
-			IL_0cee: ldc.i4.0
-			IL_0cef: ldarg.0
-			IL_0cf0: stelem.ref
-			IL_0cf1: stloc.2
-			IL_0cf2: ldloc.1
-			IL_0cf3: ldloc.2
-			IL_0cf4: ldarg.3
-			IL_0cf5: ldstr "execution"
-			IL_0cfa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cff: ldstr "harnessIncludes"
-			IL_0d04: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d09: ldc.r8 1
-			IL_0d12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0d17: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0d1c: stloc.1
-			IL_0d1d: ldstr "execution.harnessIncludes[1]: "
-			IL_0d22: ldloc.1
-			IL_0d23: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0d28: stloc.3
-			IL_0d29: ldloc.0
-			IL_0d2a: ldstr "log"
-			IL_0d2f: ldloc.3
-			IL_0d30: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0d35: pop
-			IL_0d36: ldstr "console"
-			IL_0d3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0d40: stloc.0
-			IL_0d41: ldloc.0
-			IL_0d42: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0d47: stloc.0
-			IL_0d48: ldarg.0
-			IL_0d49: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0d4e: stloc.1
-			IL_0d4f: ldstr "formatScalar"
-			IL_0d54: ldloc.1
-			IL_0d55: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0d5a: stloc.1
-			IL_0d5b: ldc.i4.1
-			IL_0d5c: newarr [System.Runtime]System.Object
-			IL_0d61: dup
-			IL_0d62: ldc.i4.0
-			IL_0d63: ldarg.0
-			IL_0d64: stelem.ref
-			IL_0d65: stloc.2
-			IL_0d66: ldloc.1
-			IL_0d67: ldloc.2
-			IL_0d68: ldarg.3
-			IL_0d69: ldstr "execution"
-			IL_0d6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d73: ldstr "harnessIncludes"
-			IL_0d78: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d7d: ldc.r8 2
-			IL_0d86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0d8b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0d90: stloc.1
-			IL_0d91: ldstr "execution.harnessIncludes[2]: "
-			IL_0d96: ldloc.1
-			IL_0d97: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0d9c: stloc.3
-			IL_0d9d: ldloc.0
-			IL_0d9e: ldstr "log"
-			IL_0da3: ldloc.3
-			IL_0da4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0da9: pop
-			IL_0daa: ldstr "console"
-			IL_0daf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0db4: stloc.0
-			IL_0db5: ldloc.0
-			IL_0db6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0dbb: stloc.0
-			IL_0dbc: ldarg.0
-			IL_0dbd: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0dc2: stloc.1
-			IL_0dc3: ldstr "formatScalar"
-			IL_0dc8: ldloc.1
-			IL_0dc9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0dce: stloc.1
-			IL_0dcf: ldc.i4.1
-			IL_0dd0: newarr [System.Runtime]System.Object
-			IL_0dd5: dup
-			IL_0dd6: ldc.i4.0
-			IL_0dd7: ldarg.0
-			IL_0dd8: stelem.ref
-			IL_0dd9: stloc.2
-			IL_0dda: ldloc.1
-			IL_0ddb: ldloc.2
-			IL_0ddc: ldarg.3
-			IL_0ddd: ldstr "execution"
-			IL_0de2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0de7: ldstr "harnessIncludes"
-			IL_0dec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0df1: ldc.r8 3
-			IL_0dfa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0dff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0e04: stloc.1
-			IL_0e05: ldstr "execution.harnessIncludes[3]: "
-			IL_0e0a: ldloc.1
-			IL_0e0b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0e10: stloc.3
-			IL_0e11: ldloc.0
-			IL_0e12: ldstr "log"
-			IL_0e17: ldloc.3
-			IL_0e18: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0e1d: pop
-			IL_0e1e: ldstr "console"
-			IL_0e23: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0e28: stloc.0
-			IL_0e29: ldloc.0
-			IL_0e2a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0e2f: stloc.0
-			IL_0e30: ldarg.0
-			IL_0e31: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0e36: stloc.1
-			IL_0e37: ldstr "formatScalar"
-			IL_0e3c: ldloc.1
-			IL_0e3d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0e42: stloc.1
-			IL_0e43: ldc.i4.1
-			IL_0e44: newarr [System.Runtime]System.Object
-			IL_0e49: dup
-			IL_0e4a: ldc.i4.0
-			IL_0e4b: ldarg.0
-			IL_0e4c: stelem.ref
-			IL_0e4d: stloc.2
-			IL_0e4e: ldloc.1
-			IL_0e4f: ldloc.2
-			IL_0e50: ldarg.3
-			IL_0e51: ldstr "execution"
-			IL_0e56: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e5b: ldstr "requiresDefaultHarness"
-			IL_0e60: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e65: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0e6a: stloc.1
-			IL_0e6b: ldstr "execution.requiresDefaultHarness: "
-			IL_0e70: ldloc.1
-			IL_0e71: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0e76: stloc.3
-			IL_0e77: ldloc.0
-			IL_0e78: ldstr "log"
-			IL_0e7d: ldloc.3
-			IL_0e7e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0e83: pop
-			IL_0e84: ldstr "console"
-			IL_0e89: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0e8e: stloc.0
-			IL_0e8f: ldloc.0
-			IL_0e90: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0e95: stloc.0
-			IL_0e96: ldarg.0
-			IL_0e97: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0e9c: stloc.1
-			IL_0e9d: ldstr "formatScalar"
-			IL_0ea2: ldloc.1
-			IL_0ea3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0ea8: stloc.1
-			IL_0ea9: ldc.i4.1
-			IL_0eaa: newarr [System.Runtime]System.Object
-			IL_0eaf: dup
-			IL_0eb0: ldc.i4.0
-			IL_0eb1: ldarg.0
-			IL_0eb2: stelem.ref
-			IL_0eb3: stloc.2
-			IL_0eb4: ldloc.1
-			IL_0eb5: ldloc.2
-			IL_0eb6: ldarg.3
-			IL_0eb7: ldstr "execution"
-			IL_0ebc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ec1: ldstr "requiresAsyncHarness"
-			IL_0ec6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ecb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0ed0: stloc.1
-			IL_0ed1: ldstr "execution.requiresAsyncHarness: "
-			IL_0ed6: ldloc.1
-			IL_0ed7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0edc: stloc.3
-			IL_0edd: ldloc.0
-			IL_0ede: ldstr "log"
-			IL_0ee3: ldloc.3
-			IL_0ee4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0ee9: pop
-			IL_0eea: ldstr "console"
-			IL_0eef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ef4: stloc.0
-			IL_0ef5: ldloc.0
-			IL_0ef6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0efb: stloc.0
-			IL_0efc: ldarg.0
-			IL_0efd: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0f02: stloc.1
-			IL_0f03: ldstr "formatScalar"
-			IL_0f08: ldloc.1
-			IL_0f09: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0f0e: stloc.1
-			IL_0f0f: ldc.i4.1
-			IL_0f10: newarr [System.Runtime]System.Object
-			IL_0f15: dup
-			IL_0f16: ldc.i4.0
-			IL_0f17: ldarg.0
-			IL_0f18: stelem.ref
-			IL_0f19: stloc.2
-			IL_0f1a: ldloc.1
-			IL_0f1b: ldloc.2
-			IL_0f1c: ldarg.3
-			IL_0f1d: ldstr "execution"
-			IL_0f22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f27: ldstr "requiresAgent"
-			IL_0f2c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f31: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0f36: stloc.1
-			IL_0f37: ldstr "execution.requiresAgent: "
-			IL_0f3c: ldloc.1
-			IL_0f3d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0f42: stloc.3
-			IL_0f43: ldloc.0
-			IL_0f44: ldstr "log"
-			IL_0f49: ldloc.3
-			IL_0f4a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0f4f: pop
-			IL_0f50: ldstr "console"
-			IL_0f55: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0f5a: stloc.0
-			IL_0f5b: ldloc.0
-			IL_0f5c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0f61: stloc.0
-			IL_0f62: ldarg.0
-			IL_0f63: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0f68: stloc.1
-			IL_0f69: ldstr "formatScalar"
-			IL_0f6e: ldloc.1
-			IL_0f6f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0f74: stloc.1
-			IL_0f75: ldc.i4.1
-			IL_0f76: newarr [System.Runtime]System.Object
-			IL_0f7b: dup
-			IL_0f7c: ldc.i4.0
-			IL_0f7d: ldarg.0
-			IL_0f7e: stelem.ref
-			IL_0f7f: stloc.2
-			IL_0f80: ldloc.1
-			IL_0f81: ldloc.2
-			IL_0f82: ldarg.3
-			IL_0f83: ldstr "execution"
-			IL_0f88: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f8d: ldstr "canBlock"
-			IL_0f92: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f97: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0f9c: stloc.1
-			IL_0f9d: ldstr "execution.canBlock: "
-			IL_0fa2: ldloc.1
-			IL_0fa3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0fa8: stloc.3
-			IL_0fa9: ldloc.0
-			IL_0faa: ldstr "log"
-			IL_0faf: ldloc.3
-			IL_0fb0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0fb5: pop
-			IL_0fb6: ldstr "console"
-			IL_0fbb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0fc0: stloc.0
-			IL_0fc1: ldloc.0
-			IL_0fc2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0fc7: stloc.0
-			IL_0fc8: ldarg.0
-			IL_0fc9: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0fce: stloc.1
-			IL_0fcf: ldstr "formatScalar"
-			IL_0fd4: ldloc.1
-			IL_0fd5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0fda: stloc.1
-			IL_0fdb: ldc.i4.1
-			IL_0fdc: newarr [System.Runtime]System.Object
-			IL_0fe1: dup
-			IL_0fe2: ldc.i4.0
-			IL_0fe3: ldarg.0
-			IL_0fe4: stelem.ref
-			IL_0fe5: stloc.2
-			IL_0fe6: ldloc.1
-			IL_0fe7: ldloc.2
-			IL_0fe8: ldarg.3
-			IL_0fe9: ldstr "execution"
-			IL_0fee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ff3: ldstr "isModule"
-			IL_0ff8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ffd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1002: stloc.1
-			IL_1003: ldstr "execution.isModule: "
-			IL_1008: ldloc.1
-			IL_1009: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_100e: stloc.3
-			IL_100f: ldloc.0
-			IL_1010: ldstr "log"
-			IL_1015: ldloc.3
-			IL_1016: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_101b: pop
-			IL_101c: ldstr "console"
-			IL_1021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_1026: stloc.0
-			IL_1027: ldloc.0
-			IL_1028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_102d: stloc.0
-			IL_102e: ldarg.0
-			IL_102f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_1034: stloc.1
-			IL_1035: ldstr "formatScalar"
-			IL_103a: ldloc.1
-			IL_103b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1040: stloc.1
-			IL_1041: ldc.i4.1
-			IL_1042: newarr [System.Runtime]System.Object
-			IL_1047: dup
-			IL_1048: ldc.i4.0
-			IL_1049: ldarg.0
-			IL_104a: stelem.ref
-			IL_104b: stloc.2
-			IL_104c: ldloc.1
-			IL_104d: ldloc.2
-			IL_104e: ldarg.3
-			IL_104f: ldstr "execution"
-			IL_1054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1059: ldstr "isRaw"
-			IL_105e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1063: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1068: stloc.1
-			IL_1069: ldstr "execution.isRaw: "
-			IL_106e: ldloc.1
-			IL_106f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1074: stloc.3
-			IL_1075: ldloc.0
-			IL_1076: ldstr "log"
-			IL_107b: ldloc.3
-			IL_107c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_1081: pop
-			IL_1082: ldstr "console"
-			IL_1087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_108c: stloc.0
-			IL_108d: ldloc.0
-			IL_108e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_1093: stloc.0
-			IL_1094: ldarg.0
-			IL_1095: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_109a: stloc.1
-			IL_109b: ldstr "formatScalar"
-			IL_10a0: ldloc.1
-			IL_10a1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_10a6: stloc.1
-			IL_10a7: ldc.i4.1
-			IL_10a8: newarr [System.Runtime]System.Object
-			IL_10ad: dup
-			IL_10ae: ldc.i4.0
-			IL_10af: ldarg.0
-			IL_10b0: stelem.ref
-			IL_10b1: stloc.2
-			IL_10b2: ldloc.1
-			IL_10b3: ldloc.2
-			IL_10b4: ldarg.3
-			IL_10b5: ldstr "execution"
-			IL_10ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_10bf: ldstr "isAsync"
-			IL_10c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_10c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_10ce: stloc.1
-			IL_10cf: ldstr "execution.isAsync: "
-			IL_10d4: ldloc.1
-			IL_10d5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_10da: stloc.3
-			IL_10db: ldloc.0
-			IL_10dc: ldstr "log"
-			IL_10e1: ldloc.3
-			IL_10e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_10e7: pop
-			IL_10e8: ldstr "console"
-			IL_10ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_10f2: stloc.0
-			IL_10f3: ldloc.0
-			IL_10f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_10f9: stloc.0
-			IL_10fa: ldarg.0
-			IL_10fb: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_1100: stloc.1
-			IL_1101: ldstr "formatScalar"
-			IL_1106: ldloc.1
-			IL_1107: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_110c: stloc.1
-			IL_110d: ldc.i4.1
-			IL_110e: newarr [System.Runtime]System.Object
-			IL_1113: dup
-			IL_1114: ldc.i4.0
-			IL_1115: ldarg.0
-			IL_1116: stelem.ref
-			IL_1117: stloc.2
-			IL_1118: ldloc.1
-			IL_1119: ldloc.2
-			IL_111a: ldarg.3
-			IL_111b: ldstr "execution"
-			IL_1120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1125: ldstr "isGenerated"
-			IL_112a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_112f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1134: stloc.1
-			IL_1135: ldstr "execution.isGenerated: "
-			IL_113a: ldloc.1
-			IL_113b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1140: stloc.3
-			IL_1141: ldloc.0
-			IL_1142: ldstr "log"
-			IL_1147: ldloc.3
-			IL_1148: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_114d: pop
-			IL_114e: ldstr "console"
-			IL_1153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_1158: stloc.0
-			IL_1159: ldloc.0
-			IL_115a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_115f: stloc.0
-			IL_1160: ldarg.0
-			IL_1161: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_1166: stloc.1
-			IL_1167: ldstr "formatScalar"
-			IL_116c: ldloc.1
-			IL_116d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1172: stloc.1
-			IL_1173: ldc.i4.1
-			IL_1174: newarr [System.Runtime]System.Object
-			IL_1179: dup
-			IL_117a: ldc.i4.0
-			IL_117b: ldarg.0
-			IL_117c: stelem.ref
-			IL_117d: stloc.2
-			IL_117e: ldloc.1
-			IL_117f: ldloc.2
-			IL_1180: ldarg.3
-			IL_1181: ldstr "execution"
-			IL_1186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_118b: ldstr "isNonDeterministic"
-			IL_1190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1195: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_119a: stloc.1
-			IL_119b: ldstr "execution.isNonDeterministic: "
-			IL_11a0: ldloc.1
-			IL_11a1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_11a6: stloc.3
-			IL_11a7: ldloc.0
-			IL_11a8: ldstr "log"
-			IL_11ad: ldloc.3
-			IL_11ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_11b3: pop
-			IL_11b4: ldstr "console"
-			IL_11b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_11be: stloc.0
-			IL_11bf: ldloc.0
-			IL_11c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_11c5: stloc.0
-			IL_11c6: ldarg.0
-			IL_11c7: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_11cc: stloc.1
-			IL_11cd: ldstr "formatScalar"
-			IL_11d2: ldloc.1
-			IL_11d3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_11d8: stloc.1
-			IL_11d9: ldc.i4.1
-			IL_11da: newarr [System.Runtime]System.Object
-			IL_11df: dup
-			IL_11e0: ldc.i4.0
-			IL_11e1: ldarg.0
-			IL_11e2: stelem.ref
-			IL_11e3: stloc.2
-			IL_11e4: ldloc.1
-			IL_11e5: ldloc.2
-			IL_11e6: ldarg.3
-			IL_11e7: ldstr "execution"
-			IL_11ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_11f1: ldstr "isFixture"
-			IL_11f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_11fb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1200: stloc.1
-			IL_1201: ldstr "execution.isFixture: "
-			IL_1206: ldloc.1
-			IL_1207: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_120c: stloc.3
-			IL_120d: ldloc.0
-			IL_120e: ldstr "log"
-			IL_1213: ldloc.3
-			IL_1214: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_1219: pop
-			IL_121a: ldstr "console"
-			IL_121f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_1224: stloc.0
-			IL_1225: ldloc.0
-			IL_1226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_122b: stloc.0
-			IL_122c: ldarg.0
-			IL_122d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_1232: stloc.1
-			IL_1233: ldstr "formatScalar"
-			IL_1238: ldloc.1
-			IL_1239: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_123e: stloc.1
-			IL_123f: ldc.i4.1
-			IL_1240: newarr [System.Runtime]System.Object
-			IL_1245: dup
-			IL_1246: ldc.i4.0
-			IL_1247: ldarg.0
-			IL_1248: stelem.ref
-			IL_1249: stloc.2
-			IL_124a: ldloc.1
-			IL_124b: ldloc.2
-			IL_124c: ldarg.3
-			IL_124d: ldstr "mvpBlockers"
-			IL_1252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1257: ldstr "length"
-			IL_125c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1261: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1266: stloc.1
-			IL_1267: ldstr "mvpBlockers.length: "
-			IL_126c: ldloc.1
-			IL_126d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1272: stloc.3
-			IL_1273: ldloc.0
-			IL_1274: ldstr "log"
-			IL_1279: ldloc.3
-			IL_127a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_127f: pop
-			IL_1280: ldstr "console"
-			IL_1285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_128a: stloc.0
-			IL_128b: ldloc.0
-			IL_128c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_1291: stloc.0
-			IL_1292: ldarg.0
-			IL_1293: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
-			IL_1298: stloc.1
-			IL_1299: ldstr "formatIssue"
-			IL_129e: ldloc.1
-			IL_129f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_12a4: stloc.1
-			IL_12a5: ldc.i4.1
-			IL_12a6: newarr [System.Runtime]System.Object
-			IL_12ab: dup
-			IL_12ac: ldc.i4.0
-			IL_12ad: ldarg.0
-			IL_12ae: stelem.ref
-			IL_12af: stloc.2
-			IL_12b0: ldloc.1
-			IL_12b1: ldloc.2
-			IL_12b2: ldarg.3
-			IL_12b3: ldstr "mvpBlockers"
-			IL_12b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_12bd: ldc.r8 0.0
-			IL_12c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_12cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_12d0: stloc.1
-			IL_12d1: ldstr "mvpBlockers[0]: "
-			IL_12d6: ldloc.1
-			IL_12d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_12dc: stloc.3
-			IL_12dd: ldloc.0
-			IL_12de: ldstr "log"
-			IL_12e3: ldloc.3
-			IL_12e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_12e9: pop
-			IL_12ea: ldstr "console"
-			IL_12ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_12f4: stloc.0
-			IL_12f5: ldloc.0
-			IL_12f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_12fb: stloc.0
-			IL_12fc: ldarg.0
-			IL_12fd: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
-			IL_1302: stloc.1
-			IL_1303: ldstr "formatIssue"
-			IL_1308: ldloc.1
-			IL_1309: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_130e: stloc.1
-			IL_130f: ldc.i4.1
-			IL_1310: newarr [System.Runtime]System.Object
-			IL_1315: dup
-			IL_1316: ldc.i4.0
-			IL_1317: ldarg.0
-			IL_1318: stelem.ref
-			IL_1319: stloc.2
-			IL_131a: ldloc.1
-			IL_131b: ldloc.2
-			IL_131c: ldarg.3
-			IL_131d: ldstr "mvpBlockers"
-			IL_1322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1327: ldc.r8 1
-			IL_1330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1335: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_133a: stloc.1
-			IL_133b: ldstr "mvpBlockers[1]: "
-			IL_1340: ldloc.1
-			IL_1341: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1346: stloc.3
-			IL_1347: ldloc.0
-			IL_1348: ldstr "log"
-			IL_134d: ldloc.3
-			IL_134e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_1353: pop
-			IL_1354: ldstr "console"
-			IL_1359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_135e: stloc.0
-			IL_135f: ldloc.0
-			IL_1360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_1365: stloc.0
-			IL_1366: ldarg.0
-			IL_1367: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
-			IL_136c: stloc.1
-			IL_136d: ldstr "formatIssue"
-			IL_1372: ldloc.1
-			IL_1373: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1378: stloc.1
-			IL_1379: ldc.i4.1
-			IL_137a: newarr [System.Runtime]System.Object
-			IL_137f: dup
-			IL_1380: ldc.i4.0
-			IL_1381: ldarg.0
-			IL_1382: stelem.ref
-			IL_1383: stloc.2
-			IL_1384: ldloc.1
-			IL_1385: ldloc.2
-			IL_1386: ldarg.3
-			IL_1387: ldstr "mvpBlockers"
-			IL_138c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1391: ldc.r8 2
-			IL_139a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_139f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_13a4: stloc.1
-			IL_13a5: ldstr "mvpBlockers[2]: "
-			IL_13aa: ldloc.1
-			IL_13ab: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_13b0: stloc.3
-			IL_13b1: ldloc.0
-			IL_13b2: ldstr "log"
-			IL_13b7: ldloc.3
-			IL_13b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_13bd: pop
-			IL_13be: ldstr "console"
-			IL_13c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_13c8: stloc.0
-			IL_13c9: ldloc.0
-			IL_13ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_13cf: stloc.0
-			IL_13d0: ldarg.0
-			IL_13d1: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
-			IL_13d6: stloc.1
-			IL_13d7: ldstr "formatIssue"
-			IL_13dc: ldloc.1
-			IL_13dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_13e2: stloc.1
-			IL_13e3: ldc.i4.1
-			IL_13e4: newarr [System.Runtime]System.Object
-			IL_13e9: dup
-			IL_13ea: ldc.i4.0
-			IL_13eb: ldarg.0
-			IL_13ec: stelem.ref
-			IL_13ed: stloc.2
-			IL_13ee: ldloc.1
-			IL_13ef: ldloc.2
-			IL_13f0: ldarg.3
-			IL_13f1: ldstr "mvpBlockers"
-			IL_13f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_13fb: ldc.r8 3
-			IL_1404: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1409: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_140e: stloc.1
-			IL_140f: ldstr "mvpBlockers[3]: "
-			IL_1414: ldloc.1
-			IL_1415: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_141a: stloc.3
-			IL_141b: ldloc.0
-			IL_141c: ldstr "log"
-			IL_1421: ldloc.3
-			IL_1422: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_1427: pop
-			IL_1428: ldstr "console"
-			IL_142d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_1432: stloc.0
-			IL_1433: ldloc.0
-			IL_1434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_1439: stloc.0
-			IL_143a: ldarg.0
-			IL_143b: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_1440: stloc.1
-			IL_1441: ldstr "formatScalar"
-			IL_1446: ldloc.1
-			IL_1447: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_144c: stloc.1
-			IL_144d: ldc.i4.1
-			IL_144e: newarr [System.Runtime]System.Object
-			IL_1453: dup
-			IL_1454: ldc.i4.0
-			IL_1455: ldarg.0
-			IL_1456: stelem.ref
-			IL_1457: stloc.2
-			IL_1458: ldloc.1
-			IL_1459: ldloc.2
-			IL_145a: ldarg.3
-			IL_145b: ldstr "unsupported"
-			IL_1460: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1465: ldstr "length"
-			IL_146a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_146f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1474: stloc.1
-			IL_1475: ldstr "unsupported.length: "
-			IL_147a: ldloc.1
-			IL_147b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1480: stloc.3
-			IL_1481: ldloc.0
-			IL_1482: ldstr "log"
-			IL_1487: ldloc.3
-			IL_1488: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_148d: pop
-			IL_148e: ldstr "console"
-			IL_1493: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_1498: stloc.0
-			IL_1499: ldloc.0
-			IL_149a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_149f: stloc.0
-			IL_14a0: ldarg.0
-			IL_14a1: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
-			IL_14a6: stloc.1
-			IL_14a7: ldstr "formatIssue"
-			IL_14ac: ldloc.1
-			IL_14ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_14b2: stloc.1
-			IL_14b3: ldc.i4.1
-			IL_14b4: newarr [System.Runtime]System.Object
-			IL_14b9: dup
-			IL_14ba: ldc.i4.0
-			IL_14bb: ldarg.0
-			IL_14bc: stelem.ref
-			IL_14bd: stloc.2
-			IL_14be: ldloc.1
-			IL_14bf: ldloc.2
-			IL_14c0: ldarg.3
-			IL_14c1: ldstr "unsupported"
-			IL_14c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_14cb: ldc.r8 0.0
-			IL_14d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_14d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_14de: stloc.1
-			IL_14df: ldstr "unsupported[0]: "
-			IL_14e4: ldloc.1
-			IL_14e5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_14ea: stloc.3
-			IL_14eb: ldloc.0
-			IL_14ec: ldstr "log"
-			IL_14f1: ldloc.3
-			IL_14f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_14f7: pop
-			IL_14f8: ldstr "console"
-			IL_14fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_1502: stloc.0
-			IL_1503: ldloc.0
-			IL_1504: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_1509: stloc.0
-			IL_150a: ldarg.0
-			IL_150b: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
-			IL_1510: stloc.1
-			IL_1511: ldstr "formatIssue"
-			IL_1516: ldloc.1
-			IL_1517: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_151c: stloc.1
-			IL_151d: ldc.i4.1
-			IL_151e: newarr [System.Runtime]System.Object
-			IL_1523: dup
-			IL_1524: ldc.i4.0
-			IL_1525: ldarg.0
-			IL_1526: stelem.ref
-			IL_1527: stloc.2
-			IL_1528: ldloc.1
-			IL_1529: ldloc.2
-			IL_152a: ldarg.3
-			IL_152b: ldstr "unsupported"
-			IL_1530: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1535: ldc.r8 1
-			IL_153e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1543: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1548: stloc.1
-			IL_1549: ldstr "unsupported[1]: "
-			IL_154e: ldloc.1
-			IL_154f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1554: stloc.3
-			IL_1555: ldloc.0
-			IL_1556: ldstr "log"
-			IL_155b: ldloc.3
-			IL_155c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_1561: pop
-			IL_1562: ldnull
-			IL_1563: ret
+			IL_0830: ldstr "log"
+			IL_0835: ldloc.3
+			IL_0836: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_083b: pop
+			IL_083c: ldstr "console"
+			IL_0841: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0846: stloc.0
+			IL_0847: ldloc.0
+			IL_0848: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_084d: stloc.0
+			IL_084e: ldarg.0
+			IL_084f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatNegative
+			IL_0854: stloc.2
+			IL_0855: ldc.i4.1
+			IL_0856: newarr [System.Runtime]System.Object
+			IL_085b: dup
+			IL_085c: ldc.i4.0
+			IL_085d: ldarg.0
+			IL_085e: stelem.ref
+			IL_085f: stloc.1
+			IL_0860: ldloc.2
+			IL_0861: ldloc.1
+			IL_0862: ldarg.3
+			IL_0863: ldstr "negative"
+			IL_0868: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0872: stloc.2
+			IL_0873: ldstr "negative: "
+			IL_0878: ldloc.2
+			IL_0879: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_087e: stloc.3
+			IL_087f: ldloc.0
+			IL_0880: ldstr "log"
+			IL_0885: ldloc.3
+			IL_0886: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_088b: pop
+			IL_088c: ldstr "console"
+			IL_0891: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0896: stloc.0
+			IL_0897: ldloc.0
+			IL_0898: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_089d: stloc.0
+			IL_089e: ldarg.0
+			IL_089f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_08a4: stloc.2
+			IL_08a5: ldc.i4.1
+			IL_08a6: newarr [System.Runtime]System.Object
+			IL_08ab: dup
+			IL_08ac: ldc.i4.0
+			IL_08ad: ldarg.0
+			IL_08ae: stelem.ref
+			IL_08af: stloc.1
+			IL_08b0: ldloc.2
+			IL_08b1: ldloc.1
+			IL_08b2: ldarg.3
+			IL_08b3: ldstr "execution"
+			IL_08b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08bd: ldstr "sourceType"
+			IL_08c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_08cc: stloc.2
+			IL_08cd: ldstr "execution.sourceType: "
+			IL_08d2: ldloc.2
+			IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_08d8: stloc.3
+			IL_08d9: ldloc.0
+			IL_08da: ldstr "log"
+			IL_08df: ldloc.3
+			IL_08e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_08e5: pop
+			IL_08e6: ldstr "console"
+			IL_08eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08f0: stloc.0
+			IL_08f1: ldloc.0
+			IL_08f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08f7: stloc.0
+			IL_08f8: ldarg.0
+			IL_08f9: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_08fe: stloc.2
+			IL_08ff: ldc.i4.1
+			IL_0900: newarr [System.Runtime]System.Object
+			IL_0905: dup
+			IL_0906: ldc.i4.0
+			IL_0907: ldarg.0
+			IL_0908: stelem.ref
+			IL_0909: stloc.1
+			IL_090a: ldloc.2
+			IL_090b: ldloc.1
+			IL_090c: ldarg.3
+			IL_090d: ldstr "execution"
+			IL_0912: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0917: ldstr "strictMode"
+			IL_091c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0921: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0926: stloc.2
+			IL_0927: ldstr "execution.strictMode: "
+			IL_092c: ldloc.2
+			IL_092d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0932: stloc.3
+			IL_0933: ldloc.0
+			IL_0934: ldstr "log"
+			IL_0939: ldloc.3
+			IL_093a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_093f: pop
+			IL_0940: ldstr "console"
+			IL_0945: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_094a: stloc.0
+			IL_094b: ldloc.0
+			IL_094c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0951: stloc.0
+			IL_0952: ldarg.0
+			IL_0953: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0958: stloc.2
+			IL_0959: ldc.i4.1
+			IL_095a: newarr [System.Runtime]System.Object
+			IL_095f: dup
+			IL_0960: ldc.i4.0
+			IL_0961: ldarg.0
+			IL_0962: stelem.ref
+			IL_0963: stloc.1
+			IL_0964: ldloc.2
+			IL_0965: ldloc.1
+			IL_0966: ldarg.3
+			IL_0967: ldstr "execution"
+			IL_096c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0971: ldstr "defaultHarnessIncludes"
+			IL_0976: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_097b: ldstr "length"
+			IL_0980: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0985: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_098a: stloc.2
+			IL_098b: ldstr "execution.defaultHarnessIncludes.length: "
+			IL_0990: ldloc.2
+			IL_0991: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0996: stloc.3
+			IL_0997: ldloc.0
+			IL_0998: ldstr "log"
+			IL_099d: ldloc.3
+			IL_099e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_09a3: pop
+			IL_09a4: ldstr "console"
+			IL_09a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09ae: stloc.0
+			IL_09af: ldloc.0
+			IL_09b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09b5: stloc.0
+			IL_09b6: ldarg.0
+			IL_09b7: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_09bc: stloc.2
+			IL_09bd: ldc.i4.1
+			IL_09be: newarr [System.Runtime]System.Object
+			IL_09c3: dup
+			IL_09c4: ldc.i4.0
+			IL_09c5: ldarg.0
+			IL_09c6: stelem.ref
+			IL_09c7: stloc.1
+			IL_09c8: ldloc.2
+			IL_09c9: ldloc.1
+			IL_09ca: ldarg.3
+			IL_09cb: ldstr "execution"
+			IL_09d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09d5: ldstr "defaultHarnessIncludes"
+			IL_09da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09df: ldc.r8 0.0
+			IL_09e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_09ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_09f2: stloc.2
+			IL_09f3: ldstr "execution.defaultHarnessIncludes[0]: "
+			IL_09f8: ldloc.2
+			IL_09f9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_09fe: stloc.3
+			IL_09ff: ldloc.0
+			IL_0a00: ldstr "log"
+			IL_0a05: ldloc.3
+			IL_0a06: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0a0b: pop
+			IL_0a0c: ldstr "console"
+			IL_0a11: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a16: stloc.0
+			IL_0a17: ldloc.0
+			IL_0a18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a1d: stloc.0
+			IL_0a1e: ldarg.0
+			IL_0a1f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0a24: stloc.2
+			IL_0a25: ldc.i4.1
+			IL_0a26: newarr [System.Runtime]System.Object
+			IL_0a2b: dup
+			IL_0a2c: ldc.i4.0
+			IL_0a2d: ldarg.0
+			IL_0a2e: stelem.ref
+			IL_0a2f: stloc.1
+			IL_0a30: ldloc.2
+			IL_0a31: ldloc.1
+			IL_0a32: ldarg.3
+			IL_0a33: ldstr "execution"
+			IL_0a38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a3d: ldstr "defaultHarnessIncludes"
+			IL_0a42: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a47: ldc.r8 1
+			IL_0a50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0a55: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0a5a: stloc.2
+			IL_0a5b: ldstr "execution.defaultHarnessIncludes[1]: "
+			IL_0a60: ldloc.2
+			IL_0a61: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0a66: stloc.3
+			IL_0a67: ldloc.0
+			IL_0a68: ldstr "log"
+			IL_0a6d: ldloc.3
+			IL_0a6e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0a73: pop
+			IL_0a74: ldstr "console"
+			IL_0a79: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a7e: stloc.0
+			IL_0a7f: ldloc.0
+			IL_0a80: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a85: stloc.0
+			IL_0a86: ldarg.0
+			IL_0a87: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0a8c: stloc.2
+			IL_0a8d: ldc.i4.1
+			IL_0a8e: newarr [System.Runtime]System.Object
+			IL_0a93: dup
+			IL_0a94: ldc.i4.0
+			IL_0a95: ldarg.0
+			IL_0a96: stelem.ref
+			IL_0a97: stloc.1
+			IL_0a98: ldloc.2
+			IL_0a99: ldloc.1
+			IL_0a9a: ldarg.3
+			IL_0a9b: ldstr "execution"
+			IL_0aa0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0aa5: ldstr "harnessIncludes"
+			IL_0aaa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0aaf: ldstr "length"
+			IL_0ab4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ab9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0abe: stloc.2
+			IL_0abf: ldstr "execution.harnessIncludes.length: "
+			IL_0ac4: ldloc.2
+			IL_0ac5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0aca: stloc.3
+			IL_0acb: ldloc.0
+			IL_0acc: ldstr "log"
+			IL_0ad1: ldloc.3
+			IL_0ad2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0ad7: pop
+			IL_0ad8: ldstr "console"
+			IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0ae2: stloc.0
+			IL_0ae3: ldloc.0
+			IL_0ae4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ae9: stloc.0
+			IL_0aea: ldarg.0
+			IL_0aeb: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0af0: stloc.2
+			IL_0af1: ldc.i4.1
+			IL_0af2: newarr [System.Runtime]System.Object
+			IL_0af7: dup
+			IL_0af8: ldc.i4.0
+			IL_0af9: ldarg.0
+			IL_0afa: stelem.ref
+			IL_0afb: stloc.1
+			IL_0afc: ldloc.2
+			IL_0afd: ldloc.1
+			IL_0afe: ldarg.3
+			IL_0aff: ldstr "execution"
+			IL_0b04: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b09: ldstr "harnessIncludes"
+			IL_0b0e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b13: ldc.r8 0.0
+			IL_0b1c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0b21: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0b26: stloc.2
+			IL_0b27: ldstr "execution.harnessIncludes[0]: "
+			IL_0b2c: ldloc.2
+			IL_0b2d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0b32: stloc.3
+			IL_0b33: ldloc.0
+			IL_0b34: ldstr "log"
+			IL_0b39: ldloc.3
+			IL_0b3a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0b3f: pop
+			IL_0b40: ldstr "console"
+			IL_0b45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b4a: stloc.0
+			IL_0b4b: ldloc.0
+			IL_0b4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b51: stloc.0
+			IL_0b52: ldarg.0
+			IL_0b53: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0b58: stloc.2
+			IL_0b59: ldc.i4.1
+			IL_0b5a: newarr [System.Runtime]System.Object
+			IL_0b5f: dup
+			IL_0b60: ldc.i4.0
+			IL_0b61: ldarg.0
+			IL_0b62: stelem.ref
+			IL_0b63: stloc.1
+			IL_0b64: ldloc.2
+			IL_0b65: ldloc.1
+			IL_0b66: ldarg.3
+			IL_0b67: ldstr "execution"
+			IL_0b6c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b71: ldstr "harnessIncludes"
+			IL_0b76: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b7b: ldc.r8 1
+			IL_0b84: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0b89: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0b8e: stloc.2
+			IL_0b8f: ldstr "execution.harnessIncludes[1]: "
+			IL_0b94: ldloc.2
+			IL_0b95: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0b9a: stloc.3
+			IL_0b9b: ldloc.0
+			IL_0b9c: ldstr "log"
+			IL_0ba1: ldloc.3
+			IL_0ba2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0ba7: pop
+			IL_0ba8: ldstr "console"
+			IL_0bad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0bb2: stloc.0
+			IL_0bb3: ldloc.0
+			IL_0bb4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0bb9: stloc.0
+			IL_0bba: ldarg.0
+			IL_0bbb: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0bc0: stloc.2
+			IL_0bc1: ldc.i4.1
+			IL_0bc2: newarr [System.Runtime]System.Object
+			IL_0bc7: dup
+			IL_0bc8: ldc.i4.0
+			IL_0bc9: ldarg.0
+			IL_0bca: stelem.ref
+			IL_0bcb: stloc.1
+			IL_0bcc: ldloc.2
+			IL_0bcd: ldloc.1
+			IL_0bce: ldarg.3
+			IL_0bcf: ldstr "execution"
+			IL_0bd4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bd9: ldstr "harnessIncludes"
+			IL_0bde: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0be3: ldc.r8 2
+			IL_0bec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0bf1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0bf6: stloc.2
+			IL_0bf7: ldstr "execution.harnessIncludes[2]: "
+			IL_0bfc: ldloc.2
+			IL_0bfd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0c02: stloc.3
+			IL_0c03: ldloc.0
+			IL_0c04: ldstr "log"
+			IL_0c09: ldloc.3
+			IL_0c0a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0c0f: pop
+			IL_0c10: ldstr "console"
+			IL_0c15: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0c1a: stloc.0
+			IL_0c1b: ldloc.0
+			IL_0c1c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0c21: stloc.0
+			IL_0c22: ldarg.0
+			IL_0c23: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0c28: stloc.2
+			IL_0c29: ldc.i4.1
+			IL_0c2a: newarr [System.Runtime]System.Object
+			IL_0c2f: dup
+			IL_0c30: ldc.i4.0
+			IL_0c31: ldarg.0
+			IL_0c32: stelem.ref
+			IL_0c33: stloc.1
+			IL_0c34: ldloc.2
+			IL_0c35: ldloc.1
+			IL_0c36: ldarg.3
+			IL_0c37: ldstr "execution"
+			IL_0c3c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c41: ldstr "harnessIncludes"
+			IL_0c46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c4b: ldc.r8 3
+			IL_0c54: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0c59: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0c5e: stloc.2
+			IL_0c5f: ldstr "execution.harnessIncludes[3]: "
+			IL_0c64: ldloc.2
+			IL_0c65: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0c6a: stloc.3
+			IL_0c6b: ldloc.0
+			IL_0c6c: ldstr "log"
+			IL_0c71: ldloc.3
+			IL_0c72: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0c77: pop
+			IL_0c78: ldstr "console"
+			IL_0c7d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0c82: stloc.0
+			IL_0c83: ldloc.0
+			IL_0c84: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0c89: stloc.0
+			IL_0c8a: ldarg.0
+			IL_0c8b: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0c90: stloc.2
+			IL_0c91: ldc.i4.1
+			IL_0c92: newarr [System.Runtime]System.Object
+			IL_0c97: dup
+			IL_0c98: ldc.i4.0
+			IL_0c99: ldarg.0
+			IL_0c9a: stelem.ref
+			IL_0c9b: stloc.1
+			IL_0c9c: ldloc.2
+			IL_0c9d: ldloc.1
+			IL_0c9e: ldarg.3
+			IL_0c9f: ldstr "execution"
+			IL_0ca4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ca9: ldstr "requiresDefaultHarness"
+			IL_0cae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0cb3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0cb8: stloc.2
+			IL_0cb9: ldstr "execution.requiresDefaultHarness: "
+			IL_0cbe: ldloc.2
+			IL_0cbf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0cc4: stloc.3
+			IL_0cc5: ldloc.0
+			IL_0cc6: ldstr "log"
+			IL_0ccb: ldloc.3
+			IL_0ccc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0cd1: pop
+			IL_0cd2: ldstr "console"
+			IL_0cd7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0cdc: stloc.0
+			IL_0cdd: ldloc.0
+			IL_0cde: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ce3: stloc.0
+			IL_0ce4: ldarg.0
+			IL_0ce5: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0cea: stloc.2
+			IL_0ceb: ldc.i4.1
+			IL_0cec: newarr [System.Runtime]System.Object
+			IL_0cf1: dup
+			IL_0cf2: ldc.i4.0
+			IL_0cf3: ldarg.0
+			IL_0cf4: stelem.ref
+			IL_0cf5: stloc.1
+			IL_0cf6: ldloc.2
+			IL_0cf7: ldloc.1
+			IL_0cf8: ldarg.3
+			IL_0cf9: ldstr "execution"
+			IL_0cfe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d03: ldstr "requiresAsyncHarness"
+			IL_0d08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d0d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0d12: stloc.2
+			IL_0d13: ldstr "execution.requiresAsyncHarness: "
+			IL_0d18: ldloc.2
+			IL_0d19: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0d1e: stloc.3
+			IL_0d1f: ldloc.0
+			IL_0d20: ldstr "log"
+			IL_0d25: ldloc.3
+			IL_0d26: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0d2b: pop
+			IL_0d2c: ldstr "console"
+			IL_0d31: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0d36: stloc.0
+			IL_0d37: ldloc.0
+			IL_0d38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0d3d: stloc.0
+			IL_0d3e: ldarg.0
+			IL_0d3f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0d44: stloc.2
+			IL_0d45: ldc.i4.1
+			IL_0d46: newarr [System.Runtime]System.Object
+			IL_0d4b: dup
+			IL_0d4c: ldc.i4.0
+			IL_0d4d: ldarg.0
+			IL_0d4e: stelem.ref
+			IL_0d4f: stloc.1
+			IL_0d50: ldloc.2
+			IL_0d51: ldloc.1
+			IL_0d52: ldarg.3
+			IL_0d53: ldstr "execution"
+			IL_0d58: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d5d: ldstr "requiresAgent"
+			IL_0d62: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d67: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0d6c: stloc.2
+			IL_0d6d: ldstr "execution.requiresAgent: "
+			IL_0d72: ldloc.2
+			IL_0d73: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0d78: stloc.3
+			IL_0d79: ldloc.0
+			IL_0d7a: ldstr "log"
+			IL_0d7f: ldloc.3
+			IL_0d80: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0d85: pop
+			IL_0d86: ldstr "console"
+			IL_0d8b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0d90: stloc.0
+			IL_0d91: ldloc.0
+			IL_0d92: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0d97: stloc.0
+			IL_0d98: ldarg.0
+			IL_0d99: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0d9e: stloc.2
+			IL_0d9f: ldc.i4.1
+			IL_0da0: newarr [System.Runtime]System.Object
+			IL_0da5: dup
+			IL_0da6: ldc.i4.0
+			IL_0da7: ldarg.0
+			IL_0da8: stelem.ref
+			IL_0da9: stloc.1
+			IL_0daa: ldloc.2
+			IL_0dab: ldloc.1
+			IL_0dac: ldarg.3
+			IL_0dad: ldstr "execution"
+			IL_0db2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0db7: ldstr "canBlock"
+			IL_0dbc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dc1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0dc6: stloc.2
+			IL_0dc7: ldstr "execution.canBlock: "
+			IL_0dcc: ldloc.2
+			IL_0dcd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0dd2: stloc.3
+			IL_0dd3: ldloc.0
+			IL_0dd4: ldstr "log"
+			IL_0dd9: ldloc.3
+			IL_0dda: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0ddf: pop
+			IL_0de0: ldstr "console"
+			IL_0de5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0dea: stloc.0
+			IL_0deb: ldloc.0
+			IL_0dec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0df1: stloc.0
+			IL_0df2: ldarg.0
+			IL_0df3: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0df8: stloc.2
+			IL_0df9: ldc.i4.1
+			IL_0dfa: newarr [System.Runtime]System.Object
+			IL_0dff: dup
+			IL_0e00: ldc.i4.0
+			IL_0e01: ldarg.0
+			IL_0e02: stelem.ref
+			IL_0e03: stloc.1
+			IL_0e04: ldloc.2
+			IL_0e05: ldloc.1
+			IL_0e06: ldarg.3
+			IL_0e07: ldstr "execution"
+			IL_0e0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e11: ldstr "isModule"
+			IL_0e16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e1b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0e20: stloc.2
+			IL_0e21: ldstr "execution.isModule: "
+			IL_0e26: ldloc.2
+			IL_0e27: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0e2c: stloc.3
+			IL_0e2d: ldloc.0
+			IL_0e2e: ldstr "log"
+			IL_0e33: ldloc.3
+			IL_0e34: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0e39: pop
+			IL_0e3a: ldstr "console"
+			IL_0e3f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0e44: stloc.0
+			IL_0e45: ldloc.0
+			IL_0e46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0e4b: stloc.0
+			IL_0e4c: ldarg.0
+			IL_0e4d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0e52: stloc.2
+			IL_0e53: ldc.i4.1
+			IL_0e54: newarr [System.Runtime]System.Object
+			IL_0e59: dup
+			IL_0e5a: ldc.i4.0
+			IL_0e5b: ldarg.0
+			IL_0e5c: stelem.ref
+			IL_0e5d: stloc.1
+			IL_0e5e: ldloc.2
+			IL_0e5f: ldloc.1
+			IL_0e60: ldarg.3
+			IL_0e61: ldstr "execution"
+			IL_0e66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e6b: ldstr "isRaw"
+			IL_0e70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e75: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0e7a: stloc.2
+			IL_0e7b: ldstr "execution.isRaw: "
+			IL_0e80: ldloc.2
+			IL_0e81: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0e86: stloc.3
+			IL_0e87: ldloc.0
+			IL_0e88: ldstr "log"
+			IL_0e8d: ldloc.3
+			IL_0e8e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0e93: pop
+			IL_0e94: ldstr "console"
+			IL_0e99: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0e9e: stloc.0
+			IL_0e9f: ldloc.0
+			IL_0ea0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ea5: stloc.0
+			IL_0ea6: ldarg.0
+			IL_0ea7: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0eac: stloc.2
+			IL_0ead: ldc.i4.1
+			IL_0eae: newarr [System.Runtime]System.Object
+			IL_0eb3: dup
+			IL_0eb4: ldc.i4.0
+			IL_0eb5: ldarg.0
+			IL_0eb6: stelem.ref
+			IL_0eb7: stloc.1
+			IL_0eb8: ldloc.2
+			IL_0eb9: ldloc.1
+			IL_0eba: ldarg.3
+			IL_0ebb: ldstr "execution"
+			IL_0ec0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ec5: ldstr "isAsync"
+			IL_0eca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ecf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0ed4: stloc.2
+			IL_0ed5: ldstr "execution.isAsync: "
+			IL_0eda: ldloc.2
+			IL_0edb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0ee0: stloc.3
+			IL_0ee1: ldloc.0
+			IL_0ee2: ldstr "log"
+			IL_0ee7: ldloc.3
+			IL_0ee8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0eed: pop
+			IL_0eee: ldstr "console"
+			IL_0ef3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0ef8: stloc.0
+			IL_0ef9: ldloc.0
+			IL_0efa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0eff: stloc.0
+			IL_0f00: ldarg.0
+			IL_0f01: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0f06: stloc.2
+			IL_0f07: ldc.i4.1
+			IL_0f08: newarr [System.Runtime]System.Object
+			IL_0f0d: dup
+			IL_0f0e: ldc.i4.0
+			IL_0f0f: ldarg.0
+			IL_0f10: stelem.ref
+			IL_0f11: stloc.1
+			IL_0f12: ldloc.2
+			IL_0f13: ldloc.1
+			IL_0f14: ldarg.3
+			IL_0f15: ldstr "execution"
+			IL_0f1a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f1f: ldstr "isGenerated"
+			IL_0f24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f29: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0f2e: stloc.2
+			IL_0f2f: ldstr "execution.isGenerated: "
+			IL_0f34: ldloc.2
+			IL_0f35: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0f3a: stloc.3
+			IL_0f3b: ldloc.0
+			IL_0f3c: ldstr "log"
+			IL_0f41: ldloc.3
+			IL_0f42: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0f47: pop
+			IL_0f48: ldstr "console"
+			IL_0f4d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0f52: stloc.0
+			IL_0f53: ldloc.0
+			IL_0f54: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0f59: stloc.0
+			IL_0f5a: ldarg.0
+			IL_0f5b: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0f60: stloc.2
+			IL_0f61: ldc.i4.1
+			IL_0f62: newarr [System.Runtime]System.Object
+			IL_0f67: dup
+			IL_0f68: ldc.i4.0
+			IL_0f69: ldarg.0
+			IL_0f6a: stelem.ref
+			IL_0f6b: stloc.1
+			IL_0f6c: ldloc.2
+			IL_0f6d: ldloc.1
+			IL_0f6e: ldarg.3
+			IL_0f6f: ldstr "execution"
+			IL_0f74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f79: ldstr "isNonDeterministic"
+			IL_0f7e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f83: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0f88: stloc.2
+			IL_0f89: ldstr "execution.isNonDeterministic: "
+			IL_0f8e: ldloc.2
+			IL_0f8f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0f94: stloc.3
+			IL_0f95: ldloc.0
+			IL_0f96: ldstr "log"
+			IL_0f9b: ldloc.3
+			IL_0f9c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0fa1: pop
+			IL_0fa2: ldstr "console"
+			IL_0fa7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0fac: stloc.0
+			IL_0fad: ldloc.0
+			IL_0fae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0fb3: stloc.0
+			IL_0fb4: ldarg.0
+			IL_0fb5: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0fba: stloc.2
+			IL_0fbb: ldc.i4.1
+			IL_0fbc: newarr [System.Runtime]System.Object
+			IL_0fc1: dup
+			IL_0fc2: ldc.i4.0
+			IL_0fc3: ldarg.0
+			IL_0fc4: stelem.ref
+			IL_0fc5: stloc.1
+			IL_0fc6: ldloc.2
+			IL_0fc7: ldloc.1
+			IL_0fc8: ldarg.3
+			IL_0fc9: ldstr "execution"
+			IL_0fce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0fd3: ldstr "isFixture"
+			IL_0fd8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0fdd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0fe2: stloc.2
+			IL_0fe3: ldstr "execution.isFixture: "
+			IL_0fe8: ldloc.2
+			IL_0fe9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0fee: stloc.3
+			IL_0fef: ldloc.0
+			IL_0ff0: ldstr "log"
+			IL_0ff5: ldloc.3
+			IL_0ff6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0ffb: pop
+			IL_0ffc: ldstr "console"
+			IL_1001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_1006: stloc.0
+			IL_1007: ldloc.0
+			IL_1008: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_100d: stloc.0
+			IL_100e: ldarg.0
+			IL_100f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_1014: stloc.2
+			IL_1015: ldc.i4.1
+			IL_1016: newarr [System.Runtime]System.Object
+			IL_101b: dup
+			IL_101c: ldc.i4.0
+			IL_101d: ldarg.0
+			IL_101e: stelem.ref
+			IL_101f: stloc.1
+			IL_1020: ldloc.2
+			IL_1021: ldloc.1
+			IL_1022: ldarg.3
+			IL_1023: ldstr "mvpBlockers"
+			IL_1028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_102d: ldstr "length"
+			IL_1032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1037: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_103c: stloc.2
+			IL_103d: ldstr "mvpBlockers.length: "
+			IL_1042: ldloc.2
+			IL_1043: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_1048: stloc.3
+			IL_1049: ldloc.0
+			IL_104a: ldstr "log"
+			IL_104f: ldloc.3
+			IL_1050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_1055: pop
+			IL_1056: ldstr "console"
+			IL_105b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_1060: stloc.0
+			IL_1061: ldloc.0
+			IL_1062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1067: stloc.0
+			IL_1068: ldarg.0
+			IL_1069: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
+			IL_106e: stloc.2
+			IL_106f: ldc.i4.1
+			IL_1070: newarr [System.Runtime]System.Object
+			IL_1075: dup
+			IL_1076: ldc.i4.0
+			IL_1077: ldarg.0
+			IL_1078: stelem.ref
+			IL_1079: stloc.1
+			IL_107a: ldloc.2
+			IL_107b: ldloc.1
+			IL_107c: ldarg.3
+			IL_107d: ldstr "mvpBlockers"
+			IL_1082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1087: ldc.r8 0.0
+			IL_1090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1095: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_109a: stloc.2
+			IL_109b: ldstr "mvpBlockers[0]: "
+			IL_10a0: ldloc.2
+			IL_10a1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_10a6: stloc.3
+			IL_10a7: ldloc.0
+			IL_10a8: ldstr "log"
+			IL_10ad: ldloc.3
+			IL_10ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_10b3: pop
+			IL_10b4: ldstr "console"
+			IL_10b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_10be: stloc.0
+			IL_10bf: ldloc.0
+			IL_10c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_10c5: stloc.0
+			IL_10c6: ldarg.0
+			IL_10c7: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
+			IL_10cc: stloc.2
+			IL_10cd: ldc.i4.1
+			IL_10ce: newarr [System.Runtime]System.Object
+			IL_10d3: dup
+			IL_10d4: ldc.i4.0
+			IL_10d5: ldarg.0
+			IL_10d6: stelem.ref
+			IL_10d7: stloc.1
+			IL_10d8: ldloc.2
+			IL_10d9: ldloc.1
+			IL_10da: ldarg.3
+			IL_10db: ldstr "mvpBlockers"
+			IL_10e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_10e5: ldc.r8 1
+			IL_10ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_10f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_10f8: stloc.2
+			IL_10f9: ldstr "mvpBlockers[1]: "
+			IL_10fe: ldloc.2
+			IL_10ff: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_1104: stloc.3
+			IL_1105: ldloc.0
+			IL_1106: ldstr "log"
+			IL_110b: ldloc.3
+			IL_110c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_1111: pop
+			IL_1112: ldstr "console"
+			IL_1117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_111c: stloc.0
+			IL_111d: ldloc.0
+			IL_111e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1123: stloc.0
+			IL_1124: ldarg.0
+			IL_1125: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
+			IL_112a: stloc.2
+			IL_112b: ldc.i4.1
+			IL_112c: newarr [System.Runtime]System.Object
+			IL_1131: dup
+			IL_1132: ldc.i4.0
+			IL_1133: ldarg.0
+			IL_1134: stelem.ref
+			IL_1135: stloc.1
+			IL_1136: ldloc.2
+			IL_1137: ldloc.1
+			IL_1138: ldarg.3
+			IL_1139: ldstr "mvpBlockers"
+			IL_113e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1143: ldc.r8 2
+			IL_114c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1151: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_1156: stloc.2
+			IL_1157: ldstr "mvpBlockers[2]: "
+			IL_115c: ldloc.2
+			IL_115d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_1162: stloc.3
+			IL_1163: ldloc.0
+			IL_1164: ldstr "log"
+			IL_1169: ldloc.3
+			IL_116a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_116f: pop
+			IL_1170: ldstr "console"
+			IL_1175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_117a: stloc.0
+			IL_117b: ldloc.0
+			IL_117c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1181: stloc.0
+			IL_1182: ldarg.0
+			IL_1183: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
+			IL_1188: stloc.2
+			IL_1189: ldc.i4.1
+			IL_118a: newarr [System.Runtime]System.Object
+			IL_118f: dup
+			IL_1190: ldc.i4.0
+			IL_1191: ldarg.0
+			IL_1192: stelem.ref
+			IL_1193: stloc.1
+			IL_1194: ldloc.2
+			IL_1195: ldloc.1
+			IL_1196: ldarg.3
+			IL_1197: ldstr "mvpBlockers"
+			IL_119c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_11a1: ldc.r8 3
+			IL_11aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_11af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_11b4: stloc.2
+			IL_11b5: ldstr "mvpBlockers[3]: "
+			IL_11ba: ldloc.2
+			IL_11bb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_11c0: stloc.3
+			IL_11c1: ldloc.0
+			IL_11c2: ldstr "log"
+			IL_11c7: ldloc.3
+			IL_11c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_11cd: pop
+			IL_11ce: ldstr "console"
+			IL_11d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_11d8: stloc.0
+			IL_11d9: ldloc.0
+			IL_11da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_11df: stloc.0
+			IL_11e0: ldarg.0
+			IL_11e1: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_11e6: stloc.2
+			IL_11e7: ldc.i4.1
+			IL_11e8: newarr [System.Runtime]System.Object
+			IL_11ed: dup
+			IL_11ee: ldc.i4.0
+			IL_11ef: ldarg.0
+			IL_11f0: stelem.ref
+			IL_11f1: stloc.1
+			IL_11f2: ldloc.2
+			IL_11f3: ldloc.1
+			IL_11f4: ldarg.3
+			IL_11f5: ldstr "unsupported"
+			IL_11fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_11ff: ldstr "length"
+			IL_1204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1209: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_120e: stloc.2
+			IL_120f: ldstr "unsupported.length: "
+			IL_1214: ldloc.2
+			IL_1215: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_121a: stloc.3
+			IL_121b: ldloc.0
+			IL_121c: ldstr "log"
+			IL_1221: ldloc.3
+			IL_1222: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_1227: pop
+			IL_1228: ldstr "console"
+			IL_122d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_1232: stloc.0
+			IL_1233: ldloc.0
+			IL_1234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1239: stloc.0
+			IL_123a: ldarg.0
+			IL_123b: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
+			IL_1240: stloc.2
+			IL_1241: ldc.i4.1
+			IL_1242: newarr [System.Runtime]System.Object
+			IL_1247: dup
+			IL_1248: ldc.i4.0
+			IL_1249: ldarg.0
+			IL_124a: stelem.ref
+			IL_124b: stloc.1
+			IL_124c: ldloc.2
+			IL_124d: ldloc.1
+			IL_124e: ldarg.3
+			IL_124f: ldstr "unsupported"
+			IL_1254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1259: ldc.r8 0.0
+			IL_1262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1267: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_126c: stloc.2
+			IL_126d: ldstr "unsupported[0]: "
+			IL_1272: ldloc.2
+			IL_1273: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_1278: stloc.3
+			IL_1279: ldloc.0
+			IL_127a: ldstr "log"
+			IL_127f: ldloc.3
+			IL_1280: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_1285: pop
+			IL_1286: ldstr "console"
+			IL_128b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_1290: stloc.0
+			IL_1291: ldloc.0
+			IL_1292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1297: stloc.0
+			IL_1298: ldarg.0
+			IL_1299: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
+			IL_129e: stloc.2
+			IL_129f: ldc.i4.1
+			IL_12a0: newarr [System.Runtime]System.Object
+			IL_12a5: dup
+			IL_12a6: ldc.i4.0
+			IL_12a7: ldarg.0
+			IL_12a8: stelem.ref
+			IL_12a9: stloc.1
+			IL_12aa: ldloc.2
+			IL_12ab: ldloc.1
+			IL_12ac: ldarg.3
+			IL_12ad: ldstr "unsupported"
+			IL_12b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_12b7: ldc.r8 1
+			IL_12c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_12c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_12ca: stloc.2
+			IL_12cb: ldstr "unsupported[1]: "
+			IL_12d0: ldloc.2
+			IL_12d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_12d6: stloc.3
+			IL_12d7: ldloc.0
+			IL_12d8: ldstr "log"
+			IL_12dd: ldloc.3
+			IL_12de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_12e3: pop
+			IL_12e4: ldnull
+			IL_12e5: ret
 		} // end of method writeParsedResult::__js_call__
 
 	} // end of class writeParsedResult
@@ -2708,7 +2474,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x706f
+			// Method begins at RVA 0x69a5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3041,7 +2807,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x70db
+				// Method begins at RVA 0x6a11
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3065,7 +2831,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x41b4
+			// Method begins at RVA 0x3efc
 			// Header size: 12
 			// Code size: 91 (0x5b)
 			.maxstack 8
@@ -3129,7 +2895,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x70f6
+						// Method begins at RVA 0x6a2c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3147,7 +2913,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x70ed
+					// Method begins at RVA 0x6a23
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3165,7 +2931,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x70e4
+				// Method begins at RVA 0x6a1a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3192,7 +2958,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x421c
+			// Method begins at RVA 0x3f64
 			// Header size: 12
 			// Code size: 183 (0xb7)
 			.maxstack 8
@@ -3305,7 +3071,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7111
+						// Method begins at RVA 0x6a47
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3323,7 +3089,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7108
+					// Method begins at RVA 0x6a3e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3341,7 +3107,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x70ff
+				// Method begins at RVA 0x6a35
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3368,7 +3134,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x42e0
+			// Method begins at RVA 0x4028
 			// Header size: 12
 			// Code size: 371 (0x173)
 			.maxstack 8
@@ -3532,7 +3298,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7123
+					// Method begins at RVA 0x6a59
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3550,7 +3316,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x711a
+				// Method begins at RVA 0x6a50
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3578,7 +3344,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x713e
+						// Method begins at RVA 0x6a74
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3596,7 +3362,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7135
+					// Method begins at RVA 0x6a6b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3614,7 +3380,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x712c
+				// Method begins at RVA 0x6a62
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3641,9 +3407,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4460
+			// Method begins at RVA 0x41a8
 			// Header size: 12
-			// Code size: 347 (0x15b)
+			// Code size: 329 (0x149)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3722,7 +3488,7 @@
 				IL_00b9: ldstr "length"
 				IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 				IL_00c3: clt
-				IL_00c5: brfalse IL_0159
+				IL_00c5: brfalse IL_0147
 
 				IL_00ca: newobj instance void Modules.test262_metadataParser/parseInlineList/Scope_For_L69C7/Block_L69C41::.ctor()
 				IL_00cf: stloc.s 5
@@ -3744,41 +3510,35 @@
 				IL_00fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
 				IL_0102: stloc.s 9
 				IL_0104: ldloc.s 9
-				IL_0106: brfalse IL_0146
+				IL_0106: brfalse IL_0134
 
 				IL_010b: newobj instance void Modules.test262_metadataParser/parseInlineList/Scope_For_L69C7/Block_L69C41/Block_L71C21::.ctor()
 				IL_0110: stloc.s 7
 				IL_0112: ldarg.0
 				IL_0113: ldfld object Modules.test262_metadataParser/Scope::unquote
-				IL_0118: stloc.s 8
-				IL_011a: ldstr "unquote"
-				IL_011f: ldloc.s 8
-				IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0126: stloc.s 8
-				IL_0128: ldloc.s 8
-				IL_012a: ldc.i4.1
-				IL_012b: newarr [System.Runtime]System.Object
-				IL_0130: dup
-				IL_0131: ldc.i4.0
-				IL_0132: ldarg.0
-				IL_0133: stelem.ref
-				IL_0134: ldloc.s 6
-				IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_013b: stloc.s 8
-				IL_013d: ldloc.3
-				IL_013e: ldloc.s 8
-				IL_0140: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0145: pop
+				IL_0118: ldc.i4.1
+				IL_0119: newarr [System.Runtime]System.Object
+				IL_011e: dup
+				IL_011f: ldc.i4.0
+				IL_0120: ldarg.0
+				IL_0121: stelem.ref
+				IL_0122: ldloc.s 6
+				IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0129: stloc.s 8
+				IL_012b: ldloc.3
+				IL_012c: ldloc.s 8
+				IL_012e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0133: pop
 
-				IL_0146: ldloc.s 4
-				IL_0148: ldc.r8 1
-				IL_0151: add
-				IL_0152: stloc.s 4
-				IL_0154: br IL_00b2
+				IL_0134: ldloc.s 4
+				IL_0136: ldc.r8 1
+				IL_013f: add
+				IL_0140: stloc.s 4
+				IL_0142: br IL_00b2
 			// end loop
 
-			IL_0159: ldloc.3
-			IL_015a: ret
+			IL_0147: ldloc.3
+			IL_0148: ret
 		} // end of method parseInlineList::__js_call__
 
 	} // end of class parseInlineList
@@ -3798,7 +3558,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7150
+					// Method begins at RVA 0x6a86
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3816,7 +3576,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7147
+				// Method begins at RVA 0x6a7d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3843,7 +3603,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x45c8
+			// Method begins at RVA 0x4300
 			// Header size: 12
 			// Code size: 151 (0x97)
 			.maxstack 8
@@ -3936,7 +3696,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7159
+				// Method begins at RVA 0x6a8f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3964,7 +3724,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7174
+						// Method begins at RVA 0x6aaa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3984,7 +3744,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x717d
+						// Method begins at RVA 0x6ab3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4004,7 +3764,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7186
+						// Method begins at RVA 0x6abc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4024,7 +3784,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x718f
+						// Method begins at RVA 0x6ac5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4042,7 +3802,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x716b
+					// Method begins at RVA 0x6aa1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4060,7 +3820,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7162
+				// Method begins at RVA 0x6a98
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4087,7 +3847,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x466c
+			// Method begins at RVA 0x43a4
 			// Header size: 12
 			// Code size: 347 (0x15b)
 			.maxstack 8
@@ -4257,7 +4017,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x71aa
+						// Method begins at RVA 0x6ae0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4277,7 +4037,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x71b3
+						// Method begins at RVA 0x6ae9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4297,7 +4057,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x71bc
+						// Method begins at RVA 0x6af2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4315,7 +4075,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x71a1
+					// Method begins at RVA 0x6ad7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4333,7 +4093,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7198
+				// Method begins at RVA 0x6ace
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4363,9 +4123,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x47d4
+			// Method begins at RVA 0x450c
 			// Header size: 12
-			// Code size: 476 (0x1dc)
+			// Code size: 458 (0x1ca)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -4407,7 +4167,7 @@
 				IL_003c: ldloc.s 9
 				IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0043: clt
-				IL_0045: brfalse IL_0199
+				IL_0045: brfalse IL_0187
 
 				IL_004a: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37::.ctor()
 				IL_004f: stloc.2
@@ -4451,110 +4211,104 @@
 
 				IL_00c7: ldarg.0
 				IL_00c8: ldfld object Modules.test262_metadataParser/Scope::countIndent
-				IL_00cd: stloc.s 9
-				IL_00cf: ldstr "countIndent"
-				IL_00d4: ldloc.s 9
-				IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00db: stloc.s 9
-				IL_00dd: ldloc.s 9
-				IL_00df: ldc.i4.1
-				IL_00e0: newarr [System.Runtime]System.Object
-				IL_00e5: dup
-				IL_00e6: ldc.i4.0
-				IL_00e7: ldarg.0
-				IL_00e8: stelem.ref
-				IL_00e9: ldloc.3
-				IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_00ef: stloc.s 9
-				IL_00f1: ldloc.s 9
-				IL_00f3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00f8: stloc.s 10
-				IL_00fa: ldloc.s 10
-				IL_00fc: stloc.s 5
-				IL_00fe: ldloc.s 5
-				IL_0100: stloc.s 10
-				IL_0102: ldloc.s 10
-				IL_0104: ldarg.s parentIndent
-				IL_0106: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_010b: cgt
-				IL_010d: ldc.i4.0
-				IL_010e: ceq
-				IL_0110: brfalse IL_0121
+				IL_00cd: ldc.i4.1
+				IL_00ce: newarr [System.Runtime]System.Object
+				IL_00d3: dup
+				IL_00d4: ldc.i4.0
+				IL_00d5: ldarg.0
+				IL_00d6: stelem.ref
+				IL_00d7: ldloc.3
+				IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_00dd: stloc.s 9
+				IL_00df: ldloc.s 9
+				IL_00e1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00e6: stloc.s 10
+				IL_00e8: ldloc.s 10
+				IL_00ea: stloc.s 5
+				IL_00ec: ldloc.s 5
+				IL_00ee: stloc.s 10
+				IL_00f0: ldloc.s 10
+				IL_00f2: ldarg.s parentIndent
+				IL_00f4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00f9: cgt
+				IL_00fb: ldc.i4.0
+				IL_00fc: ceq
+				IL_00fe: brfalse IL_010f
 
-				IL_0115: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L126C32::.ctor()
-				IL_011a: stloc.s 6
-				IL_011c: br IL_0199
+				IL_0103: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L126C32::.ctor()
+				IL_0108: stloc.s 6
+				IL_010a: br IL_0187
 
-				IL_0121: ldloc.1
-				IL_0122: stloc.s 12
-				IL_0124: ldloc.s 12
-				IL_0126: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_012b: stloc.s 10
-				IL_012d: ldloc.s 10
-				IL_012f: ldc.r8 0.0
-				IL_0138: clt
-				IL_013a: brfalse IL_0152
+				IL_010f: ldloc.1
+				IL_0110: stloc.s 12
+				IL_0112: ldloc.s 12
+				IL_0114: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0119: stloc.s 10
+				IL_011b: ldloc.s 10
+				IL_011d: ldc.r8 0.0
+				IL_0126: clt
+				IL_0128: brfalse IL_0140
 
-				IL_013f: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L130C25::.ctor()
-				IL_0144: stloc.s 7
-				IL_0146: ldloc.s 5
-				IL_0148: box [System.Runtime]System.Double
-				IL_014d: stloc.s 12
-				IL_014f: ldloc.s 12
-				IL_0151: stloc.1
+				IL_012d: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L130C25::.ctor()
+				IL_0132: stloc.s 7
+				IL_0134: ldloc.s 5
+				IL_0136: box [System.Runtime]System.Double
+				IL_013b: stloc.s 12
+				IL_013d: ldloc.s 12
+				IL_013f: stloc.1
 
-				IL_0152: ldloc.3
-				IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0158: stloc.s 9
-				IL_015a: ldloc.s 9
-				IL_015c: ldstr "substring"
-				IL_0161: ldloc.1
-				IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0167: stloc.s 9
-				IL_0169: ldloc.0
-				IL_016a: ldloc.s 9
-				IL_016c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0171: pop
-				IL_0172: ldarg.3
-				IL_0173: ldstr "index"
-				IL_0178: ldarg.3
-				IL_0179: ldstr "index"
-				IL_017e: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0183: ldc.r8 1
-				IL_018c: add
-				IL_018d: ldc.i4.1
-				IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_0193: pop
-				IL_0194: br IL_0017
+				IL_0140: ldloc.3
+				IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0146: stloc.s 9
+				IL_0148: ldloc.s 9
+				IL_014a: ldstr "substring"
+				IL_014f: ldloc.1
+				IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0155: stloc.s 9
+				IL_0157: ldloc.0
+				IL_0158: ldloc.s 9
+				IL_015a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_015f: pop
+				IL_0160: ldarg.3
+				IL_0161: ldstr "index"
+				IL_0166: ldarg.3
+				IL_0167: ldstr "index"
+				IL_016c: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0171: ldc.r8 1
+				IL_017a: add
+				IL_017b: ldc.i4.1
+				IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_0181: pop
+				IL_0182: br IL_0017
 			// end loop
 
-			IL_0199: ldarg.s style
-			IL_019b: ldstr ">"
-			IL_01a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01a5: stloc.s 11
-			IL_01a7: ldloc.s 11
-			IL_01a9: brfalse IL_01c3
+			IL_0187: ldarg.s style
+			IL_0189: ldstr ">"
+			IL_018e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0193: stloc.s 11
+			IL_0195: ldloc.s 11
+			IL_0197: brfalse IL_01b1
 
-			IL_01ae: ldarg.0
-			IL_01af: castclass Modules.test262_metadataParser/Scope
-			IL_01b4: ldnull
-			IL_01b5: ldloc.0
-			IL_01b6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01bb: tail.
-			IL_01bd: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-			IL_01c2: ret
+			IL_019c: ldarg.0
+			IL_019d: castclass Modules.test262_metadataParser/Scope
+			IL_01a2: ldnull
+			IL_01a3: ldloc.0
+			IL_01a4: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01a9: tail.
+			IL_01ab: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_01b0: ret
 
-			IL_01c3: ldloc.0
-			IL_01c4: ldc.i4.1
-			IL_01c5: newarr [System.Runtime]System.Object
-			IL_01ca: dup
-			IL_01cb: ldc.i4.0
-			IL_01cc: ldstr "\n"
-			IL_01d1: stelem.ref
-			IL_01d2: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01d7: stloc.s 13
-			IL_01d9: ldloc.s 13
-			IL_01db: ret
+			IL_01b1: ldloc.0
+			IL_01b2: ldc.i4.1
+			IL_01b3: newarr [System.Runtime]System.Object
+			IL_01b8: dup
+			IL_01b9: ldc.i4.0
+			IL_01ba: ldstr "\n"
+			IL_01bf: stelem.ref
+			IL_01c0: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_01c5: stloc.s 13
+			IL_01c7: ldloc.s 13
+			IL_01c9: ret
 		} // end of method parseBlockScalar::__js_call__
 
 	} // end of class parseBlockScalar
@@ -4574,7 +4328,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x71ce
+					// Method begins at RVA 0x6b04
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4594,7 +4348,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x71d7
+					// Method begins at RVA 0x6b0d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4614,7 +4368,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x71e0
+					// Method begins at RVA 0x6b16
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4632,7 +4386,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x71c5
+				// Method begins at RVA 0x6afb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4661,9 +4415,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x49bc
+			// Method begins at RVA 0x46e4
 			// Header size: 12
-			// Code size: 426 (0x1aa)
+			// Code size: 412 (0x19c)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4788,71 +4542,67 @@
 			IL_010e: ldarg.0
 			IL_010f: ldfld object Modules.test262_metadataParser/Scope::countIndent
 			IL_0114: stloc.s 6
-			IL_0116: ldstr "countIndent"
-			IL_011b: ldloc.s 6
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0122: stloc.s 6
-			IL_0124: ldc.i4.1
-			IL_0125: newarr [System.Runtime]System.Object
-			IL_012a: dup
-			IL_012b: ldc.i4.0
-			IL_012c: ldarg.0
-			IL_012d: stelem.ref
-			IL_012e: stloc.s 14
-			IL_0130: ldloc.s 6
-			IL_0132: ldloc.s 14
-			IL_0134: ldarg.2
-			IL_0135: ldloc.0
-			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0140: stloc.s 6
-			IL_0142: ldloc.s 6
-			IL_0144: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0149: stloc.s 7
-			IL_014b: ldloc.s 7
-			IL_014d: stloc.3
-			IL_014e: ldloc.3
-			IL_014f: stloc.s 7
-			IL_0151: ldloc.s 7
-			IL_0153: ldarg.s parentIndent
-			IL_0155: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_015a: cgt
-			IL_015c: ldc.i4.0
-			IL_015d: ceq
-			IL_015f: brfalse IL_017f
+			IL_0116: ldc.i4.1
+			IL_0117: newarr [System.Runtime]System.Object
+			IL_011c: dup
+			IL_011d: ldc.i4.0
+			IL_011e: ldarg.0
+			IL_011f: stelem.ref
+			IL_0120: stloc.s 14
+			IL_0122: ldloc.s 6
+			IL_0124: ldloc.s 14
+			IL_0126: ldarg.2
+			IL_0127: ldloc.0
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0132: stloc.s 6
+			IL_0134: ldloc.s 6
+			IL_0136: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_013b: stloc.s 7
+			IL_013d: ldloc.s 7
+			IL_013f: stloc.3
+			IL_0140: ldloc.3
+			IL_0141: stloc.s 7
+			IL_0143: ldloc.s 7
+			IL_0145: ldarg.s parentIndent
+			IL_0147: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_014c: cgt
+			IL_014e: ldc.i4.0
+			IL_014f: ceq
+			IL_0151: brfalse IL_0171
 
-			IL_0164: newobj instance void Modules.test262_metadataParser/parseIndentedValue/Scope/Block_L153C34::.ctor()
-			IL_0169: stloc.s 4
-			IL_016b: ldarg.3
-			IL_016c: ldstr "index"
-			IL_0171: ldloc.0
-			IL_0172: ldc.i4.1
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0178: pop
-			IL_0179: ldstr ""
-			IL_017e: ret
+			IL_0156: newobj instance void Modules.test262_metadataParser/parseIndentedValue/Scope/Block_L153C34::.ctor()
+			IL_015b: stloc.s 4
+			IL_015d: ldarg.3
+			IL_015e: ldstr "index"
+			IL_0163: ldloc.0
+			IL_0164: ldc.i4.1
+			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_016a: pop
+			IL_016b: ldstr ""
+			IL_0170: ret
 
-			IL_017f: ldarg.3
-			IL_0180: ldstr "index"
-			IL_0185: ldloc.0
-			IL_0186: ldc.i4.1
-			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_018c: pop
-			IL_018d: ldloc.3
-			IL_018e: box [System.Runtime]System.Double
-			IL_0193: stloc.s 13
-			IL_0195: ldarg.0
-			IL_0196: castclass Modules.test262_metadataParser/Scope
-			IL_019b: ldnull
-			IL_019c: ldarg.2
-			IL_019d: ldarg.3
-			IL_019e: ldloc.s 13
-			IL_01a0: tail.
-			IL_01a2: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_01a7: ret
+			IL_0171: ldarg.3
+			IL_0172: ldstr "index"
+			IL_0177: ldloc.0
+			IL_0178: ldc.i4.1
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_017e: pop
+			IL_017f: ldloc.3
+			IL_0180: box [System.Runtime]System.Double
+			IL_0185: stloc.s 13
+			IL_0187: ldarg.0
+			IL_0188: castclass Modules.test262_metadataParser/Scope
+			IL_018d: ldnull
+			IL_018e: ldarg.2
+			IL_018f: ldarg.3
+			IL_0190: ldloc.s 13
+			IL_0192: tail.
+			IL_0194: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0199: ret
 
-			IL_01a8: ldnull
-			IL_01a9: ret
+			IL_019a: ldnull
+			IL_019b: ret
 		} // end of method parseIndentedValue::__js_call__
 
 	} // end of class parseIndentedValue
@@ -4876,7 +4626,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x71fb
+						// Method begins at RVA 0x6b31
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4896,7 +4646,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7204
+						// Method begins at RVA 0x6b3a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4916,7 +4666,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x720d
+						// Method begins at RVA 0x6b43
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4936,7 +4686,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7216
+						// Method begins at RVA 0x6b4c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4956,7 +4706,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x721f
+						// Method begins at RVA 0x6b55
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4976,7 +4726,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7228
+						// Method begins at RVA 0x6b5e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4996,7 +4746,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7231
+						// Method begins at RVA 0x6b67
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5014,7 +4764,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x71f2
+					// Method begins at RVA 0x6b28
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5032,7 +4782,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x71e9
+				// Method begins at RVA 0x6b1f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5061,9 +4811,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4b74
+			// Method begins at RVA 0x488c
 			// Header size: 12
-			// Code size: 1069 (0x42d)
+			// Code size: 1001 (0x3e9)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -5118,7 +4868,7 @@
 				IL_002b: ldloc.s 19
 				IL_002d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0032: clt
-				IL_0034: brfalse IL_042b
+				IL_0034: brfalse IL_03e7
 
 				IL_0039: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37::.ctor()
 				IL_003e: stloc.1
@@ -5158,339 +4908,317 @@
 
 				IL_00a9: ldarg.0
 				IL_00aa: ldfld object Modules.test262_metadataParser/Scope::countIndent
-				IL_00af: stloc.s 19
-				IL_00b1: ldstr "countIndent"
-				IL_00b6: ldloc.s 19
-				IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00bd: stloc.s 19
-				IL_00bf: ldloc.s 19
-				IL_00c1: ldc.i4.1
-				IL_00c2: newarr [System.Runtime]System.Object
-				IL_00c7: dup
-				IL_00c8: ldc.i4.0
-				IL_00c9: ldarg.0
-				IL_00ca: stelem.ref
-				IL_00cb: ldloc.2
-				IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_00d1: stloc.s 19
-				IL_00d3: ldloc.s 19
-				IL_00d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00da: stloc.s 20
-				IL_00dc: ldloc.s 20
-				IL_00de: stloc.s 4
-				IL_00e0: ldloc.s 4
-				IL_00e2: stloc.s 20
-				IL_00e4: ldloc.s 20
-				IL_00e6: ldarg.s baseIndent
-				IL_00e8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ed: clt
-				IL_00ef: brfalse IL_0100
+				IL_00af: ldc.i4.1
+				IL_00b0: newarr [System.Runtime]System.Object
+				IL_00b5: dup
+				IL_00b6: ldc.i4.0
+				IL_00b7: ldarg.0
+				IL_00b8: stelem.ref
+				IL_00b9: ldloc.2
+				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_00bf: stloc.s 19
+				IL_00c1: ldloc.s 19
+				IL_00c3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00c8: stloc.s 20
+				IL_00ca: ldloc.s 20
+				IL_00cc: stloc.s 4
+				IL_00ce: ldloc.s 4
+				IL_00d0: stloc.s 20
+				IL_00d2: ldloc.s 20
+				IL_00d4: ldarg.s baseIndent
+				IL_00d6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00db: clt
+				IL_00dd: brfalse IL_00ee
 
-				IL_00f4: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L173C29::.ctor()
-				IL_00f9: stloc.s 5
-				IL_00fb: br IL_042b
+				IL_00e2: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L173C29::.ctor()
+				IL_00e7: stloc.s 5
+				IL_00e9: br IL_03e7
 
-				IL_0100: ldloc.s 4
-				IL_0102: stloc.s 20
-				IL_0104: ldloc.s 20
-				IL_0106: ldarg.s baseIndent
-				IL_0108: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_010d: cgt
-				IL_010f: brfalse IL_0184
+				IL_00ee: ldloc.s 4
+				IL_00f0: stloc.s 20
+				IL_00f2: ldloc.s 20
+				IL_00f4: ldarg.s baseIndent
+				IL_00f6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00fb: cgt
+				IL_00fd: brfalse IL_0172
 
-				IL_0114: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L177C29::.ctor()
-				IL_0119: stloc.s 6
-				IL_011b: ldarg.3
-				IL_011c: ldstr "index"
-				IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0126: ldc.r8 1
-				IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0134: stloc.s 22
-				IL_0136: ldloc.s 22
-				IL_0138: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_013d: stloc.s 23
-				IL_013f: ldstr "Unexpected indentation at frontmatter line "
-				IL_0144: ldloc.s 23
-				IL_0146: call string [System.Runtime]System.String::Concat(string, string)
-				IL_014b: stloc.s 23
-				IL_014d: ldloc.s 23
-				IL_014f: ldstr "."
-				IL_0154: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0159: stloc.s 23
-				IL_015b: ldloc.s 23
-				IL_015d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0162: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0167: stloc.s 19
-				IL_0169: ldloc.s 19
-				IL_016b: stloc.s 7
-				IL_016d: ldloc.s 7
-				IL_016f: isinst [System.Runtime]System.Exception
-				IL_0174: dup
-				IL_0175: brtrue IL_0183
+				IL_0102: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L177C29::.ctor()
+				IL_0107: stloc.s 6
+				IL_0109: ldarg.3
+				IL_010a: ldstr "index"
+				IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0114: ldc.r8 1
+				IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0122: stloc.s 22
+				IL_0124: ldloc.s 22
+				IL_0126: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_012b: stloc.s 23
+				IL_012d: ldstr "Unexpected indentation at frontmatter line "
+				IL_0132: ldloc.s 23
+				IL_0134: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0139: stloc.s 23
+				IL_013b: ldloc.s 23
+				IL_013d: ldstr "."
+				IL_0142: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0147: stloc.s 23
+				IL_0149: ldloc.s 23
+				IL_014b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0150: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0155: stloc.s 19
+				IL_0157: ldloc.s 19
+				IL_0159: stloc.s 7
+				IL_015b: ldloc.s 7
+				IL_015d: isinst [System.Runtime]System.Exception
+				IL_0162: dup
+				IL_0163: brtrue IL_0171
 
-				IL_017a: pop
-				IL_017b: ldloc.s 7
-				IL_017d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0182: throw
+				IL_0168: pop
+				IL_0169: ldloc.s 7
+				IL_016b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0170: throw
 
-				IL_0183: throw
+				IL_0171: throw
 
-				IL_0184: ldloc.2
-				IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_018a: stloc.s 19
-				IL_018c: ldloc.s 4
-				IL_018e: box [System.Runtime]System.Double
-				IL_0193: stloc.s 24
-				IL_0195: ldloc.s 19
-				IL_0197: ldstr "substring"
-				IL_019c: ldloc.s 24
-				IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_01a3: stloc.s 19
-				IL_01a5: ldloc.s 19
-				IL_01a7: stloc.s 8
-				IL_01a9: ldstr "^([A-Za-z0-9_-]+):(.*)$"
-				IL_01ae: ldstr ""
-				IL_01b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_01b8: stloc.s 25
-				IL_01ba: ldloc.s 25
-				IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01c1: stloc.s 19
-				IL_01c3: ldloc.s 19
-				IL_01c5: ldstr "exec"
-				IL_01ca: ldloc.s 8
-				IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_01d1: stloc.s 19
-				IL_01d3: ldloc.s 19
-				IL_01d5: stloc.s 9
-				IL_01d7: ldloc.s 9
-				IL_01d9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_01de: ldc.i4.0
-				IL_01df: ceq
-				IL_01e1: stloc.s 21
-				IL_01e3: ldloc.s 21
-				IL_01e5: brfalse IL_026e
+				IL_0172: ldloc.2
+				IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0178: stloc.s 19
+				IL_017a: ldloc.s 4
+				IL_017c: box [System.Runtime]System.Double
+				IL_0181: stloc.s 24
+				IL_0183: ldloc.s 19
+				IL_0185: ldstr "substring"
+				IL_018a: ldloc.s 24
+				IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0191: stloc.s 19
+				IL_0193: ldloc.s 19
+				IL_0195: stloc.s 8
+				IL_0197: ldstr "^([A-Za-z0-9_-]+):(.*)$"
+				IL_019c: ldstr ""
+				IL_01a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_01a6: stloc.s 25
+				IL_01a8: ldloc.s 25
+				IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01af: stloc.s 19
+				IL_01b1: ldloc.s 19
+				IL_01b3: ldstr "exec"
+				IL_01b8: ldloc.s 8
+				IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_01bf: stloc.s 19
+				IL_01c1: ldloc.s 19
+				IL_01c3: stloc.s 9
+				IL_01c5: ldloc.s 9
+				IL_01c7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_01cc: ldc.i4.0
+				IL_01cd: ceq
+				IL_01cf: stloc.s 21
+				IL_01d1: ldloc.s 21
+				IL_01d3: brfalse IL_025c
 
-				IL_01ea: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L183C16::.ctor()
-				IL_01ef: stloc.s 10
-				IL_01f1: ldarg.3
-				IL_01f2: ldstr "index"
-				IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01fc: ldc.r8 1
-				IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_020a: stloc.s 22
-				IL_020c: ldloc.s 22
-				IL_020e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0213: stloc.s 23
-				IL_0215: ldstr "Invalid frontmatter line "
-				IL_021a: ldloc.s 23
-				IL_021c: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0221: stloc.s 23
-				IL_0223: ldloc.s 23
-				IL_0225: ldstr ": "
-				IL_022a: call string [System.Runtime]System.String::Concat(string, string)
-				IL_022f: stloc.s 23
-				IL_0231: ldloc.s 8
-				IL_0233: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0238: stloc.s 26
-				IL_023a: ldloc.s 23
-				IL_023c: ldloc.s 26
-				IL_023e: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0243: stloc.s 26
-				IL_0245: ldloc.s 26
-				IL_0247: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_024c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0251: stloc.s 19
-				IL_0253: ldloc.s 19
-				IL_0255: stloc.s 11
-				IL_0257: ldloc.s 11
-				IL_0259: isinst [System.Runtime]System.Exception
-				IL_025e: dup
-				IL_025f: brtrue IL_026d
+				IL_01d8: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L183C16::.ctor()
+				IL_01dd: stloc.s 10
+				IL_01df: ldarg.3
+				IL_01e0: ldstr "index"
+				IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01ea: ldc.r8 1
+				IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_01f8: stloc.s 22
+				IL_01fa: ldloc.s 22
+				IL_01fc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0201: stloc.s 23
+				IL_0203: ldstr "Invalid frontmatter line "
+				IL_0208: ldloc.s 23
+				IL_020a: call string [System.Runtime]System.String::Concat(string, string)
+				IL_020f: stloc.s 23
+				IL_0211: ldloc.s 23
+				IL_0213: ldstr ": "
+				IL_0218: call string [System.Runtime]System.String::Concat(string, string)
+				IL_021d: stloc.s 23
+				IL_021f: ldloc.s 8
+				IL_0221: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0226: stloc.s 26
+				IL_0228: ldloc.s 23
+				IL_022a: ldloc.s 26
+				IL_022c: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0231: stloc.s 26
+				IL_0233: ldloc.s 26
+				IL_0235: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_023a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_023f: stloc.s 19
+				IL_0241: ldloc.s 19
+				IL_0243: stloc.s 11
+				IL_0245: ldloc.s 11
+				IL_0247: isinst [System.Runtime]System.Exception
+				IL_024c: dup
+				IL_024d: brtrue IL_025b
 
-				IL_0264: pop
-				IL_0265: ldloc.s 11
-				IL_0267: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_026c: throw
+				IL_0252: pop
+				IL_0253: ldloc.s 11
+				IL_0255: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_025a: throw
 
-				IL_026d: throw
+				IL_025b: throw
 
+				IL_025c: ldloc.s 9
+				IL_025e: ldc.r8 1
+				IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_026c: stloc.s 12
 				IL_026e: ldloc.s 9
-				IL_0270: ldc.r8 1
+				IL_0270: ldc.r8 2
 				IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_027e: stloc.s 12
-				IL_0280: ldloc.s 9
-				IL_0282: ldc.r8 2
-				IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0295: stloc.s 19
-				IL_0297: ldloc.s 19
-				IL_0299: ldstr "trim"
-				IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_02a3: stloc.s 19
-				IL_02a5: ldloc.s 19
-				IL_02a7: stloc.s 13
-				IL_02a9: ldarg.3
-				IL_02aa: ldstr "index"
-				IL_02af: ldarg.3
-				IL_02b0: ldstr "index"
-				IL_02b5: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_02ba: ldc.r8 1
-				IL_02c3: add
-				IL_02c4: ldc.i4.1
-				IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_02ca: pop
-				IL_02cb: ldnull
-				IL_02cc: stloc.s 14
-				IL_02ce: ldloc.s 13
-				IL_02d0: stloc.s 19
-				IL_02d2: ldloc.s 19
-				IL_02d4: ldstr "|"
-				IL_02d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0283: stloc.s 19
+				IL_0285: ldloc.s 19
+				IL_0287: ldstr "trim"
+				IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0291: stloc.s 19
+				IL_0293: ldloc.s 19
+				IL_0295: stloc.s 13
+				IL_0297: ldarg.3
+				IL_0298: ldstr "index"
+				IL_029d: ldarg.3
+				IL_029e: ldstr "index"
+				IL_02a3: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_02a8: ldc.r8 1
+				IL_02b1: add
+				IL_02b2: ldc.i4.1
+				IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_02b8: pop
+				IL_02b9: ldnull
+				IL_02ba: stloc.s 14
+				IL_02bc: ldloc.s 13
+				IL_02be: stloc.s 19
+				IL_02c0: ldloc.s 19
+				IL_02c2: ldstr "|"
+				IL_02c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02cc: stloc.s 21
+				IL_02ce: ldloc.s 21
+				IL_02d0: box [System.Runtime]System.Boolean
+				IL_02d5: stloc.s 27
+				IL_02d7: ldloc.s 27
+				IL_02d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_02de: stloc.s 21
 				IL_02e0: ldloc.s 21
-				IL_02e2: box [System.Runtime]System.Boolean
-				IL_02e7: stloc.s 27
-				IL_02e9: ldloc.s 27
-				IL_02eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02f0: stloc.s 21
-				IL_02f2: ldloc.s 21
-				IL_02f4: brtrue IL_031d
+				IL_02e2: brtrue IL_030b
 
-				IL_02f9: ldloc.s 13
-				IL_02fb: stloc.s 19
-				IL_02fd: ldloc.s 19
-				IL_02ff: ldstr ">"
-				IL_0304: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0309: stloc.s 21
-				IL_030b: ldloc.s 21
-				IL_030d: box [System.Runtime]System.Boolean
-				IL_0312: stloc.s 28
-				IL_0314: ldloc.s 28
-				IL_0316: stloc.s 29
-				IL_0318: br IL_0321
+				IL_02e7: ldloc.s 13
+				IL_02e9: stloc.s 19
+				IL_02eb: ldloc.s 19
+				IL_02ed: ldstr ">"
+				IL_02f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02f7: stloc.s 21
+				IL_02f9: ldloc.s 21
+				IL_02fb: box [System.Runtime]System.Boolean
+				IL_0300: stloc.s 28
+				IL_0302: ldloc.s 28
+				IL_0304: stloc.s 29
+				IL_0306: br IL_030f
 
-				IL_031d: ldloc.s 27
-				IL_031f: stloc.s 29
+				IL_030b: ldloc.s 27
+				IL_030d: stloc.s 29
 
-				IL_0321: ldloc.s 29
-				IL_0323: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0328: stloc.s 21
-				IL_032a: ldloc.s 21
-				IL_032c: brfalse IL_038a
+				IL_030f: ldloc.s 29
+				IL_0311: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0316: stloc.s 21
+				IL_0318: ldloc.s 21
+				IL_031a: brfalse IL_036a
 
-				IL_0331: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L192C48::.ctor()
-				IL_0336: stloc.s 15
-				IL_0338: ldarg.0
-				IL_0339: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
-				IL_033e: stloc.s 19
-				IL_0340: ldstr "parseBlockScalar"
-				IL_0345: ldloc.s 19
-				IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_034c: stloc.s 19
-				IL_034e: ldc.i4.1
-				IL_034f: newarr [System.Runtime]System.Object
-				IL_0354: dup
-				IL_0355: ldc.i4.0
-				IL_0356: ldarg.0
-				IL_0357: stelem.ref
-				IL_0358: stloc.s 30
-				IL_035a: ldc.i4.4
-				IL_035b: newarr [System.Runtime]System.Object
-				IL_0360: dup
-				IL_0361: ldc.i4.0
-				IL_0362: ldarg.2
-				IL_0363: stelem.ref
-				IL_0364: dup
-				IL_0365: ldc.i4.1
-				IL_0366: ldarg.3
-				IL_0367: stelem.ref
-				IL_0368: dup
-				IL_0369: ldc.i4.2
-				IL_036a: ldarg.s baseIndent
-				IL_036c: stelem.ref
-				IL_036d: dup
-				IL_036e: ldc.i4.3
-				IL_036f: ldloc.s 13
-				IL_0371: stelem.ref
-				IL_0372: stloc.s 31
-				IL_0374: ldloc.s 19
-				IL_0376: ldloc.s 30
-				IL_0378: ldloc.s 31
-				IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_037f: stloc.s 19
-				IL_0381: ldloc.s 19
-				IL_0383: stloc.s 14
-				IL_0385: br IL_041a
+				IL_031f: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L192C48::.ctor()
+				IL_0324: stloc.s 15
+				IL_0326: ldarg.0
+				IL_0327: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
+				IL_032c: stloc.s 19
+				IL_032e: ldc.i4.1
+				IL_032f: newarr [System.Runtime]System.Object
+				IL_0334: dup
+				IL_0335: ldc.i4.0
+				IL_0336: ldarg.0
+				IL_0337: stelem.ref
+				IL_0338: stloc.s 30
+				IL_033a: ldc.i4.4
+				IL_033b: newarr [System.Runtime]System.Object
+				IL_0340: dup
+				IL_0341: ldc.i4.0
+				IL_0342: ldarg.2
+				IL_0343: stelem.ref
+				IL_0344: dup
+				IL_0345: ldc.i4.1
+				IL_0346: ldarg.3
+				IL_0347: stelem.ref
+				IL_0348: dup
+				IL_0349: ldc.i4.2
+				IL_034a: ldarg.s baseIndent
+				IL_034c: stelem.ref
+				IL_034d: dup
+				IL_034e: ldc.i4.3
+				IL_034f: ldloc.s 13
+				IL_0351: stelem.ref
+				IL_0352: stloc.s 31
+				IL_0354: ldloc.s 19
+				IL_0356: ldloc.s 30
+				IL_0358: ldloc.s 31
+				IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_035f: stloc.s 19
+				IL_0361: ldloc.s 19
+				IL_0363: stloc.s 14
+				IL_0365: br IL_03d6
 
-				IL_038a: ldloc.s 13
-				IL_038c: stloc.s 19
-				IL_038e: ldloc.s 19
-				IL_0390: ldstr ""
-				IL_0395: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_039a: stloc.s 21
-				IL_039c: ldloc.s 21
-				IL_039e: brfalse IL_03e4
+				IL_036a: ldloc.s 13
+				IL_036c: stloc.s 19
+				IL_036e: ldloc.s 19
+				IL_0370: ldstr ""
+				IL_0375: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_037a: stloc.s 21
+				IL_037c: ldloc.s 21
+				IL_037e: brfalse IL_03b2
 
-				IL_03a3: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L194C33::.ctor()
-				IL_03a8: stloc.s 16
-				IL_03aa: ldarg.0
-				IL_03ab: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
-				IL_03b0: stloc.s 19
-				IL_03b2: ldstr "parseIndentedValue"
-				IL_03b7: ldloc.s 19
-				IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_03be: stloc.s 19
-				IL_03c0: ldc.i4.1
-				IL_03c1: newarr [System.Runtime]System.Object
-				IL_03c6: dup
-				IL_03c7: ldc.i4.0
-				IL_03c8: ldarg.0
-				IL_03c9: stelem.ref
-				IL_03ca: stloc.s 31
-				IL_03cc: ldloc.s 19
-				IL_03ce: ldloc.s 31
-				IL_03d0: ldarg.2
-				IL_03d1: ldarg.3
-				IL_03d2: ldarg.s baseIndent
-				IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_03d9: stloc.s 19
-				IL_03db: ldloc.s 19
-				IL_03dd: stloc.s 14
-				IL_03df: br IL_041a
+				IL_0383: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L194C33::.ctor()
+				IL_0388: stloc.s 16
+				IL_038a: ldc.i4.1
+				IL_038b: newarr [System.Runtime]System.Object
+				IL_0390: dup
+				IL_0391: ldc.i4.0
+				IL_0392: ldarg.0
+				IL_0393: stelem.ref
+				IL_0394: stloc.s 31
+				IL_0396: ldarg.0
+				IL_0397: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
+				IL_039c: ldloc.s 31
+				IL_039e: ldarg.2
+				IL_039f: ldarg.3
+				IL_03a0: ldarg.s baseIndent
+				IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_03a7: stloc.s 19
+				IL_03a9: ldloc.s 19
+				IL_03ab: stloc.s 14
+				IL_03ad: br IL_03d6
 
-				IL_03e4: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L196C11::.ctor()
-				IL_03e9: stloc.s 17
-				IL_03eb: ldarg.0
-				IL_03ec: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
-				IL_03f1: stloc.s 19
-				IL_03f3: ldstr "parseInlineValue"
-				IL_03f8: ldloc.s 19
-				IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_03ff: stloc.s 19
-				IL_0401: ldloc.s 19
-				IL_0403: ldc.i4.1
-				IL_0404: newarr [System.Runtime]System.Object
-				IL_0409: dup
-				IL_040a: ldc.i4.0
-				IL_040b: ldarg.0
-				IL_040c: stelem.ref
-				IL_040d: ldloc.s 13
-				IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0414: stloc.s 19
-				IL_0416: ldloc.s 19
-				IL_0418: stloc.s 14
+				IL_03b2: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L196C11::.ctor()
+				IL_03b7: stloc.s 17
+				IL_03b9: ldarg.0
+				IL_03ba: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
+				IL_03bf: ldc.i4.1
+				IL_03c0: newarr [System.Runtime]System.Object
+				IL_03c5: dup
+				IL_03c6: ldc.i4.0
+				IL_03c7: ldarg.0
+				IL_03c8: stelem.ref
+				IL_03c9: ldloc.s 13
+				IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_03d0: stloc.s 19
+				IL_03d2: ldloc.s 19
+				IL_03d4: stloc.s 14
 
-				IL_041a: ldloc.0
-				IL_041b: ldloc.s 12
-				IL_041d: ldloc.s 14
-				IL_041f: ldc.i4.1
-				IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_0425: pop
-				IL_0426: br IL_0006
+				IL_03d6: ldloc.0
+				IL_03d7: ldloc.s 12
+				IL_03d9: ldloc.s 14
+				IL_03db: ldc.i4.1
+				IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_03e1: pop
+				IL_03e2: br IL_0006
 			// end loop
 
-			IL_042b: ldloc.0
-			IL_042c: ret
+			IL_03e7: ldloc.0
+			IL_03e8: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -5506,7 +5234,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x723a
+				// Method begins at RVA 0x6b70
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5533,65 +5261,59 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4fb0
+			// Method begins at RVA 0x4c84
 			// Header size: 12
-			// Code size: 124 (0x7c)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] object[],
+				[1] object[],
+				[2] object,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.test262_metadataParser/Scope::normalizeLineEndings
-			IL_0006: stloc.1
-			IL_0007: ldstr "normalizeLineEndings"
-			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.2
-			IL_001e: ldloc.1
-			IL_001f: ldloc.2
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0026: stloc.1
-			IL_0027: ldloc.1
-			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002d: stloc.1
-			IL_002e: ldloc.1
-			IL_002f: ldstr "split"
-			IL_0034: ldstr "\n"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003e: stloc.1
-			IL_003f: ldloc.1
-			IL_0040: stloc.0
-			IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0046: dup
-			IL_0047: ldstr "index"
-			IL_004c: ldc.r8 0.0
-			IL_0055: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_005a: stloc.3
-			IL_005b: ldarg.0
-			IL_005c: castclass Modules.test262_metadataParser/Scope
-			IL_0061: ldnull
-			IL_0062: ldloc.0
-			IL_0063: ldloc.3
-			IL_0064: ldc.r8 0.0
-			IL_006d: box [System.Runtime]System.Double
-			IL_0072: tail.
-			IL_0074: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0079: ret
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.1
+			IL_000b: ldarg.0
+			IL_000c: ldfld object Modules.test262_metadataParser/Scope::normalizeLineEndings
+			IL_0011: ldloc.1
+			IL_0012: ldarg.2
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0018: stloc.2
+			IL_0019: ldloc.2
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001f: stloc.2
+			IL_0020: ldloc.2
+			IL_0021: ldstr "split"
+			IL_0026: ldstr "\n"
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0030: stloc.2
+			IL_0031: ldloc.2
+			IL_0032: stloc.0
+			IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0038: dup
+			IL_0039: ldstr "index"
+			IL_003e: ldc.r8 0.0
+			IL_0047: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_004c: stloc.3
+			IL_004d: ldarg.0
+			IL_004e: castclass Modules.test262_metadataParser/Scope
+			IL_0053: ldnull
+			IL_0054: ldloc.0
+			IL_0055: ldloc.3
+			IL_0056: ldc.r8 0.0
+			IL_005f: box [System.Runtime]System.Double
+			IL_0064: tail.
+			IL_0066: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_006b: ret
 
-			IL_007a: ldnull
-			IL_007b: ret
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method parseTest262Frontmatter::__js_call__
 
 	} // end of class parseTest262Frontmatter
@@ -5611,7 +5333,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x724c
+					// Method begins at RVA 0x6b82
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5631,7 +5353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7255
+					// Method begins at RVA 0x6b8b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5651,7 +5373,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x725e
+					// Method begins at RVA 0x6b94
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5669,7 +5391,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7243
+				// Method begins at RVA 0x6b79
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5696,9 +5418,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5038
+			// Method begins at RVA 0x4d00
 			// Header size: 12
-			// Code size: 401 (0x191)
+			// Code size: 383 (0x17f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5709,155 +5431,149 @@
 				[5] object,
 				[6] object,
 				[7] class Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L224C36,
-				[8] object,
-				[9] object[],
+				[8] object[],
+				[9] object,
 				[10] float64,
 				[11] object,
 				[12] object,
 				[13] bool
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.test262_metadataParser/Scope::normalizeLineEndings
-			IL_0006: stloc.s 8
-			IL_0008: ldstr "normalizeLineEndings"
-			IL_000d: ldloc.s 8
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 8
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.s 9
-			IL_0022: ldloc.s 8
-			IL_0024: ldloc.s 9
-			IL_0026: ldarg.2
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_002c: stloc.s 8
-			IL_002e: ldloc.s 8
-			IL_0030: stloc.0
-			IL_0031: ldloc.0
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0037: stloc.s 8
-			IL_0039: ldloc.s 8
-			IL_003b: ldstr "indexOf"
-			IL_0040: ldstr "/*---"
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_004a: stloc.s 8
-			IL_004c: ldloc.s 8
-			IL_004e: stloc.1
-			IL_004f: ldloc.1
-			IL_0050: stloc.s 8
-			IL_0052: ldloc.s 8
-			IL_0054: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0059: stloc.s 10
-			IL_005b: ldloc.s 10
-			IL_005d: ldc.r8 0.0
-			IL_0066: clt
-			IL_0068: brfalse IL_007a
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 8
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.test262_metadataParser/Scope::normalizeLineEndings
+			IL_0012: ldloc.s 8
+			IL_0014: ldarg.2
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_001a: stloc.s 9
+			IL_001c: ldloc.s 9
+			IL_001e: stloc.0
+			IL_001f: ldloc.0
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0025: stloc.s 9
+			IL_0027: ldloc.s 9
+			IL_0029: ldstr "indexOf"
+			IL_002e: ldstr "/*---"
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0038: stloc.s 9
+			IL_003a: ldloc.s 9
+			IL_003c: stloc.1
+			IL_003d: ldloc.1
+			IL_003e: stloc.s 9
+			IL_0040: ldloc.s 9
+			IL_0042: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0047: stloc.s 10
+			IL_0049: ldloc.s 10
+			IL_004b: ldc.r8 0.0
+			IL_0054: clt
+			IL_0056: brfalse IL_0068
 
-			IL_006d: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L214C17::.ctor()
-			IL_0072: stloc.2
-			IL_0073: ldc.i4.0
-			IL_0074: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0079: ret
+			IL_005b: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L214C17::.ctor()
+			IL_0060: stloc.2
+			IL_0061: ldc.i4.0
+			IL_0062: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0067: ret
 
-			IL_007a: ldloc.0
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0080: stloc.s 8
-			IL_0082: ldloc.1
-			IL_0083: stloc.s 11
-			IL_0085: ldloc.s 11
-			IL_0087: ldc.r8 5
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0095: stloc.s 12
-			IL_0097: ldloc.s 8
-			IL_0099: ldstr "indexOf"
-			IL_009e: ldstr "---*/"
-			IL_00a3: ldloc.s 12
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00aa: stloc.s 8
-			IL_00ac: ldloc.s 8
-			IL_00ae: stloc.3
-			IL_00af: ldloc.3
-			IL_00b0: stloc.s 8
-			IL_00b2: ldloc.s 8
-			IL_00b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00b9: stloc.s 10
-			IL_00bb: ldloc.s 10
-			IL_00bd: ldc.r8 0.0
-			IL_00c6: clt
-			IL_00c8: brfalse IL_0100
+			IL_0068: ldloc.0
+			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006e: stloc.s 9
+			IL_0070: ldloc.1
+			IL_0071: stloc.s 11
+			IL_0073: ldloc.s 11
+			IL_0075: ldc.r8 5
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0083: stloc.s 12
+			IL_0085: ldloc.s 9
+			IL_0087: ldstr "indexOf"
+			IL_008c: ldstr "---*/"
+			IL_0091: ldloc.s 12
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0098: stloc.s 9
+			IL_009a: ldloc.s 9
+			IL_009c: stloc.3
+			IL_009d: ldloc.3
+			IL_009e: stloc.s 9
+			IL_00a0: ldloc.s 9
+			IL_00a2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00a7: stloc.s 10
+			IL_00a9: ldloc.s 10
+			IL_00ab: ldc.r8 0.0
+			IL_00b4: clt
+			IL_00b6: brfalse IL_00ee
 
-			IL_00cd: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L219C15::.ctor()
-			IL_00d2: stloc.s 4
-			IL_00d4: ldstr "Unterminated test262 frontmatter block."
-			IL_00d9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00e3: stloc.s 8
-			IL_00e5: ldloc.s 8
-			IL_00e7: stloc.s 5
-			IL_00e9: ldloc.s 5
-			IL_00eb: isinst [System.Runtime]System.Exception
-			IL_00f0: dup
-			IL_00f1: brtrue IL_00ff
+			IL_00bb: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L219C15::.ctor()
+			IL_00c0: stloc.s 4
+			IL_00c2: ldstr "Unterminated test262 frontmatter block."
+			IL_00c7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00d1: stloc.s 9
+			IL_00d3: ldloc.s 9
+			IL_00d5: stloc.s 5
+			IL_00d7: ldloc.s 5
+			IL_00d9: isinst [System.Runtime]System.Exception
+			IL_00de: dup
+			IL_00df: brtrue IL_00ed
 
-			IL_00f6: pop
-			IL_00f7: ldloc.s 5
-			IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00fe: throw
+			IL_00e4: pop
+			IL_00e5: ldloc.s 5
+			IL_00e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00ec: throw
 
-			IL_00ff: throw
+			IL_00ed: throw
 
-			IL_0100: ldloc.0
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0106: stloc.s 8
-			IL_0108: ldloc.1
-			IL_0109: stloc.s 11
-			IL_010b: ldloc.s 11
-			IL_010d: ldc.r8 5
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_011b: stloc.s 12
-			IL_011d: ldloc.s 8
-			IL_011f: ldstr "substring"
-			IL_0124: ldloc.s 12
-			IL_0126: ldloc.3
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_012c: stloc.s 8
-			IL_012e: ldloc.s 8
-			IL_0130: stloc.s 6
-			IL_0132: ldloc.s 6
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0139: stloc.s 8
-			IL_013b: ldloc.s 8
-			IL_013d: ldstr "startsWith"
-			IL_0142: ldstr "\n"
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_014c: stloc.s 8
-			IL_014e: ldloc.s 8
-			IL_0150: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0155: stloc.s 13
-			IL_0157: ldloc.s 13
-			IL_0159: brfalse IL_018e
+			IL_00ee: ldloc.0
+			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f4: stloc.s 9
+			IL_00f6: ldloc.1
+			IL_00f7: stloc.s 11
+			IL_00f9: ldloc.s 11
+			IL_00fb: ldc.r8 5
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0109: stloc.s 12
+			IL_010b: ldloc.s 9
+			IL_010d: ldstr "substring"
+			IL_0112: ldloc.s 12
+			IL_0114: ldloc.3
+			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_011a: stloc.s 9
+			IL_011c: ldloc.s 9
+			IL_011e: stloc.s 6
+			IL_0120: ldloc.s 6
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0127: stloc.s 9
+			IL_0129: ldloc.s 9
+			IL_012b: ldstr "startsWith"
+			IL_0130: ldstr "\n"
+			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_013a: stloc.s 9
+			IL_013c: ldloc.s 9
+			IL_013e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0143: stloc.s 13
+			IL_0145: ldloc.s 13
+			IL_0147: brfalse IL_017c
 
-			IL_015e: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L224C36::.ctor()
-			IL_0163: stloc.s 7
-			IL_0165: ldloc.s 6
-			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_016c: stloc.s 8
-			IL_016e: ldloc.s 8
-			IL_0170: ldstr "substring"
-			IL_0175: ldc.r8 1
-			IL_017e: box [System.Runtime]System.Double
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0188: stloc.s 8
-			IL_018a: ldloc.s 8
-			IL_018c: stloc.s 6
+			IL_014c: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L224C36::.ctor()
+			IL_0151: stloc.s 7
+			IL_0153: ldloc.s 6
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015a: stloc.s 9
+			IL_015c: ldloc.s 9
+			IL_015e: ldstr "substring"
+			IL_0163: ldc.r8 1
+			IL_016c: box [System.Runtime]System.Double
+			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0176: stloc.s 9
+			IL_0178: ldloc.s 9
+			IL_017a: stloc.s 6
 
-			IL_018e: ldloc.s 6
-			IL_0190: ret
+			IL_017c: ldloc.s 6
+			IL_017e: ret
 		} // end of method extractTest262Frontmatter::__js_call__
 
 	} // end of class extractTest262Frontmatter
@@ -5873,7 +5589,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7267
+				// Method begins at RVA 0x6b9d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5897,7 +5613,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x51d8
+			// Method begins at RVA 0x4e8c
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -5956,7 +5672,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7279
+					// Method begins at RVA 0x6baf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5974,7 +5690,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7270
+				// Method begins at RVA 0x6ba6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5998,7 +5714,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x522c
+			// Method begins at RVA 0x4ee0
 			// Header size: 12
 			// Code size: 131 (0x83)
 			.maxstack 8
@@ -6081,7 +5797,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7282
+				// Method begins at RVA 0x6bb8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6106,7 +5822,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x52bc
+			// Method begins at RVA 0x4f70
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -6154,7 +5870,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x728b
+				// Method begins at RVA 0x6bc1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6181,7 +5897,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x52fc
+			// Method begins at RVA 0x4fb0
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -6230,7 +5946,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x729d
+					// Method begins at RVA 0x6bd3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6250,7 +5966,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x72a6
+					// Method begins at RVA 0x6bdc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6268,7 +5984,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7294
+				// Method begins at RVA 0x6bca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6296,7 +6012,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x72c1
+						// Method begins at RVA 0x6bf7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6314,7 +6030,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x72b8
+					// Method begins at RVA 0x6bee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6332,7 +6048,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x72af
+				// Method begins at RVA 0x6be5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6361,9 +6077,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5348
+			// Method begins at RVA 0x4ffc
 			// Header size: 12
-			// Code size: 527 (0x20f)
+			// Code size: 499 (0x1f3)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.test262_metadataParser/toStringArray/Scope/Block_L257C61,
@@ -6451,159 +6167,151 @@
 			IL_009d: ceq
 			IL_009f: stloc.s 7
 			IL_00a1: ldloc.s 7
-			IL_00a3: brfalse IL_0125
+			IL_00a3: brfalse IL_0117
 
 			IL_00a8: newobj instance void Modules.test262_metadataParser/toStringArray/Scope/Block_L261C29::.ctor()
 			IL_00ad: stloc.1
 			IL_00ae: ldarg.0
 			IL_00af: ldfld object Modules.test262_metadataParser/Scope::pushIssue
 			IL_00b4: stloc.s 13
-			IL_00b6: ldstr "pushIssue"
-			IL_00bb: ldloc.s 13
-			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c2: stloc.s 13
-			IL_00c4: ldc.i4.1
-			IL_00c5: newarr [System.Runtime]System.Object
-			IL_00ca: dup
-			IL_00cb: ldc.i4.0
-			IL_00cc: ldarg.0
-			IL_00cd: stelem.ref
-			IL_00ce: stloc.s 14
-			IL_00d0: ldarg.3
-			IL_00d1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00b6: ldc.i4.1
+			IL_00b7: newarr [System.Runtime]System.Object
+			IL_00bc: dup
+			IL_00bd: ldc.i4.0
+			IL_00be: ldarg.0
+			IL_00bf: stelem.ref
+			IL_00c0: stloc.s 14
+			IL_00c2: ldarg.3
+			IL_00c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00c8: stloc.s 15
+			IL_00ca: ldstr "Expected an array for '"
+			IL_00cf: ldloc.s 15
+			IL_00d1: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00d6: stloc.s 15
-			IL_00d8: ldstr "Expected an array for '"
-			IL_00dd: ldloc.s 15
+			IL_00d8: ldloc.s 15
+			IL_00da: ldstr "'."
 			IL_00df: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00e4: stloc.s 15
-			IL_00e6: ldloc.s 15
-			IL_00e8: ldstr "'."
-			IL_00ed: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00f2: stloc.s 15
-			IL_00f4: ldc.i4.4
-			IL_00f5: newarr [System.Runtime]System.Object
-			IL_00fa: dup
-			IL_00fb: ldc.i4.0
-			IL_00fc: ldarg.s issues
-			IL_00fe: stelem.ref
-			IL_00ff: dup
-			IL_0100: ldc.i4.1
-			IL_0101: ldstr "invalid-array"
-			IL_0106: stelem.ref
-			IL_0107: dup
-			IL_0108: ldc.i4.2
-			IL_0109: ldarg.3
-			IL_010a: stelem.ref
-			IL_010b: dup
-			IL_010c: ldc.i4.3
-			IL_010d: ldloc.s 15
-			IL_010f: stelem.ref
-			IL_0110: stloc.s 16
-			IL_0112: ldloc.s 13
-			IL_0114: ldloc.s 14
-			IL_0116: ldloc.s 16
-			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_011d: pop
-			IL_011e: ldc.i4.0
-			IL_011f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0124: ret
+			IL_00e6: ldc.i4.4
+			IL_00e7: newarr [System.Runtime]System.Object
+			IL_00ec: dup
+			IL_00ed: ldc.i4.0
+			IL_00ee: ldarg.s issues
+			IL_00f0: stelem.ref
+			IL_00f1: dup
+			IL_00f2: ldc.i4.1
+			IL_00f3: ldstr "invalid-array"
+			IL_00f8: stelem.ref
+			IL_00f9: dup
+			IL_00fa: ldc.i4.2
+			IL_00fb: ldarg.3
+			IL_00fc: stelem.ref
+			IL_00fd: dup
+			IL_00fe: ldc.i4.3
+			IL_00ff: ldloc.s 15
+			IL_0101: stelem.ref
+			IL_0102: stloc.s 16
+			IL_0104: ldloc.s 13
+			IL_0106: ldloc.s 14
+			IL_0108: ldloc.s 16
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_010f: pop
+			IL_0110: ldc.i4.0
+			IL_0111: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0116: ret
 
-			IL_0125: ldc.i4.0
-			IL_0126: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_012b: stloc.2
-			IL_012c: ldc.r8 0.0
-			IL_0135: stloc.3
-			// loop start (head: IL_0136)
-				IL_0136: ldloc.3
-				IL_0137: stloc.s 17
-				IL_0139: ldloc.s 17
-				IL_013b: ldarg.2
-				IL_013c: ldstr "length"
-				IL_0141: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0146: clt
-				IL_0148: brfalse IL_020d
+			IL_0117: ldc.i4.0
+			IL_0118: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_011d: stloc.2
+			IL_011e: ldc.r8 0.0
+			IL_0127: stloc.3
+			// loop start (head: IL_0128)
+				IL_0128: ldloc.3
+				IL_0129: stloc.s 17
+				IL_012b: ldloc.s 17
+				IL_012d: ldarg.2
+				IL_012e: ldstr "length"
+				IL_0133: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0138: clt
+				IL_013a: brfalse IL_01f1
 
-				IL_014d: newobj instance void Modules.test262_metadataParser/toStringArray/Scope_For_L267C7/Block_L267C41::.ctor()
-				IL_0152: stloc.s 4
-				IL_0154: ldarg.2
-				IL_0155: ldloc.3
-				IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_015b: stloc.s 5
-				IL_015d: ldloc.s 5
-				IL_015f: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-				IL_0164: ldstr "string"
-				IL_0169: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_016e: stloc.s 7
-				IL_0170: ldloc.s 7
-				IL_0172: brfalse IL_01f3
+				IL_013f: newobj instance void Modules.test262_metadataParser/toStringArray/Scope_For_L267C7/Block_L267C41::.ctor()
+				IL_0144: stloc.s 4
+				IL_0146: ldarg.2
+				IL_0147: ldloc.3
+				IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_014d: stloc.s 5
+				IL_014f: ldloc.s 5
+				IL_0151: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+				IL_0156: ldstr "string"
+				IL_015b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_0160: stloc.s 7
+				IL_0162: ldloc.s 7
+				IL_0164: brfalse IL_01d7
 
-				IL_0177: newobj instance void Modules.test262_metadataParser/toStringArray/Scope_For_L267C7/Block_L267C41/Block_L269C35::.ctor()
-				IL_017c: stloc.s 6
-				IL_017e: ldarg.0
-				IL_017f: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-				IL_0184: stloc.s 13
-				IL_0186: ldstr "pushIssue"
-				IL_018b: ldloc.s 13
-				IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0192: stloc.s 13
-				IL_0194: ldc.i4.1
-				IL_0195: newarr [System.Runtime]System.Object
-				IL_019a: dup
-				IL_019b: ldc.i4.0
-				IL_019c: ldarg.0
-				IL_019d: stelem.ref
-				IL_019e: stloc.s 16
-				IL_01a0: ldarg.3
-				IL_01a1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0169: newobj instance void Modules.test262_metadataParser/toStringArray/Scope_For_L267C7/Block_L267C41/Block_L269C35::.ctor()
+				IL_016e: stloc.s 6
+				IL_0170: ldarg.0
+				IL_0171: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+				IL_0176: stloc.s 13
+				IL_0178: ldc.i4.1
+				IL_0179: newarr [System.Runtime]System.Object
+				IL_017e: dup
+				IL_017f: ldc.i4.0
+				IL_0180: ldarg.0
+				IL_0181: stelem.ref
+				IL_0182: stloc.s 16
+				IL_0184: ldarg.3
+				IL_0185: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_018a: stloc.s 15
+				IL_018c: ldstr "Expected string entries for '"
+				IL_0191: ldloc.s 15
+				IL_0193: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0198: stloc.s 15
+				IL_019a: ldloc.s 15
+				IL_019c: ldstr "'."
+				IL_01a1: call string [System.Runtime]System.String::Concat(string, string)
 				IL_01a6: stloc.s 15
-				IL_01a8: ldstr "Expected string entries for '"
-				IL_01ad: ldloc.s 15
-				IL_01af: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01b4: stloc.s 15
-				IL_01b6: ldloc.s 15
-				IL_01b8: ldstr "'."
-				IL_01bd: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01c2: stloc.s 15
-				IL_01c4: ldc.i4.4
-				IL_01c5: newarr [System.Runtime]System.Object
-				IL_01ca: dup
-				IL_01cb: ldc.i4.0
-				IL_01cc: ldarg.s issues
-				IL_01ce: stelem.ref
-				IL_01cf: dup
-				IL_01d0: ldc.i4.1
-				IL_01d1: ldstr "invalid-array-entry"
-				IL_01d6: stelem.ref
-				IL_01d7: dup
-				IL_01d8: ldc.i4.2
-				IL_01d9: ldarg.3
-				IL_01da: stelem.ref
-				IL_01db: dup
-				IL_01dc: ldc.i4.3
-				IL_01dd: ldloc.s 15
-				IL_01df: stelem.ref
-				IL_01e0: stloc.s 14
-				IL_01e2: ldloc.s 13
-				IL_01e4: ldloc.s 16
-				IL_01e6: ldloc.s 14
-				IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_01ed: pop
-				IL_01ee: br IL_01fc
+				IL_01a8: ldc.i4.4
+				IL_01a9: newarr [System.Runtime]System.Object
+				IL_01ae: dup
+				IL_01af: ldc.i4.0
+				IL_01b0: ldarg.s issues
+				IL_01b2: stelem.ref
+				IL_01b3: dup
+				IL_01b4: ldc.i4.1
+				IL_01b5: ldstr "invalid-array-entry"
+				IL_01ba: stelem.ref
+				IL_01bb: dup
+				IL_01bc: ldc.i4.2
+				IL_01bd: ldarg.3
+				IL_01be: stelem.ref
+				IL_01bf: dup
+				IL_01c0: ldc.i4.3
+				IL_01c1: ldloc.s 15
+				IL_01c3: stelem.ref
+				IL_01c4: stloc.s 14
+				IL_01c6: ldloc.s 13
+				IL_01c8: ldloc.s 16
+				IL_01ca: ldloc.s 14
+				IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_01d1: pop
+				IL_01d2: br IL_01e0
 
-				IL_01f3: ldloc.2
-				IL_01f4: ldloc.s 5
-				IL_01f6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_01fb: pop
+				IL_01d7: ldloc.2
+				IL_01d8: ldloc.s 5
+				IL_01da: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_01df: pop
 
-				IL_01fc: ldloc.3
-				IL_01fd: ldc.r8 1
-				IL_0206: add
-				IL_0207: stloc.3
-				IL_0208: br IL_0136
+				IL_01e0: ldloc.3
+				IL_01e1: ldc.r8 1
+				IL_01ea: add
+				IL_01eb: stloc.3
+				IL_01ec: br IL_0128
 			// end loop
 
-			IL_020d: ldloc.2
-			IL_020e: ret
+			IL_01f1: ldloc.2
+			IL_01f2: ret
 		} // end of method toStringArray::__js_call__
 
 	} // end of class toStringArray
@@ -6623,7 +6331,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x72d3
+					// Method begins at RVA 0x6c09
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6643,7 +6351,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x72dc
+					// Method begins at RVA 0x6c12
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6661,7 +6369,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x72ca
+				// Method begins at RVA 0x6c00
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6690,9 +6398,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5564
+			// Method begins at RVA 0x51fc
 			// Header size: 12
-			// Code size: 279 (0x117)
+			// Code size: 265 (0x109)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.test262_metadataParser/toNullableString/Scope/Block_L281C61,
@@ -6772,65 +6480,61 @@
 			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
 			IL_0091: stloc.2
 			IL_0092: ldloc.2
-			IL_0093: brfalse IL_0115
+			IL_0093: brfalse IL_0107
 
 			IL_0098: newobj instance void Modules.test262_metadataParser/toNullableString/Scope/Block_L285C33::.ctor()
 			IL_009d: stloc.1
 			IL_009e: ldarg.0
 			IL_009f: ldfld object Modules.test262_metadataParser/Scope::pushIssue
 			IL_00a4: stloc.s 8
-			IL_00a6: ldstr "pushIssue"
-			IL_00ab: ldloc.s 8
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00b2: stloc.s 8
-			IL_00b4: ldc.i4.1
-			IL_00b5: newarr [System.Runtime]System.Object
-			IL_00ba: dup
-			IL_00bb: ldc.i4.0
-			IL_00bc: ldarg.0
-			IL_00bd: stelem.ref
-			IL_00be: stloc.s 9
-			IL_00c0: ldarg.3
-			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00a6: ldc.i4.1
+			IL_00a7: newarr [System.Runtime]System.Object
+			IL_00ac: dup
+			IL_00ad: ldc.i4.0
+			IL_00ae: ldarg.0
+			IL_00af: stelem.ref
+			IL_00b0: stloc.s 9
+			IL_00b2: ldarg.3
+			IL_00b3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00b8: stloc.s 10
+			IL_00ba: ldstr "Expected a string for '"
+			IL_00bf: ldloc.s 10
+			IL_00c1: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00c6: stloc.s 10
-			IL_00c8: ldstr "Expected a string for '"
-			IL_00cd: ldloc.s 10
+			IL_00c8: ldloc.s 10
+			IL_00ca: ldstr "'."
 			IL_00cf: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00d4: stloc.s 10
-			IL_00d6: ldloc.s 10
-			IL_00d8: ldstr "'."
-			IL_00dd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00e2: stloc.s 10
-			IL_00e4: ldc.i4.4
-			IL_00e5: newarr [System.Runtime]System.Object
-			IL_00ea: dup
-			IL_00eb: ldc.i4.0
-			IL_00ec: ldarg.s issues
-			IL_00ee: stelem.ref
-			IL_00ef: dup
-			IL_00f0: ldc.i4.1
-			IL_00f1: ldstr "invalid-string"
-			IL_00f6: stelem.ref
-			IL_00f7: dup
-			IL_00f8: ldc.i4.2
-			IL_00f9: ldarg.3
-			IL_00fa: stelem.ref
-			IL_00fb: dup
-			IL_00fc: ldc.i4.3
-			IL_00fd: ldloc.s 10
-			IL_00ff: stelem.ref
-			IL_0100: stloc.s 11
-			IL_0102: ldloc.s 8
-			IL_0104: ldloc.s 9
-			IL_0106: ldloc.s 11
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_010d: pop
-			IL_010e: ldc.i4.0
-			IL_010f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0114: ret
+			IL_00d6: ldc.i4.4
+			IL_00d7: newarr [System.Runtime]System.Object
+			IL_00dc: dup
+			IL_00dd: ldc.i4.0
+			IL_00de: ldarg.s issues
+			IL_00e0: stelem.ref
+			IL_00e1: dup
+			IL_00e2: ldc.i4.1
+			IL_00e3: ldstr "invalid-string"
+			IL_00e8: stelem.ref
+			IL_00e9: dup
+			IL_00ea: ldc.i4.2
+			IL_00eb: ldarg.3
+			IL_00ec: stelem.ref
+			IL_00ed: dup
+			IL_00ee: ldc.i4.3
+			IL_00ef: ldloc.s 10
+			IL_00f1: stelem.ref
+			IL_00f2: stloc.s 11
+			IL_00f4: ldloc.s 8
+			IL_00f6: ldloc.s 9
+			IL_00f8: ldloc.s 11
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_00ff: pop
+			IL_0100: ldc.i4.0
+			IL_0101: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0106: ret
 
-			IL_0115: ldarg.2
-			IL_0116: ret
+			IL_0107: ldarg.2
+			IL_0108: ret
 		} // end of method toNullableString::__js_call__
 
 	} // end of class toNullableString
@@ -6850,7 +6554,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x72ee
+					// Method begins at RVA 0x6c24
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6870,7 +6574,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x72f7
+					// Method begins at RVA 0x6c2d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6890,7 +6594,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7300
+					// Method begins at RVA 0x6c36
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6910,7 +6614,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7324
+					// Method begins at RVA 0x6c5a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6928,7 +6632,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x72e5
+				// Method begins at RVA 0x6c1b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6956,7 +6660,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x731b
+						// Method begins at RVA 0x6c51
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6974,7 +6678,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7312
+					// Method begins at RVA 0x6c48
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6992,7 +6696,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7309
+				// Method begins at RVA 0x6c3f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7020,9 +6724,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5688
+			// Method begins at RVA 0x5314
 			// Header size: 12
-			// Code size: 1218 (0x4c2)
+			// Code size: 1148 (0x47c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.test262_metadataParser/normalizeNegative/Scope/Block_L294C79,
@@ -7164,382 +6868,362 @@
 			IL_010a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_010f: stloc.s 12
 			IL_0111: ldloc.s 12
-			IL_0113: brfalse IL_0173
+			IL_0113: brfalse IL_0165
 
 			IL_0118: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L298C85::.ctor()
 			IL_011d: stloc.1
 			IL_011e: ldarg.0
 			IL_011f: ldfld object Modules.test262_metadataParser/Scope::pushIssue
 			IL_0124: stloc.s 20
-			IL_0126: ldstr "pushIssue"
-			IL_012b: ldloc.s 20
-			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0132: stloc.s 20
-			IL_0134: ldc.i4.1
-			IL_0135: newarr [System.Runtime]System.Object
-			IL_013a: dup
-			IL_013b: ldc.i4.0
-			IL_013c: ldarg.0
-			IL_013d: stelem.ref
-			IL_013e: stloc.s 21
-			IL_0140: ldloc.s 20
-			IL_0142: ldloc.s 21
-			IL_0144: ldc.i4.4
-			IL_0145: newarr [System.Runtime]System.Object
-			IL_014a: dup
-			IL_014b: ldc.i4.0
-			IL_014c: ldarg.3
-			IL_014d: stelem.ref
-			IL_014e: dup
-			IL_014f: ldc.i4.1
-			IL_0150: ldstr "invalid-negative"
-			IL_0155: stelem.ref
-			IL_0156: dup
-			IL_0157: ldc.i4.2
-			IL_0158: ldstr "negative"
-			IL_015d: stelem.ref
-			IL_015e: dup
-			IL_015f: ldc.i4.3
-			IL_0160: ldstr "Expected an object for the negative frontmatter value."
-			IL_0165: stelem.ref
-			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_016b: pop
-			IL_016c: ldc.i4.0
-			IL_016d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0172: ret
+			IL_0126: ldc.i4.1
+			IL_0127: newarr [System.Runtime]System.Object
+			IL_012c: dup
+			IL_012d: ldc.i4.0
+			IL_012e: ldarg.0
+			IL_012f: stelem.ref
+			IL_0130: stloc.s 21
+			IL_0132: ldloc.s 20
+			IL_0134: ldloc.s 21
+			IL_0136: ldc.i4.4
+			IL_0137: newarr [System.Runtime]System.Object
+			IL_013c: dup
+			IL_013d: ldc.i4.0
+			IL_013e: ldarg.3
+			IL_013f: stelem.ref
+			IL_0140: dup
+			IL_0141: ldc.i4.1
+			IL_0142: ldstr "invalid-negative"
+			IL_0147: stelem.ref
+			IL_0148: dup
+			IL_0149: ldc.i4.2
+			IL_014a: ldstr "negative"
+			IL_014f: stelem.ref
+			IL_0150: dup
+			IL_0151: ldc.i4.3
+			IL_0152: ldstr "Expected an object for the negative frontmatter value."
+			IL_0157: stelem.ref
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_015d: pop
+			IL_015e: ldc.i4.0
+			IL_015f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0164: ret
 
-			IL_0173: ldarg.0
-			IL_0174: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_0179: stloc.s 20
-			IL_017b: ldstr "toNullableString"
-			IL_0180: ldloc.s 20
-			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0187: stloc.s 20
-			IL_0189: ldc.i4.1
-			IL_018a: newarr [System.Runtime]System.Object
-			IL_018f: dup
-			IL_0190: ldc.i4.0
-			IL_0191: ldarg.0
-			IL_0192: stelem.ref
-			IL_0193: stloc.s 21
-			IL_0195: ldarg.2
-			IL_0196: ldstr "phase"
-			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a0: stloc.s 22
-			IL_01a2: ldloc.s 20
-			IL_01a4: ldloc.s 21
-			IL_01a6: ldloc.s 22
-			IL_01a8: ldstr "negative.phase"
-			IL_01ad: ldarg.3
-			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_01b3: stloc.s 22
-			IL_01b5: ldloc.s 22
-			IL_01b7: stloc.2
-			IL_01b8: ldarg.0
-			IL_01b9: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_01be: stloc.s 22
-			IL_01c0: ldstr "toNullableString"
-			IL_01c5: ldloc.s 22
-			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01cc: stloc.s 22
-			IL_01ce: ldc.i4.1
-			IL_01cf: newarr [System.Runtime]System.Object
-			IL_01d4: dup
-			IL_01d5: ldc.i4.0
-			IL_01d6: ldarg.0
-			IL_01d7: stelem.ref
-			IL_01d8: stloc.s 21
-			IL_01da: ldarg.2
-			IL_01db: ldstr "type"
-			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01e5: stloc.s 20
-			IL_01e7: ldloc.s 22
-			IL_01e9: ldloc.s 21
-			IL_01eb: ldloc.s 20
-			IL_01ed: ldstr "negative.type"
-			IL_01f2: ldarg.3
-			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_01f8: stloc.s 20
-			IL_01fa: ldloc.s 20
-			IL_01fc: stloc.3
-			IL_01fd: ldc.i4.3
-			IL_01fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0203: dup
-			IL_0204: ldstr "parse"
-			IL_0209: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_020e: dup
-			IL_020f: ldstr "resolution"
-			IL_0214: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0219: dup
-			IL_021a: ldstr "runtime"
-			IL_021f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0224: stloc.s 4
-			IL_0226: ldloc.2
-			IL_0227: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_022c: stloc.s 12
-			IL_022e: ldloc.s 12
-			IL_0230: brfalse IL_0269
+			IL_0165: ldarg.0
+			IL_0166: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_016b: stloc.s 20
+			IL_016d: ldc.i4.1
+			IL_016e: newarr [System.Runtime]System.Object
+			IL_0173: dup
+			IL_0174: ldc.i4.0
+			IL_0175: ldarg.0
+			IL_0176: stelem.ref
+			IL_0177: stloc.s 21
+			IL_0179: ldarg.2
+			IL_017a: ldstr "phase"
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0184: stloc.s 22
+			IL_0186: ldloc.s 20
+			IL_0188: ldloc.s 21
+			IL_018a: ldloc.s 22
+			IL_018c: ldstr "negative.phase"
+			IL_0191: ldarg.3
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0197: stloc.s 22
+			IL_0199: ldloc.s 22
+			IL_019b: stloc.2
+			IL_019c: ldarg.0
+			IL_019d: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_01a2: stloc.s 22
+			IL_01a4: ldc.i4.1
+			IL_01a5: newarr [System.Runtime]System.Object
+			IL_01aa: dup
+			IL_01ab: ldc.i4.0
+			IL_01ac: ldarg.0
+			IL_01ad: stelem.ref
+			IL_01ae: stloc.s 21
+			IL_01b0: ldarg.2
+			IL_01b1: ldstr "type"
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01bb: stloc.s 20
+			IL_01bd: ldloc.s 22
+			IL_01bf: ldloc.s 21
+			IL_01c1: ldloc.s 20
+			IL_01c3: ldstr "negative.type"
+			IL_01c8: ldarg.3
+			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_01ce: stloc.s 20
+			IL_01d0: ldloc.s 20
+			IL_01d2: stloc.3
+			IL_01d3: ldc.i4.3
+			IL_01d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01d9: dup
+			IL_01da: ldstr "parse"
+			IL_01df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01e4: dup
+			IL_01e5: ldstr "resolution"
+			IL_01ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01ef: dup
+			IL_01f0: ldstr "runtime"
+			IL_01f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01fa: stloc.s 4
+			IL_01fc: ldloc.2
+			IL_01fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0202: stloc.s 12
+			IL_0204: ldloc.s 12
+			IL_0206: brfalse IL_023f
 
-			IL_0235: ldloc.s 4
-			IL_0237: ldc.i4.1
-			IL_0238: newarr [System.Runtime]System.Object
-			IL_023d: dup
-			IL_023e: ldc.i4.0
+			IL_020b: ldloc.s 4
+			IL_020d: ldc.i4.1
+			IL_020e: newarr [System.Runtime]System.Object
+			IL_0213: dup
+			IL_0214: ldc.i4.0
+			IL_0215: ldloc.2
+			IL_0216: stelem.ref
+			IL_0217: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+			IL_021c: stloc.s 23
+			IL_021e: ldloc.s 23
+			IL_0220: ldc.r8 0.0
+			IL_0229: clt
+			IL_022b: stloc.s 12
+			IL_022d: ldloc.s 12
+			IL_022f: box [System.Runtime]System.Boolean
+			IL_0234: stloc.s 13
+			IL_0236: ldloc.s 13
+			IL_0238: stloc.s 24
+			IL_023a: br IL_0242
+
 			IL_023f: ldloc.2
-			IL_0240: stelem.ref
-			IL_0241: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-			IL_0246: stloc.s 23
-			IL_0248: ldloc.s 23
-			IL_024a: ldc.r8 0.0
-			IL_0253: clt
-			IL_0255: stloc.s 12
-			IL_0257: ldloc.s 12
-			IL_0259: box [System.Runtime]System.Boolean
-			IL_025e: stloc.s 13
-			IL_0260: ldloc.s 13
-			IL_0262: stloc.s 24
-			IL_0264: br IL_026c
+			IL_0240: stloc.s 24
 
-			IL_0269: ldloc.2
-			IL_026a: stloc.s 24
+			IL_0242: ldloc.s 24
+			IL_0244: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0249: stloc.s 12
+			IL_024b: ldloc.s 12
+			IL_024d: brfalse IL_02be
 
-			IL_026c: ldloc.s 24
-			IL_026e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0273: stloc.s 12
-			IL_0275: ldloc.s 12
-			IL_0277: brfalse IL_02f6
-
-			IL_027c: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L307C49::.ctor()
-			IL_0281: stloc.s 5
-			IL_0283: ldarg.0
-			IL_0284: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_0289: stloc.s 20
-			IL_028b: ldstr "pushIssue"
-			IL_0290: ldloc.s 20
-			IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0297: stloc.s 20
-			IL_0299: ldc.i4.1
-			IL_029a: newarr [System.Runtime]System.Object
-			IL_029f: dup
-			IL_02a0: ldc.i4.0
-			IL_02a1: ldarg.0
+			IL_0252: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L307C49::.ctor()
+			IL_0257: stloc.s 5
+			IL_0259: ldarg.0
+			IL_025a: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_025f: stloc.s 20
+			IL_0261: ldc.i4.1
+			IL_0262: newarr [System.Runtime]System.Object
+			IL_0267: dup
+			IL_0268: ldc.i4.0
+			IL_0269: ldarg.0
+			IL_026a: stelem.ref
+			IL_026b: stloc.s 21
+			IL_026d: ldloc.2
+			IL_026e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0273: stloc.s 25
+			IL_0275: ldstr "Unsupported negative phase '"
+			IL_027a: ldloc.s 25
+			IL_027c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0281: stloc.s 25
+			IL_0283: ldloc.s 25
+			IL_0285: ldstr "'."
+			IL_028a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_028f: stloc.s 25
+			IL_0291: ldc.i4.4
+			IL_0292: newarr [System.Runtime]System.Object
+			IL_0297: dup
+			IL_0298: ldc.i4.0
+			IL_0299: ldarg.3
+			IL_029a: stelem.ref
+			IL_029b: dup
+			IL_029c: ldc.i4.1
+			IL_029d: ldstr "unknown-negative-phase"
 			IL_02a2: stelem.ref
-			IL_02a3: stloc.s 21
-			IL_02a5: ldloc.2
-			IL_02a6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02ab: stloc.s 25
-			IL_02ad: ldstr "Unsupported negative phase '"
-			IL_02b2: ldloc.s 25
-			IL_02b4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02b9: stloc.s 25
-			IL_02bb: ldloc.s 25
-			IL_02bd: ldstr "'."
-			IL_02c2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02c7: stloc.s 25
-			IL_02c9: ldc.i4.4
-			IL_02ca: newarr [System.Runtime]System.Object
-			IL_02cf: dup
-			IL_02d0: ldc.i4.0
-			IL_02d1: ldarg.3
-			IL_02d2: stelem.ref
-			IL_02d3: dup
-			IL_02d4: ldc.i4.1
-			IL_02d5: ldstr "unknown-negative-phase"
-			IL_02da: stelem.ref
-			IL_02db: dup
-			IL_02dc: ldc.i4.2
-			IL_02dd: ldstr "negative.phase"
-			IL_02e2: stelem.ref
-			IL_02e3: dup
-			IL_02e4: ldc.i4.3
-			IL_02e5: ldloc.s 25
-			IL_02e7: stelem.ref
-			IL_02e8: stloc.s 26
-			IL_02ea: ldloc.s 20
-			IL_02ec: ldloc.s 21
-			IL_02ee: ldloc.s 26
-			IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_02f5: pop
+			IL_02a3: dup
+			IL_02a4: ldc.i4.2
+			IL_02a5: ldstr "negative.phase"
+			IL_02aa: stelem.ref
+			IL_02ab: dup
+			IL_02ac: ldc.i4.3
+			IL_02ad: ldloc.s 25
+			IL_02af: stelem.ref
+			IL_02b0: stloc.s 26
+			IL_02b2: ldloc.s 20
+			IL_02b4: ldloc.s 21
+			IL_02b6: ldloc.s 26
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_02bd: pop
 
-			IL_02f6: ldarg.2
-			IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_02fc: stloc.s 20
-			IL_02fe: ldloc.s 20
-			IL_0300: stloc.s 6
-			IL_0302: ldc.r8 0.0
-			IL_030b: stloc.s 7
-			// loop start (head: IL_030d)
-				IL_030d: ldloc.s 7
-				IL_030f: stloc.s 23
-				IL_0311: ldloc.s 23
-				IL_0313: ldloc.s 6
-				IL_0315: ldstr "length"
-				IL_031a: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_031f: clt
-				IL_0321: brfalse IL_043d
+			IL_02be: ldarg.2
+			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_02c4: stloc.s 20
+			IL_02c6: ldloc.s 20
+			IL_02c8: stloc.s 6
+			IL_02ca: ldc.r8 0.0
+			IL_02d3: stloc.s 7
+			// loop start (head: IL_02d5)
+				IL_02d5: ldloc.s 7
+				IL_02d7: stloc.s 23
+				IL_02d9: ldloc.s 23
+				IL_02db: ldloc.s 6
+				IL_02dd: ldstr "length"
+				IL_02e2: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_02e7: clt
+				IL_02e9: brfalse IL_03f7
 
-				IL_0326: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40::.ctor()
-				IL_032b: stloc.s 8
-				IL_032d: ldloc.s 6
-				IL_032f: ldloc.s 7
-				IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0336: stloc.s 9
-				IL_0338: ldloc.s 9
-				IL_033a: stloc.s 20
-				IL_033c: ldloc.s 20
-				IL_033e: ldstr "phase"
-				IL_0343: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_0348: stloc.s 12
-				IL_034a: ldloc.s 12
-				IL_034c: box [System.Runtime]System.Boolean
-				IL_0351: stloc.s 13
-				IL_0353: ldloc.s 13
+				IL_02ee: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40::.ctor()
+				IL_02f3: stloc.s 8
+				IL_02f5: ldloc.s 6
+				IL_02f7: ldloc.s 7
+				IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02fe: stloc.s 9
+				IL_0300: ldloc.s 9
+				IL_0302: stloc.s 20
+				IL_0304: ldloc.s 20
+				IL_0306: ldstr "phase"
+				IL_030b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_0310: stloc.s 12
+				IL_0312: ldloc.s 12
+				IL_0314: box [System.Runtime]System.Boolean
+				IL_0319: stloc.s 13
+				IL_031b: ldloc.s 13
+				IL_031d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0322: stloc.s 12
+				IL_0324: ldloc.s 12
+				IL_0326: brfalse IL_034f
+
+				IL_032b: ldloc.s 9
+				IL_032d: stloc.s 20
+				IL_032f: ldloc.s 20
+				IL_0331: ldstr "type"
+				IL_0336: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_033b: stloc.s 12
+				IL_033d: ldloc.s 12
+				IL_033f: box [System.Runtime]System.Boolean
+				IL_0344: stloc.s 14
+				IL_0346: ldloc.s 14
+				IL_0348: stloc.s 27
+				IL_034a: br IL_0353
+
+				IL_034f: ldloc.s 13
+				IL_0351: stloc.s 27
+
+				IL_0353: ldloc.s 27
 				IL_0355: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_035a: stloc.s 12
 				IL_035c: ldloc.s 12
-				IL_035e: brfalse IL_0387
+				IL_035e: brfalse IL_03e4
 
-				IL_0363: ldloc.s 9
-				IL_0365: stloc.s 20
-				IL_0367: ldloc.s 20
-				IL_0369: ldstr "type"
-				IL_036e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_0373: stloc.s 12
-				IL_0375: ldloc.s 12
-				IL_0377: box [System.Runtime]System.Boolean
-				IL_037c: stloc.s 14
-				IL_037e: ldloc.s 14
-				IL_0380: stloc.s 27
-				IL_0382: br IL_038b
+				IL_0363: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40/Block_L314C43::.ctor()
+				IL_0368: stloc.s 10
+				IL_036a: ldarg.0
+				IL_036b: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+				IL_0370: stloc.s 20
+				IL_0372: ldc.i4.1
+				IL_0373: newarr [System.Runtime]System.Object
+				IL_0378: dup
+				IL_0379: ldc.i4.0
+				IL_037a: ldarg.0
+				IL_037b: stelem.ref
+				IL_037c: stloc.s 26
+				IL_037e: ldloc.s 9
+				IL_0380: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0385: stloc.s 25
+				IL_0387: ldstr "negative."
+				IL_038c: ldloc.s 25
+				IL_038e: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0393: stloc.s 25
+				IL_0395: ldloc.s 9
+				IL_0397: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_039c: stloc.s 28
+				IL_039e: ldstr "Unsupported negative metadata key '"
+				IL_03a3: ldloc.s 28
+				IL_03a5: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03aa: stloc.s 28
+				IL_03ac: ldloc.s 28
+				IL_03ae: ldstr "'."
+				IL_03b3: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03b8: stloc.s 28
+				IL_03ba: ldc.i4.4
+				IL_03bb: newarr [System.Runtime]System.Object
+				IL_03c0: dup
+				IL_03c1: ldc.i4.0
+				IL_03c2: ldarg.3
+				IL_03c3: stelem.ref
+				IL_03c4: dup
+				IL_03c5: ldc.i4.1
+				IL_03c6: ldstr "unknown-negative-key"
+				IL_03cb: stelem.ref
+				IL_03cc: dup
+				IL_03cd: ldc.i4.2
+				IL_03ce: ldloc.s 25
+				IL_03d0: stelem.ref
+				IL_03d1: dup
+				IL_03d2: ldc.i4.3
+				IL_03d3: ldloc.s 28
+				IL_03d5: stelem.ref
+				IL_03d6: stloc.s 21
+				IL_03d8: ldloc.s 20
+				IL_03da: ldloc.s 26
+				IL_03dc: ldloc.s 21
+				IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_03e3: pop
 
-				IL_0387: ldloc.s 13
-				IL_0389: stloc.s 27
-
-				IL_038b: ldloc.s 27
-				IL_038d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0392: stloc.s 12
-				IL_0394: ldloc.s 12
-				IL_0396: brfalse IL_042a
-
-				IL_039b: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40/Block_L314C43::.ctor()
-				IL_03a0: stloc.s 10
-				IL_03a2: ldarg.0
-				IL_03a3: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-				IL_03a8: stloc.s 20
-				IL_03aa: ldstr "pushIssue"
-				IL_03af: ldloc.s 20
-				IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_03b6: stloc.s 20
-				IL_03b8: ldc.i4.1
-				IL_03b9: newarr [System.Runtime]System.Object
-				IL_03be: dup
-				IL_03bf: ldc.i4.0
-				IL_03c0: ldarg.0
-				IL_03c1: stelem.ref
-				IL_03c2: stloc.s 26
-				IL_03c4: ldloc.s 9
-				IL_03c6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_03cb: stloc.s 25
-				IL_03cd: ldstr "negative."
-				IL_03d2: ldloc.s 25
-				IL_03d4: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03d9: stloc.s 25
-				IL_03db: ldloc.s 9
-				IL_03dd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_03e2: stloc.s 28
-				IL_03e4: ldstr "Unsupported negative metadata key '"
-				IL_03e9: ldloc.s 28
-				IL_03eb: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03f0: stloc.s 28
-				IL_03f2: ldloc.s 28
-				IL_03f4: ldstr "'."
-				IL_03f9: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03fe: stloc.s 28
-				IL_0400: ldc.i4.4
-				IL_0401: newarr [System.Runtime]System.Object
-				IL_0406: dup
-				IL_0407: ldc.i4.0
-				IL_0408: ldarg.3
-				IL_0409: stelem.ref
-				IL_040a: dup
-				IL_040b: ldc.i4.1
-				IL_040c: ldstr "unknown-negative-key"
-				IL_0411: stelem.ref
-				IL_0412: dup
-				IL_0413: ldc.i4.2
-				IL_0414: ldloc.s 25
-				IL_0416: stelem.ref
-				IL_0417: dup
-				IL_0418: ldc.i4.3
-				IL_0419: ldloc.s 28
-				IL_041b: stelem.ref
-				IL_041c: stloc.s 21
-				IL_041e: ldloc.s 20
-				IL_0420: ldloc.s 26
-				IL_0422: ldloc.s 21
-				IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_0429: pop
-
-				IL_042a: ldloc.s 7
-				IL_042c: ldc.r8 1
-				IL_0435: add
-				IL_0436: stloc.s 7
-				IL_0438: br IL_030d
+				IL_03e4: ldloc.s 7
+				IL_03e6: ldc.r8 1
+				IL_03ef: add
+				IL_03f0: stloc.s 7
+				IL_03f2: br IL_02d5
 			// end loop
 
-			IL_043d: ldloc.2
-			IL_043e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0443: ldc.i4.0
-			IL_0444: ceq
-			IL_0446: stloc.s 12
-			IL_0448: ldloc.s 12
-			IL_044a: box [System.Runtime]System.Boolean
-			IL_044f: stloc.s 13
-			IL_0451: ldloc.s 13
-			IL_0453: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0458: stloc.s 12
-			IL_045a: ldloc.s 12
-			IL_045c: brtrue IL_047e
+			IL_03f7: ldloc.2
+			IL_03f8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03fd: ldc.i4.0
+			IL_03fe: ceq
+			IL_0400: stloc.s 12
+			IL_0402: ldloc.s 12
+			IL_0404: box [System.Runtime]System.Boolean
+			IL_0409: stloc.s 13
+			IL_040b: ldloc.s 13
+			IL_040d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0412: stloc.s 12
+			IL_0414: ldloc.s 12
+			IL_0416: brtrue IL_0438
 
-			IL_0461: ldloc.3
-			IL_0462: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0467: ldc.i4.0
-			IL_0468: ceq
-			IL_046a: stloc.s 12
-			IL_046c: ldloc.s 12
-			IL_046e: box [System.Runtime]System.Boolean
-			IL_0473: stloc.s 14
-			IL_0475: ldloc.s 14
-			IL_0477: stloc.s 29
-			IL_0479: br IL_0482
+			IL_041b: ldloc.3
+			IL_041c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0421: ldc.i4.0
+			IL_0422: ceq
+			IL_0424: stloc.s 12
+			IL_0426: ldloc.s 12
+			IL_0428: box [System.Runtime]System.Boolean
+			IL_042d: stloc.s 14
+			IL_042f: ldloc.s 14
+			IL_0431: stloc.s 29
+			IL_0433: br IL_043c
 
-			IL_047e: ldloc.s 13
-			IL_0480: stloc.s 29
+			IL_0438: ldloc.s 13
+			IL_043a: stloc.s 29
 
-			IL_0482: ldloc.s 29
-			IL_0484: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0489: stloc.s 12
-			IL_048b: ldloc.s 12
-			IL_048d: brfalse IL_04a0
+			IL_043c: ldloc.s 29
+			IL_043e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0443: stloc.s 12
+			IL_0445: ldloc.s 12
+			IL_0447: brfalse IL_045a
 
-			IL_0492: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L319C23::.ctor()
-			IL_0497: stloc.s 11
-			IL_0499: ldc.i4.0
-			IL_049a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_049f: ret
+			IL_044c: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L319C23::.ctor()
+			IL_0451: stloc.s 11
+			IL_0453: ldc.i4.0
+			IL_0454: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0459: ret
 
-			IL_04a0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04a5: dup
-			IL_04a6: ldstr "phase"
-			IL_04ab: ldloc.2
-			IL_04ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04b1: dup
-			IL_04b2: ldstr "type"
-			IL_04b7: ldloc.3
-			IL_04b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04bd: stloc.s 30
-			IL_04bf: ldloc.s 30
-			IL_04c1: ret
+			IL_045a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_045f: dup
+			IL_0460: ldstr "phase"
+			IL_0465: ldloc.2
+			IL_0466: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_046b: dup
+			IL_046c: ldstr "type"
+			IL_0471: ldloc.3
+			IL_0472: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0477: stloc.s 30
+			IL_0479: ldloc.s 30
+			IL_047b: ret
 		} // end of method normalizeNegative::__js_call__
 
 	} // end of class normalizeNegative
@@ -7563,7 +7247,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x735a
+						// Method begins at RVA 0x6c90
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7583,7 +7267,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7363
+						// Method begins at RVA 0x6c99
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7603,7 +7287,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x736c
+						// Method begins at RVA 0x6ca2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7621,7 +7305,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7351
+					// Method begins at RVA 0x6c87
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7641,7 +7325,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7375
+					// Method begins at RVA 0x6cab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7661,7 +7345,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x737e
+					// Method begins at RVA 0x6cb4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7679,7 +7363,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x732d
+				// Method begins at RVA 0x6c63
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7707,7 +7391,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7348
+						// Method begins at RVA 0x6c7e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7725,7 +7409,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x733f
+					// Method begins at RVA 0x6c75
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7743,7 +7427,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7336
+				// Method begins at RVA 0x6c6c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7771,7 +7455,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7399
+						// Method begins at RVA 0x6ccf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7789,7 +7473,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7390
+					// Method begins at RVA 0x6cc6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7807,7 +7491,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7387
+				// Method begins at RVA 0x6cbd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7836,9 +7520,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5b58
+			// Method begins at RVA 0x579c
 			// Header size: 12
-			// Code size: 2007 (0x7d7)
+			// Code size: 1709 (0x6ad)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7872,8 +7556,8 @@
 				[28] object,
 				[29] object,
 				[30] object,
-				[31] object,
-				[32] object[],
+				[31] object[],
+				[32] object,
 				[33] float64,
 				[34] bool,
 				[35] string,
@@ -7884,754 +7568,655 @@
 				[40] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[41] object,
 				[42] object,
-				[43] object,
-				[44] bool,
+				[43] bool,
+				[44] object,
 				[45] object,
 				[46] object,
-				[47] object,
-				[48] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[47] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0006: stloc.s 31
-			IL_0008: ldstr "contains"
-			IL_000d: ldloc.s 31
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 31
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.s 32
-			IL_0022: ldloc.s 31
-			IL_0024: ldloc.s 32
-			IL_0026: ldarg.2
-			IL_0027: ldstr "module"
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0031: stloc.s 31
-			IL_0033: ldloc.s 31
-			IL_0035: stloc.0
-			IL_0036: ldarg.0
-			IL_0037: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_003c: stloc.s 31
-			IL_003e: ldstr "contains"
-			IL_0043: ldloc.s 31
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_004a: stloc.s 31
-			IL_004c: ldc.i4.1
-			IL_004d: newarr [System.Runtime]System.Object
-			IL_0052: dup
-			IL_0053: ldc.i4.0
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 31
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0012: ldloc.s 31
+			IL_0014: ldarg.2
+			IL_0015: ldstr "module"
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_001f: stloc.s 32
+			IL_0021: ldloc.s 32
+			IL_0023: stloc.0
+			IL_0024: ldc.i4.1
+			IL_0025: newarr [System.Runtime]System.Object
+			IL_002a: dup
+			IL_002b: ldc.i4.0
+			IL_002c: ldarg.0
+			IL_002d: stelem.ref
+			IL_002e: stloc.s 31
+			IL_0030: ldarg.0
+			IL_0031: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0036: ldloc.s 31
+			IL_0038: ldarg.2
+			IL_0039: ldstr "raw"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0043: stloc.s 32
+			IL_0045: ldloc.s 32
+			IL_0047: stloc.1
+			IL_0048: ldc.i4.1
+			IL_0049: newarr [System.Runtime]System.Object
+			IL_004e: dup
+			IL_004f: ldc.i4.0
+			IL_0050: ldarg.0
+			IL_0051: stelem.ref
+			IL_0052: stloc.s 31
 			IL_0054: ldarg.0
-			IL_0055: stelem.ref
-			IL_0056: stloc.s 32
-			IL_0058: ldloc.s 31
-			IL_005a: ldloc.s 32
+			IL_0055: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_005a: ldloc.s 31
 			IL_005c: ldarg.2
-			IL_005d: ldstr "raw"
+			IL_005d: ldstr "async"
 			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0067: stloc.s 31
-			IL_0069: ldloc.s 31
-			IL_006b: stloc.1
-			IL_006c: ldarg.0
-			IL_006d: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0072: stloc.s 31
-			IL_0074: ldstr "contains"
-			IL_0079: ldloc.s 31
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0080: stloc.s 31
-			IL_0082: ldc.i4.1
-			IL_0083: newarr [System.Runtime]System.Object
-			IL_0088: dup
-			IL_0089: ldc.i4.0
-			IL_008a: ldarg.0
-			IL_008b: stelem.ref
-			IL_008c: stloc.s 32
-			IL_008e: ldloc.s 31
-			IL_0090: ldloc.s 32
-			IL_0092: ldarg.2
-			IL_0093: ldstr "async"
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_009d: stloc.s 31
-			IL_009f: ldloc.s 31
-			IL_00a1: stloc.2
-			IL_00a2: ldarg.0
-			IL_00a3: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_00a8: stloc.s 31
-			IL_00aa: ldstr "contains"
-			IL_00af: ldloc.s 31
-			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00b6: stloc.s 31
-			IL_00b8: ldc.i4.1
-			IL_00b9: newarr [System.Runtime]System.Object
-			IL_00be: dup
-			IL_00bf: ldc.i4.0
-			IL_00c0: ldarg.0
-			IL_00c1: stelem.ref
-			IL_00c2: stloc.s 32
-			IL_00c4: ldloc.s 31
-			IL_00c6: ldloc.s 32
-			IL_00c8: ldarg.2
-			IL_00c9: ldstr "generated"
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_00d3: stloc.s 31
-			IL_00d5: ldloc.s 31
-			IL_00d7: stloc.3
-			IL_00d8: ldarg.0
-			IL_00d9: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_00de: stloc.s 31
-			IL_00e0: ldstr "contains"
-			IL_00e5: ldloc.s 31
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ec: stloc.s 31
-			IL_00ee: ldc.i4.1
-			IL_00ef: newarr [System.Runtime]System.Object
-			IL_00f4: dup
-			IL_00f5: ldc.i4.0
-			IL_00f6: ldarg.0
-			IL_00f7: stelem.ref
-			IL_00f8: stloc.s 32
-			IL_00fa: ldloc.s 31
-			IL_00fc: ldloc.s 32
-			IL_00fe: ldarg.2
-			IL_00ff: ldstr "non-deterministic"
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0109: stloc.s 31
-			IL_010b: ldloc.s 31
-			IL_010d: stloc.s 4
-			IL_010f: ldarg.s fileName
-			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0116: stloc.s 31
-			IL_0118: ldloc.s 31
-			IL_011a: ldstr "indexOf"
-			IL_011f: ldstr "_FIXTURE"
-			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0129: stloc.s 31
-			IL_012b: ldloc.s 31
-			IL_012d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0132: stloc.s 33
-			IL_0134: ldloc.s 33
-			IL_0136: ldc.r8 0.0
-			IL_013f: clt
-			IL_0141: ldc.i4.0
-			IL_0142: ceq
-			IL_0144: stloc.s 34
-			IL_0146: ldloc.s 34
-			IL_0148: stloc.s 5
-			IL_014a: ldc.i4.0
-			IL_014b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0150: stloc.s 6
-			IL_0152: ldc.i4.4
-			IL_0153: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0158: dup
-			IL_0159: ldstr "onlyStrict"
-			IL_015e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0163: dup
-			IL_0164: ldstr "noStrict"
-			IL_0169: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_016e: dup
-			IL_016f: ldstr "module"
-			IL_0174: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0179: dup
-			IL_017a: ldstr "raw"
-			IL_017f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0184: stloc.s 7
-			IL_0186: ldc.r8 0.0
-			IL_018f: stloc.s 8
-			// loop start (head: IL_0191)
-				IL_0191: ldloc.s 8
-				IL_0193: stloc.s 33
-				IL_0195: ldloc.s 33
-				IL_0197: ldloc.s 7
-				IL_0199: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-				IL_019e: conv.r8
-				IL_019f: clt
-				IL_01a1: brfalse IL_0221
+			IL_0067: stloc.s 32
+			IL_0069: ldloc.s 32
+			IL_006b: stloc.2
+			IL_006c: ldc.i4.1
+			IL_006d: newarr [System.Runtime]System.Object
+			IL_0072: dup
+			IL_0073: ldc.i4.0
+			IL_0074: ldarg.0
+			IL_0075: stelem.ref
+			IL_0076: stloc.s 31
+			IL_0078: ldarg.0
+			IL_0079: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_007e: ldloc.s 31
+			IL_0080: ldarg.2
+			IL_0081: ldstr "generated"
+			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_008b: stloc.s 32
+			IL_008d: ldloc.s 32
+			IL_008f: stloc.3
+			IL_0090: ldc.i4.1
+			IL_0091: newarr [System.Runtime]System.Object
+			IL_0096: dup
+			IL_0097: ldc.i4.0
+			IL_0098: ldarg.0
+			IL_0099: stelem.ref
+			IL_009a: stloc.s 31
+			IL_009c: ldarg.0
+			IL_009d: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_00a2: ldloc.s 31
+			IL_00a4: ldarg.2
+			IL_00a5: ldstr "non-deterministic"
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_00af: stloc.s 32
+			IL_00b1: ldloc.s 32
+			IL_00b3: stloc.s 4
+			IL_00b5: ldarg.s fileName
+			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00bc: stloc.s 32
+			IL_00be: ldloc.s 32
+			IL_00c0: ldstr "indexOf"
+			IL_00c5: ldstr "_FIXTURE"
+			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00cf: stloc.s 32
+			IL_00d1: ldloc.s 32
+			IL_00d3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00d8: stloc.s 33
+			IL_00da: ldloc.s 33
+			IL_00dc: ldc.r8 0.0
+			IL_00e5: clt
+			IL_00e7: ldc.i4.0
+			IL_00e8: ceq
+			IL_00ea: stloc.s 34
+			IL_00ec: ldloc.s 34
+			IL_00ee: stloc.s 5
+			IL_00f0: ldc.i4.0
+			IL_00f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00f6: stloc.s 6
+			IL_00f8: ldc.i4.4
+			IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00fe: dup
+			IL_00ff: ldstr "onlyStrict"
+			IL_0104: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0109: dup
+			IL_010a: ldstr "noStrict"
+			IL_010f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0114: dup
+			IL_0115: ldstr "module"
+			IL_011a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_011f: dup
+			IL_0120: ldstr "raw"
+			IL_0125: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_012a: stloc.s 7
+			IL_012c: ldc.r8 0.0
+			IL_0135: stloc.s 8
+			// loop start (head: IL_0137)
+				IL_0137: ldloc.s 8
+				IL_0139: stloc.s 33
+				IL_013b: ldloc.s 33
+				IL_013d: ldloc.s 7
+				IL_013f: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+				IL_0144: conv.r8
+				IL_0145: clt
+				IL_0147: brfalse IL_01b5
 
-				IL_01a6: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L336C7/Block_L336C51::.ctor()
-				IL_01ab: stloc.s 9
-				IL_01ad: ldloc.s 7
-				IL_01af: ldloc.s 8
-				IL_01b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_01b6: castclass [System.Runtime]System.String
-				IL_01bb: stloc.s 10
-				IL_01bd: ldarg.0
-				IL_01be: ldfld object Modules.test262_metadataParser/Scope::contains
-				IL_01c3: stloc.s 31
-				IL_01c5: ldstr "contains"
-				IL_01ca: ldloc.s 31
-				IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_01d1: stloc.s 31
-				IL_01d3: ldc.i4.1
-				IL_01d4: newarr [System.Runtime]System.Object
-				IL_01d9: dup
-				IL_01da: ldc.i4.0
-				IL_01db: ldarg.0
-				IL_01dc: stelem.ref
-				IL_01dd: stloc.s 32
-				IL_01df: ldloc.s 31
-				IL_01e1: ldloc.s 32
-				IL_01e3: ldarg.2
-				IL_01e4: ldloc.s 10
-				IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_01eb: stloc.s 31
-				IL_01ed: ldloc.s 31
-				IL_01ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01f4: stloc.s 34
-				IL_01f6: ldloc.s 34
-				IL_01f8: brfalse IL_020e
+				IL_014c: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L336C7/Block_L336C51::.ctor()
+				IL_0151: stloc.s 9
+				IL_0153: ldloc.s 7
+				IL_0155: ldloc.s 8
+				IL_0157: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_015c: castclass [System.Runtime]System.String
+				IL_0161: stloc.s 10
+				IL_0163: ldc.i4.1
+				IL_0164: newarr [System.Runtime]System.Object
+				IL_0169: dup
+				IL_016a: ldc.i4.0
+				IL_016b: ldarg.0
+				IL_016c: stelem.ref
+				IL_016d: stloc.s 31
+				IL_016f: ldarg.0
+				IL_0170: ldfld object Modules.test262_metadataParser/Scope::contains
+				IL_0175: ldloc.s 31
+				IL_0177: ldarg.2
+				IL_0178: ldloc.s 10
+				IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_017f: stloc.s 32
+				IL_0181: ldloc.s 32
+				IL_0183: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0188: stloc.s 34
+				IL_018a: ldloc.s 34
+				IL_018c: brfalse IL_01a2
 
-				IL_01fd: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L336C7/Block_L336C51/Block_L338C31::.ctor()
-				IL_0202: stloc.s 11
-				IL_0204: ldloc.s 6
-				IL_0206: ldloc.s 10
-				IL_0208: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_020d: pop
+				IL_0191: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L336C7/Block_L336C51/Block_L338C31::.ctor()
+				IL_0196: stloc.s 11
+				IL_0198: ldloc.s 6
+				IL_019a: ldloc.s 10
+				IL_019c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_01a1: pop
 
-				IL_020e: ldloc.s 8
-				IL_0210: ldc.r8 1
-				IL_0219: add
-				IL_021a: stloc.s 8
-				IL_021c: br IL_0191
+				IL_01a2: ldloc.s 8
+				IL_01a4: ldc.r8 1
+				IL_01ad: add
+				IL_01ae: stloc.s 8
+				IL_01b0: br IL_0137
 			// end loop
 
-			IL_0221: ldstr "strict-and-non-strict"
-			IL_0226: stloc.s 12
-			IL_0228: ldloc.s 6
-			IL_022a: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_022f: conv.r8
-			IL_0230: ldc.r8 1
-			IL_0239: ceq
-			IL_023b: brfalse IL_0333
+			IL_01b5: ldstr "strict-and-non-strict"
+			IL_01ba: stloc.s 12
+			IL_01bc: ldloc.s 6
+			IL_01be: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_01c3: conv.r8
+			IL_01c4: ldc.r8 1
+			IL_01cd: ceq
+			IL_01cf: brfalse IL_02c7
 
-			IL_0240: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36::.ctor()
-			IL_0245: stloc.s 13
-			IL_0247: ldloc.s 6
-			IL_0249: ldc.r8 0.0
-			IL_0252: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0257: stloc.s 14
-			IL_0259: ldloc.s 14
-			IL_025b: stloc.s 31
-			IL_025d: ldloc.s 31
-			IL_025f: ldstr "onlyStrict"
-			IL_0264: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0269: stloc.s 34
-			IL_026b: ldloc.s 34
-			IL_026d: brfalse IL_0289
+			IL_01d4: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36::.ctor()
+			IL_01d9: stloc.s 13
+			IL_01db: ldloc.s 6
+			IL_01dd: ldc.r8 0.0
+			IL_01e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_01eb: stloc.s 14
+			IL_01ed: ldloc.s 14
+			IL_01ef: stloc.s 32
+			IL_01f1: ldloc.s 32
+			IL_01f3: ldstr "onlyStrict"
+			IL_01f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01fd: stloc.s 34
+			IL_01ff: ldloc.s 34
+			IL_0201: brfalse IL_021d
 
-			IL_0272: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36/Block_L346C31::.ctor()
-			IL_0277: stloc.s 15
-			IL_0279: ldstr "strict-only"
-			IL_027e: stloc.s 35
-			IL_0280: ldloc.s 35
-			IL_0282: stloc.s 12
-			IL_0284: br IL_032e
+			IL_0206: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36/Block_L346C31::.ctor()
+			IL_020b: stloc.s 15
+			IL_020d: ldstr "strict-only"
+			IL_0212: stloc.s 35
+			IL_0214: ldloc.s 35
+			IL_0216: stloc.s 12
+			IL_0218: br IL_02c2
 
-			IL_0289: ldloc.s 14
-			IL_028b: stloc.s 31
-			IL_028d: ldloc.s 31
-			IL_028f: ldstr "noStrict"
-			IL_0294: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0299: stloc.s 34
-			IL_029b: ldloc.s 34
-			IL_029d: box [System.Runtime]System.Boolean
-			IL_02a2: stloc.s 36
-			IL_02a4: ldloc.s 36
-			IL_02a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02ab: stloc.s 34
-			IL_02ad: ldloc.s 34
-			IL_02af: brtrue IL_02d8
+			IL_021d: ldloc.s 14
+			IL_021f: stloc.s 32
+			IL_0221: ldloc.s 32
+			IL_0223: ldstr "noStrict"
+			IL_0228: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_022d: stloc.s 34
+			IL_022f: ldloc.s 34
+			IL_0231: box [System.Runtime]System.Boolean
+			IL_0236: stloc.s 36
+			IL_0238: ldloc.s 36
+			IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_023f: stloc.s 34
+			IL_0241: ldloc.s 34
+			IL_0243: brtrue IL_026c
 
-			IL_02b4: ldloc.s 14
-			IL_02b6: stloc.s 31
-			IL_02b8: ldloc.s 31
-			IL_02ba: ldstr "raw"
-			IL_02bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_02c4: stloc.s 34
-			IL_02c6: ldloc.s 34
-			IL_02c8: box [System.Runtime]System.Boolean
-			IL_02cd: stloc.s 37
-			IL_02cf: ldloc.s 37
-			IL_02d1: stloc.s 39
-			IL_02d3: br IL_02dc
+			IL_0248: ldloc.s 14
+			IL_024a: stloc.s 32
+			IL_024c: ldloc.s 32
+			IL_024e: ldstr "raw"
+			IL_0253: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0258: stloc.s 34
+			IL_025a: ldloc.s 34
+			IL_025c: box [System.Runtime]System.Boolean
+			IL_0261: stloc.s 37
+			IL_0263: ldloc.s 37
+			IL_0265: stloc.s 39
+			IL_0267: br IL_0270
 
-			IL_02d8: ldloc.s 36
-			IL_02da: stloc.s 39
+			IL_026c: ldloc.s 36
+			IL_026e: stloc.s 39
 
-			IL_02dc: ldloc.s 39
-			IL_02de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02e3: stloc.s 34
-			IL_02e5: ldloc.s 34
-			IL_02e7: brfalse IL_0303
+			IL_0270: ldloc.s 39
+			IL_0272: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0277: stloc.s 34
+			IL_0279: ldloc.s 34
+			IL_027b: brfalse IL_0297
 
-			IL_02ec: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36/Block_L348C54::.ctor()
-			IL_02f1: stloc.s 16
-			IL_02f3: ldstr "non-strict-only"
-			IL_02f8: stloc.s 35
-			IL_02fa: ldloc.s 35
-			IL_02fc: stloc.s 12
-			IL_02fe: br IL_032e
+			IL_0280: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36/Block_L348C54::.ctor()
+			IL_0285: stloc.s 16
+			IL_0287: ldstr "non-strict-only"
+			IL_028c: stloc.s 35
+			IL_028e: ldloc.s 35
+			IL_0290: stloc.s 12
+			IL_0292: br IL_02c2
 
-			IL_0303: ldloc.s 14
-			IL_0305: stloc.s 31
-			IL_0307: ldloc.s 31
-			IL_0309: ldstr "module"
-			IL_030e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0313: stloc.s 34
-			IL_0315: ldloc.s 34
-			IL_0317: brfalse IL_032e
+			IL_0297: ldloc.s 14
+			IL_0299: stloc.s 32
+			IL_029b: ldloc.s 32
+			IL_029d: ldstr "module"
+			IL_02a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_02a7: stloc.s 34
+			IL_02a9: ldloc.s 34
+			IL_02ab: brfalse IL_02c2
 
-			IL_031c: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36/Block_L350C34::.ctor()
-			IL_0321: stloc.s 17
-			IL_0323: ldstr "module"
-			IL_0328: stloc.s 35
-			IL_032a: ldloc.s 35
-			IL_032c: stloc.s 12
+			IL_02b0: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36/Block_L350C34::.ctor()
+			IL_02b5: stloc.s 17
+			IL_02b7: ldstr "module"
+			IL_02bc: stloc.s 35
+			IL_02be: ldloc.s 35
+			IL_02c0: stloc.s 12
 
-			IL_032e: br IL_035d
+			IL_02c2: br IL_02f1
 
-			IL_0333: ldloc.s 6
-			IL_0335: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_033a: conv.r8
-			IL_033b: ldc.r8 1
-			IL_0344: cgt
-			IL_0346: brfalse IL_035d
+			IL_02c7: ldloc.s 6
+			IL_02c9: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_02ce: conv.r8
+			IL_02cf: ldc.r8 1
+			IL_02d8: cgt
+			IL_02da: brfalse IL_02f1
 
-			IL_034b: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L353C41::.ctor()
-			IL_0350: stloc.s 18
-			IL_0352: ldstr "conflicting-flags"
-			IL_0357: stloc.s 35
-			IL_0359: ldloc.s 35
-			IL_035b: stloc.s 12
+			IL_02df: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L353C41::.ctor()
+			IL_02e4: stloc.s 18
+			IL_02e6: ldstr "conflicting-flags"
+			IL_02eb: stloc.s 35
+			IL_02ed: ldloc.s 35
+			IL_02ef: stloc.s 12
 
-			IL_035d: ldloc.1
-			IL_035e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0363: stloc.s 34
-			IL_0365: ldloc.s 34
-			IL_0367: brfalse IL_0379
+			IL_02f1: ldloc.1
+			IL_02f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02f7: stloc.s 34
+			IL_02f9: ldloc.s 34
+			IL_02fb: brfalse IL_030d
 
-			IL_036c: ldc.i4.0
-			IL_036d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0372: stloc.s 19
-			IL_0374: br IL_03aa
+			IL_0300: ldc.i4.0
+			IL_0301: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0306: stloc.s 19
+			IL_0308: br IL_031e
 
-			IL_0379: ldarg.0
-			IL_037a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
-			IL_037f: stloc.s 40
-			IL_0381: ldstr "DEFAULT_HARNESS_INCLUDES"
-			IL_0386: ldloc.s 40
-			IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_038d: stloc.s 31
-			IL_038f: ldloc.s 31
-			IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0396: stloc.s 31
-			IL_0398: ldloc.s 31
-			IL_039a: ldstr "slice"
-			IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_03a4: stloc.s 31
-			IL_03a6: ldloc.s 31
-			IL_03a8: stloc.s 19
+			IL_030d: ldarg.0
+			IL_030e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
+			IL_0313: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_0318: stloc.s 40
+			IL_031a: ldloc.s 40
+			IL_031c: stloc.s 19
 
-			IL_03aa: ldloc.s 19
-			IL_03ac: stloc.s 20
-			IL_03ae: ldloc.s 20
-			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b5: stloc.s 31
-			IL_03b7: ldloc.s 31
-			IL_03b9: ldstr "slice"
-			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_03c3: stloc.s 31
-			IL_03c5: ldloc.s 31
-			IL_03c7: stloc.s 21
-			IL_03c9: ldloc.2
-			IL_03ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03cf: stloc.s 34
-			IL_03d1: ldloc.s 34
-			IL_03d3: brfalse IL_03f5
+			IL_031e: ldloc.s 19
+			IL_0320: stloc.s 20
+			IL_0322: ldloc.s 20
+			IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0329: stloc.s 32
+			IL_032b: ldloc.s 32
+			IL_032d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0332: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_0337: stloc.s 40
+			IL_0339: ldloc.s 40
+			IL_033b: stloc.s 21
+			IL_033d: ldloc.2
+			IL_033e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0343: stloc.s 34
+			IL_0345: ldloc.s 34
+			IL_0347: brfalse IL_0369
 
-			IL_03d8: ldloc.1
-			IL_03d9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_03de: ldc.i4.0
-			IL_03df: ceq
-			IL_03e1: stloc.s 34
-			IL_03e3: ldloc.s 34
-			IL_03e5: box [System.Runtime]System.Boolean
-			IL_03ea: stloc.s 36
-			IL_03ec: ldloc.s 36
-			IL_03ee: stloc.s 41
-			IL_03f0: br IL_03f8
+			IL_034c: ldloc.1
+			IL_034d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0352: ldc.i4.0
+			IL_0353: ceq
+			IL_0355: stloc.s 34
+			IL_0357: ldloc.s 34
+			IL_0359: box [System.Runtime]System.Boolean
+			IL_035e: stloc.s 36
+			IL_0360: ldloc.s 36
+			IL_0362: stloc.s 41
+			IL_0364: br IL_036c
 
-			IL_03f5: ldloc.2
-			IL_03f6: stloc.s 41
+			IL_0369: ldloc.2
+			IL_036a: stloc.s 41
 
-			IL_03f8: ldloc.s 41
-			IL_03fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03ff: stloc.s 34
-			IL_0401: ldloc.s 34
-			IL_0403: brfalse IL_046d
+			IL_036c: ldloc.s 41
+			IL_036e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0373: stloc.s 34
+			IL_0375: ldloc.s 34
+			IL_0377: brfalse IL_03bd
 
-			IL_0408: ldarg.0
-			IL_0409: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_040e: stloc.s 31
-			IL_0410: ldstr "contains"
-			IL_0415: ldloc.s 31
-			IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_041c: stloc.s 31
-			IL_041e: ldc.i4.1
-			IL_041f: newarr [System.Runtime]System.Object
-			IL_0424: dup
-			IL_0425: ldc.i4.0
-			IL_0426: ldarg.0
-			IL_0427: stelem.ref
-			IL_0428: stloc.s 32
-			IL_042a: ldarg.0
-			IL_042b: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0430: stloc.s 42
-			IL_0432: ldstr "ASYNC_HARNESS_INCLUDE"
-			IL_0437: ldloc.s 42
-			IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_043e: stloc.s 42
-			IL_0440: ldloc.s 31
-			IL_0442: ldloc.s 32
-			IL_0444: ldloc.s 21
-			IL_0446: ldloc.s 42
-			IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_044d: stloc.s 42
-			IL_044f: ldloc.s 42
-			IL_0451: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0456: ldc.i4.0
-			IL_0457: ceq
-			IL_0459: stloc.s 34
-			IL_045b: ldloc.s 34
-			IL_045d: box [System.Runtime]System.Boolean
-			IL_0462: stloc.s 36
-			IL_0464: ldloc.s 36
-			IL_0466: stloc.s 41
-			IL_0468: br IL_046d
+			IL_037c: ldc.i4.1
+			IL_037d: newarr [System.Runtime]System.Object
+			IL_0382: dup
+			IL_0383: ldc.i4.0
+			IL_0384: ldarg.0
+			IL_0385: stelem.ref
+			IL_0386: stloc.s 31
+			IL_0388: ldarg.0
+			IL_0389: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_038e: ldloc.s 31
+			IL_0390: ldloc.s 21
+			IL_0392: ldarg.0
+			IL_0393: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_039d: stloc.s 32
+			IL_039f: ldloc.s 32
+			IL_03a1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03a6: ldc.i4.0
+			IL_03a7: ceq
+			IL_03a9: stloc.s 34
+			IL_03ab: ldloc.s 34
+			IL_03ad: box [System.Runtime]System.Boolean
+			IL_03b2: stloc.s 36
+			IL_03b4: ldloc.s 36
+			IL_03b6: stloc.s 41
+			IL_03b8: br IL_03bd
 
-			IL_046d: ldloc.s 41
-			IL_046f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0474: stloc.s 34
-			IL_0476: ldloc.s 34
-			IL_0478: brfalse IL_04b2
+			IL_03bd: ldloc.s 41
+			IL_03bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03c4: stloc.s 34
+			IL_03c6: ldloc.s 34
+			IL_03c8: brfalse IL_03f0
 
-			IL_047d: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L360C78::.ctor()
-			IL_0482: stloc.s 22
-			IL_0484: ldloc.s 21
-			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_048b: stloc.s 42
-			IL_048d: ldarg.0
-			IL_048e: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0493: stloc.s 31
-			IL_0495: ldstr "ASYNC_HARNESS_INCLUDE"
-			IL_049a: ldloc.s 31
-			IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_04a1: stloc.s 31
-			IL_04a3: ldloc.s 42
-			IL_04a5: ldstr "push"
-			IL_04aa: ldloc.s 31
-			IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_04b1: pop
+			IL_03cd: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L360C78::.ctor()
+			IL_03d2: stloc.s 22
+			IL_03d4: ldloc.s 21
+			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03db: stloc.s 32
+			IL_03dd: ldloc.s 32
+			IL_03df: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_03e4: ldarg.0
+			IL_03e5: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_03ea: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03ef: pop
 
-			IL_04b2: ldc.r8 0.0
-			IL_04bb: stloc.s 23
-			// loop start (head: IL_04bd)
-				IL_04bd: ldloc.s 23
-				IL_04bf: stloc.s 33
-				IL_04c1: ldloc.s 33
-				IL_04c3: ldarg.3
-				IL_04c4: ldstr "length"
-				IL_04c9: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_04ce: clt
-				IL_04d0: brfalse IL_055e
+			IL_03f0: ldc.r8 0.0
+			IL_03f9: stloc.s 23
+			// loop start (head: IL_03fb)
+				IL_03fb: ldloc.s 23
+				IL_03fd: stloc.s 33
+				IL_03ff: ldloc.s 33
+				IL_0401: ldarg.3
+				IL_0402: ldstr "length"
+				IL_0407: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_040c: clt
+				IL_040e: brfalse IL_048e
 
-				IL_04d5: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44::.ctor()
-				IL_04da: stloc.s 24
-				IL_04dc: ldarg.0
-				IL_04dd: ldfld object Modules.test262_metadataParser/Scope::contains
-				IL_04e2: stloc.s 31
-				IL_04e4: ldstr "contains"
-				IL_04e9: ldloc.s 31
-				IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_04f0: stloc.s 31
-				IL_04f2: ldc.i4.1
-				IL_04f3: newarr [System.Runtime]System.Object
-				IL_04f8: dup
-				IL_04f9: ldc.i4.0
-				IL_04fa: ldarg.0
-				IL_04fb: stelem.ref
-				IL_04fc: stloc.s 32
-				IL_04fe: ldloc.s 31
-				IL_0500: ldloc.s 32
-				IL_0502: ldloc.s 21
-				IL_0504: ldarg.3
-				IL_0505: ldloc.s 23
-				IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_050c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_0511: stloc.s 31
-				IL_0513: ldloc.s 31
-				IL_0515: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_051a: ldc.i4.0
-				IL_051b: ceq
-				IL_051d: stloc.s 34
-				IL_051f: ldloc.s 34
-				IL_0521: brfalse IL_054b
+				IL_0413: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44::.ctor()
+				IL_0418: stloc.s 24
+				IL_041a: ldarg.0
+				IL_041b: ldfld object Modules.test262_metadataParser/Scope::contains
+				IL_0420: stloc.s 32
+				IL_0422: ldc.i4.1
+				IL_0423: newarr [System.Runtime]System.Object
+				IL_0428: dup
+				IL_0429: ldc.i4.0
+				IL_042a: ldarg.0
+				IL_042b: stelem.ref
+				IL_042c: stloc.s 31
+				IL_042e: ldloc.s 32
+				IL_0430: ldloc.s 31
+				IL_0432: ldloc.s 21
+				IL_0434: ldarg.3
+				IL_0435: ldloc.s 23
+				IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_0441: stloc.s 32
+				IL_0443: ldloc.s 32
+				IL_0445: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_044a: ldc.i4.0
+				IL_044b: ceq
+				IL_044d: stloc.s 34
+				IL_044f: ldloc.s 34
+				IL_0451: brfalse IL_047b
 
-				IL_0526: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44/Block_L365C49::.ctor()
-				IL_052b: stloc.s 25
-				IL_052d: ldloc.s 21
-				IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0534: stloc.s 31
-				IL_0536: ldloc.s 31
-				IL_0538: ldstr "push"
-				IL_053d: ldarg.3
-				IL_053e: ldloc.s 23
-				IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_054a: pop
+				IL_0456: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44/Block_L365C49::.ctor()
+				IL_045b: stloc.s 25
+				IL_045d: ldloc.s 21
+				IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0464: stloc.s 32
+				IL_0466: ldloc.s 32
+				IL_0468: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_046d: ldarg.3
+				IL_046e: ldloc.s 23
+				IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0475: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_047a: pop
 
-				IL_054b: ldloc.s 23
-				IL_054d: ldc.r8 1
-				IL_0556: add
-				IL_0557: stloc.s 23
-				IL_0559: br IL_04bd
+				IL_047b: ldloc.s 23
+				IL_047d: ldc.r8 1
+				IL_0486: add
+				IL_0487: stloc.s 23
+				IL_0489: br IL_03fb
 			// end loop
 
-			IL_055e: ldarg.0
-			IL_055f: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0564: stloc.s 31
-			IL_0566: ldstr "contains"
-			IL_056b: ldloc.s 31
-			IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0572: stloc.s 31
-			IL_0574: ldc.i4.1
-			IL_0575: newarr [System.Runtime]System.Object
-			IL_057a: dup
-			IL_057b: ldc.i4.0
-			IL_057c: ldarg.0
-			IL_057d: stelem.ref
-			IL_057e: stloc.s 32
-			IL_0580: ldloc.s 31
-			IL_0582: ldloc.s 32
-			IL_0584: ldarg.3
-			IL_0585: ldstr "agent.js"
-			IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_058f: stloc.s 31
-			IL_0591: ldloc.s 31
-			IL_0593: stloc.s 26
-			IL_0595: ldarg.0
-			IL_0596: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_059b: stloc.s 31
-			IL_059d: ldstr "contains"
-			IL_05a2: ldloc.s 31
-			IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_05a9: stloc.s 31
-			IL_05ab: ldc.i4.1
-			IL_05ac: newarr [System.Runtime]System.Object
-			IL_05b1: dup
-			IL_05b2: ldc.i4.0
-			IL_05b3: ldarg.0
-			IL_05b4: stelem.ref
-			IL_05b5: stloc.s 32
-			IL_05b7: ldloc.s 31
-			IL_05b9: ldloc.s 32
-			IL_05bb: ldarg.2
-			IL_05bc: ldstr "CanBlockIsFalse"
-			IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05c6: stloc.s 31
-			IL_05c8: ldloc.s 31
-			IL_05ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05cf: stloc.s 34
-			IL_05d1: ldloc.s 34
-			IL_05d3: brfalse IL_05e4
+			IL_048e: ldc.i4.1
+			IL_048f: newarr [System.Runtime]System.Object
+			IL_0494: dup
+			IL_0495: ldc.i4.0
+			IL_0496: ldarg.0
+			IL_0497: stelem.ref
+			IL_0498: stloc.s 31
+			IL_049a: ldarg.0
+			IL_049b: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_04a0: ldloc.s 31
+			IL_04a2: ldarg.3
+			IL_04a3: ldstr "agent.js"
+			IL_04a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04ad: stloc.s 32
+			IL_04af: ldloc.s 32
+			IL_04b1: stloc.s 26
+			IL_04b3: ldc.i4.1
+			IL_04b4: newarr [System.Runtime]System.Object
+			IL_04b9: dup
+			IL_04ba: ldc.i4.0
+			IL_04bb: ldarg.0
+			IL_04bc: stelem.ref
+			IL_04bd: stloc.s 31
+			IL_04bf: ldarg.0
+			IL_04c0: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_04c5: ldloc.s 31
+			IL_04c7: ldarg.2
+			IL_04c8: ldstr "CanBlockIsFalse"
+			IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04d2: stloc.s 32
+			IL_04d4: ldloc.s 32
+			IL_04d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04db: stloc.s 34
+			IL_04dd: ldloc.s 34
+			IL_04df: brfalse IL_04f0
 
-			IL_05d8: ldstr "false"
-			IL_05dd: stloc.s 27
-			IL_05df: br IL_063e
+			IL_04e4: ldstr "false"
+			IL_04e9: stloc.s 27
+			IL_04eb: br IL_0538
 
-			IL_05e4: ldarg.0
-			IL_05e5: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_05ea: stloc.s 31
-			IL_05ec: ldstr "contains"
-			IL_05f1: ldloc.s 31
-			IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_05f8: stloc.s 31
-			IL_05fa: ldc.i4.1
-			IL_05fb: newarr [System.Runtime]System.Object
-			IL_0600: dup
-			IL_0601: ldc.i4.0
-			IL_0602: ldarg.0
-			IL_0603: stelem.ref
-			IL_0604: stloc.s 32
-			IL_0606: ldloc.s 31
-			IL_0608: ldloc.s 32
-			IL_060a: ldarg.2
-			IL_060b: ldstr "CanBlockIsTrue"
-			IL_0610: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0615: stloc.s 31
-			IL_0617: ldloc.s 31
-			IL_0619: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_061e: stloc.s 34
-			IL_0620: ldloc.s 34
-			IL_0622: brfalse IL_0633
+			IL_04f0: ldc.i4.1
+			IL_04f1: newarr [System.Runtime]System.Object
+			IL_04f6: dup
+			IL_04f7: ldc.i4.0
+			IL_04f8: ldarg.0
+			IL_04f9: stelem.ref
+			IL_04fa: stloc.s 31
+			IL_04fc: ldarg.0
+			IL_04fd: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0502: ldloc.s 31
+			IL_0504: ldarg.2
+			IL_0505: ldstr "CanBlockIsTrue"
+			IL_050a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_050f: stloc.s 32
+			IL_0511: ldloc.s 32
+			IL_0513: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0518: stloc.s 34
+			IL_051a: ldloc.s 34
+			IL_051c: brfalse IL_052d
 
-			IL_0627: ldstr "true"
-			IL_062c: stloc.s 28
-			IL_062e: br IL_063a
+			IL_0521: ldstr "true"
+			IL_0526: stloc.s 28
+			IL_0528: br IL_0534
 
-			IL_0633: ldstr "unspecified"
-			IL_0638: stloc.s 28
+			IL_052d: ldstr "unspecified"
+			IL_0532: stloc.s 28
 
-			IL_063a: ldloc.s 28
-			IL_063c: stloc.s 27
+			IL_0534: ldloc.s 28
+			IL_0536: stloc.s 27
 
-			IL_063e: ldloc.s 27
-			IL_0640: stloc.s 29
-			IL_0642: ldloc.0
-			IL_0643: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0648: stloc.s 34
-			IL_064a: ldloc.s 34
-			IL_064c: brfalse IL_065d
+			IL_0538: ldloc.s 27
+			IL_053a: stloc.s 29
+			IL_053c: ldloc.0
+			IL_053d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0542: stloc.s 34
+			IL_0544: ldloc.s 34
+			IL_0546: brfalse IL_0557
 
-			IL_0651: ldstr "module"
-			IL_0656: stloc.s 30
-			IL_0658: br IL_0664
+			IL_054b: ldstr "module"
+			IL_0550: stloc.s 30
+			IL_0552: br IL_055e
 
-			IL_065d: ldstr "script"
-			IL_0662: stloc.s 30
+			IL_0557: ldstr "script"
+			IL_055c: stloc.s 30
 
-			IL_0664: ldloc.s 20
-			IL_0666: ldstr "length"
-			IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0670: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0675: ldc.r8 0.0
-			IL_067e: cgt
-			IL_0680: stloc.s 34
-			IL_0682: ldloc.2
-			IL_0683: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0688: stloc.s 44
-			IL_068a: ldloc.s 44
-			IL_068c: brtrue IL_06e0
+			IL_055e: ldloc.s 20
+			IL_0560: ldstr "length"
+			IL_0565: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_056a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_056f: ldc.r8 0.0
+			IL_0578: cgt
+			IL_057a: stloc.s 34
+			IL_057c: ldloc.2
+			IL_057d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0582: stloc.s 43
+			IL_0584: ldloc.s 43
+			IL_0586: brtrue IL_05b6
 
-			IL_0691: ldarg.0
-			IL_0692: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0697: stloc.s 31
-			IL_0699: ldstr "contains"
-			IL_069e: ldloc.s 31
-			IL_06a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06a5: stloc.s 31
-			IL_06a7: ldc.i4.1
-			IL_06a8: newarr [System.Runtime]System.Object
-			IL_06ad: dup
-			IL_06ae: ldc.i4.0
-			IL_06af: ldarg.0
-			IL_06b0: stelem.ref
-			IL_06b1: stloc.s 32
-			IL_06b3: ldarg.0
-			IL_06b4: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_06b9: stloc.s 42
-			IL_06bb: ldstr "ASYNC_HARNESS_INCLUDE"
-			IL_06c0: ldloc.s 42
-			IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06c7: stloc.s 42
-			IL_06c9: ldloc.s 31
-			IL_06cb: ldloc.s 32
-			IL_06cd: ldarg.3
-			IL_06ce: ldloc.s 42
-			IL_06d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06d5: stloc.s 42
-			IL_06d7: ldloc.s 42
-			IL_06d9: stloc.s 45
-			IL_06db: br IL_06e3
+			IL_058b: ldc.i4.1
+			IL_058c: newarr [System.Runtime]System.Object
+			IL_0591: dup
+			IL_0592: ldc.i4.0
+			IL_0593: ldarg.0
+			IL_0594: stelem.ref
+			IL_0595: stloc.s 31
+			IL_0597: ldarg.0
+			IL_0598: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_059d: ldloc.s 31
+			IL_059f: ldarg.3
+			IL_05a0: ldarg.0
+			IL_05a1: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05ab: stloc.s 32
+			IL_05ad: ldloc.s 32
+			IL_05af: stloc.s 44
+			IL_05b1: br IL_05b9
 
-			IL_06e0: ldloc.2
-			IL_06e1: stloc.s 45
+			IL_05b6: ldloc.2
+			IL_05b7: stloc.s 44
 
-			IL_06e3: ldloc.s 26
-			IL_06e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_06ea: stloc.s 44
-			IL_06ec: ldloc.s 44
-			IL_06ee: brtrue IL_0717
+			IL_05b9: ldloc.s 26
+			IL_05bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05c0: stloc.s 43
+			IL_05c2: ldloc.s 43
+			IL_05c4: brtrue IL_05ed
 
-			IL_06f3: ldloc.s 29
-			IL_06f5: stloc.s 46
-			IL_06f7: ldloc.s 46
-			IL_06f9: ldstr "unspecified"
-			IL_06fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0703: stloc.s 44
-			IL_0705: ldloc.s 44
-			IL_0707: box [System.Runtime]System.Boolean
-			IL_070c: stloc.s 36
-			IL_070e: ldloc.s 36
-			IL_0710: stloc.s 47
-			IL_0712: br IL_071b
+			IL_05c9: ldloc.s 29
+			IL_05cb: stloc.s 45
+			IL_05cd: ldloc.s 45
+			IL_05cf: ldstr "unspecified"
+			IL_05d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_05d9: stloc.s 43
+			IL_05db: ldloc.s 43
+			IL_05dd: box [System.Runtime]System.Boolean
+			IL_05e2: stloc.s 36
+			IL_05e4: ldloc.s 36
+			IL_05e6: stloc.s 46
+			IL_05e8: br IL_05f1
 
-			IL_0717: ldloc.s 26
-			IL_0719: stloc.s 47
+			IL_05ed: ldloc.s 26
+			IL_05ef: stloc.s 46
 
-			IL_071b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0720: dup
-			IL_0721: ldstr "sourceType"
-			IL_0726: ldloc.s 30
-			IL_0728: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_072d: dup
-			IL_072e: ldstr "strictMode"
-			IL_0733: ldloc.s 12
-			IL_0735: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_073a: dup
-			IL_073b: ldstr "defaultHarnessIncludes"
-			IL_0740: ldloc.s 20
-			IL_0742: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0747: dup
-			IL_0748: ldstr "harnessIncludes"
-			IL_074d: ldloc.s 21
-			IL_074f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0754: dup
-			IL_0755: ldstr "requiresDefaultHarness"
-			IL_075a: ldloc.s 34
-			IL_075c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0761: dup
-			IL_0762: ldstr "requiresAsyncHarness"
-			IL_0767: ldloc.s 45
-			IL_0769: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_076e: dup
-			IL_076f: ldstr "requiresAgent"
-			IL_0774: ldloc.s 47
-			IL_0776: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_077b: dup
-			IL_077c: ldstr "canBlock"
-			IL_0781: ldloc.s 29
-			IL_0783: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0788: dup
-			IL_0789: ldstr "isModule"
-			IL_078e: ldloc.0
-			IL_078f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0794: dup
-			IL_0795: ldstr "isRaw"
-			IL_079a: ldloc.1
-			IL_079b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_07a0: dup
-			IL_07a1: ldstr "isAsync"
-			IL_07a6: ldloc.2
-			IL_07a7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_07ac: dup
-			IL_07ad: ldstr "isGenerated"
-			IL_07b2: ldloc.3
-			IL_07b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_07b8: dup
-			IL_07b9: ldstr "isNonDeterministic"
-			IL_07be: ldloc.s 4
-			IL_07c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_07c5: dup
-			IL_07c6: ldstr "isFixture"
-			IL_07cb: ldloc.s 5
-			IL_07cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_07d2: stloc.s 48
-			IL_07d4: ldloc.s 48
-			IL_07d6: ret
+			IL_05f1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05f6: dup
+			IL_05f7: ldstr "sourceType"
+			IL_05fc: ldloc.s 30
+			IL_05fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0603: dup
+			IL_0604: ldstr "strictMode"
+			IL_0609: ldloc.s 12
+			IL_060b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0610: dup
+			IL_0611: ldstr "defaultHarnessIncludes"
+			IL_0616: ldloc.s 20
+			IL_0618: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_061d: dup
+			IL_061e: ldstr "harnessIncludes"
+			IL_0623: ldloc.s 21
+			IL_0625: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_062a: dup
+			IL_062b: ldstr "requiresDefaultHarness"
+			IL_0630: ldloc.s 34
+			IL_0632: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0637: dup
+			IL_0638: ldstr "requiresAsyncHarness"
+			IL_063d: ldloc.s 44
+			IL_063f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0644: dup
+			IL_0645: ldstr "requiresAgent"
+			IL_064a: ldloc.s 46
+			IL_064c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0651: dup
+			IL_0652: ldstr "canBlock"
+			IL_0657: ldloc.s 29
+			IL_0659: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_065e: dup
+			IL_065f: ldstr "isModule"
+			IL_0664: ldloc.0
+			IL_0665: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_066a: dup
+			IL_066b: ldstr "isRaw"
+			IL_0670: ldloc.1
+			IL_0671: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0676: dup
+			IL_0677: ldstr "isAsync"
+			IL_067c: ldloc.2
+			IL_067d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0682: dup
+			IL_0683: ldstr "isGenerated"
+			IL_0688: ldloc.3
+			IL_0689: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_068e: dup
+			IL_068f: ldstr "isNonDeterministic"
+			IL_0694: ldloc.s 4
+			IL_0696: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_069b: dup
+			IL_069c: ldstr "isFixture"
+			IL_06a1: ldloc.s 5
+			IL_06a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_06a8: stloc.s 47
+			IL_06aa: ldloc.s 47
+			IL_06ac: ret
 		} // end of method buildExecutionMetadata::__js_call__
 
 	} // end of class buildExecutionMetadata
@@ -8651,7 +8236,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x73ab
+					// Method begins at RVA 0x6ce1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8671,7 +8256,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x73b4
+					// Method begins at RVA 0x6cea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8691,7 +8276,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x73bd
+					// Method begins at RVA 0x6cf3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8711,7 +8296,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x73c6
+					// Method begins at RVA 0x6cfc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8731,7 +8316,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x73cf
+					// Method begins at RVA 0x6d05
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8751,7 +8336,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x73d8
+					// Method begins at RVA 0x6d0e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8771,7 +8356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x73e1
+					// Method begins at RVA 0x6d17
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8789,7 +8374,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x73a2
+				// Method begins at RVA 0x6cd8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8818,9 +8403,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x633c
+			// Method begins at RVA 0x5e58
 			// Header size: 12
-			// Code size: 962 (0x3c2)
+			// Code size: 864 (0x360)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -8852,402 +8437,374 @@
 			IL_0013: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0018: stloc.s 9
 			IL_001a: ldloc.s 9
-			IL_001c: brfalse IL_0094
+			IL_001c: brfalse IL_0086
 
 			IL_0021: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L398C27::.ctor()
 			IL_0026: stloc.1
 			IL_0027: ldarg.0
 			IL_0028: ldfld object Modules.test262_metadataParser/Scope::pushIssue
 			IL_002d: stloc.s 10
-			IL_002f: ldstr "pushIssue"
-			IL_0034: ldloc.s 10
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003b: stloc.s 10
-			IL_003d: ldc.i4.1
-			IL_003e: newarr [System.Runtime]System.Object
-			IL_0043: dup
-			IL_0044: ldc.i4.0
-			IL_0045: ldarg.0
-			IL_0046: stelem.ref
-			IL_0047: stloc.s 11
-			IL_0049: ldarg.2
-			IL_004a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_004f: stloc.s 9
-			IL_0051: ldloc.s 9
-			IL_0053: brtrue IL_0064
+			IL_002f: ldc.i4.1
+			IL_0030: newarr [System.Runtime]System.Object
+			IL_0035: dup
+			IL_0036: ldc.i4.0
+			IL_0037: ldarg.0
+			IL_0038: stelem.ref
+			IL_0039: stloc.s 11
+			IL_003b: ldarg.2
+			IL_003c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0041: stloc.s 9
+			IL_0043: ldloc.s 9
+			IL_0045: brtrue IL_0056
 
-			IL_0058: ldstr "<anonymous>"
-			IL_005d: stloc.s 13
-			IL_005f: br IL_0067
+			IL_004a: ldstr "<anonymous>"
+			IL_004f: stloc.s 13
+			IL_0051: br IL_0059
 
-			IL_0064: ldarg.2
-			IL_0065: stloc.s 13
+			IL_0056: ldarg.2
+			IL_0057: stloc.s 13
 
-			IL_0067: ldc.i4.4
-			IL_0068: newarr [System.Runtime]System.Object
-			IL_006d: dup
-			IL_006e: ldc.i4.0
-			IL_006f: ldloc.0
-			IL_0070: stelem.ref
-			IL_0071: dup
-			IL_0072: ldc.i4.1
-			IL_0073: ldstr "fixture-file"
-			IL_0078: stelem.ref
-			IL_0079: dup
-			IL_007a: ldc.i4.2
-			IL_007b: ldloc.s 13
-			IL_007d: stelem.ref
-			IL_007e: dup
-			IL_007f: ldc.i4.3
-			IL_0080: ldstr "Files whose names include `_FIXTURE` are support files, not standalone MVP tests."
-			IL_0085: stelem.ref
-			IL_0086: stloc.s 14
-			IL_0088: ldloc.s 10
-			IL_008a: ldloc.s 11
-			IL_008c: ldloc.s 14
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0093: pop
+			IL_0059: ldc.i4.4
+			IL_005a: newarr [System.Runtime]System.Object
+			IL_005f: dup
+			IL_0060: ldc.i4.0
+			IL_0061: ldloc.0
+			IL_0062: stelem.ref
+			IL_0063: dup
+			IL_0064: ldc.i4.1
+			IL_0065: ldstr "fixture-file"
+			IL_006a: stelem.ref
+			IL_006b: dup
+			IL_006c: ldc.i4.2
+			IL_006d: ldloc.s 13
+			IL_006f: stelem.ref
+			IL_0070: dup
+			IL_0071: ldc.i4.3
+			IL_0072: ldstr "Files whose names include `_FIXTURE` are support files, not standalone MVP tests."
+			IL_0077: stelem.ref
+			IL_0078: stloc.s 14
+			IL_007a: ldloc.s 10
+			IL_007c: ldloc.s 11
+			IL_007e: ldloc.s 14
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0085: pop
 
-			IL_0094: ldarg.s execution
-			IL_0096: ldstr "isModule"
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00a5: stloc.s 9
-			IL_00a7: ldloc.s 9
-			IL_00a9: brfalse IL_0106
+			IL_0086: ldarg.s execution
+			IL_0088: ldstr "isModule"
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0092: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0097: stloc.s 9
+			IL_0099: ldloc.s 9
+			IL_009b: brfalse IL_00ea
 
-			IL_00ae: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L402C26::.ctor()
-			IL_00b3: stloc.2
-			IL_00b4: ldarg.0
-			IL_00b5: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_00ba: stloc.s 10
-			IL_00bc: ldstr "pushIssue"
-			IL_00c1: ldloc.s 10
-			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c8: stloc.s 10
-			IL_00ca: ldc.i4.1
-			IL_00cb: newarr [System.Runtime]System.Object
-			IL_00d0: dup
-			IL_00d1: ldc.i4.0
-			IL_00d2: ldarg.0
+			IL_00a0: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L402C26::.ctor()
+			IL_00a5: stloc.2
+			IL_00a6: ldarg.0
+			IL_00a7: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_00ac: stloc.s 10
+			IL_00ae: ldc.i4.1
+			IL_00af: newarr [System.Runtime]System.Object
+			IL_00b4: dup
+			IL_00b5: ldc.i4.0
+			IL_00b6: ldarg.0
+			IL_00b7: stelem.ref
+			IL_00b8: stloc.s 14
+			IL_00ba: ldc.i4.4
+			IL_00bb: newarr [System.Runtime]System.Object
+			IL_00c0: dup
+			IL_00c1: ldc.i4.0
+			IL_00c2: ldloc.0
+			IL_00c3: stelem.ref
+			IL_00c4: dup
+			IL_00c5: ldc.i4.1
+			IL_00c6: ldstr "module-flag"
+			IL_00cb: stelem.ref
+			IL_00cc: dup
+			IL_00cd: ldc.i4.2
+			IL_00ce: ldstr "flags:module"
 			IL_00d3: stelem.ref
-			IL_00d4: stloc.s 14
-			IL_00d6: ldc.i4.4
-			IL_00d7: newarr [System.Runtime]System.Object
-			IL_00dc: dup
-			IL_00dd: ldc.i4.0
-			IL_00de: ldloc.0
-			IL_00df: stelem.ref
-			IL_00e0: dup
-			IL_00e1: ldc.i4.1
-			IL_00e2: ldstr "module-flag"
-			IL_00e7: stelem.ref
-			IL_00e8: dup
-			IL_00e9: ldc.i4.2
-			IL_00ea: ldstr "flags:module"
-			IL_00ef: stelem.ref
-			IL_00f0: dup
-			IL_00f1: ldc.i4.3
-			IL_00f2: ldstr "Module tests are outside the plain synchronous script MVP."
-			IL_00f7: stelem.ref
-			IL_00f8: stloc.s 11
-			IL_00fa: ldloc.s 10
-			IL_00fc: ldloc.s 14
-			IL_00fe: ldloc.s 11
-			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0105: pop
+			IL_00d4: dup
+			IL_00d5: ldc.i4.3
+			IL_00d6: ldstr "Module tests are outside the plain synchronous script MVP."
+			IL_00db: stelem.ref
+			IL_00dc: stloc.s 11
+			IL_00de: ldloc.s 10
+			IL_00e0: ldloc.s 14
+			IL_00e2: ldloc.s 11
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_00e9: pop
 
-			IL_0106: ldarg.s execution
-			IL_0108: ldstr "isRaw"
-			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0112: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0117: stloc.s 9
-			IL_0119: ldloc.s 9
-			IL_011b: brfalse IL_0178
+			IL_00ea: ldarg.s execution
+			IL_00ec: ldstr "isRaw"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00fb: stloc.s 9
+			IL_00fd: ldloc.s 9
+			IL_00ff: brfalse IL_014e
 
-			IL_0120: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L406C23::.ctor()
-			IL_0125: stloc.3
-			IL_0126: ldarg.0
-			IL_0127: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_012c: stloc.s 10
-			IL_012e: ldstr "pushIssue"
-			IL_0133: ldloc.s 10
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_013a: stloc.s 10
-			IL_013c: ldc.i4.1
-			IL_013d: newarr [System.Runtime]System.Object
-			IL_0142: dup
-			IL_0143: ldc.i4.0
-			IL_0144: ldarg.0
-			IL_0145: stelem.ref
-			IL_0146: stloc.s 11
-			IL_0148: ldc.i4.4
-			IL_0149: newarr [System.Runtime]System.Object
-			IL_014e: dup
-			IL_014f: ldc.i4.0
-			IL_0150: ldloc.0
-			IL_0151: stelem.ref
-			IL_0152: dup
-			IL_0153: ldc.i4.1
-			IL_0154: ldstr "raw-flag"
-			IL_0159: stelem.ref
-			IL_015a: dup
-			IL_015b: ldc.i4.2
-			IL_015c: ldstr "flags:raw"
-			IL_0161: stelem.ref
-			IL_0162: dup
-			IL_0163: ldc.i4.3
-			IL_0164: ldstr "Raw tests bypass default harness injection and are outside the initial MVP."
-			IL_0169: stelem.ref
-			IL_016a: stloc.s 14
-			IL_016c: ldloc.s 10
-			IL_016e: ldloc.s 11
-			IL_0170: ldloc.s 14
-			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0177: pop
+			IL_0104: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L406C23::.ctor()
+			IL_0109: stloc.3
+			IL_010a: ldarg.0
+			IL_010b: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0110: stloc.s 10
+			IL_0112: ldc.i4.1
+			IL_0113: newarr [System.Runtime]System.Object
+			IL_0118: dup
+			IL_0119: ldc.i4.0
+			IL_011a: ldarg.0
+			IL_011b: stelem.ref
+			IL_011c: stloc.s 11
+			IL_011e: ldc.i4.4
+			IL_011f: newarr [System.Runtime]System.Object
+			IL_0124: dup
+			IL_0125: ldc.i4.0
+			IL_0126: ldloc.0
+			IL_0127: stelem.ref
+			IL_0128: dup
+			IL_0129: ldc.i4.1
+			IL_012a: ldstr "raw-flag"
+			IL_012f: stelem.ref
+			IL_0130: dup
+			IL_0131: ldc.i4.2
+			IL_0132: ldstr "flags:raw"
+			IL_0137: stelem.ref
+			IL_0138: dup
+			IL_0139: ldc.i4.3
+			IL_013a: ldstr "Raw tests bypass default harness injection and are outside the initial MVP."
+			IL_013f: stelem.ref
+			IL_0140: stloc.s 14
+			IL_0142: ldloc.s 10
+			IL_0144: ldloc.s 11
+			IL_0146: ldloc.s 14
+			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_014d: pop
 
-			IL_0178: ldarg.s execution
-			IL_017a: ldstr "requiresAsyncHarness"
-			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0189: stloc.s 9
-			IL_018b: ldloc.s 9
-			IL_018d: brfalse IL_01eb
+			IL_014e: ldarg.s execution
+			IL_0150: ldstr "requiresAsyncHarness"
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_015f: stloc.s 9
+			IL_0161: ldloc.s 9
+			IL_0163: brfalse IL_01b3
 
-			IL_0192: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L410C38::.ctor()
-			IL_0197: stloc.s 4
-			IL_0199: ldarg.0
-			IL_019a: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_019f: stloc.s 10
-			IL_01a1: ldstr "pushIssue"
-			IL_01a6: ldloc.s 10
-			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01ad: stloc.s 10
-			IL_01af: ldc.i4.1
-			IL_01b0: newarr [System.Runtime]System.Object
-			IL_01b5: dup
-			IL_01b6: ldc.i4.0
-			IL_01b7: ldarg.0
-			IL_01b8: stelem.ref
-			IL_01b9: stloc.s 14
-			IL_01bb: ldc.i4.4
-			IL_01bc: newarr [System.Runtime]System.Object
-			IL_01c1: dup
-			IL_01c2: ldc.i4.0
-			IL_01c3: ldloc.0
-			IL_01c4: stelem.ref
-			IL_01c5: dup
-			IL_01c6: ldc.i4.1
-			IL_01c7: ldstr "async-requirement"
-			IL_01cc: stelem.ref
-			IL_01cd: dup
-			IL_01ce: ldc.i4.2
-			IL_01cf: ldstr "flags/includes"
-			IL_01d4: stelem.ref
-			IL_01d5: dup
-			IL_01d6: ldc.i4.3
-			IL_01d7: ldstr "Async tests and async harness requirements are outside the initial MVP."
-			IL_01dc: stelem.ref
-			IL_01dd: stloc.s 11
-			IL_01df: ldloc.s 10
-			IL_01e1: ldloc.s 14
-			IL_01e3: ldloc.s 11
-			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_01ea: pop
+			IL_0168: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L410C38::.ctor()
+			IL_016d: stloc.s 4
+			IL_016f: ldarg.0
+			IL_0170: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0175: stloc.s 10
+			IL_0177: ldc.i4.1
+			IL_0178: newarr [System.Runtime]System.Object
+			IL_017d: dup
+			IL_017e: ldc.i4.0
+			IL_017f: ldarg.0
+			IL_0180: stelem.ref
+			IL_0181: stloc.s 14
+			IL_0183: ldc.i4.4
+			IL_0184: newarr [System.Runtime]System.Object
+			IL_0189: dup
+			IL_018a: ldc.i4.0
+			IL_018b: ldloc.0
+			IL_018c: stelem.ref
+			IL_018d: dup
+			IL_018e: ldc.i4.1
+			IL_018f: ldstr "async-requirement"
+			IL_0194: stelem.ref
+			IL_0195: dup
+			IL_0196: ldc.i4.2
+			IL_0197: ldstr "flags/includes"
+			IL_019c: stelem.ref
+			IL_019d: dup
+			IL_019e: ldc.i4.3
+			IL_019f: ldstr "Async tests and async harness requirements are outside the initial MVP."
+			IL_01a4: stelem.ref
+			IL_01a5: stloc.s 11
+			IL_01a7: ldloc.s 10
+			IL_01a9: ldloc.s 14
+			IL_01ab: ldloc.s 11
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_01b2: pop
 
-			IL_01eb: ldarg.s execution
-			IL_01ed: ldstr "requiresAgent"
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01fc: stloc.s 9
-			IL_01fe: ldloc.s 9
-			IL_0200: brfalse IL_025e
+			IL_01b3: ldarg.s execution
+			IL_01b5: ldstr "requiresAgent"
+			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01c4: stloc.s 9
+			IL_01c6: ldloc.s 9
+			IL_01c8: brfalse IL_0218
 
-			IL_0205: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L414C31::.ctor()
-			IL_020a: stloc.s 5
-			IL_020c: ldarg.0
-			IL_020d: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_0212: stloc.s 10
-			IL_0214: ldstr "pushIssue"
-			IL_0219: ldloc.s 10
-			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0220: stloc.s 10
-			IL_0222: ldc.i4.1
-			IL_0223: newarr [System.Runtime]System.Object
-			IL_0228: dup
-			IL_0229: ldc.i4.0
-			IL_022a: ldarg.0
-			IL_022b: stelem.ref
-			IL_022c: stloc.s 11
-			IL_022e: ldc.i4.4
-			IL_022f: newarr [System.Runtime]System.Object
-			IL_0234: dup
-			IL_0235: ldc.i4.0
-			IL_0236: ldloc.0
-			IL_0237: stelem.ref
-			IL_0238: dup
-			IL_0239: ldc.i4.1
-			IL_023a: ldstr "agent-requirement"
-			IL_023f: stelem.ref
-			IL_0240: dup
-			IL_0241: ldc.i4.2
-			IL_0242: ldstr "flags/includes"
-			IL_0247: stelem.ref
-			IL_0248: dup
-			IL_0249: ldc.i4.3
-			IL_024a: ldstr "Agent-sensitive tests are outside the initial MVP."
+			IL_01cd: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L414C31::.ctor()
+			IL_01d2: stloc.s 5
+			IL_01d4: ldarg.0
+			IL_01d5: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_01da: stloc.s 10
+			IL_01dc: ldc.i4.1
+			IL_01dd: newarr [System.Runtime]System.Object
+			IL_01e2: dup
+			IL_01e3: ldc.i4.0
+			IL_01e4: ldarg.0
+			IL_01e5: stelem.ref
+			IL_01e6: stloc.s 11
+			IL_01e8: ldc.i4.4
+			IL_01e9: newarr [System.Runtime]System.Object
+			IL_01ee: dup
+			IL_01ef: ldc.i4.0
+			IL_01f0: ldloc.0
+			IL_01f1: stelem.ref
+			IL_01f2: dup
+			IL_01f3: ldc.i4.1
+			IL_01f4: ldstr "agent-requirement"
+			IL_01f9: stelem.ref
+			IL_01fa: dup
+			IL_01fb: ldc.i4.2
+			IL_01fc: ldstr "flags/includes"
+			IL_0201: stelem.ref
+			IL_0202: dup
+			IL_0203: ldc.i4.3
+			IL_0204: ldstr "Agent-sensitive tests are outside the initial MVP."
+			IL_0209: stelem.ref
+			IL_020a: stloc.s 14
+			IL_020c: ldloc.s 10
+			IL_020e: ldloc.s 11
+			IL_0210: ldloc.s 14
+			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0217: pop
+
+			IL_0218: ldarg.s execution
+			IL_021a: ldstr "canBlock"
+			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0224: ldstr "unspecified"
+			IL_0229: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_022e: stloc.s 9
+			IL_0230: ldloc.s 9
+			IL_0232: brfalse IL_02c8
+
+			IL_0237: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L418C44::.ctor()
+			IL_023c: stloc.s 6
+			IL_023e: ldarg.0
+			IL_023f: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0244: stloc.s 10
+			IL_0246: ldc.i4.1
+			IL_0247: newarr [System.Runtime]System.Object
+			IL_024c: dup
+			IL_024d: ldc.i4.0
+			IL_024e: ldarg.0
 			IL_024f: stelem.ref
 			IL_0250: stloc.s 14
-			IL_0252: ldloc.s 10
-			IL_0254: ldloc.s 11
-			IL_0256: ldloc.s 14
-			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_025d: pop
+			IL_0252: ldarg.s execution
+			IL_0254: ldstr "canBlock"
+			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_025e: ldstr "true"
+			IL_0263: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0268: stloc.s 9
+			IL_026a: ldloc.s 9
+			IL_026c: brfalse IL_027d
 
-			IL_025e: ldarg.s execution
-			IL_0260: ldstr "canBlock"
-			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_026a: ldstr "unspecified"
-			IL_026f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0274: stloc.s 9
-			IL_0276: ldloc.s 9
-			IL_0278: brfalse IL_031c
+			IL_0271: ldstr "True"
+			IL_0276: stloc.s 7
+			IL_0278: br IL_0284
 
-			IL_027d: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L418C44::.ctor()
-			IL_0282: stloc.s 6
-			IL_0284: ldarg.0
-			IL_0285: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_028a: stloc.s 10
-			IL_028c: ldstr "pushIssue"
-			IL_0291: ldloc.s 10
-			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0298: stloc.s 10
-			IL_029a: ldc.i4.1
-			IL_029b: newarr [System.Runtime]System.Object
-			IL_02a0: dup
-			IL_02a1: ldc.i4.0
-			IL_02a2: ldarg.0
-			IL_02a3: stelem.ref
-			IL_02a4: stloc.s 14
-			IL_02a6: ldarg.s execution
-			IL_02a8: ldstr "canBlock"
-			IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b2: ldstr "true"
-			IL_02b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_02bc: stloc.s 9
-			IL_02be: ldloc.s 9
-			IL_02c0: brfalse IL_02d1
+			IL_027d: ldstr "False"
+			IL_0282: stloc.s 7
 
-			IL_02c5: ldstr "True"
-			IL_02ca: stloc.s 7
-			IL_02cc: br IL_02d8
+			IL_0284: ldloc.s 7
+			IL_0286: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_028b: stloc.s 15
+			IL_028d: ldstr "flags:CanBlockIs"
+			IL_0292: ldloc.s 15
+			IL_0294: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0299: stloc.s 15
+			IL_029b: ldc.i4.4
+			IL_029c: newarr [System.Runtime]System.Object
+			IL_02a1: dup
+			IL_02a2: ldc.i4.0
+			IL_02a3: ldloc.0
+			IL_02a4: stelem.ref
+			IL_02a5: dup
+			IL_02a6: ldc.i4.1
+			IL_02a7: ldstr "can-block-requirement"
+			IL_02ac: stelem.ref
+			IL_02ad: dup
+			IL_02ae: ldc.i4.2
+			IL_02af: ldloc.s 15
+			IL_02b1: stelem.ref
+			IL_02b2: dup
+			IL_02b3: ldc.i4.3
+			IL_02b4: ldstr "Tests requiring a specific [[CanBlock]] mode are outside the initial MVP."
+			IL_02b9: stelem.ref
+			IL_02ba: stloc.s 11
+			IL_02bc: ldloc.s 10
+			IL_02be: ldloc.s 14
+			IL_02c0: ldloc.s 11
+			IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_02c7: pop
 
-			IL_02d1: ldstr "False"
-			IL_02d6: stloc.s 7
+			IL_02c8: ldarg.3
+			IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02ce: stloc.s 9
+			IL_02d0: ldloc.s 9
+			IL_02d2: brfalse IL_0300
 
-			IL_02d8: ldloc.s 7
-			IL_02da: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02df: stloc.s 15
-			IL_02e1: ldstr "flags:CanBlockIs"
-			IL_02e6: ldloc.s 15
-			IL_02e8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02ed: stloc.s 15
-			IL_02ef: ldc.i4.4
-			IL_02f0: newarr [System.Runtime]System.Object
-			IL_02f5: dup
-			IL_02f6: ldc.i4.0
-			IL_02f7: ldloc.0
-			IL_02f8: stelem.ref
-			IL_02f9: dup
-			IL_02fa: ldc.i4.1
-			IL_02fb: ldstr "can-block-requirement"
-			IL_0300: stelem.ref
-			IL_0301: dup
-			IL_0302: ldc.i4.2
-			IL_0303: ldloc.s 15
-			IL_0305: stelem.ref
-			IL_0306: dup
-			IL_0307: ldc.i4.3
-			IL_0308: ldstr "Tests requiring a specific [[CanBlock]] mode are outside the initial MVP."
-			IL_030d: stelem.ref
-			IL_030e: stloc.s 11
-			IL_0310: ldloc.s 10
-			IL_0312: ldloc.s 14
-			IL_0314: ldloc.s 11
-			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_031b: pop
+			IL_02d7: ldarg.3
+			IL_02d8: ldstr "phase"
+			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02e2: ldstr "resolution"
+			IL_02e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_02ec: stloc.s 9
+			IL_02ee: ldloc.s 9
+			IL_02f0: box [System.Runtime]System.Boolean
+			IL_02f5: stloc.s 16
+			IL_02f7: ldloc.s 16
+			IL_02f9: stloc.s 17
+			IL_02fb: br IL_0303
 
-			IL_031c: ldarg.3
-			IL_031d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0322: stloc.s 9
-			IL_0324: ldloc.s 9
-			IL_0326: brfalse IL_0354
+			IL_0300: ldarg.3
+			IL_0301: stloc.s 17
 
-			IL_032b: ldarg.3
-			IL_032c: ldstr "phase"
-			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0336: ldstr "resolution"
-			IL_033b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0340: stloc.s 9
-			IL_0342: ldloc.s 9
-			IL_0344: box [System.Runtime]System.Boolean
-			IL_0349: stloc.s 16
-			IL_034b: ldloc.s 16
-			IL_034d: stloc.s 17
-			IL_034f: br IL_0357
+			IL_0303: ldloc.s 17
+			IL_0305: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_030a: stloc.s 9
+			IL_030c: ldloc.s 9
+			IL_030e: brfalse IL_035e
 
-			IL_0354: ldarg.3
-			IL_0355: stloc.s 17
+			IL_0313: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L422C51::.ctor()
+			IL_0318: stloc.s 8
+			IL_031a: ldarg.0
+			IL_031b: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0320: stloc.s 10
+			IL_0322: ldc.i4.1
+			IL_0323: newarr [System.Runtime]System.Object
+			IL_0328: dup
+			IL_0329: ldc.i4.0
+			IL_032a: ldarg.0
+			IL_032b: stelem.ref
+			IL_032c: stloc.s 11
+			IL_032e: ldc.i4.4
+			IL_032f: newarr [System.Runtime]System.Object
+			IL_0334: dup
+			IL_0335: ldc.i4.0
+			IL_0336: ldloc.0
+			IL_0337: stelem.ref
+			IL_0338: dup
+			IL_0339: ldc.i4.1
+			IL_033a: ldstr "resolution-negative"
+			IL_033f: stelem.ref
+			IL_0340: dup
+			IL_0341: ldc.i4.2
+			IL_0342: ldstr "negative.phase"
+			IL_0347: stelem.ref
+			IL_0348: dup
+			IL_0349: ldc.i4.3
+			IL_034a: ldstr "Module resolution failures are outside the plain script MVP."
+			IL_034f: stelem.ref
+			IL_0350: stloc.s 14
+			IL_0352: ldloc.s 10
+			IL_0354: ldloc.s 11
+			IL_0356: ldloc.s 14
+			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_035d: pop
 
-			IL_0357: ldloc.s 17
-			IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_035e: stloc.s 9
-			IL_0360: ldloc.s 9
-			IL_0362: brfalse IL_03c0
-
-			IL_0367: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L422C51::.ctor()
-			IL_036c: stloc.s 8
-			IL_036e: ldarg.0
-			IL_036f: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_0374: stloc.s 10
-			IL_0376: ldstr "pushIssue"
-			IL_037b: ldloc.s 10
-			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0382: stloc.s 10
-			IL_0384: ldc.i4.1
-			IL_0385: newarr [System.Runtime]System.Object
-			IL_038a: dup
-			IL_038b: ldc.i4.0
-			IL_038c: ldarg.0
-			IL_038d: stelem.ref
-			IL_038e: stloc.s 11
-			IL_0390: ldc.i4.4
-			IL_0391: newarr [System.Runtime]System.Object
-			IL_0396: dup
-			IL_0397: ldc.i4.0
-			IL_0398: ldloc.0
-			IL_0399: stelem.ref
-			IL_039a: dup
-			IL_039b: ldc.i4.1
-			IL_039c: ldstr "resolution-negative"
-			IL_03a1: stelem.ref
-			IL_03a2: dup
-			IL_03a3: ldc.i4.2
-			IL_03a4: ldstr "negative.phase"
-			IL_03a9: stelem.ref
-			IL_03aa: dup
-			IL_03ab: ldc.i4.3
-			IL_03ac: ldstr "Module resolution failures are outside the plain script MVP."
-			IL_03b1: stelem.ref
-			IL_03b2: stloc.s 14
-			IL_03b4: ldloc.s 10
-			IL_03b6: ldloc.s 11
-			IL_03b8: ldloc.s 14
-			IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_03bf: pop
-
-			IL_03c0: ldloc.0
-			IL_03c1: ret
+			IL_035e: ldloc.0
+			IL_035f: ret
 		} // end of method buildMvpBlockers::__js_call__
 
 	} // end of class buildMvpBlockers
@@ -9267,7 +8824,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7429
+					// Method begins at RVA 0x6d5f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -9285,7 +8842,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x73ea
+				// Method begins at RVA 0x6d20
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -9313,7 +8870,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7405
+						// Method begins at RVA 0x6d3b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -9331,7 +8888,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x73fc
+					// Method begins at RVA 0x6d32
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -9349,7 +8906,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x73f3
+				// Method begins at RVA 0x6d29
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -9377,7 +8934,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7420
+						// Method begins at RVA 0x6d56
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -9395,7 +8952,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7417
+					// Method begins at RVA 0x6d4d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -9413,7 +8970,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x740e
+				// Method begins at RVA 0x6d44
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -9441,9 +8998,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x670c
+			// Method begins at RVA 0x61c4
 			// Header size: 12
-			// Code size: 2296 (0x8f8)
+			// Code size: 1922 (0x782)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -9479,9 +9036,9 @@
 				[30] object,
 				[31] object,
 				[32] float64,
-				[33] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[34] string,
-				[35] object[],
+				[33] string,
+				[34] object[],
+				[35] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[36] string,
 				[37] object,
 				[38] object,
@@ -9512,853 +9069,745 @@
 			IL_0021: ldarg.0
 			IL_0022: ldfld object Modules.test262_metadataParser/Scope::normalizePath
 			IL_0027: stloc.s 28
-			IL_0029: ldstr "normalizePath"
-			IL_002e: ldloc.s 28
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0035: stloc.s 28
-			IL_0037: ldc.i4.1
-			IL_0038: newarr [System.Runtime]System.Object
-			IL_003d: dup
-			IL_003e: ldc.i4.0
-			IL_003f: ldarg.0
-			IL_0040: stelem.ref
-			IL_0041: stloc.s 29
-			IL_0043: ldloc.0
-			IL_0044: ldstr "filePath"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004e: stloc.s 30
-			IL_0050: ldloc.s 30
-			IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0057: stloc.s 25
-			IL_0059: ldloc.s 25
-			IL_005b: brtrue IL_006c
+			IL_0029: ldc.i4.1
+			IL_002a: newarr [System.Runtime]System.Object
+			IL_002f: dup
+			IL_0030: ldc.i4.0
+			IL_0031: ldarg.0
+			IL_0032: stelem.ref
+			IL_0033: stloc.s 29
+			IL_0035: ldloc.0
+			IL_0036: ldstr "filePath"
+			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0040: stloc.s 30
+			IL_0042: ldloc.s 30
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0049: stloc.s 25
+			IL_004b: ldloc.s 25
+			IL_004d: brtrue IL_005e
 
-			IL_0060: ldstr ""
-			IL_0065: stloc.s 31
-			IL_0067: br IL_0070
+			IL_0052: ldstr ""
+			IL_0057: stloc.s 31
+			IL_0059: br IL_0062
 
-			IL_006c: ldloc.s 30
-			IL_006e: stloc.s 31
+			IL_005e: ldloc.s 30
+			IL_0060: stloc.s 31
 
-			IL_0070: ldloc.s 28
-			IL_0072: ldloc.s 29
-			IL_0074: ldloc.s 31
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_007b: stloc.s 28
-			IL_007d: ldloc.s 28
-			IL_007f: stloc.1
+			IL_0062: ldloc.s 28
+			IL_0064: ldloc.s 29
+			IL_0066: ldloc.s 31
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_006d: stloc.s 28
+			IL_006f: ldloc.s 28
+			IL_0071: stloc.1
+			IL_0072: ldarg.0
+			IL_0073: ldfld object Modules.test262_metadataParser/Scope::getFileName
+			IL_0078: ldc.i4.1
+			IL_0079: newarr [System.Runtime]System.Object
+			IL_007e: dup
+			IL_007f: ldc.i4.0
 			IL_0080: ldarg.0
-			IL_0081: ldfld object Modules.test262_metadataParser/Scope::getFileName
-			IL_0086: stloc.s 28
-			IL_0088: ldstr "getFileName"
-			IL_008d: ldloc.s 28
-			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0094: stloc.s 28
-			IL_0096: ldloc.s 28
-			IL_0098: ldc.i4.1
-			IL_0099: newarr [System.Runtime]System.Object
-			IL_009e: dup
-			IL_009f: ldc.i4.0
-			IL_00a0: ldarg.0
-			IL_00a1: stelem.ref
-			IL_00a2: ldloc.1
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00a8: stloc.s 28
-			IL_00aa: ldloc.s 28
-			IL_00ac: stloc.2
-			IL_00ad: ldarg.0
-			IL_00ae: ldfld object Modules.test262_metadataParser/Scope::extractTest262Frontmatter
-			IL_00b3: stloc.s 28
-			IL_00b5: ldstr "extractTest262Frontmatter"
-			IL_00ba: ldloc.s 28
-			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c1: stloc.s 28
-			IL_00c3: ldc.i4.1
-			IL_00c4: newarr [System.Runtime]System.Object
-			IL_00c9: dup
-			IL_00ca: ldc.i4.0
-			IL_00cb: ldarg.0
-			IL_00cc: stelem.ref
-			IL_00cd: stloc.s 29
-			IL_00cf: ldloc.s 28
-			IL_00d1: ldloc.s 29
-			IL_00d3: ldarg.2
-			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00d9: stloc.s 28
-			IL_00db: ldloc.s 28
-			IL_00dd: stloc.3
+			IL_0081: stelem.ref
+			IL_0082: ldloc.1
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0088: stloc.s 28
+			IL_008a: ldloc.s 28
+			IL_008c: stloc.2
+			IL_008d: ldc.i4.1
+			IL_008e: newarr [System.Runtime]System.Object
+			IL_0093: dup
+			IL_0094: ldc.i4.0
+			IL_0095: ldarg.0
+			IL_0096: stelem.ref
+			IL_0097: stloc.s 29
+			IL_0099: ldarg.0
+			IL_009a: ldfld object Modules.test262_metadataParser/Scope::extractTest262Frontmatter
+			IL_009f: ldloc.s 29
+			IL_00a1: ldarg.2
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00a7: stloc.s 28
+			IL_00a9: ldloc.s 28
+			IL_00ab: stloc.3
+			IL_00ac: ldc.i4.0
+			IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00b2: stloc.s 4
+			IL_00b4: ldloc.3
+			IL_00b5: stloc.s 28
+			IL_00b7: ldloc.s 28
+			IL_00b9: ldc.i4.0
+			IL_00ba: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_00c4: stloc.s 25
+			IL_00c6: ldloc.s 25
+			IL_00c8: stloc.s 5
+			IL_00ca: ldloc.s 5
+			IL_00cc: brfalse IL_00f2
+
+			IL_00d1: ldarg.0
+			IL_00d2: ldfld object Modules.test262_metadataParser/Scope::parseTest262Frontmatter
+			IL_00d7: ldc.i4.1
+			IL_00d8: newarr [System.Runtime]System.Object
+			IL_00dd: dup
 			IL_00de: ldc.i4.0
-			IL_00df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00e4: stloc.s 4
-			IL_00e6: ldloc.3
+			IL_00df: ldarg.0
+			IL_00e0: stelem.ref
+			IL_00e1: ldloc.3
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 			IL_00e7: stloc.s 28
 			IL_00e9: ldloc.s 28
-			IL_00eb: ldc.i4.0
-			IL_00ec: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00f6: stloc.s 25
-			IL_00f8: ldloc.s 25
-			IL_00fa: stloc.s 5
-			IL_00fc: ldloc.s 5
-			IL_00fe: brfalse IL_0136
+			IL_00eb: stloc.s 6
+			IL_00ed: br IL_00f9
 
-			IL_0103: ldarg.0
-			IL_0104: ldfld object Modules.test262_metadataParser/Scope::parseTest262Frontmatter
-			IL_0109: stloc.s 28
-			IL_010b: ldstr "parseTest262Frontmatter"
-			IL_0110: ldloc.s 28
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0117: stloc.s 28
-			IL_0119: ldloc.s 28
-			IL_011b: ldc.i4.1
-			IL_011c: newarr [System.Runtime]System.Object
-			IL_0121: dup
-			IL_0122: ldc.i4.0
-			IL_0123: ldarg.0
-			IL_0124: stelem.ref
-			IL_0125: ldloc.3
-			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_012b: stloc.s 28
-			IL_012d: ldloc.s 28
-			IL_012f: stloc.s 6
-			IL_0131: br IL_013d
+			IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00f7: stloc.s 6
 
-			IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_013b: stloc.s 6
+			IL_00f9: ldloc.s 6
+			IL_00fb: stloc.s 7
+			IL_00fd: ldloc.s 7
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_0104: stloc.s 28
+			IL_0106: ldloc.s 28
+			IL_0108: stloc.s 8
+			IL_010a: ldc.i4.0
+			IL_010b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0110: stloc.s 9
+			IL_0112: ldc.r8 0.0
+			IL_011b: stloc.s 10
+			// loop start (head: IL_011d)
+				IL_011d: ldloc.s 10
+				IL_011f: stloc.s 32
+				IL_0121: ldloc.s 32
+				IL_0123: ldloc.s 8
+				IL_0125: ldstr "length"
+				IL_012a: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_012f: clt
+				IL_0131: brfalse IL_01fa
 
-			IL_013d: ldloc.s 6
-			IL_013f: stloc.s 7
-			IL_0141: ldloc.s 7
-			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_0148: stloc.s 28
-			IL_014a: ldloc.s 28
-			IL_014c: stloc.s 8
-			IL_014e: ldc.i4.0
-			IL_014f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0154: stloc.s 9
-			IL_0156: ldc.r8 0.0
-			IL_015f: stloc.s 10
-			// loop start (head: IL_0161)
-				IL_0161: ldloc.s 10
-				IL_0163: stloc.s 32
-				IL_0165: ldloc.s 32
-				IL_0167: ldloc.s 8
-				IL_0169: ldstr "length"
-				IL_016e: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0173: clt
-				IL_0175: brfalse IL_026c
+				IL_0136: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48::.ctor()
+				IL_013b: stloc.s 11
+				IL_013d: ldloc.s 8
+				IL_013f: ldloc.s 10
+				IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0146: stloc.s 12
+				IL_0148: ldarg.0
+				IL_0149: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
+				IL_014e: ldc.i4.1
+				IL_014f: newarr [System.Runtime]System.Object
+				IL_0154: dup
+				IL_0155: ldc.i4.0
+				IL_0156: ldloc.s 12
+				IL_0158: stelem.ref
+				IL_0159: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_015e: stloc.s 32
+				IL_0160: ldloc.s 32
+				IL_0162: ldc.r8 0.0
+				IL_016b: clt
+				IL_016d: brfalse IL_01e7
 
-				IL_017a: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48::.ctor()
-				IL_017f: stloc.s 11
-				IL_0181: ldloc.s 8
-				IL_0183: ldloc.s 10
-				IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_018a: stloc.s 12
-				IL_018c: ldarg.0
-				IL_018d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
-				IL_0192: stloc.s 33
-				IL_0194: ldstr "KNOWN_FRONTMATTER_KEYS"
-				IL_0199: ldloc.s 33
-				IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_01a0: stloc.s 28
-				IL_01a2: ldloc.s 28
-				IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01a9: stloc.s 28
-				IL_01ab: ldloc.s 28
-				IL_01ad: ldstr "indexOf"
-				IL_01b2: ldloc.s 12
-				IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_01b9: stloc.s 28
-				IL_01bb: ldloc.s 28
-				IL_01bd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01c2: stloc.s 32
-				IL_01c4: ldloc.s 32
-				IL_01c6: ldc.r8 0.0
-				IL_01cf: clt
-				IL_01d1: brfalse IL_0259
-
-				IL_01d6: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48/Block_L442C49::.ctor()
-				IL_01db: stloc.s 13
-				IL_01dd: ldloc.s 9
-				IL_01df: ldloc.s 12
-				IL_01e1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0172: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48/Block_L442C49::.ctor()
+				IL_0177: stloc.s 13
+				IL_0179: ldloc.s 9
+				IL_017b: ldloc.s 12
+				IL_017d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0182: pop
+				IL_0183: ldarg.0
+				IL_0184: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+				IL_0189: stloc.s 28
+				IL_018b: ldc.i4.1
+				IL_018c: newarr [System.Runtime]System.Object
+				IL_0191: dup
+				IL_0192: ldc.i4.0
+				IL_0193: ldarg.0
+				IL_0194: stelem.ref
+				IL_0195: stloc.s 29
+				IL_0197: ldloc.s 12
+				IL_0199: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_019e: stloc.s 33
+				IL_01a0: ldstr "Unsupported frontmatter key '"
+				IL_01a5: ldloc.s 33
+				IL_01a7: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01ac: stloc.s 33
+				IL_01ae: ldloc.s 33
+				IL_01b0: ldstr "'."
+				IL_01b5: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01ba: stloc.s 33
+				IL_01bc: ldc.i4.4
+				IL_01bd: newarr [System.Runtime]System.Object
+				IL_01c2: dup
+				IL_01c3: ldc.i4.0
+				IL_01c4: ldloc.s 4
+				IL_01c6: stelem.ref
+				IL_01c7: dup
+				IL_01c8: ldc.i4.1
+				IL_01c9: ldstr "unknown-frontmatter-key"
+				IL_01ce: stelem.ref
+				IL_01cf: dup
+				IL_01d0: ldc.i4.2
+				IL_01d1: ldloc.s 12
+				IL_01d3: stelem.ref
+				IL_01d4: dup
+				IL_01d5: ldc.i4.3
+				IL_01d6: ldloc.s 33
+				IL_01d8: stelem.ref
+				IL_01d9: stloc.s 34
+				IL_01db: ldloc.s 28
+				IL_01dd: ldloc.s 29
+				IL_01df: ldloc.s 34
+				IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_01e6: pop
-				IL_01e7: ldarg.0
-				IL_01e8: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-				IL_01ed: stloc.s 28
-				IL_01ef: ldstr "pushIssue"
-				IL_01f4: ldloc.s 28
-				IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_01fb: stloc.s 28
-				IL_01fd: ldc.i4.1
-				IL_01fe: newarr [System.Runtime]System.Object
-				IL_0203: dup
-				IL_0204: ldc.i4.0
-				IL_0205: ldarg.0
-				IL_0206: stelem.ref
-				IL_0207: stloc.s 29
-				IL_0209: ldloc.s 12
-				IL_020b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0210: stloc.s 34
-				IL_0212: ldstr "Unsupported frontmatter key '"
-				IL_0217: ldloc.s 34
-				IL_0219: call string [System.Runtime]System.String::Concat(string, string)
-				IL_021e: stloc.s 34
-				IL_0220: ldloc.s 34
-				IL_0222: ldstr "'."
-				IL_0227: call string [System.Runtime]System.String::Concat(string, string)
-				IL_022c: stloc.s 34
-				IL_022e: ldc.i4.4
-				IL_022f: newarr [System.Runtime]System.Object
-				IL_0234: dup
-				IL_0235: ldc.i4.0
-				IL_0236: ldloc.s 4
-				IL_0238: stelem.ref
-				IL_0239: dup
-				IL_023a: ldc.i4.1
-				IL_023b: ldstr "unknown-frontmatter-key"
-				IL_0240: stelem.ref
-				IL_0241: dup
-				IL_0242: ldc.i4.2
-				IL_0243: ldloc.s 12
-				IL_0245: stelem.ref
-				IL_0246: dup
-				IL_0247: ldc.i4.3
-				IL_0248: ldloc.s 34
-				IL_024a: stelem.ref
-				IL_024b: stloc.s 35
-				IL_024d: ldloc.s 28
-				IL_024f: ldloc.s 29
-				IL_0251: ldloc.s 35
-				IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_0258: pop
 
-				IL_0259: ldloc.s 10
-				IL_025b: ldc.r8 1
-				IL_0264: add
-				IL_0265: stloc.s 10
-				IL_0267: br IL_0161
+				IL_01e7: ldloc.s 10
+				IL_01e9: ldc.r8 1
+				IL_01f2: add
+				IL_01f3: stloc.s 10
+				IL_01f5: br IL_011d
 			// end loop
 
-			IL_026c: ldarg.0
-			IL_026d: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_0272: stloc.s 28
-			IL_0274: ldstr "toStringArray"
-			IL_0279: ldloc.s 28
-			IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0280: stloc.s 28
-			IL_0282: ldc.i4.1
-			IL_0283: newarr [System.Runtime]System.Object
-			IL_0288: dup
-			IL_0289: ldc.i4.0
-			IL_028a: ldarg.0
-			IL_028b: stelem.ref
-			IL_028c: stloc.s 35
-			IL_028e: ldloc.s 7
-			IL_0290: ldstr "includes"
-			IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_029a: stloc.s 30
-			IL_029c: ldloc.s 28
-			IL_029e: ldloc.s 35
-			IL_02a0: ldloc.s 30
-			IL_02a2: ldstr "includes"
-			IL_02a7: ldloc.s 4
-			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_01fa: ldarg.0
+			IL_01fb: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_0200: stloc.s 28
+			IL_0202: ldc.i4.1
+			IL_0203: newarr [System.Runtime]System.Object
+			IL_0208: dup
+			IL_0209: ldc.i4.0
+			IL_020a: ldarg.0
+			IL_020b: stelem.ref
+			IL_020c: stloc.s 34
+			IL_020e: ldloc.s 7
+			IL_0210: ldstr "includes"
+			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_021a: stloc.s 30
+			IL_021c: ldloc.s 28
+			IL_021e: ldloc.s 34
+			IL_0220: ldloc.s 30
+			IL_0222: ldstr "includes"
+			IL_0227: ldloc.s 4
+			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_022e: stloc.s 30
+			IL_0230: ldloc.s 30
+			IL_0232: stloc.s 14
+			IL_0234: ldarg.0
+			IL_0235: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_023a: stloc.s 30
+			IL_023c: ldc.i4.1
+			IL_023d: newarr [System.Runtime]System.Object
+			IL_0242: dup
+			IL_0243: ldc.i4.0
+			IL_0244: ldarg.0
+			IL_0245: stelem.ref
+			IL_0246: stloc.s 34
+			IL_0248: ldloc.s 7
+			IL_024a: ldstr "flags"
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0254: stloc.s 28
+			IL_0256: ldloc.s 30
+			IL_0258: ldloc.s 34
+			IL_025a: ldloc.s 28
+			IL_025c: ldstr "flags"
+			IL_0261: ldloc.s 4
+			IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0268: stloc.s 28
+			IL_026a: ldloc.s 28
+			IL_026c: stloc.s 15
+			IL_026e: ldarg.0
+			IL_026f: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_0274: stloc.s 28
+			IL_0276: ldc.i4.1
+			IL_0277: newarr [System.Runtime]System.Object
+			IL_027c: dup
+			IL_027d: ldc.i4.0
+			IL_027e: ldarg.0
+			IL_027f: stelem.ref
+			IL_0280: stloc.s 34
+			IL_0282: ldloc.s 7
+			IL_0284: ldstr "features"
+			IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_028e: stloc.s 30
+			IL_0290: ldloc.s 28
+			IL_0292: ldloc.s 34
+			IL_0294: ldloc.s 30
+			IL_0296: ldstr "features"
+			IL_029b: ldloc.s 4
+			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_02a2: stloc.s 30
+			IL_02a4: ldloc.s 30
+			IL_02a6: stloc.s 16
+			IL_02a8: ldarg.0
+			IL_02a9: ldfld object Modules.test262_metadataParser/Scope::toStringArray
 			IL_02ae: stloc.s 30
-			IL_02b0: ldloc.s 30
-			IL_02b2: stloc.s 14
-			IL_02b4: ldarg.0
-			IL_02b5: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_02ba: stloc.s 30
-			IL_02bc: ldstr "toStringArray"
-			IL_02c1: ldloc.s 30
-			IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02c8: stloc.s 30
-			IL_02ca: ldc.i4.1
-			IL_02cb: newarr [System.Runtime]System.Object
-			IL_02d0: dup
-			IL_02d1: ldc.i4.0
-			IL_02d2: ldarg.0
-			IL_02d3: stelem.ref
-			IL_02d4: stloc.s 35
-			IL_02d6: ldloc.s 7
-			IL_02d8: ldstr "flags"
-			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02e2: stloc.s 28
-			IL_02e4: ldloc.s 30
-			IL_02e6: ldloc.s 35
-			IL_02e8: ldloc.s 28
-			IL_02ea: ldstr "flags"
-			IL_02ef: ldloc.s 4
-			IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_02f6: stloc.s 28
-			IL_02f8: ldloc.s 28
-			IL_02fa: stloc.s 15
-			IL_02fc: ldarg.0
-			IL_02fd: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_0302: stloc.s 28
-			IL_0304: ldstr "toStringArray"
-			IL_0309: ldloc.s 28
-			IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0310: stloc.s 28
-			IL_0312: ldc.i4.1
-			IL_0313: newarr [System.Runtime]System.Object
-			IL_0318: dup
-			IL_0319: ldc.i4.0
-			IL_031a: ldarg.0
-			IL_031b: stelem.ref
-			IL_031c: stloc.s 35
-			IL_031e: ldloc.s 7
-			IL_0320: ldstr "features"
-			IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_032a: stloc.s 30
-			IL_032c: ldloc.s 28
-			IL_032e: ldloc.s 35
+			IL_02b0: ldc.i4.1
+			IL_02b1: newarr [System.Runtime]System.Object
+			IL_02b6: dup
+			IL_02b7: ldc.i4.0
+			IL_02b8: ldarg.0
+			IL_02b9: stelem.ref
+			IL_02ba: stloc.s 34
+			IL_02bc: ldloc.s 7
+			IL_02be: ldstr "locale"
+			IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c8: stloc.s 28
+			IL_02ca: ldloc.s 30
+			IL_02cc: ldloc.s 34
+			IL_02ce: ldloc.s 28
+			IL_02d0: ldstr "locale"
+			IL_02d5: ldloc.s 4
+			IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_02dc: stloc.s 28
+			IL_02de: ldloc.s 28
+			IL_02e0: stloc.s 17
+			IL_02e2: ldarg.0
+			IL_02e3: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_02e8: stloc.s 28
+			IL_02ea: ldc.i4.1
+			IL_02eb: newarr [System.Runtime]System.Object
+			IL_02f0: dup
+			IL_02f1: ldc.i4.0
+			IL_02f2: ldarg.0
+			IL_02f3: stelem.ref
+			IL_02f4: stloc.s 34
+			IL_02f6: ldloc.s 7
+			IL_02f8: ldstr "defines"
+			IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0302: stloc.s 30
+			IL_0304: ldloc.s 28
+			IL_0306: ldloc.s 34
+			IL_0308: ldloc.s 30
+			IL_030a: ldstr "defines"
+			IL_030f: ldloc.s 4
+			IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0316: stloc.s 30
+			IL_0318: ldloc.s 30
+			IL_031a: stloc.s 18
+			IL_031c: ldarg.0
+			IL_031d: ldfld object Modules.test262_metadataParser/Scope::normalizeNegative
+			IL_0322: stloc.s 30
+			IL_0324: ldc.i4.1
+			IL_0325: newarr [System.Runtime]System.Object
+			IL_032a: dup
+			IL_032b: ldc.i4.0
+			IL_032c: ldarg.0
+			IL_032d: stelem.ref
+			IL_032e: stloc.s 34
 			IL_0330: ldloc.s 30
-			IL_0332: ldstr "features"
-			IL_0337: ldloc.s 4
-			IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_033e: stloc.s 30
-			IL_0340: ldloc.s 30
-			IL_0342: stloc.s 16
-			IL_0344: ldarg.0
-			IL_0345: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_034a: stloc.s 30
-			IL_034c: ldstr "toStringArray"
-			IL_0351: ldloc.s 30
-			IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0358: stloc.s 30
-			IL_035a: ldc.i4.1
-			IL_035b: newarr [System.Runtime]System.Object
-			IL_0360: dup
-			IL_0361: ldc.i4.0
-			IL_0362: ldarg.0
-			IL_0363: stelem.ref
-			IL_0364: stloc.s 35
-			IL_0366: ldloc.s 7
-			IL_0368: ldstr "locale"
-			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0372: stloc.s 28
-			IL_0374: ldloc.s 30
-			IL_0376: ldloc.s 35
-			IL_0378: ldloc.s 28
-			IL_037a: ldstr "locale"
-			IL_037f: ldloc.s 4
-			IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0386: stloc.s 28
-			IL_0388: ldloc.s 28
-			IL_038a: stloc.s 17
-			IL_038c: ldarg.0
-			IL_038d: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_0392: stloc.s 28
-			IL_0394: ldstr "toStringArray"
-			IL_0399: ldloc.s 28
-			IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03a0: stloc.s 28
-			IL_03a2: ldc.i4.1
-			IL_03a3: newarr [System.Runtime]System.Object
-			IL_03a8: dup
-			IL_03a9: ldc.i4.0
-			IL_03aa: ldarg.0
-			IL_03ab: stelem.ref
-			IL_03ac: stloc.s 35
-			IL_03ae: ldloc.s 7
-			IL_03b0: ldstr "defines"
-			IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ba: stloc.s 30
-			IL_03bc: ldloc.s 28
-			IL_03be: ldloc.s 35
-			IL_03c0: ldloc.s 30
-			IL_03c2: ldstr "defines"
-			IL_03c7: ldloc.s 4
-			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_03ce: stloc.s 30
-			IL_03d0: ldloc.s 30
-			IL_03d2: stloc.s 18
-			IL_03d4: ldarg.0
-			IL_03d5: ldfld object Modules.test262_metadataParser/Scope::normalizeNegative
-			IL_03da: stloc.s 30
-			IL_03dc: ldstr "normalizeNegative"
-			IL_03e1: ldloc.s 30
-			IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03e8: stloc.s 30
-			IL_03ea: ldc.i4.1
-			IL_03eb: newarr [System.Runtime]System.Object
-			IL_03f0: dup
-			IL_03f1: ldc.i4.0
-			IL_03f2: ldarg.0
-			IL_03f3: stelem.ref
-			IL_03f4: stloc.s 35
-			IL_03f6: ldloc.s 30
-			IL_03f8: ldloc.s 35
-			IL_03fa: ldloc.s 7
-			IL_03fc: ldstr "negative"
-			IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0406: ldloc.s 4
-			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_040d: stloc.s 30
-			IL_040f: ldloc.s 30
-			IL_0411: stloc.s 19
-			IL_0413: ldc.r8 0.0
-			IL_041c: stloc.s 20
-			// loop start (head: IL_041e)
-				IL_041e: ldloc.s 20
-				IL_0420: stloc.s 32
-				IL_0422: ldloc.s 32
-				IL_0424: ldloc.s 15
-				IL_0426: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_042b: clt
-				IL_042d: brfalse IL_053b
+			IL_0332: ldloc.s 34
+			IL_0334: ldloc.s 7
+			IL_0336: ldstr "negative"
+			IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0340: ldloc.s 4
+			IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0347: stloc.s 30
+			IL_0349: ldloc.s 30
+			IL_034b: stloc.s 19
+			IL_034d: ldc.r8 0.0
+			IL_0356: stloc.s 20
+			// loop start (head: IL_0358)
+				IL_0358: ldloc.s 20
+				IL_035a: stloc.s 32
+				IL_035c: ldloc.s 32
+				IL_035e: ldloc.s 15
+				IL_0360: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+				IL_0365: clt
+				IL_0367: brfalse IL_044b
 
-				IL_0432: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41::.ctor()
-				IL_0437: stloc.s 21
-				IL_0439: ldarg.0
-				IL_043a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
-				IL_043f: stloc.s 33
-				IL_0441: ldstr "KNOWN_FLAG_VALUES"
-				IL_0446: ldloc.s 33
-				IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_044d: stloc.s 30
-				IL_044f: ldloc.s 30
-				IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0456: stloc.s 30
-				IL_0458: ldloc.s 30
-				IL_045a: ldstr "indexOf"
-				IL_045f: ldloc.s 15
-				IL_0461: ldloc.s 20
-				IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_046d: stloc.s 30
-				IL_046f: ldloc.s 30
-				IL_0471: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0476: stloc.s 32
-				IL_0478: ldloc.s 32
-				IL_047a: ldc.r8 0.0
-				IL_0483: clt
-				IL_0485: brfalse IL_0528
+				IL_036c: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41::.ctor()
+				IL_0371: stloc.s 21
+				IL_0373: ldarg.0
+				IL_0374: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
+				IL_0379: stloc.s 35
+				IL_037b: ldloc.s 35
+				IL_037d: ldc.i4.1
+				IL_037e: newarr [System.Runtime]System.Object
+				IL_0383: dup
+				IL_0384: ldc.i4.0
+				IL_0385: ldloc.s 15
+				IL_0387: ldloc.s 20
+				IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_038e: stelem.ref
+				IL_038f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_0394: stloc.s 32
+				IL_0396: ldloc.s 32
+				IL_0398: ldc.r8 0.0
+				IL_03a1: clt
+				IL_03a3: brfalse IL_0438
 
-				IL_048a: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41/Block_L456C49::.ctor()
-				IL_048f: stloc.s 22
-				IL_0491: ldarg.0
-				IL_0492: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-				IL_0497: stloc.s 30
-				IL_0499: ldstr "pushIssue"
-				IL_049e: ldloc.s 30
-				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_04a5: stloc.s 30
-				IL_04a7: ldc.i4.1
-				IL_04a8: newarr [System.Runtime]System.Object
-				IL_04ad: dup
-				IL_04ae: ldc.i4.0
-				IL_04af: ldarg.0
-				IL_04b0: stelem.ref
-				IL_04b1: stloc.s 35
-				IL_04b3: ldloc.s 15
-				IL_04b5: ldloc.s 20
-				IL_04b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_04bc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_04c1: stloc.s 34
-				IL_04c3: ldstr "flags:"
-				IL_04c8: ldloc.s 34
-				IL_04ca: call string [System.Runtime]System.String::Concat(string, string)
-				IL_04cf: stloc.s 34
-				IL_04d1: ldloc.s 15
-				IL_04d3: ldloc.s 20
-				IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_04da: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_04df: stloc.s 36
-				IL_04e1: ldstr "Unsupported flag '"
-				IL_04e6: ldloc.s 36
-				IL_04e8: call string [System.Runtime]System.String::Concat(string, string)
-				IL_04ed: stloc.s 36
-				IL_04ef: ldloc.s 36
-				IL_04f1: ldstr "'."
-				IL_04f6: call string [System.Runtime]System.String::Concat(string, string)
-				IL_04fb: stloc.s 36
-				IL_04fd: ldc.i4.4
-				IL_04fe: newarr [System.Runtime]System.Object
-				IL_0503: dup
-				IL_0504: ldc.i4.0
-				IL_0505: ldloc.s 4
-				IL_0507: stelem.ref
-				IL_0508: dup
-				IL_0509: ldc.i4.1
-				IL_050a: ldstr "unknown-flag"
-				IL_050f: stelem.ref
-				IL_0510: dup
-				IL_0511: ldc.i4.2
-				IL_0512: ldloc.s 34
-				IL_0514: stelem.ref
-				IL_0515: dup
-				IL_0516: ldc.i4.3
-				IL_0517: ldloc.s 36
-				IL_0519: stelem.ref
-				IL_051a: stloc.s 29
-				IL_051c: ldloc.s 30
-				IL_051e: ldloc.s 35
-				IL_0520: ldloc.s 29
-				IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_0527: pop
+				IL_03a8: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41/Block_L456C49::.ctor()
+				IL_03ad: stloc.s 22
+				IL_03af: ldarg.0
+				IL_03b0: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+				IL_03b5: stloc.s 30
+				IL_03b7: ldc.i4.1
+				IL_03b8: newarr [System.Runtime]System.Object
+				IL_03bd: dup
+				IL_03be: ldc.i4.0
+				IL_03bf: ldarg.0
+				IL_03c0: stelem.ref
+				IL_03c1: stloc.s 34
+				IL_03c3: ldloc.s 15
+				IL_03c5: ldloc.s 20
+				IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_03cc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_03d1: stloc.s 33
+				IL_03d3: ldstr "flags:"
+				IL_03d8: ldloc.s 33
+				IL_03da: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03df: stloc.s 33
+				IL_03e1: ldloc.s 15
+				IL_03e3: ldloc.s 20
+				IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_03ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_03ef: stloc.s 36
+				IL_03f1: ldstr "Unsupported flag '"
+				IL_03f6: ldloc.s 36
+				IL_03f8: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03fd: stloc.s 36
+				IL_03ff: ldloc.s 36
+				IL_0401: ldstr "'."
+				IL_0406: call string [System.Runtime]System.String::Concat(string, string)
+				IL_040b: stloc.s 36
+				IL_040d: ldc.i4.4
+				IL_040e: newarr [System.Runtime]System.Object
+				IL_0413: dup
+				IL_0414: ldc.i4.0
+				IL_0415: ldloc.s 4
+				IL_0417: stelem.ref
+				IL_0418: dup
+				IL_0419: ldc.i4.1
+				IL_041a: ldstr "unknown-flag"
+				IL_041f: stelem.ref
+				IL_0420: dup
+				IL_0421: ldc.i4.2
+				IL_0422: ldloc.s 33
+				IL_0424: stelem.ref
+				IL_0425: dup
+				IL_0426: ldc.i4.3
+				IL_0427: ldloc.s 36
+				IL_0429: stelem.ref
+				IL_042a: stloc.s 29
+				IL_042c: ldloc.s 30
+				IL_042e: ldloc.s 34
+				IL_0430: ldloc.s 29
+				IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_0437: pop
 
-				IL_0528: ldloc.s 20
-				IL_052a: ldc.r8 1
-				IL_0533: add
-				IL_0534: stloc.s 20
-				IL_0536: br IL_041e
+				IL_0438: ldloc.s 20
+				IL_043a: ldc.r8 1
+				IL_0443: add
+				IL_0444: stloc.s 20
+				IL_0446: br IL_0358
 			// end loop
 
-			IL_053b: ldarg.0
-			IL_053c: ldfld object Modules.test262_metadataParser/Scope::buildExecutionMetadata
-			IL_0541: stloc.s 30
-			IL_0543: ldstr "buildExecutionMetadata"
-			IL_0548: ldloc.s 30
-			IL_054a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_054f: stloc.s 30
-			IL_0551: ldloc.s 30
-			IL_0553: ldc.i4.1
-			IL_0554: newarr [System.Runtime]System.Object
-			IL_0559: dup
-			IL_055a: ldc.i4.0
-			IL_055b: ldarg.0
-			IL_055c: stelem.ref
-			IL_055d: ldloc.s 15
-			IL_055f: ldloc.s 14
-			IL_0561: ldloc.2
-			IL_0562: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0567: stloc.s 30
-			IL_0569: ldloc.s 30
-			IL_056b: stloc.s 23
-			IL_056d: ldloc.s 23
-			IL_056f: ldstr "strictMode"
-			IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0579: ldstr "conflicting-flags"
-			IL_057e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0583: stloc.s 25
-			IL_0585: ldloc.s 25
-			IL_0587: brfalse IL_05e6
+			IL_044b: ldarg.0
+			IL_044c: ldfld object Modules.test262_metadataParser/Scope::buildExecutionMetadata
+			IL_0451: ldc.i4.1
+			IL_0452: newarr [System.Runtime]System.Object
+			IL_0457: dup
+			IL_0458: ldc.i4.0
+			IL_0459: ldarg.0
+			IL_045a: stelem.ref
+			IL_045b: ldloc.s 15
+			IL_045d: ldloc.s 14
+			IL_045f: ldloc.2
+			IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0465: stloc.s 30
+			IL_0467: ldloc.s 30
+			IL_0469: stloc.s 23
+			IL_046b: ldloc.s 23
+			IL_046d: ldstr "strictMode"
+			IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0477: ldstr "conflicting-flags"
+			IL_047c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0481: stloc.s 25
+			IL_0483: ldloc.s 25
+			IL_0485: brfalse IL_04d6
 
-			IL_058c: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope/Block_L462C52::.ctor()
-			IL_0591: stloc.s 24
-			IL_0593: ldarg.0
-			IL_0594: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_0599: stloc.s 30
-			IL_059b: ldstr "pushIssue"
-			IL_05a0: ldloc.s 30
-			IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_05a7: stloc.s 30
-			IL_05a9: ldc.i4.1
-			IL_05aa: newarr [System.Runtime]System.Object
-			IL_05af: dup
-			IL_05b0: ldc.i4.0
-			IL_05b1: ldarg.0
-			IL_05b2: stelem.ref
-			IL_05b3: stloc.s 29
-			IL_05b5: ldc.i4.4
-			IL_05b6: newarr [System.Runtime]System.Object
-			IL_05bb: dup
-			IL_05bc: ldc.i4.0
-			IL_05bd: ldloc.s 4
-			IL_05bf: stelem.ref
-			IL_05c0: dup
-			IL_05c1: ldc.i4.1
-			IL_05c2: ldstr "conflicting-strictness-flags"
+			IL_048a: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope/Block_L462C52::.ctor()
+			IL_048f: stloc.s 24
+			IL_0491: ldarg.0
+			IL_0492: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0497: stloc.s 30
+			IL_0499: ldc.i4.1
+			IL_049a: newarr [System.Runtime]System.Object
+			IL_049f: dup
+			IL_04a0: ldc.i4.0
+			IL_04a1: ldarg.0
+			IL_04a2: stelem.ref
+			IL_04a3: stloc.s 29
+			IL_04a5: ldc.i4.4
+			IL_04a6: newarr [System.Runtime]System.Object
+			IL_04ab: dup
+			IL_04ac: ldc.i4.0
+			IL_04ad: ldloc.s 4
+			IL_04af: stelem.ref
+			IL_04b0: dup
+			IL_04b1: ldc.i4.1
+			IL_04b2: ldstr "conflicting-strictness-flags"
+			IL_04b7: stelem.ref
+			IL_04b8: dup
+			IL_04b9: ldc.i4.2
+			IL_04ba: ldstr "flags"
+			IL_04bf: stelem.ref
+			IL_04c0: dup
+			IL_04c1: ldc.i4.3
+			IL_04c2: ldstr "Multiple strictness/source-type flags were declared together."
+			IL_04c7: stelem.ref
+			IL_04c8: stloc.s 34
+			IL_04ca: ldloc.s 30
+			IL_04cc: ldloc.s 29
+			IL_04ce: ldloc.s 34
+			IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_04d5: pop
+
+			IL_04d6: ldloc.1
+			IL_04d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04dc: stloc.s 25
+			IL_04de: ldloc.s 25
+			IL_04e0: brtrue IL_04f2
+
+			IL_04e5: ldc.i4.0
+			IL_04e6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04eb: stloc.s 37
+			IL_04ed: br IL_04f5
+
+			IL_04f2: ldloc.1
+			IL_04f3: stloc.s 37
+
+			IL_04f5: ldloc.2
+			IL_04f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04fb: stloc.s 25
+			IL_04fd: ldloc.s 25
+			IL_04ff: brtrue IL_0511
+
+			IL_0504: ldc.i4.0
+			IL_0505: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_050a: stloc.s 39
+			IL_050c: br IL_0514
+
+			IL_0511: ldloc.2
+			IL_0512: stloc.s 39
+
+			IL_0514: ldarg.0
+			IL_0515: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_051a: stloc.s 30
+			IL_051c: ldc.i4.1
+			IL_051d: newarr [System.Runtime]System.Object
+			IL_0522: dup
+			IL_0523: ldc.i4.0
+			IL_0524: ldarg.0
+			IL_0525: stelem.ref
+			IL_0526: stloc.s 34
+			IL_0528: ldloc.s 7
+			IL_052a: ldstr "description"
+			IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0534: stloc.s 28
+			IL_0536: ldloc.s 30
+			IL_0538: ldloc.s 34
+			IL_053a: ldloc.s 28
+			IL_053c: ldstr "description"
+			IL_0541: ldloc.s 4
+			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0548: stloc.s 28
+			IL_054a: ldarg.0
+			IL_054b: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_0550: stloc.s 30
+			IL_0552: ldc.i4.1
+			IL_0553: newarr [System.Runtime]System.Object
+			IL_0558: dup
+			IL_0559: ldc.i4.0
+			IL_055a: ldarg.0
+			IL_055b: stelem.ref
+			IL_055c: stloc.s 34
+			IL_055e: ldloc.s 7
+			IL_0560: ldstr "info"
+			IL_0565: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_056a: stloc.s 40
+			IL_056c: ldloc.s 30
+			IL_056e: ldloc.s 34
+			IL_0570: ldloc.s 40
+			IL_0572: ldstr "info"
+			IL_0577: ldloc.s 4
+			IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_057e: stloc.s 40
+			IL_0580: ldarg.0
+			IL_0581: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_0586: stloc.s 30
+			IL_0588: ldc.i4.1
+			IL_0589: newarr [System.Runtime]System.Object
+			IL_058e: dup
+			IL_058f: ldc.i4.0
+			IL_0590: ldarg.0
+			IL_0591: stelem.ref
+			IL_0592: stloc.s 34
+			IL_0594: ldloc.s 7
+			IL_0596: ldstr "esid"
+			IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05a0: stloc.s 41
+			IL_05a2: ldloc.s 30
+			IL_05a4: ldloc.s 34
+			IL_05a6: ldloc.s 41
+			IL_05a8: ldstr "esid"
+			IL_05ad: ldloc.s 4
+			IL_05af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_05b4: stloc.s 41
+			IL_05b6: ldarg.0
+			IL_05b7: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_05bc: stloc.s 30
+			IL_05be: ldc.i4.1
+			IL_05bf: newarr [System.Runtime]System.Object
+			IL_05c4: dup
+			IL_05c5: ldc.i4.0
+			IL_05c6: ldarg.0
 			IL_05c7: stelem.ref
-			IL_05c8: dup
-			IL_05c9: ldc.i4.2
-			IL_05ca: ldstr "flags"
-			IL_05cf: stelem.ref
-			IL_05d0: dup
-			IL_05d1: ldc.i4.3
-			IL_05d2: ldstr "Multiple strictness/source-type flags were declared together."
-			IL_05d7: stelem.ref
-			IL_05d8: stloc.s 35
-			IL_05da: ldloc.s 30
-			IL_05dc: ldloc.s 29
-			IL_05de: ldloc.s 35
-			IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_05e5: pop
-
-			IL_05e6: ldloc.1
-			IL_05e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05ec: stloc.s 25
-			IL_05ee: ldloc.s 25
-			IL_05f0: brtrue IL_0602
-
-			IL_05f5: ldc.i4.0
-			IL_05f6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_05fb: stloc.s 37
-			IL_05fd: br IL_0605
-
-			IL_0602: ldloc.1
-			IL_0603: stloc.s 37
-
-			IL_0605: ldloc.2
-			IL_0606: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_060b: stloc.s 25
-			IL_060d: ldloc.s 25
-			IL_060f: brtrue IL_0621
-
-			IL_0614: ldc.i4.0
-			IL_0615: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_061a: stloc.s 39
-			IL_061c: br IL_0624
-
-			IL_0621: ldloc.2
-			IL_0622: stloc.s 39
-
-			IL_0624: ldarg.0
-			IL_0625: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_062a: stloc.s 30
-			IL_062c: ldstr "toNullableString"
-			IL_0631: ldloc.s 30
-			IL_0633: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0638: stloc.s 30
-			IL_063a: ldc.i4.1
-			IL_063b: newarr [System.Runtime]System.Object
-			IL_0640: dup
-			IL_0641: ldc.i4.0
-			IL_0642: ldarg.0
-			IL_0643: stelem.ref
-			IL_0644: stloc.s 35
-			IL_0646: ldloc.s 7
-			IL_0648: ldstr "description"
-			IL_064d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0652: stloc.s 28
-			IL_0654: ldloc.s 30
-			IL_0656: ldloc.s 35
-			IL_0658: ldloc.s 28
-			IL_065a: ldstr "description"
-			IL_065f: ldloc.s 4
-			IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0666: stloc.s 28
-			IL_0668: ldarg.0
-			IL_0669: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_066e: stloc.s 30
-			IL_0670: ldstr "toNullableString"
-			IL_0675: ldloc.s 30
-			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_067c: stloc.s 30
-			IL_067e: ldc.i4.1
-			IL_067f: newarr [System.Runtime]System.Object
-			IL_0684: dup
-			IL_0685: ldc.i4.0
-			IL_0686: ldarg.0
-			IL_0687: stelem.ref
-			IL_0688: stloc.s 35
-			IL_068a: ldloc.s 7
-			IL_068c: ldstr "info"
-			IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0696: stloc.s 40
-			IL_0698: ldloc.s 30
-			IL_069a: ldloc.s 35
-			IL_069c: ldloc.s 40
-			IL_069e: ldstr "info"
-			IL_06a3: ldloc.s 4
-			IL_06a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_06aa: stloc.s 40
-			IL_06ac: ldarg.0
-			IL_06ad: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_06b2: stloc.s 30
-			IL_06b4: ldstr "toNullableString"
-			IL_06b9: ldloc.s 30
-			IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06c0: stloc.s 30
-			IL_06c2: ldc.i4.1
-			IL_06c3: newarr [System.Runtime]System.Object
-			IL_06c8: dup
-			IL_06c9: ldc.i4.0
-			IL_06ca: ldarg.0
-			IL_06cb: stelem.ref
-			IL_06cc: stloc.s 35
-			IL_06ce: ldloc.s 7
-			IL_06d0: ldstr "esid"
-			IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06da: stloc.s 41
-			IL_06dc: ldloc.s 30
-			IL_06de: ldloc.s 35
-			IL_06e0: ldloc.s 41
-			IL_06e2: ldstr "esid"
-			IL_06e7: ldloc.s 4
-			IL_06e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_06ee: stloc.s 41
-			IL_06f0: ldarg.0
-			IL_06f1: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_06f6: stloc.s 30
-			IL_06f8: ldstr "toNullableString"
-			IL_06fd: ldloc.s 30
-			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0704: stloc.s 30
-			IL_0706: ldc.i4.1
-			IL_0707: newarr [System.Runtime]System.Object
-			IL_070c: dup
-			IL_070d: ldc.i4.0
-			IL_070e: ldarg.0
-			IL_070f: stelem.ref
-			IL_0710: stloc.s 35
-			IL_0712: ldloc.s 7
-			IL_0714: ldstr "es5id"
-			IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_071e: stloc.s 42
-			IL_0720: ldloc.s 30
-			IL_0722: ldloc.s 35
-			IL_0724: ldloc.s 42
-			IL_0726: ldstr "es5id"
-			IL_072b: ldloc.s 4
-			IL_072d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0732: stloc.s 42
-			IL_0734: ldarg.0
-			IL_0735: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_073a: stloc.s 30
-			IL_073c: ldstr "toNullableString"
-			IL_0741: ldloc.s 30
-			IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0748: stloc.s 30
-			IL_074a: ldc.i4.1
-			IL_074b: newarr [System.Runtime]System.Object
-			IL_0750: dup
-			IL_0751: ldc.i4.0
-			IL_0752: ldarg.0
-			IL_0753: stelem.ref
-			IL_0754: stloc.s 35
-			IL_0756: ldloc.s 7
-			IL_0758: ldstr "es6id"
-			IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0762: stloc.s 43
-			IL_0764: ldloc.s 30
-			IL_0766: ldloc.s 35
-			IL_0768: ldloc.s 43
-			IL_076a: ldstr "es6id"
-			IL_076f: ldloc.s 4
-			IL_0771: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0776: stloc.s 43
-			IL_0778: ldarg.0
-			IL_0779: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_077e: stloc.s 30
-			IL_0780: ldstr "toNullableString"
-			IL_0785: ldloc.s 30
-			IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_078c: stloc.s 30
-			IL_078e: ldc.i4.1
-			IL_078f: newarr [System.Runtime]System.Object
-			IL_0794: dup
-			IL_0795: ldc.i4.0
-			IL_0796: ldarg.0
-			IL_0797: stelem.ref
-			IL_0798: stloc.s 35
-			IL_079a: ldloc.s 7
-			IL_079c: ldstr "author"
-			IL_07a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07a6: stloc.s 44
-			IL_07a8: ldloc.s 30
-			IL_07aa: ldloc.s 35
-			IL_07ac: ldloc.s 44
-			IL_07ae: ldstr "author"
-			IL_07b3: ldloc.s 4
-			IL_07b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_07ba: stloc.s 44
-			IL_07bc: ldarg.0
-			IL_07bd: ldfld object Modules.test262_metadataParser/Scope::buildMvpBlockers
-			IL_07c2: stloc.s 30
-			IL_07c4: ldstr "buildMvpBlockers"
-			IL_07c9: ldloc.s 30
-			IL_07cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_07d0: stloc.s 30
-			IL_07d2: ldloc.s 30
-			IL_07d4: ldc.i4.1
-			IL_07d5: newarr [System.Runtime]System.Object
-			IL_07da: dup
-			IL_07db: ldc.i4.0
-			IL_07dc: ldarg.0
-			IL_07dd: stelem.ref
-			IL_07de: ldloc.1
-			IL_07df: ldloc.s 19
-			IL_07e1: ldloc.s 23
-			IL_07e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_07e8: stloc.s 30
-			IL_07ea: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_07ef: dup
-			IL_07f0: ldstr "filePath"
-			IL_07f5: ldloc.s 37
-			IL_07f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_07fc: dup
-			IL_07fd: ldstr "fileName"
-			IL_0802: ldloc.s 39
-			IL_0804: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0809: dup
-			IL_080a: ldstr "hasFrontmatter"
-			IL_080f: ldloc.s 5
-			IL_0811: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0816: dup
-			IL_0817: ldstr "frontmatter"
-			IL_081c: ldloc.s 7
-			IL_081e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0823: dup
-			IL_0824: ldstr "unknownKeys"
-			IL_0829: ldloc.s 9
-			IL_082b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0830: dup
-			IL_0831: ldstr "description"
-			IL_0836: ldloc.s 28
-			IL_0838: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_083d: dup
-			IL_083e: ldstr "info"
-			IL_0843: ldloc.s 40
-			IL_0845: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_084a: dup
-			IL_084b: ldstr "esid"
-			IL_0850: ldloc.s 41
-			IL_0852: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0857: dup
-			IL_0858: ldstr "es5id"
-			IL_085d: ldloc.s 42
-			IL_085f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0864: dup
-			IL_0865: ldstr "es6id"
-			IL_086a: ldloc.s 43
-			IL_086c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0871: dup
-			IL_0872: ldstr "author"
-			IL_0877: ldloc.s 44
-			IL_0879: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_087e: dup
-			IL_087f: ldstr "includes"
-			IL_0884: ldloc.s 14
-			IL_0886: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_088b: dup
-			IL_088c: ldstr "flags"
-			IL_0891: ldloc.s 15
-			IL_0893: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0898: dup
-			IL_0899: ldstr "features"
-			IL_089e: ldloc.s 16
-			IL_08a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08a5: dup
-			IL_08a6: ldstr "locale"
-			IL_08ab: ldloc.s 17
-			IL_08ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08b2: dup
-			IL_08b3: ldstr "defines"
-			IL_08b8: ldloc.s 18
-			IL_08ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08bf: dup
-			IL_08c0: ldstr "negative"
-			IL_08c5: ldloc.s 19
-			IL_08c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08cc: dup
-			IL_08cd: ldstr "execution"
-			IL_08d2: ldloc.s 23
-			IL_08d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08d9: dup
-			IL_08da: ldstr "mvpBlockers"
-			IL_08df: ldloc.s 30
-			IL_08e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08e6: dup
-			IL_08e7: ldstr "unsupported"
-			IL_08ec: ldloc.s 4
-			IL_08ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08f3: stloc.s 45
-			IL_08f5: ldloc.s 45
-			IL_08f7: ret
+			IL_05c8: stloc.s 34
+			IL_05ca: ldloc.s 7
+			IL_05cc: ldstr "es5id"
+			IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05d6: stloc.s 42
+			IL_05d8: ldloc.s 30
+			IL_05da: ldloc.s 34
+			IL_05dc: ldloc.s 42
+			IL_05de: ldstr "es5id"
+			IL_05e3: ldloc.s 4
+			IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_05ea: stloc.s 42
+			IL_05ec: ldarg.0
+			IL_05ed: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_05f2: stloc.s 30
+			IL_05f4: ldc.i4.1
+			IL_05f5: newarr [System.Runtime]System.Object
+			IL_05fa: dup
+			IL_05fb: ldc.i4.0
+			IL_05fc: ldarg.0
+			IL_05fd: stelem.ref
+			IL_05fe: stloc.s 34
+			IL_0600: ldloc.s 7
+			IL_0602: ldstr "es6id"
+			IL_0607: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_060c: stloc.s 43
+			IL_060e: ldloc.s 30
+			IL_0610: ldloc.s 34
+			IL_0612: ldloc.s 43
+			IL_0614: ldstr "es6id"
+			IL_0619: ldloc.s 4
+			IL_061b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0620: stloc.s 43
+			IL_0622: ldarg.0
+			IL_0623: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_0628: stloc.s 30
+			IL_062a: ldc.i4.1
+			IL_062b: newarr [System.Runtime]System.Object
+			IL_0630: dup
+			IL_0631: ldc.i4.0
+			IL_0632: ldarg.0
+			IL_0633: stelem.ref
+			IL_0634: stloc.s 34
+			IL_0636: ldloc.s 7
+			IL_0638: ldstr "author"
+			IL_063d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0642: stloc.s 44
+			IL_0644: ldloc.s 30
+			IL_0646: ldloc.s 34
+			IL_0648: ldloc.s 44
+			IL_064a: ldstr "author"
+			IL_064f: ldloc.s 4
+			IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0656: stloc.s 44
+			IL_0658: ldarg.0
+			IL_0659: ldfld object Modules.test262_metadataParser/Scope::buildMvpBlockers
+			IL_065e: ldc.i4.1
+			IL_065f: newarr [System.Runtime]System.Object
+			IL_0664: dup
+			IL_0665: ldc.i4.0
+			IL_0666: ldarg.0
+			IL_0667: stelem.ref
+			IL_0668: ldloc.1
+			IL_0669: ldloc.s 19
+			IL_066b: ldloc.s 23
+			IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0672: stloc.s 30
+			IL_0674: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0679: dup
+			IL_067a: ldstr "filePath"
+			IL_067f: ldloc.s 37
+			IL_0681: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0686: dup
+			IL_0687: ldstr "fileName"
+			IL_068c: ldloc.s 39
+			IL_068e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0693: dup
+			IL_0694: ldstr "hasFrontmatter"
+			IL_0699: ldloc.s 5
+			IL_069b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_06a0: dup
+			IL_06a1: ldstr "frontmatter"
+			IL_06a6: ldloc.s 7
+			IL_06a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06ad: dup
+			IL_06ae: ldstr "unknownKeys"
+			IL_06b3: ldloc.s 9
+			IL_06b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06ba: dup
+			IL_06bb: ldstr "description"
+			IL_06c0: ldloc.s 28
+			IL_06c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06c7: dup
+			IL_06c8: ldstr "info"
+			IL_06cd: ldloc.s 40
+			IL_06cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06d4: dup
+			IL_06d5: ldstr "esid"
+			IL_06da: ldloc.s 41
+			IL_06dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06e1: dup
+			IL_06e2: ldstr "es5id"
+			IL_06e7: ldloc.s 42
+			IL_06e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06ee: dup
+			IL_06ef: ldstr "es6id"
+			IL_06f4: ldloc.s 43
+			IL_06f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06fb: dup
+			IL_06fc: ldstr "author"
+			IL_0701: ldloc.s 44
+			IL_0703: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0708: dup
+			IL_0709: ldstr "includes"
+			IL_070e: ldloc.s 14
+			IL_0710: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0715: dup
+			IL_0716: ldstr "flags"
+			IL_071b: ldloc.s 15
+			IL_071d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0722: dup
+			IL_0723: ldstr "features"
+			IL_0728: ldloc.s 16
+			IL_072a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_072f: dup
+			IL_0730: ldstr "locale"
+			IL_0735: ldloc.s 17
+			IL_0737: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_073c: dup
+			IL_073d: ldstr "defines"
+			IL_0742: ldloc.s 18
+			IL_0744: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0749: dup
+			IL_074a: ldstr "negative"
+			IL_074f: ldloc.s 19
+			IL_0751: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0756: dup
+			IL_0757: ldstr "execution"
+			IL_075c: ldloc.s 23
+			IL_075e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0763: dup
+			IL_0764: ldstr "mvpBlockers"
+			IL_0769: ldloc.s 30
+			IL_076b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0770: dup
+			IL_0771: ldstr "unsupported"
+			IL_0776: ldloc.s 4
+			IL_0778: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_077d: stloc.s 45
+			IL_077f: ldloc.s 45
+			IL_0781: ret
 		} // end of method parseTest262Metadata::__js_call__
 
 	} // end of class parseTest262Metadata
@@ -10374,7 +9823,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7432
+				// Method begins at RVA 0x6d68
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -10401,9 +9850,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x7010
+			// Method begins at RVA 0x6954
 			// Header size: 12
-			// Code size: 83 (0x53)
+			// Code size: 69 (0x45)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -10413,39 +9862,33 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.test262_metadataParser/Scope::fs
-			IL_0006: stloc.1
-			IL_0007: ldstr "fs"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.1
 			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "readFileSync"
-			IL_0020: ldarg.2
-			IL_0021: ldstr "utf8"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_002b: stloc.1
-			IL_002c: ldloc.1
-			IL_002d: stloc.0
-			IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0033: dup
-			IL_0034: ldstr "filePath"
-			IL_0039: ldarg.2
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: stloc.2
-			IL_0040: ldarg.0
-			IL_0041: castclass Modules.test262_metadataParser/Scope
-			IL_0046: ldnull
-			IL_0047: ldloc.0
-			IL_0048: ldloc.2
-			IL_0049: tail.
-			IL_004b: call object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
-			IL_0050: ret
+			IL_000d: ldstr "readFileSync"
+			IL_0012: ldarg.2
+			IL_0013: ldstr "utf8"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_001d: stloc.1
+			IL_001e: ldloc.1
+			IL_001f: stloc.0
+			IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0025: dup
+			IL_0026: ldstr "filePath"
+			IL_002b: ldarg.2
+			IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0031: stloc.2
+			IL_0032: ldarg.0
+			IL_0033: castclass Modules.test262_metadataParser/Scope
+			IL_0038: ldnull
+			IL_0039: ldloc.0
+			IL_003a: ldloc.2
+			IL_003b: tail.
+			IL_003d: call object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
+			IL_0042: ret
 
-			IL_0051: ldnull
-			IL_0052: ret
+			IL_0043: ldnull
+			IL_0044: ret
 		} // end of method parseTest262File::__js_call__
 
 	} // end of class parseTest262File
@@ -10507,7 +9950,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x70d2
+			// Method begins at RVA 0x6a08
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -11097,7 +10540,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x743b
+		// Method begins at RVA 0x6d71
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Iterator_Methods.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Iterator_Methods.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x28fb
+						// Method begins at RVA 0x28ed
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x28f2
+					// Method begins at RVA 0x28e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -70,12 +70,11 @@
 				)
 				// Method begins at RVA 0x2854
 				// Header size: 12
-				// Code size: 128 (0x80)
+				// Code size: 114 (0x72)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/Scope/Block_L45C16,
-					[1] object,
-					[2] bool
+					[1] bool
 				)
 
 				IL_0000: ldarg.0
@@ -83,47 +82,41 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope
 				IL_0008: ldfld object Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope::used
-				IL_000d: stloc.1
-				IL_000e: ldstr "used"
+				IL_000d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0012: stloc.1
 				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldloc.1
-				IL_001b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0020: stloc.2
-				IL_0021: ldloc.2
-				IL_0022: brfalse IL_004b
+				IL_0014: brfalse IL_003d
 
-				IL_0027: newobj instance void Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/Scope/Block_L45C16::.ctor()
-				IL_002c: stloc.0
-				IL_002d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0032: dup
-				IL_0033: ldstr "value"
-				IL_0038: ldnull
-				IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_003e: dup
-				IL_003f: ldstr "done"
-				IL_0044: ldc.i4.1
-				IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_004a: ret
+				IL_0019: newobj instance void Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/Scope/Block_L45C16::.ctor()
+				IL_001e: stloc.0
+				IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0024: dup
+				IL_0025: ldstr "value"
+				IL_002a: ldnull
+				IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0030: dup
+				IL_0031: ldstr "done"
+				IL_0036: ldc.i4.1
+				IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_003c: ret
 
-				IL_004b: ldarg.0
-				IL_004c: ldc.i4.1
-				IL_004d: ldelem.ref
-				IL_004e: castclass Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope
-				IL_0053: ldc.i4.1
-				IL_0054: box [System.Runtime]System.Boolean
-				IL_0059: stfld object Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope::used
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0063: dup
-				IL_0064: ldstr "value"
-				IL_0069: ldstr "override"
-				IL_006e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0073: dup
-				IL_0074: ldstr "done"
-				IL_0079: ldc.i4.0
-				IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007f: ret
+				IL_003d: ldarg.0
+				IL_003e: ldc.i4.1
+				IL_003f: ldelem.ref
+				IL_0040: castclass Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope
+				IL_0045: ldc.i4.1
+				IL_0046: box [System.Runtime]System.Boolean
+				IL_004b: stfld object Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope::used
+				IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0055: dup
+				IL_0056: ldstr "value"
+				IL_005b: ldstr "override"
+				IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0065: dup
+				IL_0066: ldstr "done"
+				IL_006b: ldc.i4.0
+				IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0071: ret
 			} // end of method FunctionExpression_L44C10::__js_call__
 
 		} // end of class FunctionExpression_L44C10
@@ -142,7 +135,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28e9
+				// Method begins at RVA 0x28db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -222,7 +215,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x28e0
+			// Method begins at RVA 0x28d2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -246,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x290d
+				// Method begins at RVA 0x28ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +257,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2904
+			// Method begins at RVA 0x28f6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -909,7 +902,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2916
+		// Method begins at RVA 0x2908
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x224b
+					// Method begins at RVA 0x223d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -49,7 +49,7 @@
 				)
 				// Method begins at RVA 0x21f0
 				// Header size: 12
-				// Code size: 48 (0x30)
+				// Code size: 34 (0x22)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -60,21 +60,15 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Array_Map_NestedParam/outer/Scope
 				IL_0008: ldfld object Modules.Array_Map_NestedParam/outer/Scope::arr
-				IL_000d: stloc.0
-				IL_000e: ldstr "arr"
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
 				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldloc.0
-				IL_0022: ldstr "map"
-				IL_0027: ldarg.2
-				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_002d: stloc.0
-				IL_002e: ldloc.0
-				IL_002f: ret
+				IL_0014: ldstr "map"
+				IL_0019: ldarg.2
+				IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_001f: stloc.0
+				IL_0020: ldloc.0
+				IL_0021: ret
 			} // end of method inner::__js_call__
 
 		} // end of class inner
@@ -96,7 +90,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2254
+					// Method begins at RVA 0x2246
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -120,7 +114,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x222c
+				// Method begins at RVA 0x221e
 				// Header size: 1
 				// Code size: 12 (0xc)
 				.maxstack 8
@@ -149,7 +143,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2242
+				// Method begins at RVA 0x2234
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -267,7 +261,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2239
+			// Method begins at RVA 0x222b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -291,7 +285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2266
+				// Method begins at RVA 0x2258
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -309,7 +303,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x225d
+			// Method begins at RVA 0x224f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -451,7 +445,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x226f
+		// Method begins at RVA 0x2261
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_EdgeCases.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bbb
+				// Method begins at RVA 0x2b6b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,41 +48,26 @@
 			)
 			// Method begins at RVA 0x2a30
 			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] float64,
-				[2] object,
-				[3] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-			IL_0006: stloc.0
-			IL_0007: ldstr "calls"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldc.r8 1
-			IL_0024: add
-			IL_0025: stloc.1
-			IL_0026: ldloc.1
-			IL_0027: box [System.Runtime]System.Double
-			IL_002c: stloc.2
-			IL_002d: ldarg.0
-			IL_002e: ldloc.2
-			IL_002f: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-			IL_0034: ldarg.2
-			IL_0035: ldarg.3
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_003b: stloc.3
-			IL_003c: ldloc.3
-			IL_003d: ret
+			IL_0001: ldarg.0
+			IL_0002: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+			IL_0007: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000c: ldc.r8 1
+			IL_0015: add
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+			IL_0020: ldarg.2
+			IL_0021: ldarg.3
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0027: stloc.0
+			IL_0028: ldloc.0
+			IL_0029: ret
 		} // end of method FunctionExpression_r1::__js_call__
 
 	} // end of class FunctionExpression_r1
@@ -98,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bc4
+				// Method begins at RVA 0x2b74
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,43 +111,28 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2a7c
+			// Method begins at RVA 0x2a68
 			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] float64,
-				[2] object,
-				[3] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-			IL_0006: stloc.0
-			IL_0007: ldstr "calls"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldc.r8 1
-			IL_0024: add
-			IL_0025: stloc.1
-			IL_0026: ldloc.1
-			IL_0027: box [System.Runtime]System.Double
-			IL_002c: stloc.2
-			IL_002d: ldarg.0
-			IL_002e: ldloc.2
-			IL_002f: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-			IL_0034: ldarg.2
-			IL_0035: ldarg.3
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_003b: stloc.3
-			IL_003c: ldloc.3
-			IL_003d: ret
+			IL_0001: ldarg.0
+			IL_0002: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+			IL_0007: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000c: ldc.r8 1
+			IL_0015: add
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+			IL_0020: ldarg.2
+			IL_0021: ldarg.3
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0027: stloc.0
+			IL_0028: ldloc.0
+			IL_0029: ret
 		} // end of method FunctionExpression_r2::__js_call__
 
 	} // end of class FunctionExpression_r2
@@ -178,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bcd
+				// Method begins at RVA 0x2b7d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -206,43 +176,28 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2ac8
+			// Method begins at RVA 0x2aa0
 			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] float64,
-				[2] object,
-				[3] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-			IL_0006: stloc.0
-			IL_0007: ldstr "calls"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldc.r8 1
-			IL_0024: add
-			IL_0025: stloc.1
-			IL_0026: ldloc.1
-			IL_0027: box [System.Runtime]System.Double
-			IL_002c: stloc.2
-			IL_002d: ldarg.0
-			IL_002e: ldloc.2
-			IL_002f: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-			IL_0034: ldarg.2
-			IL_0035: ldarg.3
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_003b: stloc.3
-			IL_003c: ldloc.3
-			IL_003d: ret
+			IL_0001: ldarg.0
+			IL_0002: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+			IL_0007: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000c: ldc.r8 1
+			IL_0015: add
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+			IL_0020: ldarg.2
+			IL_0021: ldarg.3
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0027: stloc.0
+			IL_0028: ldloc.0
+			IL_0029: ret
 		} // end of method FunctionExpression_r3::__js_call__
 
 	} // end of class FunctionExpression_r3
@@ -258,7 +213,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bd6
+				// Method begins at RVA 0x2b86
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,43 +241,28 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2b14
+			// Method begins at RVA 0x2ad8
 			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] float64,
-				[2] object,
-				[3] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-			IL_0006: stloc.0
-			IL_0007: ldstr "calls"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldc.r8 1
-			IL_0024: add
-			IL_0025: stloc.1
-			IL_0026: ldloc.1
-			IL_0027: box [System.Runtime]System.Double
-			IL_002c: stloc.2
-			IL_002d: ldarg.0
-			IL_002e: ldloc.2
-			IL_002f: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-			IL_0034: ldarg.2
-			IL_0035: ldarg.3
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_003b: stloc.3
-			IL_003c: ldloc.3
-			IL_003d: ret
+			IL_0001: ldarg.0
+			IL_0002: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+			IL_0007: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000c: ldc.r8 1
+			IL_0015: add
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+			IL_0020: ldarg.2
+			IL_0021: ldarg.3
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0027: stloc.0
+			IL_0028: ldloc.0
+			IL_0029: ret
 		} // end of method FunctionExpression_r4::__js_call__
 
 	} // end of class FunctionExpression_r4
@@ -338,7 +278,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2be8
+				// Method begins at RVA 0x2b98
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -363,7 +303,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b60
+			// Method begins at RVA 0x2b10
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -392,7 +332,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c03
+				// Method begins at RVA 0x2bb3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -417,7 +357,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b78
+			// Method begins at RVA 0x2b28
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -450,7 +390,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b97
+				// Method begins at RVA 0x2b47
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -470,7 +410,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ba0
+				// Method begins at RVA 0x2b50
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -490,7 +430,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ba9
+				// Method begins at RVA 0x2b59
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -510,7 +450,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bb2
+				// Method begins at RVA 0x2b62
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -530,7 +470,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bdf
+				// Method begins at RVA 0x2b8f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -550,7 +490,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bf1
+				// Method begins at RVA 0x2ba1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -570,7 +510,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bfa
+				// Method begins at RVA 0x2baa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -590,7 +530,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c0c
+				// Method begins at RVA 0x2bbc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -611,7 +551,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b8e
+			// Method begins at RVA 0x2b3e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1474,7 +1414,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2c15
+		// Method begins at RVA 0x2bc5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Some_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Some_Basic.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2355
+				// Method begins at RVA 0x233f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x235e
+				// Method begins at RVA 0x2348
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -152,7 +152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2367
+				// Method begins at RVA 0x2351
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -181,46 +181,31 @@
 			)
 			// Method begins at RVA 0x22e4
 			// Header size: 12
-			// Code size: 84 (0x54)
+			// Code size: 62 (0x3e)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] float64,
-				[2] object,
-				[3] bool,
-				[4] object
+				[0] bool,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Array_Some_Basic/Scope::calls
-			IL_0006: stloc.0
-			IL_0007: ldstr "calls"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldc.r8 1
-			IL_0024: add
-			IL_0025: stloc.1
-			IL_0026: ldloc.1
-			IL_0027: box [System.Runtime]System.Double
-			IL_002c: stloc.2
-			IL_002d: ldarg.0
-			IL_002e: ldloc.2
-			IL_002f: stfld object Modules.Array_Some_Basic/Scope::calls
-			IL_0034: ldarg.2
-			IL_0035: ldc.r8 2
-			IL_003e: box [System.Runtime]System.Double
-			IL_0043: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0048: stloc.3
-			IL_0049: ldloc.3
-			IL_004a: box [System.Runtime]System.Boolean
-			IL_004f: stloc.s 4
-			IL_0051: ldloc.s 4
-			IL_0053: ret
+			IL_0001: ldarg.0
+			IL_0002: ldfld object Modules.Array_Some_Basic/Scope::calls
+			IL_0007: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000c: ldc.r8 1
+			IL_0015: add
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: stfld object Modules.Array_Some_Basic/Scope::calls
+			IL_0020: ldarg.2
+			IL_0021: ldc.r8 2
+			IL_002a: box [System.Runtime]System.Double
+			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0034: stloc.0
+			IL_0035: ldloc.0
+			IL_0036: box [System.Runtime]System.Boolean
+			IL_003b: stloc.1
+			IL_003c: ldloc.1
+			IL_003d: ret
 		} // end of method ArrowFunction_L10C22::__js_call__
 
 	} // end of class ArrowFunction_L10C22
@@ -242,7 +227,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2370
+				// Method begins at RVA 0x235a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -266,7 +251,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2344
+			// Method begins at RVA 0x232e
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -292,7 +277,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x234c
+			// Method begins at RVA 0x2336
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -531,7 +516,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2379
+		// Method begins at RVA 0x2363
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Splice_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Splice_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x236d
+			// Method begins at RVA 0x2381
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 785 (0x311)
+		// Code size: 805 (0x325)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Splice_Basic/Scope,
@@ -99,206 +99,210 @@
 		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00bf: stloc.s 4
 		IL_00c1: ldloc.2
-		IL_00c2: ldc.i4.1
-		IL_00c3: newarr [System.Runtime]System.Object
-		IL_00c8: dup
-		IL_00c9: ldc.i4.0
-		IL_00ca: ldstr ","
-		IL_00cf: stelem.ref
-		IL_00d0: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_00d5: stloc.s 5
-		IL_00d7: ldloc.s 4
-		IL_00d9: ldstr "log"
-		IL_00de: ldloc.s 5
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00e5: pop
-		IL_00e6: ldstr "console"
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f0: stloc.s 4
-		IL_00f2: ldloc.s 4
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f9: stloc.s 4
-		IL_00fb: ldloc.1
-		IL_00fc: ldc.i4.1
-		IL_00fd: newarr [System.Runtime]System.Object
-		IL_0102: dup
-		IL_0103: ldc.i4.0
-		IL_0104: ldstr ","
-		IL_0109: stelem.ref
-		IL_010a: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_010f: stloc.s 5
-		IL_0111: ldloc.s 4
-		IL_0113: ldstr "log"
-		IL_0118: ldloc.s 5
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_011f: pop
-		IL_0120: ldloc.1
-		IL_0121: ldc.i4.4
-		IL_0122: newarr [System.Runtime]System.Object
-		IL_0127: dup
-		IL_0128: ldc.i4.0
-		IL_0129: ldc.r8 2
-		IL_0132: box [System.Runtime]System.Double
-		IL_0137: stelem.ref
-		IL_0138: dup
-		IL_0139: ldc.i4.1
-		IL_013a: ldc.r8 0.0
-		IL_0143: box [System.Runtime]System.Double
-		IL_0148: stelem.ref
-		IL_0149: dup
-		IL_014a: ldc.i4.2
-		IL_014b: ldc.r8 2
-		IL_0154: box [System.Runtime]System.Double
-		IL_0159: stelem.ref
-		IL_015a: dup
-		IL_015b: ldc.i4.3
-		IL_015c: ldc.r8 3
-		IL_0165: box [System.Runtime]System.Double
-		IL_016a: stelem.ref
-		IL_016b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object[])
-		IL_0170: stloc.3
-		IL_0171: ldloc.3
-		IL_0172: stloc.2
-		IL_0173: ldstr "console"
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017d: stloc.s 4
-		IL_017f: ldloc.s 4
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0186: stloc.s 4
-		IL_0188: ldloc.2
-		IL_0189: ldc.i4.1
-		IL_018a: newarr [System.Runtime]System.Object
-		IL_018f: dup
-		IL_0190: ldc.i4.0
-		IL_0191: ldstr ","
-		IL_0196: stelem.ref
-		IL_0197: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_019c: stloc.s 5
-		IL_019e: ldloc.s 4
-		IL_01a0: ldstr "log"
-		IL_01a5: ldloc.s 5
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01ac: pop
-		IL_01ad: ldstr "console"
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b7: stloc.s 4
-		IL_01b9: ldloc.s 4
-		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c0: stloc.s 4
-		IL_01c2: ldloc.1
-		IL_01c3: ldc.i4.1
-		IL_01c4: newarr [System.Runtime]System.Object
-		IL_01c9: dup
-		IL_01ca: ldc.i4.0
-		IL_01cb: ldstr ","
-		IL_01d0: stelem.ref
-		IL_01d1: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_01d6: stloc.s 5
-		IL_01d8: ldloc.s 4
-		IL_01da: ldstr "log"
-		IL_01df: ldloc.s 5
-		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01e6: pop
-		IL_01e7: ldloc.1
-		IL_01e8: ldc.r8 4
-		IL_01f1: box [System.Runtime]System.Double
-		IL_01f6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object)
-		IL_01fb: stloc.3
-		IL_01fc: ldloc.3
-		IL_01fd: stloc.2
-		IL_01fe: ldstr "console"
-		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0208: stloc.s 4
-		IL_020a: ldloc.s 4
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0211: stloc.s 4
-		IL_0213: ldloc.2
-		IL_0214: ldc.i4.1
-		IL_0215: newarr [System.Runtime]System.Object
-		IL_021a: dup
-		IL_021b: ldc.i4.0
-		IL_021c: ldstr ","
-		IL_0221: stelem.ref
-		IL_0222: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0227: stloc.s 5
-		IL_0229: ldloc.s 4
-		IL_022b: ldstr "log"
-		IL_0230: ldloc.s 5
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0237: pop
-		IL_0238: ldstr "console"
-		IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0242: stloc.s 4
-		IL_0244: ldloc.s 4
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024b: stloc.s 4
-		IL_024d: ldloc.1
-		IL_024e: ldc.i4.1
-		IL_024f: newarr [System.Runtime]System.Object
-		IL_0254: dup
-		IL_0255: ldc.i4.0
-		IL_0256: ldstr ","
-		IL_025b: stelem.ref
-		IL_025c: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0261: stloc.s 5
-		IL_0263: ldloc.s 4
-		IL_0265: ldstr "log"
-		IL_026a: ldloc.s 5
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0271: pop
-		IL_0272: ldc.r8 3
-		IL_027b: neg
-		IL_027c: box [System.Runtime]System.Double
-		IL_0281: stloc.s 6
-		IL_0283: ldloc.1
-		IL_0284: ldloc.s 6
-		IL_0286: ldc.r8 10
-		IL_028f: box [System.Runtime]System.Double
-		IL_0294: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object)
-		IL_0299: stloc.3
-		IL_029a: ldloc.3
-		IL_029b: stloc.2
-		IL_029c: ldstr "console"
-		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a6: stloc.s 4
-		IL_02a8: ldloc.s 4
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02af: stloc.s 4
-		IL_02b1: ldloc.2
-		IL_02b2: ldc.i4.1
-		IL_02b3: newarr [System.Runtime]System.Object
-		IL_02b8: dup
-		IL_02b9: ldc.i4.0
-		IL_02ba: ldstr ","
-		IL_02bf: stelem.ref
-		IL_02c0: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_02c5: stloc.s 5
-		IL_02c7: ldloc.s 4
-		IL_02c9: ldstr "log"
-		IL_02ce: ldloc.s 5
-		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02d5: pop
-		IL_02d6: ldstr "console"
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e0: stloc.s 4
-		IL_02e2: ldloc.s 4
-		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e9: stloc.s 4
-		IL_02eb: ldloc.1
-		IL_02ec: ldc.i4.1
-		IL_02ed: newarr [System.Runtime]System.Object
-		IL_02f2: dup
-		IL_02f3: ldc.i4.0
-		IL_02f4: ldstr ","
-		IL_02f9: stelem.ref
-		IL_02fa: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_02ff: stloc.s 5
-		IL_0301: ldloc.s 4
-		IL_0303: ldstr "log"
-		IL_0308: ldloc.s 5
-		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_030f: pop
-		IL_0310: ret
+		IL_00c2: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_00c7: ldc.i4.1
+		IL_00c8: newarr [System.Runtime]System.Object
+		IL_00cd: dup
+		IL_00ce: ldc.i4.0
+		IL_00cf: ldstr ","
+		IL_00d4: stelem.ref
+		IL_00d5: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_00da: stloc.s 5
+		IL_00dc: ldloc.s 4
+		IL_00de: ldstr "log"
+		IL_00e3: ldloc.s 5
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ea: pop
+		IL_00eb: ldstr "console"
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f5: stloc.s 4
+		IL_00f7: ldloc.s 4
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fe: stloc.s 4
+		IL_0100: ldloc.1
+		IL_0101: ldc.i4.1
+		IL_0102: newarr [System.Runtime]System.Object
+		IL_0107: dup
+		IL_0108: ldc.i4.0
+		IL_0109: ldstr ","
+		IL_010e: stelem.ref
+		IL_010f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0114: stloc.s 5
+		IL_0116: ldloc.s 4
+		IL_0118: ldstr "log"
+		IL_011d: ldloc.s 5
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0124: pop
+		IL_0125: ldloc.1
+		IL_0126: ldc.i4.4
+		IL_0127: newarr [System.Runtime]System.Object
+		IL_012c: dup
+		IL_012d: ldc.i4.0
+		IL_012e: ldc.r8 2
+		IL_0137: box [System.Runtime]System.Double
+		IL_013c: stelem.ref
+		IL_013d: dup
+		IL_013e: ldc.i4.1
+		IL_013f: ldc.r8 0.0
+		IL_0148: box [System.Runtime]System.Double
+		IL_014d: stelem.ref
+		IL_014e: dup
+		IL_014f: ldc.i4.2
+		IL_0150: ldc.r8 2
+		IL_0159: box [System.Runtime]System.Double
+		IL_015e: stelem.ref
+		IL_015f: dup
+		IL_0160: ldc.i4.3
+		IL_0161: ldc.r8 3
+		IL_016a: box [System.Runtime]System.Double
+		IL_016f: stelem.ref
+		IL_0170: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object[])
+		IL_0175: stloc.3
+		IL_0176: ldloc.3
+		IL_0177: stloc.2
+		IL_0178: ldstr "console"
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0182: stloc.s 4
+		IL_0184: ldloc.s 4
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018b: stloc.s 4
+		IL_018d: ldloc.2
+		IL_018e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_0193: ldc.i4.1
+		IL_0194: newarr [System.Runtime]System.Object
+		IL_0199: dup
+		IL_019a: ldc.i4.0
+		IL_019b: ldstr ","
+		IL_01a0: stelem.ref
+		IL_01a1: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_01a6: stloc.s 5
+		IL_01a8: ldloc.s 4
+		IL_01aa: ldstr "log"
+		IL_01af: ldloc.s 5
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01b6: pop
+		IL_01b7: ldstr "console"
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c1: stloc.s 4
+		IL_01c3: ldloc.s 4
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ca: stloc.s 4
+		IL_01cc: ldloc.1
+		IL_01cd: ldc.i4.1
+		IL_01ce: newarr [System.Runtime]System.Object
+		IL_01d3: dup
+		IL_01d4: ldc.i4.0
+		IL_01d5: ldstr ","
+		IL_01da: stelem.ref
+		IL_01db: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_01e0: stloc.s 5
+		IL_01e2: ldloc.s 4
+		IL_01e4: ldstr "log"
+		IL_01e9: ldloc.s 5
+		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01f0: pop
+		IL_01f1: ldloc.1
+		IL_01f2: ldc.r8 4
+		IL_01fb: box [System.Runtime]System.Double
+		IL_0200: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object)
+		IL_0205: stloc.3
+		IL_0206: ldloc.3
+		IL_0207: stloc.2
+		IL_0208: ldstr "console"
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0212: stloc.s 4
+		IL_0214: ldloc.s 4
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021b: stloc.s 4
+		IL_021d: ldloc.2
+		IL_021e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_0223: ldc.i4.1
+		IL_0224: newarr [System.Runtime]System.Object
+		IL_0229: dup
+		IL_022a: ldc.i4.0
+		IL_022b: ldstr ","
+		IL_0230: stelem.ref
+		IL_0231: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0236: stloc.s 5
+		IL_0238: ldloc.s 4
+		IL_023a: ldstr "log"
+		IL_023f: ldloc.s 5
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0246: pop
+		IL_0247: ldstr "console"
+		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0251: stloc.s 4
+		IL_0253: ldloc.s 4
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025a: stloc.s 4
+		IL_025c: ldloc.1
+		IL_025d: ldc.i4.1
+		IL_025e: newarr [System.Runtime]System.Object
+		IL_0263: dup
+		IL_0264: ldc.i4.0
+		IL_0265: ldstr ","
+		IL_026a: stelem.ref
+		IL_026b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0270: stloc.s 5
+		IL_0272: ldloc.s 4
+		IL_0274: ldstr "log"
+		IL_0279: ldloc.s 5
+		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0280: pop
+		IL_0281: ldc.r8 3
+		IL_028a: neg
+		IL_028b: box [System.Runtime]System.Double
+		IL_0290: stloc.s 6
+		IL_0292: ldloc.1
+		IL_0293: ldloc.s 6
+		IL_0295: ldc.r8 10
+		IL_029e: box [System.Runtime]System.Double
+		IL_02a3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object)
+		IL_02a8: stloc.3
+		IL_02a9: ldloc.3
+		IL_02aa: stloc.2
+		IL_02ab: ldstr "console"
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02b5: stloc.s 4
+		IL_02b7: ldloc.s 4
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02be: stloc.s 4
+		IL_02c0: ldloc.2
+		IL_02c1: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_02c6: ldc.i4.1
+		IL_02c7: newarr [System.Runtime]System.Object
+		IL_02cc: dup
+		IL_02cd: ldc.i4.0
+		IL_02ce: ldstr ","
+		IL_02d3: stelem.ref
+		IL_02d4: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_02d9: stloc.s 5
+		IL_02db: ldloc.s 4
+		IL_02dd: ldstr "log"
+		IL_02e2: ldloc.s 5
+		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02e9: pop
+		IL_02ea: ldstr "console"
+		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f4: stloc.s 4
+		IL_02f6: ldloc.s 4
+		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fd: stloc.s 4
+		IL_02ff: ldloc.1
+		IL_0300: ldc.i4.1
+		IL_0301: newarr [System.Runtime]System.Object
+		IL_0306: dup
+		IL_0307: ldc.i4.0
+		IL_0308: ldstr ","
+		IL_030d: stelem.ref
+		IL_030e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0313: stloc.s 5
+		IL_0315: ldloc.s 4
+		IL_0317: ldstr "log"
+		IL_031c: ldloc.s 5
+		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0323: pop
+		IL_0324: ret
 	} // end of method Array_Splice_Basic::__js_module_init__
 
 } // end of class Modules.Array_Splice_Basic
@@ -310,7 +314,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2376
+		// Method begins at RVA 0x238a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x213f
+				// Method begins at RVA 0x2116
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,34 +51,17 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2100
-			// Header size: 12
-			// Code size: 42 (0x2a)
+			// Method begins at RVA 0x20fe
+			// Header size: 1
+			// Code size: 14 (0xe)
 			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] float64,
-				[2] object
-			)
 
-			IL_0000: ldstr "n"
-			IL_0005: ldarg.0
-			IL_0006: ldfld float64 Modules.ArrowFunction_CapturesOuterVariable/Scope::n
-			IL_000b: box [System.Runtime]System.Double
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0015: stloc.0
-			IL_0016: ldloc.0
-			IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001c: stloc.1
-			IL_001d: ldarg.2
-			IL_001e: ldloc.1
-			IL_001f: mul
-			IL_0020: stloc.1
-			IL_0021: ldloc.1
-			IL_0022: box [System.Runtime]System.Double
-			IL_0027: stloc.2
-			IL_0028: ldloc.2
-			IL_0029: ret
+			IL_0000: ldarg.2
+			IL_0001: ldarg.0
+			IL_0002: ldfld float64 Modules.ArrowFunction_CapturesOuterVariable/Scope::n
+			IL_0007: mul
+			IL_0008: box [System.Runtime]System.Double
+			IL_000d: ret
 		} // end of method ArrowFunction_L4C13::__js_call__
 
 	} // end of class ArrowFunction_L4C13
@@ -96,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2136
+			// Method begins at RVA 0x210d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -199,7 +182,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2148
+		// Method begins at RVA 0x211f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2222
+					// Method begins at RVA 0x2206
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,11 +48,10 @@
 				)
 				// Method begins at RVA 0x21b0
 				// Header size: 12
-				// Code size: 84 (0x54)
+				// Code size: 56 (0x38)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldarg.0
@@ -60,33 +59,21 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/Scope
 				IL_0008: ldfld object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/Scope::count
-				IL_000d: stloc.0
-				IL_000e: ldstr "count"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ldc.r8 1
-				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0029: stloc.1
+				IL_000d: ldc.r8 1
+				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_001b: stloc.0
+				IL_001c: ldarg.0
+				IL_001d: ldc.i4.1
+				IL_001e: ldelem.ref
+				IL_001f: castclass Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/Scope
+				IL_0024: ldloc.0
+				IL_0025: stfld object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/Scope::count
 				IL_002a: ldarg.0
 				IL_002b: ldc.i4.1
 				IL_002c: ldelem.ref
 				IL_002d: castclass Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/Scope
-				IL_0032: ldloc.1
-				IL_0033: stfld object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/Scope::count
-				IL_0038: ldarg.0
-				IL_0039: ldc.i4.1
-				IL_003a: ldelem.ref
-				IL_003b: castclass Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/Scope
-				IL_0040: ldfld object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/Scope::count
-				IL_0045: stloc.0
-				IL_0046: ldstr "count"
-				IL_004b: ldloc.0
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0051: stloc.0
-				IL_0052: ldloc.0
-				IL_0053: ret
+				IL_0032: ldfld object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/Scope::count
+				IL_0037: ret
 			} // end of method ArrowFunction_L9C23::__js_call__
 
 		} // end of class ArrowFunction_L9C23
@@ -105,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2219
+				// Method begins at RVA 0x21fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -198,7 +185,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2210
+			// Method begins at RVA 0x21f4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -327,7 +314,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x222b
+		// Method begins at RVA 0x220f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ForLetBodyBlockClosure.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ForLetBodyBlockClosure.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x226f
+					// Method begins at RVA 0x2258
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,24 +47,17 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Method begins at RVA 0x2220
-				// Header size: 12
-				// Code size: 31 (0x1f)
+				// Header size: 1
+				// Code size: 19 (0x13)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
-				IL_0000: ldstr "argPosition"
-				IL_0005: ldarg.0
-				IL_0006: ldc.i4.3
-				IL_0007: ldelem.ref
-				IL_0008: castclass Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49
-				IL_000d: ldfld float64 Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49::argPosition
-				IL_0012: box [System.Runtime]System.Double
-				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_001c: stloc.0
-				IL_001d: ldloc.0
-				IL_001e: ret
+				IL_0000: ldarg.0
+				IL_0001: ldc.i4.3
+				IL_0002: ldelem.ref
+				IL_0003: castclass Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49
+				IL_0008: ldfld float64 Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49::argPosition
+				IL_000d: box [System.Runtime]System.Double
+				IL_0012: ret
 			} // end of method ArrowFunction_L6C24::__js_call__
 
 		} // end of class ArrowFunction_L6C24
@@ -76,7 +69,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2254
+				// Method begins at RVA 0x223d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +101,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2266
+					// Method begins at RVA 0x224f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -126,7 +119,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x225d
+				// Method begins at RVA 0x2246
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -258,7 +251,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x224b
+			// Method begins at RVA 0x2234
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -389,7 +382,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2278
+		// Method begins at RVA 0x2261
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ForOfIterableArrowCallback.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ForOfIterableArrowCallback.verified.txt
@@ -69,9 +69,9 @@
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0016: stloc.1
 				IL_0017: ldloc.1
-				IL_0018: ldstr "test"
+				IL_0018: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 				IL_001d: ldarg.1
-				IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_001e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 				IL_0023: stloc.1
 				IL_0024: ldloc.1
 				IL_0025: ret

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ec
+					// Method begins at RVA 0x21d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,11 +48,10 @@
 				)
 				// Method begins at RVA 0x2150
 				// Header size: 12
-				// Code size: 126 (0x7e)
+				// Code size: 98 (0x62)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldstr "console"
@@ -61,46 +60,34 @@
 				IL_000b: ldloc.0
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0011: stloc.0
-				IL_0012: ldarg.0
-				IL_0013: ldc.i4.1
-				IL_0014: ldelem.ref
-				IL_0015: castclass Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/ArrowFunction_L5C15/Scope
-				IL_001a: ldfld object Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/ArrowFunction_L5C15/Scope::p
-				IL_001f: stloc.1
-				IL_0020: ldstr "p"
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002b: stloc.1
-				IL_002c: ldloc.0
-				IL_002d: ldstr "log"
-				IL_0032: ldstr "param:"
-				IL_0037: ldloc.1
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_003d: pop
-				IL_003e: ldstr "console"
-				IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0048: stloc.1
-				IL_0049: ldloc.1
-				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004f: stloc.1
-				IL_0050: ldarg.0
-				IL_0051: ldc.i4.0
-				IL_0052: ldelem.ref
-				IL_0053: castclass Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
-				IL_0058: ldfld string Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope::g
-				IL_005d: stloc.0
-				IL_005e: ldstr "g"
-				IL_0063: ldloc.0
-				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0069: stloc.0
-				IL_006a: ldloc.1
-				IL_006b: ldstr "log"
-				IL_0070: ldstr "global:"
-				IL_0075: ldloc.0
-				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_007b: pop
-				IL_007c: ldnull
-				IL_007d: ret
+				IL_0012: ldloc.0
+				IL_0013: ldstr "log"
+				IL_0018: ldstr "param:"
+				IL_001d: ldarg.0
+				IL_001e: ldc.i4.1
+				IL_001f: ldelem.ref
+				IL_0020: castclass Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/ArrowFunction_L5C15/Scope
+				IL_0025: ldfld object Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/ArrowFunction_L5C15/Scope::p
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_002f: pop
+				IL_0030: ldstr "console"
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_003a: stloc.0
+				IL_003b: ldloc.0
+				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0041: stloc.0
+				IL_0042: ldloc.0
+				IL_0043: ldstr "log"
+				IL_0048: ldstr "global:"
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.0
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
+				IL_0055: ldfld string Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope::g
+				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_005f: pop
+				IL_0060: ldnull
+				IL_0061: ret
 			} // end of method ArrowFunction_L6C19::__js_call__
 
 		} // end of class ArrowFunction_L6C19
@@ -118,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e3
+				// Method begins at RVA 0x21c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -208,7 +195,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21da
+			// Method begins at RVA 0x21be
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -306,7 +293,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f5
+		// Method begins at RVA 0x21d9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_TopLevelCallback.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_TopLevelCallback.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2205
+				// Method begins at RVA 0x21cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,89 +54,62 @@
 			)
 			// Method begins at RVA 0x2128
 			// Header size: 12
-			// Code size: 200 (0xc8)
+			// Code size: 144 (0x90)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] float64,
-				[2] object,
-				[3] object,
-				[4] bool,
-				[5] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.ArrowFunction_LexicalThis_TopLevelCallback/Scope::calls
-			IL_0006: stloc.0
-			IL_0007: ldstr "calls"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldc.r8 1
-			IL_0024: add
-			IL_0025: stloc.1
-			IL_0026: ldloc.1
-			IL_0027: box [System.Runtime]System.Double
-			IL_002c: stloc.2
-			IL_002d: ldarg.0
-			IL_002e: ldloc.2
-			IL_002f: stfld object Modules.ArrowFunction_LexicalThis_TopLevelCallback/Scope::calls
-			IL_0034: ldstr "console"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_003e: stloc.0
-			IL_003f: ldloc.0
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0045: stloc.0
-			IL_0046: ldarg.0
-			IL_0047: ldfld object Modules.ArrowFunction_LexicalThis_TopLevelCallback/Scope::lexicalThis
-			IL_004c: stloc.3
-			IL_004d: ldstr "lexicalThis"
-			IL_0052: ldloc.3
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0058: stloc.3
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_005e: ldloc.3
-			IL_005f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0064: stloc.s 4
-			IL_0066: ldloc.s 4
-			IL_0068: box [System.Runtime]System.Boolean
-			IL_006d: stloc.s 5
-			IL_006f: ldloc.0
-			IL_0070: ldstr "log"
-			IL_0075: ldloc.s 5
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_007c: pop
-			IL_007d: ldstr "console"
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0087: stloc.0
-			IL_0088: ldloc.0
-			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_008e: stloc.0
-			IL_008f: ldarg.0
-			IL_0090: ldfld object Modules.ArrowFunction_LexicalThis_TopLevelCallback/Scope::usurper
-			IL_0095: stloc.3
-			IL_0096: ldstr "usurper"
-			IL_009b: ldloc.3
-			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a1: stloc.3
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00a7: ldloc.3
-			IL_00a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00ad: stloc.s 4
-			IL_00af: ldloc.s 4
-			IL_00b1: box [System.Runtime]System.Boolean
-			IL_00b6: stloc.s 5
-			IL_00b8: ldloc.0
-			IL_00b9: ldstr "log"
-			IL_00be: ldloc.s 5
-			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00c5: pop
-			IL_00c6: ldnull
-			IL_00c7: ret
+			IL_0001: ldarg.0
+			IL_0002: ldfld object Modules.ArrowFunction_LexicalThis_TopLevelCallback/Scope::calls
+			IL_0007: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000c: ldc.r8 1
+			IL_0015: add
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: stfld object Modules.ArrowFunction_LexicalThis_TopLevelCallback/Scope::calls
+			IL_0020: ldstr "console"
+			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_002a: stloc.0
+			IL_002b: ldloc.0
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0031: stloc.0
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0037: ldarg.0
+			IL_0038: ldfld object Modules.ArrowFunction_LexicalThis_TopLevelCallback/Scope::lexicalThis
+			IL_003d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0042: stloc.1
+			IL_0043: ldloc.1
+			IL_0044: box [System.Runtime]System.Boolean
+			IL_0049: stloc.2
+			IL_004a: ldloc.0
+			IL_004b: ldstr "log"
+			IL_0050: ldloc.2
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0056: pop
+			IL_0057: ldstr "console"
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0061: stloc.0
+			IL_0062: ldloc.0
+			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0068: stloc.0
+			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_006e: ldarg.0
+			IL_006f: ldfld object Modules.ArrowFunction_LexicalThis_TopLevelCallback/Scope::usurper
+			IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0079: stloc.1
+			IL_007a: ldloc.1
+			IL_007b: box [System.Runtime]System.Boolean
+			IL_0080: stloc.2
+			IL_0081: ldloc.0
+			IL_0082: ldstr "log"
+			IL_0087: ldloc.2
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_008d: pop
+			IL_008e: ldnull
+			IL_008f: ret
 		} // end of method ArrowFunction_L7C13::__js_call__
 
 	} // end of class ArrowFunction_L7C13
@@ -160,7 +133,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21fc
+			// Method begins at RVA 0x21c4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -275,7 +248,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220e
+		// Method begins at RVA 0x21d6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2212
+					// Method begins at RVA 0x21f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,12 +48,11 @@
 				)
 				// Method begins at RVA 0x214c
 				// Header size: 12
-				// Code size: 168 (0xa8)
+				// Code size: 140 (0x8c)
 				.maxstack 8
 				.locals init (
 					[0] string,
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: ldstr "inner"
@@ -64,58 +63,46 @@
 				IL_0011: ldloc.1
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0017: stloc.1
-				IL_0018: ldarg.0
-				IL_0019: ldc.i4.0
-				IL_001a: ldelem.ref
-				IL_001b: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
-				IL_0020: ldfld string Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope::globalVar
-				IL_0025: stloc.2
-				IL_0026: ldstr "globalVar"
-				IL_002b: ldloc.2
-				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0031: stloc.2
-				IL_0032: ldloc.1
-				IL_0033: ldstr "log"
-				IL_0038: ldstr "Global:"
-				IL_003d: ldloc.2
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0043: pop
-				IL_0044: ldstr "console"
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_004e: stloc.2
-				IL_004f: ldloc.2
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0055: stloc.2
-				IL_0056: ldarg.0
-				IL_0057: ldc.i4.1
-				IL_0058: ldelem.ref
-				IL_0059: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope
-				IL_005e: ldfld string Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope::outerVar
-				IL_0063: stloc.1
-				IL_0064: ldstr "outerVar"
-				IL_0069: ldloc.1
-				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006f: stloc.1
-				IL_0070: ldloc.2
-				IL_0071: ldstr "log"
-				IL_0076: ldstr "Outer:"
-				IL_007b: ldloc.1
-				IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0081: pop
-				IL_0082: ldstr "console"
-				IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_008c: stloc.1
-				IL_008d: ldloc.1
-				IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0093: stloc.1
-				IL_0094: ldloc.1
-				IL_0095: ldstr "log"
-				IL_009a: ldstr "Inner:"
-				IL_009f: ldloc.0
-				IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00a5: pop
-				IL_00a6: ldnull
-				IL_00a7: ret
+				IL_0018: ldloc.1
+				IL_0019: ldstr "log"
+				IL_001e: ldstr "Global:"
+				IL_0023: ldarg.0
+				IL_0024: ldc.i4.0
+				IL_0025: ldelem.ref
+				IL_0026: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
+				IL_002b: ldfld string Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope::globalVar
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0035: pop
+				IL_0036: ldstr "console"
+				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0040: stloc.1
+				IL_0041: ldloc.1
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0047: stloc.1
+				IL_0048: ldloc.1
+				IL_0049: ldstr "log"
+				IL_004e: ldstr "Outer:"
+				IL_0053: ldarg.0
+				IL_0054: ldc.i4.1
+				IL_0055: ldelem.ref
+				IL_0056: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope
+				IL_005b: ldfld string Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope::outerVar
+				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0065: pop
+				IL_0066: ldstr "console"
+				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0070: stloc.1
+				IL_0071: ldloc.1
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0077: stloc.1
+				IL_0078: ldloc.1
+				IL_0079: ldstr "log"
+				IL_007e: ldstr "Inner:"
+				IL_0083: ldloc.0
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0089: pop
+				IL_008a: ldnull
+				IL_008b: ret
 			} // end of method ArrowFunction_L8C28::__js_call__
 
 		} // end of class ArrowFunction_L8C28
@@ -134,7 +121,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2209
+				// Method begins at RVA 0x21ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -237,7 +224,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2200
+			// Method begins at RVA 0x21e4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -326,7 +313,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x221b
+		// Method begins at RVA 0x21ff
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Calls_Module_Function_Before_Await.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Calls_Module_Function_Before_Await.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2316
+				// Method begins at RVA 0x2306
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -81,7 +81,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x231f
+				// Method begins at RVA 0x230f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -107,13 +107,13 @@
 			)
 			// Method begins at RVA 0x211c
 			// Header size: 12
-			// Code size: 338 (0x152)
+			// Code size: 324 (0x144)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_Calls_Module_Function_Before_Await/main/Scope,
 				[1] object,
-				[2] object,
-				[3] object[]
+				[2] object[],
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -164,107 +164,101 @@
 			IL_0069: dup
 			IL_006a: ldc.i4.1
 			IL_006b: ldelem.ref
-			IL_006c: stloc.2
-			IL_006d: dup
-			IL_006e: ldc.i4.2
-			IL_006f: ldelem.ref
-			IL_0070: castclass object[]
+			IL_006c: castclass object[]
+			IL_0071: stloc.2
+			IL_0072: dup
+			IL_0073: ldc.i4.2
+			IL_0074: ldelem.ref
 			IL_0075: stloc.3
 			IL_0076: pop
 
 			IL_0077: ldloc.0
 			IL_0078: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_007d: switch (IL_008a, IL_0101)
+			IL_007d: switch (IL_008a, IL_00f3)
 
-			IL_008a: ldarg.0
-			IL_008b: ldc.i4.1
-			IL_008c: ldelem.ref
-			IL_008d: castclass Modules.Async_Calls_Module_Function_Before_Await/Scope
-			IL_0092: ldfld object Modules.Async_Calls_Module_Function_Before_Await/Scope::formatSection
-			IL_0097: stloc.2
-			IL_0098: ldstr "formatSection"
-			IL_009d: ldloc.2
-			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a3: stloc.2
-			IL_00a4: ldc.i4.1
-			IL_00a5: newarr [System.Runtime]System.Object
-			IL_00aa: dup
-			IL_00ab: ldc.i4.0
-			IL_00ac: ldarg.0
-			IL_00ad: ldc.i4.1
-			IL_00ae: ldelem.ref
-			IL_00af: stelem.ref
-			IL_00b0: stloc.3
-			IL_00b1: ldloc.2
-			IL_00b2: ldloc.3
-			IL_00b3: ldstr "27.3"
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00bd: stloc.2
-			IL_00be: ldloc.2
-			IL_00bf: stloc.1
-			IL_00c0: ldc.i4.0
-			IL_00c1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-			IL_00cb: stloc.2
-			IL_00cc: ldloc.0
-			IL_00cd: ldc.i4.1
-			IL_00ce: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00d3: ldloc.0
-			IL_00d4: ldloc.2
-			IL_00d5: ldarg.0
-			IL_00d6: ldc.i4.1
-			IL_00d7: ldloc.0
-			IL_00d8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_00e2: ldloc.0
-			IL_00e3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00e8: dup
-			IL_00e9: ldc.i4.0
-			IL_00ea: ldloc.1
-			IL_00eb: stelem.ref
-			IL_00ec: dup
-			IL_00ed: ldc.i4.1
-			IL_00ee: ldloc.2
-			IL_00ef: stelem.ref
-			IL_00f0: dup
-			IL_00f1: ldc.i4.2
-			IL_00f2: ldloc.3
-			IL_00f3: stelem.ref
-			IL_00f4: pop
-			IL_00f5: ldloc.0
-			IL_00f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_00fb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0100: ret
+			IL_008a: ldc.i4.1
+			IL_008b: newarr [System.Runtime]System.Object
+			IL_0090: dup
+			IL_0091: ldc.i4.0
+			IL_0092: ldarg.0
+			IL_0093: ldc.i4.1
+			IL_0094: ldelem.ref
+			IL_0095: stelem.ref
+			IL_0096: stloc.2
+			IL_0097: ldarg.0
+			IL_0098: ldc.i4.1
+			IL_0099: ldelem.ref
+			IL_009a: castclass Modules.Async_Calls_Module_Function_Before_Await/Scope
+			IL_009f: ldfld object Modules.Async_Calls_Module_Function_Before_Await/Scope::formatSection
+			IL_00a4: ldloc.2
+			IL_00a5: ldstr "27.3"
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00af: stloc.3
+			IL_00b0: ldloc.3
+			IL_00b1: stloc.1
+			IL_00b2: ldc.i4.0
+			IL_00b3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+			IL_00bd: stloc.3
+			IL_00be: ldloc.0
+			IL_00bf: ldc.i4.1
+			IL_00c0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00c5: ldloc.0
+			IL_00c6: ldloc.3
+			IL_00c7: ldarg.0
+			IL_00c8: ldc.i4.1
+			IL_00c9: ldloc.0
+			IL_00ca: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00d4: ldloc.0
+			IL_00d5: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00da: dup
+			IL_00db: ldc.i4.0
+			IL_00dc: ldloc.1
+			IL_00dd: stelem.ref
+			IL_00de: dup
+			IL_00df: ldc.i4.1
+			IL_00e0: ldloc.2
+			IL_00e1: stelem.ref
+			IL_00e2: dup
+			IL_00e3: ldc.i4.2
+			IL_00e4: ldloc.3
+			IL_00e5: stelem.ref
+			IL_00e6: pop
+			IL_00e7: ldloc.0
+			IL_00e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_00f2: ret
 
-			IL_0101: ldloc.0
-			IL_0102: ldfld object Modules.Async_Calls_Module_Function_Before_Await/main/Scope::_awaited1
-			IL_0107: pop
-			IL_0108: ldstr "console"
-			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0112: stloc.2
-			IL_0113: ldloc.2
-			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0119: stloc.2
-			IL_011a: ldloc.2
-			IL_011b: ldstr "log"
-			IL_0120: ldloc.1
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0126: pop
-			IL_0127: ldloc.0
-			IL_0128: ldc.i4.m1
-			IL_0129: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_012e: ldloc.0
-			IL_012f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0134: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0139: ldarg.0
-			IL_013a: ldc.i4.1
-			IL_013b: newarr [System.Runtime]System.Object
-			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0145: pop
-			IL_0146: ldloc.0
-			IL_0147: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_014c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0151: ret
+			IL_00f3: ldloc.0
+			IL_00f4: ldfld object Modules.Async_Calls_Module_Function_Before_Await/main/Scope::_awaited1
+			IL_00f9: pop
+			IL_00fa: ldstr "console"
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0104: stloc.3
+			IL_0105: ldloc.3
+			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010b: stloc.3
+			IL_010c: ldloc.3
+			IL_010d: ldstr "log"
+			IL_0112: ldloc.1
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0118: pop
+			IL_0119: ldloc.0
+			IL_011a: ldc.i4.m1
+			IL_011b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0120: ldloc.0
+			IL_0121: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0126: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_012b: ldarg.0
+			IL_012c: ldc.i4.1
+			IL_012d: newarr [System.Runtime]System.Object
+			IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0137: pop
+			IL_0138: ldloc.0
+			IL_0139: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_013e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0143: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -287,7 +281,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2328
+				// Method begins at RVA 0x2318
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -311,7 +305,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x227c
+			// Method begins at RVA 0x226c
 			// Header size: 12
 			// Code size: 133 (0x85)
 			.maxstack 8
@@ -396,7 +390,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x230d
+			// Method begins at RVA 0x22fd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -506,7 +500,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2331
+		// Method begins at RVA 0x2321
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x272a
+					// Method begins at RVA 0x26f2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,17 +46,14 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2610
+				// Method begins at RVA 0x2600
 				// Header size: 12
-				// Code size: 164 (0xa4)
+				// Code size: 122 (0x7a)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] float64,
-					[2] object,
-					[3] object,
-					[4] bool,
-					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+					[0] float64,
+					[1] object,
+					[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
 				IL_0000: ldarg.0
@@ -64,64 +61,42 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/Scope
 				IL_0008: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/Scope::i
-				IL_000d: stloc.0
-				IL_000e: ldstr "i"
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: stloc.0
 				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: stloc.2
-				IL_0028: ldloc.2
-				IL_0029: stloc.0
-				IL_002a: ldloc.1
-				IL_002b: ldc.r8 1
-				IL_0034: add
-				IL_0035: stloc.1
-				IL_0036: ldloc.1
-				IL_0037: box [System.Runtime]System.Double
-				IL_003c: stloc.2
-				IL_003d: ldarg.0
-				IL_003e: ldc.i4.1
-				IL_003f: ldelem.ref
-				IL_0040: castclass Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/Scope
-				IL_0045: ldloc.2
-				IL_0046: stfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/Scope::i
-				IL_004b: ldarg.0
-				IL_004c: ldc.i4.1
-				IL_004d: ldelem.ref
-				IL_004e: castclass Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/Scope
-				IL_0053: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/Scope::i
-				IL_0058: stloc.3
-				IL_0059: ldstr "i"
-				IL_005e: ldloc.3
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0064: stloc.3
-				IL_0065: ldloc.3
-				IL_0066: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_006b: stloc.1
-				IL_006c: ldloc.1
-				IL_006d: ldc.r8 3
-				IL_0076: cgt
-				IL_0078: stloc.s 4
-				IL_007a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_007f: dup
-				IL_0080: ldstr "value"
-				IL_0085: ldloc.0
-				IL_0086: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_008b: dup
-				IL_008c: ldstr "done"
-				IL_0091: ldloc.s 4
-				IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0098: stloc.s 5
-				IL_009a: ldloc.s 5
-				IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-				IL_00a1: stloc.0
-				IL_00a2: ldloc.0
-				IL_00a3: ret
+				IL_0014: box [System.Runtime]System.Double
+				IL_0019: stloc.1
+				IL_001a: ldarg.0
+				IL_001b: ldc.i4.1
+				IL_001c: ldelem.ref
+				IL_001d: castclass Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/Scope
+				IL_0022: ldloc.0
+				IL_0023: ldc.r8 1
+				IL_002c: add
+				IL_002d: box [System.Runtime]System.Double
+				IL_0032: stfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/Scope::i
+				IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_003c: dup
+				IL_003d: ldstr "value"
+				IL_0042: ldloc.1
+				IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0048: dup
+				IL_0049: ldstr "done"
+				IL_004e: ldarg.0
+				IL_004f: ldc.i4.1
+				IL_0050: ldelem.ref
+				IL_0051: castclass Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/Scope
+				IL_0056: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/Scope::i
+				IL_005b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0060: ldc.r8 3
+				IL_0069: cgt
+				IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0070: stloc.2
+				IL_0071: ldloc.2
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+				IL_0077: stloc.1
+				IL_0078: ldloc.1
+				IL_0079: ret
 			} // end of method ArrowFunction_L8C19::__js_call__
 
 		} // end of class ArrowFunction_L8C19
@@ -137,7 +112,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2733
+					// Method begins at RVA 0x26fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -161,7 +136,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26c0
+				// Method begins at RVA 0x2688
 				// Header size: 12
 				// Code size: 76 (0x4c)
 				.maxstack 8
@@ -210,7 +185,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2721
+				// Method begins at RVA 0x26e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -336,7 +311,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x273c
+				// Method begins at RVA 0x2704
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -364,7 +339,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2757
+						// Method begins at RVA 0x271f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -382,7 +357,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x274e
+					// Method begins at RVA 0x2716
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -400,7 +375,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2745
+				// Method begins at RVA 0x270d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -426,7 +401,7 @@
 			)
 			// Method begins at RVA 0x21ec
 			// Header size: 12
-			// Code size: 995 (0x3e3)
+			// Code size: 977 (0x3d1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope,
@@ -535,340 +510,334 @@
 
 			IL_00bf: ldloc.0
 			IL_00c0: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00c5: switch (IL_00de, IL_0242, IL_02f0, IL_01ae, IL_02e4)
+			IL_00c5: switch (IL_00de, IL_0230, IL_02de, IL_019c, IL_02d2)
 
 			IL_00de: ldarg.0
 			IL_00df: ldc.i4.1
 			IL_00e0: ldelem.ref
 			IL_00e1: castclass Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope
 			IL_00e6: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope::iterable
-			IL_00eb: stloc.s 9
-			IL_00ed: ldstr "iterable"
-			IL_00f2: ldloc.s 9
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00f9: stloc.s 9
-			IL_00fb: ldloc.s 9
-			IL_00fd: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-			IL_0102: stloc.1
-			IL_0103: ldc.i4.0
-			IL_0104: stloc.2
-			IL_0105: ldc.i4.0
-			IL_0106: stloc.3
-			IL_0107: ldloc.0
-			IL_0108: ldc.i4.0
-			IL_0109: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_010e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0113: ldloc.0
-			IL_0114: ldc.i4.0
-			IL_0115: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_011a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_011f: ldloc.0
-			IL_0120: ldc.i4.0
-			IL_0121: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0126: ldloc.0
-			IL_0127: ldc.i4.0
-			IL_0128: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_00eb: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+			IL_00f0: stloc.1
+			IL_00f1: ldc.i4.0
+			IL_00f2: stloc.2
+			IL_00f3: ldc.i4.0
+			IL_00f4: stloc.3
+			IL_00f5: ldloc.0
+			IL_00f6: ldc.i4.0
+			IL_00f7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00fc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0101: ldloc.0
+			IL_0102: ldc.i4.0
+			IL_0103: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0108: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_010d: ldloc.0
+			IL_010e: ldc.i4.0
+			IL_010f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0114: ldloc.0
+			IL_0115: ldc.i4.0
+			IL_0116: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-			IL_012d: ldloc.1
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-			IL_0133: stloc.s 9
-			IL_0135: ldloc.0
-			IL_0136: ldc.i4.3
-			IL_0137: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_013c: ldloc.0
-			IL_013d: ldloc.s 9
-			IL_013f: ldarg.0
-			IL_0140: ldc.i4.1
-			IL_0141: ldloc.0
-			IL_0142: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0147: ldc.i4.1
-			IL_0148: ldstr "_pendingException"
-			IL_014d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0152: ldloc.0
-			IL_0153: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0158: dup
-			IL_0159: ldc.i4.0
-			IL_015a: ldloc.1
+			IL_011b: ldloc.1
+			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+			IL_0121: stloc.s 9
+			IL_0123: ldloc.0
+			IL_0124: ldc.i4.3
+			IL_0125: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_012a: ldloc.0
+			IL_012b: ldloc.s 9
+			IL_012d: ldarg.0
+			IL_012e: ldc.i4.1
+			IL_012f: ldloc.0
+			IL_0130: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0135: ldc.i4.1
+			IL_0136: ldstr "_pendingException"
+			IL_013b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0140: ldloc.0
+			IL_0141: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0146: dup
+			IL_0147: ldc.i4.0
+			IL_0148: ldloc.1
+			IL_0149: stelem.ref
+			IL_014a: dup
+			IL_014b: ldc.i4.1
+			IL_014c: ldloc.2
+			IL_014d: box [System.Runtime]System.Boolean
+			IL_0152: stelem.ref
+			IL_0153: dup
+			IL_0154: ldc.i4.2
+			IL_0155: ldloc.3
+			IL_0156: box [System.Runtime]System.Boolean
 			IL_015b: stelem.ref
 			IL_015c: dup
-			IL_015d: ldc.i4.1
-			IL_015e: ldloc.2
-			IL_015f: box [System.Runtime]System.Boolean
-			IL_0164: stelem.ref
-			IL_0165: dup
-			IL_0166: ldc.i4.2
-			IL_0167: ldloc.3
-			IL_0168: box [System.Runtime]System.Boolean
-			IL_016d: stelem.ref
-			IL_016e: dup
-			IL_016f: ldc.i4.3
-			IL_0170: ldloc.s 4
-			IL_0172: stelem.ref
-			IL_0173: dup
-			IL_0174: ldc.i4.4
-			IL_0175: ldloc.s 5
-			IL_0177: stelem.ref
-			IL_0178: dup
-			IL_0179: ldc.i4.5
-			IL_017a: ldloc.s 6
-			IL_017c: stelem.ref
-			IL_017d: dup
-			IL_017e: ldc.i4.6
-			IL_017f: ldloc.s 7
-			IL_0181: box [System.Runtime]System.Boolean
-			IL_0186: stelem.ref
-			IL_0187: dup
-			IL_0188: ldc.i4.7
-			IL_0189: ldloc.s 8
-			IL_018b: box [System.Runtime]System.Boolean
-			IL_0190: stelem.ref
-			IL_0191: dup
-			IL_0192: ldc.i4.8
-			IL_0193: ldloc.s 9
-			IL_0195: stelem.ref
-			IL_0196: dup
-			IL_0197: ldc.i4.s 9
-			IL_0199: ldloc.s 10
-			IL_019b: box [System.Runtime]System.Boolean
-			IL_01a0: stelem.ref
-			IL_01a1: pop
-			IL_01a2: ldloc.0
-			IL_01a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01a8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01ad: ret
+			IL_015d: ldc.i4.3
+			IL_015e: ldloc.s 4
+			IL_0160: stelem.ref
+			IL_0161: dup
+			IL_0162: ldc.i4.4
+			IL_0163: ldloc.s 5
+			IL_0165: stelem.ref
+			IL_0166: dup
+			IL_0167: ldc.i4.5
+			IL_0168: ldloc.s 6
+			IL_016a: stelem.ref
+			IL_016b: dup
+			IL_016c: ldc.i4.6
+			IL_016d: ldloc.s 7
+			IL_016f: box [System.Runtime]System.Boolean
+			IL_0174: stelem.ref
+			IL_0175: dup
+			IL_0176: ldc.i4.7
+			IL_0177: ldloc.s 8
+			IL_0179: box [System.Runtime]System.Boolean
+			IL_017e: stelem.ref
+			IL_017f: dup
+			IL_0180: ldc.i4.8
+			IL_0181: ldloc.s 9
+			IL_0183: stelem.ref
+			IL_0184: dup
+			IL_0185: ldc.i4.s 9
+			IL_0187: ldloc.s 10
+			IL_0189: box [System.Runtime]System.Boolean
+			IL_018e: stelem.ref
+			IL_018f: pop
+			IL_0190: ldloc.0
+			IL_0191: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0196: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_019b: ret
 
-			IL_01ae: ldloc.0
-			IL_01af: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope::_awaited1
-			IL_01b4: stloc.s 9
-			IL_01b6: ldloc.s 9
-			IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_01bd: stloc.s 10
-			IL_01bf: ldloc.s 10
-			IL_01c1: brtrue IL_023b
+			IL_019c: ldloc.0
+			IL_019d: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope::_awaited1
+			IL_01a2: stloc.s 9
+			IL_01a4: ldloc.s 9
+			IL_01a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_01ab: stloc.s 10
+			IL_01ad: ldloc.s 10
+			IL_01af: brtrue IL_0229
 
-			IL_01c6: ldloc.s 9
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_01cd: stloc.s 9
-			IL_01cf: ldloc.s 9
-			IL_01d1: stloc.s 4
-			IL_01d3: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope_ForOf_L18C15/Block_L18C36::.ctor()
-			IL_01d8: stloc.s 5
-			IL_01da: ldstr "console"
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01e4: stloc.s 9
-			IL_01e6: ldloc.s 9
-			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ed: stloc.s 9
-			IL_01ef: ldloc.s 9
-			IL_01f1: ldstr "log"
-			IL_01f6: ldstr "x:"
-			IL_01fb: ldloc.s 4
-			IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0202: pop
-			IL_0203: ldloc.s 4
-			IL_0205: stloc.s 9
-			IL_0207: ldloc.s 9
-			IL_0209: ldc.r8 1
-			IL_0212: box [System.Runtime]System.Double
-			IL_0217: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_021c: stloc.s 10
-			IL_021e: ldloc.s 10
-			IL_0220: brfalse IL_0231
+			IL_01b4: ldloc.s 9
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_01bb: stloc.s 9
+			IL_01bd: ldloc.s 9
+			IL_01bf: stloc.s 4
+			IL_01c1: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope_ForOf_L18C15/Block_L18C36::.ctor()
+			IL_01c6: stloc.s 5
+			IL_01c8: ldstr "console"
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01d2: stloc.s 9
+			IL_01d4: ldloc.s 9
+			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01db: stloc.s 9
+			IL_01dd: ldloc.s 9
+			IL_01df: ldstr "log"
+			IL_01e4: ldstr "x:"
+			IL_01e9: ldloc.s 4
+			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01f0: pop
+			IL_01f1: ldloc.s 4
+			IL_01f3: stloc.s 9
+			IL_01f5: ldloc.s 9
+			IL_01f7: ldc.r8 1
+			IL_0200: box [System.Runtime]System.Double
+			IL_0205: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_020a: stloc.s 10
+			IL_020c: ldloc.s 10
+			IL_020e: brfalse IL_021f
 
-			IL_0225: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope_ForOf_L18C15/Block_L18C36/Block_L20C21::.ctor()
-			IL_022a: stloc.s 6
-			IL_022c: br IL_0236
+			IL_0213: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope_ForOf_L18C15/Block_L18C36/Block_L20C21::.ctor()
+			IL_0218: stloc.s 6
+			IL_021a: br IL_0224
 
-			IL_0231: br IL_012d
+			IL_021f: br IL_011b
 
-			IL_0236: br IL_0255
+			IL_0224: br IL_0243
 
-			IL_023b: ldc.i4.1
-			IL_023c: stloc.2
-			IL_023d: br IL_0255
+			IL_0229: ldc.i4.1
+			IL_022a: stloc.2
+			IL_022b: br IL_0243
 
-			IL_0242: ldloc.0
-			IL_0243: ldc.i4.1
-			IL_0244: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0249: ldloc.0
-			IL_024a: ldc.i4.0
-			IL_024b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0250: br IL_0255
+			IL_0230: ldloc.0
+			IL_0231: ldc.i4.1
+			IL_0232: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0237: ldloc.0
+			IL_0238: ldc.i4.0
+			IL_0239: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_023e: br IL_0243
 
-			IL_0255: ldloc.2
-			IL_0256: brtrue IL_02eb
+			IL_0243: ldloc.2
+			IL_0244: brtrue IL_02d9
 
-			IL_025b: ldloc.3
-			IL_025c: brtrue IL_02eb
+			IL_0249: ldloc.3
+			IL_024a: brtrue IL_02d9
 
-			IL_0261: ldc.i4.1
-			IL_0262: stloc.3
-			IL_0263: ldloc.1
-			IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-			IL_0269: stloc.s 9
-			IL_026b: ldloc.0
-			IL_026c: ldc.i4.4
-			IL_026d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0272: ldloc.0
-			IL_0273: ldloc.s 9
-			IL_0275: ldarg.0
-			IL_0276: ldc.i4.2
-			IL_0277: ldloc.0
-			IL_0278: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_027d: ldc.i4.2
-			IL_027e: ldstr "_pendingException"
-			IL_0283: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0288: ldloc.0
-			IL_0289: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_028e: dup
-			IL_028f: ldc.i4.0
-			IL_0290: ldloc.1
+			IL_024f: ldc.i4.1
+			IL_0250: stloc.3
+			IL_0251: ldloc.1
+			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+			IL_0257: stloc.s 9
+			IL_0259: ldloc.0
+			IL_025a: ldc.i4.4
+			IL_025b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0260: ldloc.0
+			IL_0261: ldloc.s 9
+			IL_0263: ldarg.0
+			IL_0264: ldc.i4.2
+			IL_0265: ldloc.0
+			IL_0266: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_026b: ldc.i4.2
+			IL_026c: ldstr "_pendingException"
+			IL_0271: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0276: ldloc.0
+			IL_0277: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_027c: dup
+			IL_027d: ldc.i4.0
+			IL_027e: ldloc.1
+			IL_027f: stelem.ref
+			IL_0280: dup
+			IL_0281: ldc.i4.1
+			IL_0282: ldloc.2
+			IL_0283: box [System.Runtime]System.Boolean
+			IL_0288: stelem.ref
+			IL_0289: dup
+			IL_028a: ldc.i4.2
+			IL_028b: ldloc.3
+			IL_028c: box [System.Runtime]System.Boolean
 			IL_0291: stelem.ref
 			IL_0292: dup
-			IL_0293: ldc.i4.1
-			IL_0294: ldloc.2
-			IL_0295: box [System.Runtime]System.Boolean
-			IL_029a: stelem.ref
-			IL_029b: dup
-			IL_029c: ldc.i4.2
-			IL_029d: ldloc.3
-			IL_029e: box [System.Runtime]System.Boolean
-			IL_02a3: stelem.ref
-			IL_02a4: dup
-			IL_02a5: ldc.i4.3
-			IL_02a6: ldloc.s 4
-			IL_02a8: stelem.ref
-			IL_02a9: dup
-			IL_02aa: ldc.i4.4
-			IL_02ab: ldloc.s 5
-			IL_02ad: stelem.ref
-			IL_02ae: dup
-			IL_02af: ldc.i4.5
-			IL_02b0: ldloc.s 6
-			IL_02b2: stelem.ref
-			IL_02b3: dup
-			IL_02b4: ldc.i4.6
-			IL_02b5: ldloc.s 7
-			IL_02b7: box [System.Runtime]System.Boolean
-			IL_02bc: stelem.ref
-			IL_02bd: dup
-			IL_02be: ldc.i4.7
-			IL_02bf: ldloc.s 8
-			IL_02c1: box [System.Runtime]System.Boolean
-			IL_02c6: stelem.ref
-			IL_02c7: dup
-			IL_02c8: ldc.i4.8
-			IL_02c9: ldloc.s 9
-			IL_02cb: stelem.ref
-			IL_02cc: dup
-			IL_02cd: ldc.i4.s 9
-			IL_02cf: ldloc.s 10
-			IL_02d1: box [System.Runtime]System.Boolean
-			IL_02d6: stelem.ref
-			IL_02d7: pop
-			IL_02d8: ldloc.0
-			IL_02d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02de: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02e3: ret
+			IL_0293: ldc.i4.3
+			IL_0294: ldloc.s 4
+			IL_0296: stelem.ref
+			IL_0297: dup
+			IL_0298: ldc.i4.4
+			IL_0299: ldloc.s 5
+			IL_029b: stelem.ref
+			IL_029c: dup
+			IL_029d: ldc.i4.5
+			IL_029e: ldloc.s 6
+			IL_02a0: stelem.ref
+			IL_02a1: dup
+			IL_02a2: ldc.i4.6
+			IL_02a3: ldloc.s 7
+			IL_02a5: box [System.Runtime]System.Boolean
+			IL_02aa: stelem.ref
+			IL_02ab: dup
+			IL_02ac: ldc.i4.7
+			IL_02ad: ldloc.s 8
+			IL_02af: box [System.Runtime]System.Boolean
+			IL_02b4: stelem.ref
+			IL_02b5: dup
+			IL_02b6: ldc.i4.8
+			IL_02b7: ldloc.s 9
+			IL_02b9: stelem.ref
+			IL_02ba: dup
+			IL_02bb: ldc.i4.s 9
+			IL_02bd: ldloc.s 10
+			IL_02bf: box [System.Runtime]System.Boolean
+			IL_02c4: stelem.ref
+			IL_02c5: pop
+			IL_02c6: ldloc.0
+			IL_02c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02cc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02d1: ret
 
-			IL_02e4: ldloc.0
-			IL_02e5: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope::_awaited2
-			IL_02ea: pop
+			IL_02d2: ldloc.0
+			IL_02d3: ldfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/Scope::_awaited2
+			IL_02d8: pop
 
-			IL_02eb: br IL_0303
+			IL_02d9: br IL_02f1
 
-			IL_02f0: ldloc.0
-			IL_02f1: ldc.i4.1
-			IL_02f2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02f7: ldloc.0
-			IL_02f8: ldc.i4.0
-			IL_02f9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02fe: br IL_0303
+			IL_02de: ldloc.0
+			IL_02df: ldc.i4.1
+			IL_02e0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02e5: ldloc.0
+			IL_02e6: ldc.i4.0
+			IL_02e7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02ec: br IL_02f1
 
-			IL_0303: ldloc.0
-			IL_0304: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0309: stloc.s 7
-			IL_030b: ldloc.s 7
-			IL_030d: brfalse IL_034a
+			IL_02f1: ldloc.0
+			IL_02f2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02f7: stloc.s 7
+			IL_02f9: ldloc.s 7
+			IL_02fb: brfalse IL_0338
 
-			IL_0312: ldloc.0
-			IL_0313: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0318: stloc.s 9
-			IL_031a: ldloc.0
-			IL_031b: ldc.i4.m1
-			IL_031c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0321: ldloc.0
-			IL_0322: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0327: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_032c: ldarg.0
-			IL_032d: ldc.i4.1
-			IL_032e: newarr [System.Runtime]System.Object
-			IL_0333: dup
-			IL_0334: ldc.i4.0
-			IL_0335: ldloc.s 9
-			IL_0337: stelem.ref
-			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_033d: pop
-			IL_033e: ldloc.0
-			IL_033f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0344: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0349: ret
+			IL_0300: ldloc.0
+			IL_0301: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0306: stloc.s 9
+			IL_0308: ldloc.0
+			IL_0309: ldc.i4.m1
+			IL_030a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_030f: ldloc.0
+			IL_0310: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0315: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_031a: ldarg.0
+			IL_031b: ldc.i4.1
+			IL_031c: newarr [System.Runtime]System.Object
+			IL_0321: dup
+			IL_0322: ldc.i4.0
+			IL_0323: ldloc.s 9
+			IL_0325: stelem.ref
+			IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_032b: pop
+			IL_032c: ldloc.0
+			IL_032d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0332: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0337: ret
 
-			IL_034a: ldloc.0
-			IL_034b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0350: stloc.s 8
-			IL_0352: ldloc.s 8
-			IL_0354: brfalse IL_0391
+			IL_0338: ldloc.0
+			IL_0339: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_033e: stloc.s 8
+			IL_0340: ldloc.s 8
+			IL_0342: brfalse IL_037f
 
-			IL_0359: ldloc.0
-			IL_035a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_035f: stloc.s 9
-			IL_0361: ldloc.0
-			IL_0362: ldc.i4.m1
-			IL_0363: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0368: ldloc.0
-			IL_0369: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_036e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0373: ldarg.0
-			IL_0374: ldc.i4.1
-			IL_0375: newarr [System.Runtime]System.Object
-			IL_037a: dup
-			IL_037b: ldc.i4.0
-			IL_037c: ldloc.s 9
-			IL_037e: stelem.ref
-			IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0384: pop
-			IL_0385: ldloc.0
-			IL_0386: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_038b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0390: ret
+			IL_0347: ldloc.0
+			IL_0348: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_034d: stloc.s 9
+			IL_034f: ldloc.0
+			IL_0350: ldc.i4.m1
+			IL_0351: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0356: ldloc.0
+			IL_0357: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_035c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0361: ldarg.0
+			IL_0362: ldc.i4.1
+			IL_0363: newarr [System.Runtime]System.Object
+			IL_0368: dup
+			IL_0369: ldc.i4.0
+			IL_036a: ldloc.s 9
+			IL_036c: stelem.ref
+			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0372: pop
+			IL_0373: ldloc.0
+			IL_0374: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0379: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_037e: ret
 
-			IL_0391: ldstr "console"
-			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_039b: stloc.s 9
-			IL_039d: ldloc.s 9
-			IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03a4: stloc.s 9
-			IL_03a6: ldloc.s 9
-			IL_03a8: ldstr "log"
-			IL_03ad: ldstr "after"
-			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03b7: pop
-			IL_03b8: ldloc.0
-			IL_03b9: ldc.i4.m1
-			IL_03ba: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03bf: ldloc.0
-			IL_03c0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_03ca: ldarg.0
-			IL_03cb: ldc.i4.1
-			IL_03cc: newarr [System.Runtime]System.Object
-			IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03d6: pop
-			IL_03d7: ldloc.0
-			IL_03d8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03dd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03e2: ret
+			IL_037f: ldstr "console"
+			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0389: stloc.s 9
+			IL_038b: ldloc.s 9
+			IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0392: stloc.s 9
+			IL_0394: ldloc.s 9
+			IL_0396: ldstr "log"
+			IL_039b: ldstr "after"
+			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03a5: pop
+			IL_03a6: ldloc.0
+			IL_03a7: ldc.i4.m1
+			IL_03a8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03ad: ldloc.0
+			IL_03ae: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_03b8: ldarg.0
+			IL_03b9: ldc.i4.1
+			IL_03ba: newarr [System.Runtime]System.Object
+			IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03c4: pop
+			IL_03c5: ldloc.0
+			IL_03c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03cb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03d0: ret
 		} // end of method test::__js_call__
 
 	} // end of class test
@@ -884,7 +853,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2760
+				// Method begins at RVA 0x2728
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -907,7 +876,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25dc
+			// Method begins at RVA 0x25cc
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -948,7 +917,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2718
+			// Method begins at RVA 0x26e0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1080,7 +1049,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2769
+		// Method begins at RVA 0x2731
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x270f
+					// Method begins at RVA 0x26d3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,17 +46,14 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2610
+				// Method begins at RVA 0x2600
 				// Header size: 12
-				// Code size: 157 (0x9d)
+				// Code size: 115 (0x73)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] float64,
-					[2] object,
-					[3] object,
-					[4] bool,
-					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+					[0] float64,
+					[1] object,
+					[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
 				IL_0000: ldarg.0
@@ -64,61 +61,39 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/Scope
 				IL_0008: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/Scope::i
-				IL_000d: stloc.0
-				IL_000e: ldstr "i"
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: stloc.0
 				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: stloc.2
-				IL_0028: ldloc.2
-				IL_0029: stloc.0
-				IL_002a: ldloc.1
-				IL_002b: ldc.r8 1
-				IL_0034: add
-				IL_0035: stloc.1
-				IL_0036: ldloc.1
-				IL_0037: box [System.Runtime]System.Double
-				IL_003c: stloc.2
-				IL_003d: ldarg.0
-				IL_003e: ldc.i4.1
-				IL_003f: ldelem.ref
-				IL_0040: castclass Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/Scope
-				IL_0045: ldloc.2
-				IL_0046: stfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/Scope::i
-				IL_004b: ldarg.0
-				IL_004c: ldc.i4.1
-				IL_004d: ldelem.ref
-				IL_004e: castclass Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/Scope
-				IL_0053: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/Scope::i
-				IL_0058: stloc.3
-				IL_0059: ldstr "i"
-				IL_005e: ldloc.3
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0064: stloc.3
-				IL_0065: ldloc.3
-				IL_0066: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_006b: stloc.1
-				IL_006c: ldloc.1
-				IL_006d: ldc.r8 3
-				IL_0076: cgt
-				IL_0078: stloc.s 4
-				IL_007a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_007f: dup
-				IL_0080: ldstr "value"
-				IL_0085: ldloc.0
-				IL_0086: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_008b: dup
-				IL_008c: ldstr "done"
-				IL_0091: ldloc.s 4
-				IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0098: stloc.s 5
-				IL_009a: ldloc.s 5
-				IL_009c: ret
+				IL_0014: box [System.Runtime]System.Double
+				IL_0019: stloc.1
+				IL_001a: ldarg.0
+				IL_001b: ldc.i4.1
+				IL_001c: ldelem.ref
+				IL_001d: castclass Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/Scope
+				IL_0022: ldloc.0
+				IL_0023: ldc.r8 1
+				IL_002c: add
+				IL_002d: box [System.Runtime]System.Double
+				IL_0032: stfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/Scope::i
+				IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_003c: dup
+				IL_003d: ldstr "value"
+				IL_0042: ldloc.1
+				IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0048: dup
+				IL_0049: ldstr "done"
+				IL_004e: ldarg.0
+				IL_004f: ldc.i4.1
+				IL_0050: ldelem.ref
+				IL_0051: castclass Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/Scope
+				IL_0056: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/Scope::i
+				IL_005b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0060: ldc.r8 3
+				IL_0069: cgt
+				IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0070: stloc.2
+				IL_0071: ldloc.2
+				IL_0072: ret
 			} // end of method ArrowFunction_L9C19::__js_call__
 
 		} // end of class ArrowFunction_L9C19
@@ -134,7 +109,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2718
+					// Method begins at RVA 0x26dc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -158,7 +133,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26bc
+				// Method begins at RVA 0x2680
 				// Header size: 12
 				// Code size: 53 (0x35)
 				.maxstack 8
@@ -200,7 +175,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2706
+				// Method begins at RVA 0x26ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -326,7 +301,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2721
+				// Method begins at RVA 0x26e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -354,7 +329,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x273c
+						// Method begins at RVA 0x2700
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -372,7 +347,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2733
+					// Method begins at RVA 0x26f7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -390,7 +365,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x272a
+				// Method begins at RVA 0x26ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -416,7 +391,7 @@
 			)
 			// Method begins at RVA 0x21ec
 			// Header size: 12
-			// Code size: 995 (0x3e3)
+			// Code size: 977 (0x3d1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope,
@@ -525,340 +500,334 @@
 
 			IL_00bf: ldloc.0
 			IL_00c0: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00c5: switch (IL_00de, IL_0242, IL_02f0, IL_01ae, IL_02e4)
+			IL_00c5: switch (IL_00de, IL_0230, IL_02de, IL_019c, IL_02d2)
 
 			IL_00de: ldarg.0
 			IL_00df: ldc.i4.1
 			IL_00e0: ldelem.ref
 			IL_00e1: castclass Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope
 			IL_00e6: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope::iterable
-			IL_00eb: stloc.s 9
-			IL_00ed: ldstr "iterable"
-			IL_00f2: ldloc.s 9
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00f9: stloc.s 9
-			IL_00fb: ldloc.s 9
-			IL_00fd: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-			IL_0102: stloc.1
-			IL_0103: ldc.i4.0
-			IL_0104: stloc.2
-			IL_0105: ldc.i4.0
-			IL_0106: stloc.3
-			IL_0107: ldloc.0
-			IL_0108: ldc.i4.0
-			IL_0109: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_010e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0113: ldloc.0
-			IL_0114: ldc.i4.0
-			IL_0115: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_011a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_011f: ldloc.0
-			IL_0120: ldc.i4.0
-			IL_0121: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0126: ldloc.0
-			IL_0127: ldc.i4.0
-			IL_0128: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_00eb: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+			IL_00f0: stloc.1
+			IL_00f1: ldc.i4.0
+			IL_00f2: stloc.2
+			IL_00f3: ldc.i4.0
+			IL_00f4: stloc.3
+			IL_00f5: ldloc.0
+			IL_00f6: ldc.i4.0
+			IL_00f7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00fc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0101: ldloc.0
+			IL_0102: ldc.i4.0
+			IL_0103: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0108: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_010d: ldloc.0
+			IL_010e: ldc.i4.0
+			IL_010f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0114: ldloc.0
+			IL_0115: ldc.i4.0
+			IL_0116: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-			IL_012d: ldloc.1
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-			IL_0133: stloc.s 9
-			IL_0135: ldloc.0
-			IL_0136: ldc.i4.3
-			IL_0137: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_013c: ldloc.0
-			IL_013d: ldloc.s 9
-			IL_013f: ldarg.0
-			IL_0140: ldc.i4.1
-			IL_0141: ldloc.0
-			IL_0142: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0147: ldc.i4.1
-			IL_0148: ldstr "_pendingException"
-			IL_014d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0152: ldloc.0
-			IL_0153: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0158: dup
-			IL_0159: ldc.i4.0
-			IL_015a: ldloc.1
+			IL_011b: ldloc.1
+			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+			IL_0121: stloc.s 9
+			IL_0123: ldloc.0
+			IL_0124: ldc.i4.3
+			IL_0125: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_012a: ldloc.0
+			IL_012b: ldloc.s 9
+			IL_012d: ldarg.0
+			IL_012e: ldc.i4.1
+			IL_012f: ldloc.0
+			IL_0130: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0135: ldc.i4.1
+			IL_0136: ldstr "_pendingException"
+			IL_013b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0140: ldloc.0
+			IL_0141: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0146: dup
+			IL_0147: ldc.i4.0
+			IL_0148: ldloc.1
+			IL_0149: stelem.ref
+			IL_014a: dup
+			IL_014b: ldc.i4.1
+			IL_014c: ldloc.2
+			IL_014d: box [System.Runtime]System.Boolean
+			IL_0152: stelem.ref
+			IL_0153: dup
+			IL_0154: ldc.i4.2
+			IL_0155: ldloc.3
+			IL_0156: box [System.Runtime]System.Boolean
 			IL_015b: stelem.ref
 			IL_015c: dup
-			IL_015d: ldc.i4.1
-			IL_015e: ldloc.2
-			IL_015f: box [System.Runtime]System.Boolean
-			IL_0164: stelem.ref
-			IL_0165: dup
-			IL_0166: ldc.i4.2
-			IL_0167: ldloc.3
-			IL_0168: box [System.Runtime]System.Boolean
-			IL_016d: stelem.ref
-			IL_016e: dup
-			IL_016f: ldc.i4.3
-			IL_0170: ldloc.s 4
-			IL_0172: stelem.ref
-			IL_0173: dup
-			IL_0174: ldc.i4.4
-			IL_0175: ldloc.s 5
-			IL_0177: stelem.ref
-			IL_0178: dup
-			IL_0179: ldc.i4.5
-			IL_017a: ldloc.s 6
-			IL_017c: stelem.ref
-			IL_017d: dup
-			IL_017e: ldc.i4.6
-			IL_017f: ldloc.s 7
-			IL_0181: box [System.Runtime]System.Boolean
-			IL_0186: stelem.ref
-			IL_0187: dup
-			IL_0188: ldc.i4.7
-			IL_0189: ldloc.s 8
-			IL_018b: box [System.Runtime]System.Boolean
-			IL_0190: stelem.ref
-			IL_0191: dup
-			IL_0192: ldc.i4.8
-			IL_0193: ldloc.s 9
-			IL_0195: stelem.ref
-			IL_0196: dup
-			IL_0197: ldc.i4.s 9
-			IL_0199: ldloc.s 10
-			IL_019b: box [System.Runtime]System.Boolean
-			IL_01a0: stelem.ref
-			IL_01a1: pop
-			IL_01a2: ldloc.0
-			IL_01a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01a8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01ad: ret
+			IL_015d: ldc.i4.3
+			IL_015e: ldloc.s 4
+			IL_0160: stelem.ref
+			IL_0161: dup
+			IL_0162: ldc.i4.4
+			IL_0163: ldloc.s 5
+			IL_0165: stelem.ref
+			IL_0166: dup
+			IL_0167: ldc.i4.5
+			IL_0168: ldloc.s 6
+			IL_016a: stelem.ref
+			IL_016b: dup
+			IL_016c: ldc.i4.6
+			IL_016d: ldloc.s 7
+			IL_016f: box [System.Runtime]System.Boolean
+			IL_0174: stelem.ref
+			IL_0175: dup
+			IL_0176: ldc.i4.7
+			IL_0177: ldloc.s 8
+			IL_0179: box [System.Runtime]System.Boolean
+			IL_017e: stelem.ref
+			IL_017f: dup
+			IL_0180: ldc.i4.8
+			IL_0181: ldloc.s 9
+			IL_0183: stelem.ref
+			IL_0184: dup
+			IL_0185: ldc.i4.s 9
+			IL_0187: ldloc.s 10
+			IL_0189: box [System.Runtime]System.Boolean
+			IL_018e: stelem.ref
+			IL_018f: pop
+			IL_0190: ldloc.0
+			IL_0191: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0196: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_019b: ret
 
-			IL_01ae: ldloc.0
-			IL_01af: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope::_awaited1
-			IL_01b4: stloc.s 9
-			IL_01b6: ldloc.s 9
-			IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_01bd: stloc.s 10
-			IL_01bf: ldloc.s 10
-			IL_01c1: brtrue IL_023b
+			IL_019c: ldloc.0
+			IL_019d: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope::_awaited1
+			IL_01a2: stloc.s 9
+			IL_01a4: ldloc.s 9
+			IL_01a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_01ab: stloc.s 10
+			IL_01ad: ldloc.s 10
+			IL_01af: brtrue IL_0229
 
-			IL_01c6: ldloc.s 9
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_01cd: stloc.s 9
-			IL_01cf: ldloc.s 9
-			IL_01d1: stloc.s 4
-			IL_01d3: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope_ForOf_L19C15/Block_L19C36::.ctor()
-			IL_01d8: stloc.s 5
-			IL_01da: ldstr "console"
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01e4: stloc.s 9
-			IL_01e6: ldloc.s 9
-			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ed: stloc.s 9
-			IL_01ef: ldloc.s 9
-			IL_01f1: ldstr "log"
-			IL_01f6: ldstr "x:"
-			IL_01fb: ldloc.s 4
-			IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0202: pop
-			IL_0203: ldloc.s 4
-			IL_0205: stloc.s 9
-			IL_0207: ldloc.s 9
-			IL_0209: ldc.r8 1
-			IL_0212: box [System.Runtime]System.Double
-			IL_0217: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_021c: stloc.s 10
-			IL_021e: ldloc.s 10
-			IL_0220: brfalse IL_0231
+			IL_01b4: ldloc.s 9
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_01bb: stloc.s 9
+			IL_01bd: ldloc.s 9
+			IL_01bf: stloc.s 4
+			IL_01c1: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope_ForOf_L19C15/Block_L19C36::.ctor()
+			IL_01c6: stloc.s 5
+			IL_01c8: ldstr "console"
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01d2: stloc.s 9
+			IL_01d4: ldloc.s 9
+			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01db: stloc.s 9
+			IL_01dd: ldloc.s 9
+			IL_01df: ldstr "log"
+			IL_01e4: ldstr "x:"
+			IL_01e9: ldloc.s 4
+			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01f0: pop
+			IL_01f1: ldloc.s 4
+			IL_01f3: stloc.s 9
+			IL_01f5: ldloc.s 9
+			IL_01f7: ldc.r8 1
+			IL_0200: box [System.Runtime]System.Double
+			IL_0205: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_020a: stloc.s 10
+			IL_020c: ldloc.s 10
+			IL_020e: brfalse IL_021f
 
-			IL_0225: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope_ForOf_L19C15/Block_L19C36/Block_L21C21::.ctor()
-			IL_022a: stloc.s 6
-			IL_022c: br IL_0236
+			IL_0213: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope_ForOf_L19C15/Block_L19C36/Block_L21C21::.ctor()
+			IL_0218: stloc.s 6
+			IL_021a: br IL_0224
 
-			IL_0231: br IL_012d
+			IL_021f: br IL_011b
 
-			IL_0236: br IL_0255
+			IL_0224: br IL_0243
 
-			IL_023b: ldc.i4.1
-			IL_023c: stloc.2
-			IL_023d: br IL_0255
+			IL_0229: ldc.i4.1
+			IL_022a: stloc.2
+			IL_022b: br IL_0243
 
-			IL_0242: ldloc.0
-			IL_0243: ldc.i4.1
-			IL_0244: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0249: ldloc.0
-			IL_024a: ldc.i4.0
-			IL_024b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0250: br IL_0255
+			IL_0230: ldloc.0
+			IL_0231: ldc.i4.1
+			IL_0232: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0237: ldloc.0
+			IL_0238: ldc.i4.0
+			IL_0239: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_023e: br IL_0243
 
-			IL_0255: ldloc.2
-			IL_0256: brtrue IL_02eb
+			IL_0243: ldloc.2
+			IL_0244: brtrue IL_02d9
 
-			IL_025b: ldloc.3
-			IL_025c: brtrue IL_02eb
+			IL_0249: ldloc.3
+			IL_024a: brtrue IL_02d9
 
-			IL_0261: ldc.i4.1
-			IL_0262: stloc.3
-			IL_0263: ldloc.1
-			IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-			IL_0269: stloc.s 9
-			IL_026b: ldloc.0
-			IL_026c: ldc.i4.4
-			IL_026d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0272: ldloc.0
-			IL_0273: ldloc.s 9
-			IL_0275: ldarg.0
-			IL_0276: ldc.i4.2
-			IL_0277: ldloc.0
-			IL_0278: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_027d: ldc.i4.2
-			IL_027e: ldstr "_pendingException"
-			IL_0283: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0288: ldloc.0
-			IL_0289: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_028e: dup
-			IL_028f: ldc.i4.0
-			IL_0290: ldloc.1
+			IL_024f: ldc.i4.1
+			IL_0250: stloc.3
+			IL_0251: ldloc.1
+			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+			IL_0257: stloc.s 9
+			IL_0259: ldloc.0
+			IL_025a: ldc.i4.4
+			IL_025b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0260: ldloc.0
+			IL_0261: ldloc.s 9
+			IL_0263: ldarg.0
+			IL_0264: ldc.i4.2
+			IL_0265: ldloc.0
+			IL_0266: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_026b: ldc.i4.2
+			IL_026c: ldstr "_pendingException"
+			IL_0271: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0276: ldloc.0
+			IL_0277: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_027c: dup
+			IL_027d: ldc.i4.0
+			IL_027e: ldloc.1
+			IL_027f: stelem.ref
+			IL_0280: dup
+			IL_0281: ldc.i4.1
+			IL_0282: ldloc.2
+			IL_0283: box [System.Runtime]System.Boolean
+			IL_0288: stelem.ref
+			IL_0289: dup
+			IL_028a: ldc.i4.2
+			IL_028b: ldloc.3
+			IL_028c: box [System.Runtime]System.Boolean
 			IL_0291: stelem.ref
 			IL_0292: dup
-			IL_0293: ldc.i4.1
-			IL_0294: ldloc.2
-			IL_0295: box [System.Runtime]System.Boolean
-			IL_029a: stelem.ref
-			IL_029b: dup
-			IL_029c: ldc.i4.2
-			IL_029d: ldloc.3
-			IL_029e: box [System.Runtime]System.Boolean
-			IL_02a3: stelem.ref
-			IL_02a4: dup
-			IL_02a5: ldc.i4.3
-			IL_02a6: ldloc.s 4
-			IL_02a8: stelem.ref
-			IL_02a9: dup
-			IL_02aa: ldc.i4.4
-			IL_02ab: ldloc.s 5
-			IL_02ad: stelem.ref
-			IL_02ae: dup
-			IL_02af: ldc.i4.5
-			IL_02b0: ldloc.s 6
-			IL_02b2: stelem.ref
-			IL_02b3: dup
-			IL_02b4: ldc.i4.6
-			IL_02b5: ldloc.s 7
-			IL_02b7: box [System.Runtime]System.Boolean
-			IL_02bc: stelem.ref
-			IL_02bd: dup
-			IL_02be: ldc.i4.7
-			IL_02bf: ldloc.s 8
-			IL_02c1: box [System.Runtime]System.Boolean
-			IL_02c6: stelem.ref
-			IL_02c7: dup
-			IL_02c8: ldc.i4.8
-			IL_02c9: ldloc.s 9
-			IL_02cb: stelem.ref
-			IL_02cc: dup
-			IL_02cd: ldc.i4.s 9
-			IL_02cf: ldloc.s 10
-			IL_02d1: box [System.Runtime]System.Boolean
-			IL_02d6: stelem.ref
-			IL_02d7: pop
-			IL_02d8: ldloc.0
-			IL_02d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02de: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02e3: ret
+			IL_0293: ldc.i4.3
+			IL_0294: ldloc.s 4
+			IL_0296: stelem.ref
+			IL_0297: dup
+			IL_0298: ldc.i4.4
+			IL_0299: ldloc.s 5
+			IL_029b: stelem.ref
+			IL_029c: dup
+			IL_029d: ldc.i4.5
+			IL_029e: ldloc.s 6
+			IL_02a0: stelem.ref
+			IL_02a1: dup
+			IL_02a2: ldc.i4.6
+			IL_02a3: ldloc.s 7
+			IL_02a5: box [System.Runtime]System.Boolean
+			IL_02aa: stelem.ref
+			IL_02ab: dup
+			IL_02ac: ldc.i4.7
+			IL_02ad: ldloc.s 8
+			IL_02af: box [System.Runtime]System.Boolean
+			IL_02b4: stelem.ref
+			IL_02b5: dup
+			IL_02b6: ldc.i4.8
+			IL_02b7: ldloc.s 9
+			IL_02b9: stelem.ref
+			IL_02ba: dup
+			IL_02bb: ldc.i4.s 9
+			IL_02bd: ldloc.s 10
+			IL_02bf: box [System.Runtime]System.Boolean
+			IL_02c4: stelem.ref
+			IL_02c5: pop
+			IL_02c6: ldloc.0
+			IL_02c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02cc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02d1: ret
 
-			IL_02e4: ldloc.0
-			IL_02e5: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope::_awaited2
-			IL_02ea: pop
+			IL_02d2: ldloc.0
+			IL_02d3: ldfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/Scope::_awaited2
+			IL_02d8: pop
 
-			IL_02eb: br IL_0303
+			IL_02d9: br IL_02f1
 
-			IL_02f0: ldloc.0
-			IL_02f1: ldc.i4.1
-			IL_02f2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02f7: ldloc.0
-			IL_02f8: ldc.i4.0
-			IL_02f9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02fe: br IL_0303
+			IL_02de: ldloc.0
+			IL_02df: ldc.i4.1
+			IL_02e0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02e5: ldloc.0
+			IL_02e6: ldc.i4.0
+			IL_02e7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02ec: br IL_02f1
 
-			IL_0303: ldloc.0
-			IL_0304: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0309: stloc.s 7
-			IL_030b: ldloc.s 7
-			IL_030d: brfalse IL_034a
+			IL_02f1: ldloc.0
+			IL_02f2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02f7: stloc.s 7
+			IL_02f9: ldloc.s 7
+			IL_02fb: brfalse IL_0338
 
-			IL_0312: ldloc.0
-			IL_0313: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0318: stloc.s 9
-			IL_031a: ldloc.0
-			IL_031b: ldc.i4.m1
-			IL_031c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0321: ldloc.0
-			IL_0322: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0327: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_032c: ldarg.0
-			IL_032d: ldc.i4.1
-			IL_032e: newarr [System.Runtime]System.Object
-			IL_0333: dup
-			IL_0334: ldc.i4.0
-			IL_0335: ldloc.s 9
-			IL_0337: stelem.ref
-			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_033d: pop
-			IL_033e: ldloc.0
-			IL_033f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0344: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0349: ret
+			IL_0300: ldloc.0
+			IL_0301: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0306: stloc.s 9
+			IL_0308: ldloc.0
+			IL_0309: ldc.i4.m1
+			IL_030a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_030f: ldloc.0
+			IL_0310: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0315: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_031a: ldarg.0
+			IL_031b: ldc.i4.1
+			IL_031c: newarr [System.Runtime]System.Object
+			IL_0321: dup
+			IL_0322: ldc.i4.0
+			IL_0323: ldloc.s 9
+			IL_0325: stelem.ref
+			IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_032b: pop
+			IL_032c: ldloc.0
+			IL_032d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0332: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0337: ret
 
-			IL_034a: ldloc.0
-			IL_034b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0350: stloc.s 8
-			IL_0352: ldloc.s 8
-			IL_0354: brfalse IL_0391
+			IL_0338: ldloc.0
+			IL_0339: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_033e: stloc.s 8
+			IL_0340: ldloc.s 8
+			IL_0342: brfalse IL_037f
 
-			IL_0359: ldloc.0
-			IL_035a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_035f: stloc.s 9
-			IL_0361: ldloc.0
-			IL_0362: ldc.i4.m1
-			IL_0363: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0368: ldloc.0
-			IL_0369: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_036e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0373: ldarg.0
-			IL_0374: ldc.i4.1
-			IL_0375: newarr [System.Runtime]System.Object
-			IL_037a: dup
-			IL_037b: ldc.i4.0
-			IL_037c: ldloc.s 9
-			IL_037e: stelem.ref
-			IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0384: pop
-			IL_0385: ldloc.0
-			IL_0386: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_038b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0390: ret
+			IL_0347: ldloc.0
+			IL_0348: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_034d: stloc.s 9
+			IL_034f: ldloc.0
+			IL_0350: ldc.i4.m1
+			IL_0351: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0356: ldloc.0
+			IL_0357: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_035c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0361: ldarg.0
+			IL_0362: ldc.i4.1
+			IL_0363: newarr [System.Runtime]System.Object
+			IL_0368: dup
+			IL_0369: ldc.i4.0
+			IL_036a: ldloc.s 9
+			IL_036c: stelem.ref
+			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0372: pop
+			IL_0373: ldloc.0
+			IL_0374: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0379: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_037e: ret
 
-			IL_0391: ldstr "console"
-			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_039b: stloc.s 9
-			IL_039d: ldloc.s 9
-			IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03a4: stloc.s 9
-			IL_03a6: ldloc.s 9
-			IL_03a8: ldstr "log"
-			IL_03ad: ldstr "after"
-			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03b7: pop
-			IL_03b8: ldloc.0
-			IL_03b9: ldc.i4.m1
-			IL_03ba: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03bf: ldloc.0
-			IL_03c0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_03ca: ldarg.0
-			IL_03cb: ldc.i4.1
-			IL_03cc: newarr [System.Runtime]System.Object
-			IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03d6: pop
-			IL_03d7: ldloc.0
-			IL_03d8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03dd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03e2: ret
+			IL_037f: ldstr "console"
+			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0389: stloc.s 9
+			IL_038b: ldloc.s 9
+			IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0392: stloc.s 9
+			IL_0394: ldloc.s 9
+			IL_0396: ldstr "log"
+			IL_039b: ldstr "after"
+			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03a5: pop
+			IL_03a6: ldloc.0
+			IL_03a7: ldc.i4.m1
+			IL_03a8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03ad: ldloc.0
+			IL_03ae: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_03b8: ldarg.0
+			IL_03b9: ldc.i4.1
+			IL_03ba: newarr [System.Runtime]System.Object
+			IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03c4: pop
+			IL_03c5: ldloc.0
+			IL_03c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03cb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03d0: ret
 		} // end of method test::__js_call__
 
 	} // end of class test
@@ -874,7 +843,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2745
+				// Method begins at RVA 0x2709
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -897,7 +866,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25dc
+			// Method begins at RVA 0x25cc
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -938,7 +907,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26fd
+			// Method begins at RVA 0x26c1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1070,7 +1039,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x274e
+		// Method begins at RVA 0x2712
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_PendingPromiseAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_PendingPromiseAwait.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x23f1
+						// Method begins at RVA 0x23e5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -52,7 +52,7 @@
 					)
 					// Method begins at RVA 0x235c
 					// Header size: 12
-					// Code size: 110 (0x6e)
+					// Code size: 98 (0x62)
 					.maxstack 8
 					.locals init (
 						[0] object,
@@ -76,39 +76,35 @@
 					IL_0026: castclass Modules.Async_PendingPromiseAwait/test/ArrowFunction_L9C38/Scope
 					IL_002b: ldfld object Modules.Async_PendingPromiseAwait/test/ArrowFunction_L9C38/Scope::resolve
 					IL_0030: stloc.0
-					IL_0031: ldstr "resolve"
-					IL_0036: ldloc.0
-					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_003c: stloc.0
-					IL_003d: ldc.i4.3
-					IL_003e: newarr [System.Runtime]System.Object
+					IL_0031: ldc.i4.3
+					IL_0032: newarr [System.Runtime]System.Object
+					IL_0037: dup
+					IL_0038: ldc.i4.0
+					IL_0039: ldarg.0
+					IL_003a: ldc.i4.0
+					IL_003b: ldelem.ref
+					IL_003c: stelem.ref
+					IL_003d: dup
+					IL_003e: ldc.i4.1
+					IL_003f: ldarg.0
+					IL_0040: ldc.i4.1
+					IL_0041: ldelem.ref
+					IL_0042: stelem.ref
 					IL_0043: dup
-					IL_0044: ldc.i4.0
+					IL_0044: ldc.i4.2
 					IL_0045: ldarg.0
-					IL_0046: ldc.i4.0
+					IL_0046: ldc.i4.2
 					IL_0047: ldelem.ref
 					IL_0048: stelem.ref
-					IL_0049: dup
-					IL_004a: ldc.i4.1
-					IL_004b: ldarg.0
-					IL_004c: ldc.i4.1
-					IL_004d: ldelem.ref
-					IL_004e: stelem.ref
-					IL_004f: dup
-					IL_0050: ldc.i4.2
-					IL_0051: ldarg.0
-					IL_0052: ldc.i4.2
-					IL_0053: ldelem.ref
-					IL_0054: stelem.ref
-					IL_0055: stloc.1
-					IL_0056: ldloc.0
-					IL_0057: ldloc.1
-					IL_0058: ldc.r8 42
-					IL_0061: box [System.Runtime]System.Double
-					IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_006b: pop
-					IL_006c: ldnull
-					IL_006d: ret
+					IL_0049: stloc.1
+					IL_004a: ldloc.0
+					IL_004b: ldloc.1
+					IL_004c: ldc.r8 42
+					IL_0055: box [System.Runtime]System.Double
+					IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_005f: pop
+					IL_0060: ldnull
+					IL_0061: ret
 				} // end of method ArrowFunction_L10C20::__js_call__
 
 			} // end of class ArrowFunction_L10C20
@@ -127,7 +123,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23e8
+					// Method begins at RVA 0x23dc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -227,7 +223,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23df
+				// Method begins at RVA 0x23d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -449,7 +445,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23fa
+				// Method begins at RVA 0x23ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -513,7 +509,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23d6
+			// Method begins at RVA 0x23ca
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -632,7 +628,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2403
+		// Method begins at RVA 0x23f7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x232d
+						// Method begins at RVA 0x231f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -52,7 +52,7 @@
 					)
 					// Method begins at RVA 0x22a8
 					// Header size: 12
-					// Code size: 94 (0x5e)
+					// Code size: 80 (0x50)
 					.maxstack 8
 					.locals init (
 						[0] object
@@ -74,36 +74,30 @@
 					IL_0025: ldelem.ref
 					IL_0026: castclass Modules.Async_RealSuspension_SetTimeout/run/ArrowFunction_L8C24/Scope
 					IL_002b: ldfld object Modules.Async_RealSuspension_SetTimeout/run/ArrowFunction_L8C24/Scope::resolve
-					IL_0030: stloc.0
-					IL_0031: ldstr "resolve"
-					IL_0036: ldloc.0
-					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_003c: stloc.0
-					IL_003d: ldloc.0
-					IL_003e: ldc.i4.3
-					IL_003f: newarr [System.Runtime]System.Object
-					IL_0044: dup
-					IL_0045: ldc.i4.0
-					IL_0046: ldarg.0
-					IL_0047: ldc.i4.0
-					IL_0048: ldelem.ref
-					IL_0049: stelem.ref
-					IL_004a: dup
-					IL_004b: ldc.i4.1
-					IL_004c: ldarg.0
-					IL_004d: ldc.i4.1
-					IL_004e: ldelem.ref
-					IL_004f: stelem.ref
-					IL_0050: dup
-					IL_0051: ldc.i4.2
-					IL_0052: ldarg.0
-					IL_0053: ldc.i4.2
-					IL_0054: ldelem.ref
-					IL_0055: stelem.ref
-					IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-					IL_005b: pop
-					IL_005c: ldnull
-					IL_005d: ret
+					IL_0030: ldc.i4.3
+					IL_0031: newarr [System.Runtime]System.Object
+					IL_0036: dup
+					IL_0037: ldc.i4.0
+					IL_0038: ldarg.0
+					IL_0039: ldc.i4.0
+					IL_003a: ldelem.ref
+					IL_003b: stelem.ref
+					IL_003c: dup
+					IL_003d: ldc.i4.1
+					IL_003e: ldarg.0
+					IL_003f: ldc.i4.1
+					IL_0040: ldelem.ref
+					IL_0041: stelem.ref
+					IL_0042: dup
+					IL_0043: ldc.i4.2
+					IL_0044: ldarg.0
+					IL_0045: ldc.i4.2
+					IL_0046: ldelem.ref
+					IL_0047: stelem.ref
+					IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+					IL_004d: pop
+					IL_004e: ldnull
+					IL_004f: ret
 				} // end of method ArrowFunction_L9C20::__js_call__
 
 			} // end of class ArrowFunction_L9C20
@@ -122,7 +116,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2324
+					// Method begins at RVA 0x2316
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -216,7 +210,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2336
+					// Method begins at RVA 0x2328
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -271,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x231b
+				// Method begins at RVA 0x230d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -391,7 +385,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x233f
+				// Method begins at RVA 0x2331
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -453,7 +447,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2312
+			// Method begins at RVA 0x2304
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -564,7 +558,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2348
+		// Method begins at RVA 0x233a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ForOfClosureCapture.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ForOfClosureCapture.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26b7
+				// Method begins at RVA 0x269e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,25 +43,16 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Method begins at RVA 0x2674
-			// Header size: 12
-			// Code size: 28 (0x1c)
+			// Header size: 1
+			// Code size: 14 (0xe)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldc.i4.1
 			IL_0002: ldelem.ref
 			IL_0003: castclass Modules.Async_TopLevelAwait_ForOfClosureCapture/Scope_ForOf_L3C5
 			IL_0008: ldfld object Modules.Async_TopLevelAwait_ForOfClosureCapture/Scope_ForOf_L3C5::'value'
-			IL_000d: stloc.0
-			IL_000e: ldstr "value"
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ret
+			IL_000d: ret
 		} // end of method ArrowFunction_L4C20::__js_call__
 
 	} // end of class ArrowFunction_L4C20
@@ -83,7 +74,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x269c
+			// Method begins at RVA 0x2683
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -112,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26ae
+				// Method begins at RVA 0x2695
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +124,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26a5
+			// Method begins at RVA 0x268c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -157,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26c9
+				// Method begins at RVA 0x26b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -175,7 +166,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26c0
+			// Method begins at RVA 0x26a7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -910,7 +901,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26d2
+		// Method begins at RVA 0x26b9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x353c
+					// Method begins at RVA 0x3408
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3533
+				// Method begins at RVA 0x33ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			)
 			// Method begins at RVA 0x246c
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/Scope/Block_L10C70,
@@ -94,53 +94,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/Scope/Block_L10C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/Scope/Block_L10C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -156,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3545
+				// Method begins at RVA 0x3411
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +172,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2528
+			// Method begins at RVA 0x2510
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -261,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x354e
+				// Method begins at RVA 0x341a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +278,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25b8
+			// Method begins at RVA 0x25a0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,7 +306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x357b
+					// Method begins at RVA 0x3447
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -338,26 +330,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b74
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2b4f
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L34C86::__js_call__
 
 		} // end of class FunctionExpression_L34C86
@@ -373,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3584
+					// Method begins at RVA 0x3450
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -397,26 +380,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b9c
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2b5e
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L35C93::__js_call__
 
 		} // end of class FunctionExpression_L35C93
@@ -436,7 +410,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35b1
+						// Method begins at RVA 0x347d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -460,41 +434,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2c68
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x2c05
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope
-					IL_0022: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope
+					IL_0015: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L45C86::__js_call__
 
 			} // end of class FunctionExpression_L45C86
@@ -512,7 +468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35a8
+					// Method begins at RVA 0x3474
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,9 +493,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bc4
+				// Method begins at RVA 0x2b70
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope,
@@ -560,61 +516,57 @@
 				IL_0010: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.0
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.0
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L44C9::__js_call__
 
 		} // end of class FunctionExpression_L44C9
@@ -634,7 +586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3560
+					// Method begins at RVA 0x342c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -654,7 +606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3569
+					// Method begins at RVA 0x3435
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -674,7 +626,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3572
+					// Method begins at RVA 0x343e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -698,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3596
+						// Method begins at RVA 0x3462
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -718,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x359f
+						// Method begins at RVA 0x346b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -736,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x358d
+					// Method begins at RVA 0x3459
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -756,7 +708,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35ba
+					// Method begins at RVA 0x3486
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35c3
+					// Method begins at RVA 0x348f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -798,7 +750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3557
+				// Method begins at RVA 0x3423
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -825,7 +777,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x25c4
+			// Method begins at RVA 0x25ac
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -1372,7 +1324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35cc
+				// Method begins at RVA 0x3498
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1400,9 +1352,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2b14
+			// Method begins at RVA 0x2afc
 			// Header size: 12
-			// Code size: 83 (0x53)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1416,29 +1368,25 @@
 			IL_000d: ldarg.0
 			IL_000e: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope::exports
 			IL_0013: stloc.0
-			IL_0014: ldstr "exports"
-			IL_0019: ldloc.0
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001f: stloc.0
-			IL_0020: ldloc.0
-			IL_0021: ldarg.2
-			IL_0022: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0027: dup
-			IL_0028: ldstr "enumerable"
+			IL_0028: ldstr "configurable"
 			IL_002d: ldc.i4.1
 			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0033: dup
-			IL_0034: ldstr "configurable"
-			IL_0039: ldc.i4.1
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003f: dup
-			IL_0040: ldstr "get"
-			IL_0045: ldarg.3
-			IL_0046: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0050: pop
-			IL_0051: ldnull
-			IL_0052: ret
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1464,7 +1412,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x352a
+			// Method begins at RVA 0x33f6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1850,7 +1798,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35de
+				// Method begins at RVA 0x34aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1876,23 +1824,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2b 00 00 02
 			)
-			// Method begins at RVA 0x2cb4
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x2c26
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope::run
-			IL_0006: stloc.0
-			IL_0007: ldstr "run"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L3C25::__js_call__
 
 	} // end of class FunctionExpression_L3C25
@@ -1908,7 +1847,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35e7
+				// Method begins at RVA 0x34b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1932,7 +1871,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cd5
+			// Method begins at RVA 0x2c2e
 			// Header size: 1
 			// Code size: 11 (0xb)
 			.maxstack 8
@@ -1959,7 +1898,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35f9
+					// Method begins at RVA 0x34c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1977,7 +1916,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35f0
+				// Method begins at RVA 0x34bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2003,9 +1942,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2b 00 00 02
 			)
-			// Method begins at RVA 0x2ce4
+			// Method begins at RVA 0x2c3c
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/Scope/Block_L10C70,
@@ -2031,53 +1970,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/Scope/Block_L10C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/Scope/Block_L10C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -2093,7 +2024,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3602
+				// Method begins at RVA 0x34ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2117,7 +2048,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2da0
+			// Method begins at RVA 0x2ce0
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2198,7 +2129,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x360b
+				// Method begins at RVA 0x34d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2223,7 +2154,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e30
+			// Method begins at RVA 0x2d70
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2251,7 +2182,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3638
+					// Method begins at RVA 0x3504
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2275,26 +2206,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33ec
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x331f
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L34C86::__js_call__
 
 		} // end of class FunctionExpression_L34C86
@@ -2310,7 +2232,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3641
+					// Method begins at RVA 0x350d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2334,26 +2256,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3414
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x332e
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L35C93::__js_call__
 
 		} // end of class FunctionExpression_L35C93
@@ -2373,7 +2286,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x366e
+						// Method begins at RVA 0x353a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2397,41 +2310,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x34e0
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x33d5
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope
-					IL_0022: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope
+					IL_0015: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L45C86::__js_call__
 
 			} // end of class FunctionExpression_L45C86
@@ -2449,7 +2344,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3665
+					// Method begins at RVA 0x3531
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2474,9 +2369,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x343c
+				// Method begins at RVA 0x3340
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope,
@@ -2497,61 +2392,57 @@
 				IL_0010: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.0
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.0
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L44C9::__js_call__
 
 		} // end of class FunctionExpression_L44C9
@@ -2571,7 +2462,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x361d
+					// Method begins at RVA 0x34e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2591,7 +2482,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3626
+					// Method begins at RVA 0x34f2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2611,7 +2502,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x362f
+					// Method begins at RVA 0x34fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2635,7 +2526,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3653
+						// Method begins at RVA 0x351f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2655,7 +2546,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x365c
+						// Method begins at RVA 0x3528
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2673,7 +2564,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x364a
+					// Method begins at RVA 0x3516
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2693,7 +2584,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3677
+					// Method begins at RVA 0x3543
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2713,7 +2604,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3680
+					// Method begins at RVA 0x354c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2735,7 +2626,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3614
+				// Method begins at RVA 0x34e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2762,7 +2653,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2b 00 00 02
 			)
-			// Method begins at RVA 0x2e3c
+			// Method begins at RVA 0x2d7c
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -3309,7 +3200,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3689
+				// Method begins at RVA 0x3555
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3337,9 +3228,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2b 00 00 02
 			)
-			// Method begins at RVA 0x338c
+			// Method begins at RVA 0x32cc
 			// Header size: 12
-			// Code size: 83 (0x53)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -3353,29 +3244,25 @@
 			IL_000d: ldarg.0
 			IL_000e: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope::exports
 			IL_0013: stloc.0
-			IL_0014: ldstr "exports"
-			IL_0019: ldloc.0
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001f: stloc.0
-			IL_0020: ldloc.0
-			IL_0021: ldarg.2
-			IL_0022: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0027: dup
-			IL_0028: ldstr "enumerable"
+			IL_0028: ldstr "configurable"
 			IL_002d: ldc.i4.1
 			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0033: dup
-			IL_0034: ldstr "configurable"
-			IL_0039: ldc.i4.1
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003f: dup
-			IL_0040: ldstr "get"
-			IL_0045: ldarg.3
-			IL_0046: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0050: pop
-			IL_0051: ldnull
-			IL_0052: ret
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3401,7 +3288,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x35d5
+			// Method begins at RVA 0x34a1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3588,7 +3475,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3692
+		// Method begins at RVA 0x355e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_PendingPromise.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_PendingPromise.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2383
+						// Method begins at RVA 0x2367
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -52,62 +52,49 @@
 					)
 					// Method begins at RVA 0x2304
 					// Header size: 12
-					// Code size: 88 (0x58)
+					// Code size: 60 (0x3c)
 					.maxstack 8
 					.locals init (
-						[0] object,
-						[1] object[],
-						[2] object
+						[0] object[],
+						[1] object
 					)
 
-					IL_0000: ldarg.0
-					IL_0001: ldc.i4.2
-					IL_0002: ldelem.ref
-					IL_0003: castclass Modules.Async_TopLevelAwait_PendingPromise/delay/ArrowFunction_L2C24/Scope
-					IL_0008: ldfld object Modules.Async_TopLevelAwait_PendingPromise/delay/ArrowFunction_L2C24/Scope::resolve
-					IL_000d: stloc.0
-					IL_000e: ldstr "resolve"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldc.i4.3
-					IL_001b: newarr [System.Runtime]System.Object
-					IL_0020: dup
-					IL_0021: ldc.i4.0
-					IL_0022: ldarg.0
-					IL_0023: ldc.i4.0
-					IL_0024: ldelem.ref
-					IL_0025: stelem.ref
-					IL_0026: dup
-					IL_0027: ldc.i4.1
-					IL_0028: ldarg.0
-					IL_0029: ldc.i4.1
-					IL_002a: ldelem.ref
-					IL_002b: stelem.ref
-					IL_002c: dup
-					IL_002d: ldc.i4.2
-					IL_002e: ldarg.0
-					IL_002f: ldc.i4.2
-					IL_0030: ldelem.ref
-					IL_0031: stelem.ref
-					IL_0032: stloc.1
-					IL_0033: ldarg.0
-					IL_0034: ldc.i4.1
-					IL_0035: ldelem.ref
-					IL_0036: castclass Modules.Async_TopLevelAwait_PendingPromise/delay/Scope
-					IL_003b: ldfld object Modules.Async_TopLevelAwait_PendingPromise/delay/Scope::'value'
-					IL_0040: stloc.2
-					IL_0041: ldstr "value"
-					IL_0046: ldloc.2
-					IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_004c: stloc.2
-					IL_004d: ldloc.0
-					IL_004e: ldloc.1
-					IL_004f: ldloc.2
-					IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0055: stloc.2
-					IL_0056: ldloc.2
-					IL_0057: ret
+					IL_0000: ldc.i4.3
+					IL_0001: newarr [System.Runtime]System.Object
+					IL_0006: dup
+					IL_0007: ldc.i4.0
+					IL_0008: ldarg.0
+					IL_0009: ldc.i4.0
+					IL_000a: ldelem.ref
+					IL_000b: stelem.ref
+					IL_000c: dup
+					IL_000d: ldc.i4.1
+					IL_000e: ldarg.0
+					IL_000f: ldc.i4.1
+					IL_0010: ldelem.ref
+					IL_0011: stelem.ref
+					IL_0012: dup
+					IL_0013: ldc.i4.2
+					IL_0014: ldarg.0
+					IL_0015: ldc.i4.2
+					IL_0016: ldelem.ref
+					IL_0017: stelem.ref
+					IL_0018: stloc.0
+					IL_0019: ldarg.0
+					IL_001a: ldc.i4.2
+					IL_001b: ldelem.ref
+					IL_001c: castclass Modules.Async_TopLevelAwait_PendingPromise/delay/ArrowFunction_L2C24/Scope
+					IL_0021: ldfld object Modules.Async_TopLevelAwait_PendingPromise/delay/ArrowFunction_L2C24/Scope::resolve
+					IL_0026: ldloc.0
+					IL_0027: ldarg.0
+					IL_0028: ldc.i4.1
+					IL_0029: ldelem.ref
+					IL_002a: castclass Modules.Async_TopLevelAwait_PendingPromise/delay/Scope
+					IL_002f: ldfld object Modules.Async_TopLevelAwait_PendingPromise/delay/Scope::'value'
+					IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0039: stloc.1
+					IL_003a: ldloc.1
+					IL_003b: ret
 				} // end of method ArrowFunction_L2C48::__js_call__
 
 			} // end of class ArrowFunction_L2C48
@@ -126,7 +113,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x237a
+					// Method begins at RVA 0x235e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -223,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2371
+				// Method begins at RVA 0x2355
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -313,7 +300,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2368
+			// Method begins at RVA 0x234c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -583,7 +570,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x238c
+		// Method begins at RVA 0x2370
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_BasicNext.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_BasicNext.verified.txt
@@ -33,7 +33,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2709
+				// Method begins at RVA 0x26f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -339,7 +339,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2712
+				// Method begins at RVA 0x2700
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -365,7 +365,7 @@
 			)
 			// Method begins at RVA 0x2358
 			// Header size: 12
-			// Code size: 924 (0x39c)
+			// Code size: 906 (0x38a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope,
@@ -453,319 +453,313 @@
 
 			IL_0090: ldloc.0
 			IL_0091: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0096: switch (IL_00ab, IL_0140, IL_021a, IL_02f4)
+			IL_0096: switch (IL_00ab, IL_012e, IL_0208, IL_02e2)
 
 			IL_00ab: ldarg.0
 			IL_00ac: ldc.i4.1
 			IL_00ad: ldelem.ref
 			IL_00ae: castclass Modules.AsyncGenerator_BasicNext/Scope
 			IL_00b3: ldfld object Modules.AsyncGenerator_BasicNext/Scope::g
-			IL_00b8: stloc.s 5
-			IL_00ba: ldstr "g"
-			IL_00bf: ldloc.s 5
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c6: stloc.s 5
-			IL_00c8: ldloc.s 5
-			IL_00ca: ldc.i4.1
-			IL_00cb: newarr [System.Runtime]System.Object
-			IL_00d0: dup
-			IL_00d1: ldc.i4.0
-			IL_00d2: ldarg.0
-			IL_00d3: ldc.i4.1
-			IL_00d4: ldelem.ref
-			IL_00d5: stelem.ref
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00db: stloc.s 5
-			IL_00dd: ldloc.s 5
-			IL_00df: stloc.1
-			IL_00e0: ldloc.1
-			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e6: stloc.s 5
-			IL_00e8: ldloc.s 5
-			IL_00ea: ldstr "next"
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00f4: stloc.s 5
-			IL_00f6: ldloc.0
-			IL_00f7: ldc.i4.1
-			IL_00f8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00fd: ldloc.0
-			IL_00fe: ldloc.s 5
-			IL_0100: ldarg.0
-			IL_0101: ldc.i4.1
-			IL_0102: ldloc.0
-			IL_0103: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0108: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_010d: ldloc.0
-			IL_010e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0113: dup
-			IL_0114: ldc.i4.0
-			IL_0115: ldloc.1
+			IL_00b8: ldc.i4.1
+			IL_00b9: newarr [System.Runtime]System.Object
+			IL_00be: dup
+			IL_00bf: ldc.i4.0
+			IL_00c0: ldarg.0
+			IL_00c1: ldc.i4.1
+			IL_00c2: ldelem.ref
+			IL_00c3: stelem.ref
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00c9: stloc.s 5
+			IL_00cb: ldloc.s 5
+			IL_00cd: stloc.1
+			IL_00ce: ldloc.1
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d4: stloc.s 5
+			IL_00d6: ldloc.s 5
+			IL_00d8: ldstr "next"
+			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00e2: stloc.s 5
+			IL_00e4: ldloc.0
+			IL_00e5: ldc.i4.1
+			IL_00e6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00eb: ldloc.0
+			IL_00ec: ldloc.s 5
+			IL_00ee: ldarg.0
+			IL_00ef: ldc.i4.1
+			IL_00f0: ldloc.0
+			IL_00f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00fb: ldloc.0
+			IL_00fc: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0101: dup
+			IL_0102: ldc.i4.0
+			IL_0103: ldloc.1
+			IL_0104: stelem.ref
+			IL_0105: dup
+			IL_0106: ldc.i4.1
+			IL_0107: ldloc.2
+			IL_0108: stelem.ref
+			IL_0109: dup
+			IL_010a: ldc.i4.2
+			IL_010b: ldloc.3
+			IL_010c: stelem.ref
+			IL_010d: dup
+			IL_010e: ldc.i4.3
+			IL_010f: ldloc.s 4
+			IL_0111: stelem.ref
+			IL_0112: dup
+			IL_0113: ldc.i4.4
+			IL_0114: ldloc.s 5
 			IL_0116: stelem.ref
 			IL_0117: dup
-			IL_0118: ldc.i4.1
-			IL_0119: ldloc.2
-			IL_011a: stelem.ref
-			IL_011b: dup
-			IL_011c: ldc.i4.2
-			IL_011d: ldloc.3
-			IL_011e: stelem.ref
-			IL_011f: dup
-			IL_0120: ldc.i4.3
-			IL_0121: ldloc.s 4
-			IL_0123: stelem.ref
-			IL_0124: dup
-			IL_0125: ldc.i4.4
-			IL_0126: ldloc.s 5
-			IL_0128: stelem.ref
-			IL_0129: dup
-			IL_012a: ldc.i4.5
-			IL_012b: ldloc.s 6
-			IL_012d: stelem.ref
-			IL_012e: dup
-			IL_012f: ldc.i4.6
-			IL_0130: ldloc.s 7
-			IL_0132: stelem.ref
-			IL_0133: pop
-			IL_0134: ldloc.0
-			IL_0135: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_013a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_013f: ret
+			IL_0118: ldc.i4.5
+			IL_0119: ldloc.s 6
+			IL_011b: stelem.ref
+			IL_011c: dup
+			IL_011d: ldc.i4.6
+			IL_011e: ldloc.s 7
+			IL_0120: stelem.ref
+			IL_0121: pop
+			IL_0122: ldloc.0
+			IL_0123: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0128: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_012d: ret
 
-			IL_0140: ldloc.0
-			IL_0141: ldfld object Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope::_awaited1
-			IL_0146: stloc.s 5
-			IL_0148: ldloc.s 5
-			IL_014a: stloc.2
-			IL_014b: ldstr "console"
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0155: stloc.s 5
-			IL_0157: ldloc.s 5
-			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_015e: stloc.s 5
-			IL_0160: ldloc.2
-			IL_0161: ldstr "value"
-			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_016b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0170: stloc.s 6
-			IL_0172: ldstr "v1: "
-			IL_0177: ldloc.s 6
-			IL_0179: call string [System.Runtime]System.String::Concat(string, string)
-			IL_017e: stloc.s 6
-			IL_0180: ldloc.s 6
-			IL_0182: ldstr " done: "
-			IL_0187: call string [System.Runtime]System.String::Concat(string, string)
-			IL_018c: stloc.s 6
-			IL_018e: ldloc.2
-			IL_018f: ldstr "done"
-			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0199: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_019e: stloc.s 7
-			IL_01a0: ldloc.s 6
-			IL_01a2: ldloc.s 7
-			IL_01a4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01a9: stloc.s 7
-			IL_01ab: ldloc.s 5
-			IL_01ad: ldstr "log"
-			IL_01b2: ldloc.s 7
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01b9: pop
-			IL_01ba: ldloc.1
-			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c0: stloc.s 5
-			IL_01c2: ldloc.s 5
-			IL_01c4: ldstr "next"
-			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01ce: stloc.s 5
-			IL_01d0: ldloc.0
-			IL_01d1: ldc.i4.2
-			IL_01d2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01d7: ldloc.0
-			IL_01d8: ldloc.s 5
-			IL_01da: ldarg.0
-			IL_01db: ldc.i4.2
-			IL_01dc: ldloc.0
-			IL_01dd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01e7: ldloc.0
-			IL_01e8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01ed: dup
-			IL_01ee: ldc.i4.0
-			IL_01ef: ldloc.1
+			IL_012e: ldloc.0
+			IL_012f: ldfld object Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope::_awaited1
+			IL_0134: stloc.s 5
+			IL_0136: ldloc.s 5
+			IL_0138: stloc.2
+			IL_0139: ldstr "console"
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0143: stloc.s 5
+			IL_0145: ldloc.s 5
+			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014c: stloc.s 5
+			IL_014e: ldloc.2
+			IL_014f: ldstr "value"
+			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0159: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_015e: stloc.s 6
+			IL_0160: ldstr "v1: "
+			IL_0165: ldloc.s 6
+			IL_0167: call string [System.Runtime]System.String::Concat(string, string)
+			IL_016c: stloc.s 6
+			IL_016e: ldloc.s 6
+			IL_0170: ldstr " done: "
+			IL_0175: call string [System.Runtime]System.String::Concat(string, string)
+			IL_017a: stloc.s 6
+			IL_017c: ldloc.2
+			IL_017d: ldstr "done"
+			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0187: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_018c: stloc.s 7
+			IL_018e: ldloc.s 6
+			IL_0190: ldloc.s 7
+			IL_0192: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0197: stloc.s 7
+			IL_0199: ldloc.s 5
+			IL_019b: ldstr "log"
+			IL_01a0: ldloc.s 7
+			IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01a7: pop
+			IL_01a8: ldloc.1
+			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ae: stloc.s 5
+			IL_01b0: ldloc.s 5
+			IL_01b2: ldstr "next"
+			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01bc: stloc.s 5
+			IL_01be: ldloc.0
+			IL_01bf: ldc.i4.2
+			IL_01c0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01c5: ldloc.0
+			IL_01c6: ldloc.s 5
+			IL_01c8: ldarg.0
+			IL_01c9: ldc.i4.2
+			IL_01ca: ldloc.0
+			IL_01cb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01d5: ldloc.0
+			IL_01d6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01db: dup
+			IL_01dc: ldc.i4.0
+			IL_01dd: ldloc.1
+			IL_01de: stelem.ref
+			IL_01df: dup
+			IL_01e0: ldc.i4.1
+			IL_01e1: ldloc.2
+			IL_01e2: stelem.ref
+			IL_01e3: dup
+			IL_01e4: ldc.i4.2
+			IL_01e5: ldloc.3
+			IL_01e6: stelem.ref
+			IL_01e7: dup
+			IL_01e8: ldc.i4.3
+			IL_01e9: ldloc.s 4
+			IL_01eb: stelem.ref
+			IL_01ec: dup
+			IL_01ed: ldc.i4.4
+			IL_01ee: ldloc.s 5
 			IL_01f0: stelem.ref
 			IL_01f1: dup
-			IL_01f2: ldc.i4.1
-			IL_01f3: ldloc.2
-			IL_01f4: stelem.ref
-			IL_01f5: dup
-			IL_01f6: ldc.i4.2
-			IL_01f7: ldloc.3
-			IL_01f8: stelem.ref
-			IL_01f9: dup
-			IL_01fa: ldc.i4.3
-			IL_01fb: ldloc.s 4
-			IL_01fd: stelem.ref
-			IL_01fe: dup
-			IL_01ff: ldc.i4.4
-			IL_0200: ldloc.s 5
-			IL_0202: stelem.ref
-			IL_0203: dup
-			IL_0204: ldc.i4.5
-			IL_0205: ldloc.s 6
-			IL_0207: stelem.ref
-			IL_0208: dup
-			IL_0209: ldc.i4.6
-			IL_020a: ldloc.s 7
-			IL_020c: stelem.ref
-			IL_020d: pop
-			IL_020e: ldloc.0
-			IL_020f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0214: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0219: ret
+			IL_01f2: ldc.i4.5
+			IL_01f3: ldloc.s 6
+			IL_01f5: stelem.ref
+			IL_01f6: dup
+			IL_01f7: ldc.i4.6
+			IL_01f8: ldloc.s 7
+			IL_01fa: stelem.ref
+			IL_01fb: pop
+			IL_01fc: ldloc.0
+			IL_01fd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0202: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0207: ret
 
-			IL_021a: ldloc.0
-			IL_021b: ldfld object Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope::_awaited2
-			IL_0220: stloc.s 5
-			IL_0222: ldloc.s 5
-			IL_0224: stloc.3
-			IL_0225: ldstr "console"
-			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_022f: stloc.s 5
-			IL_0231: ldloc.s 5
-			IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0238: stloc.s 5
-			IL_023a: ldloc.3
-			IL_023b: ldstr "value"
-			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0245: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_024a: stloc.s 7
-			IL_024c: ldstr "v2: "
-			IL_0251: ldloc.s 7
-			IL_0253: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0258: stloc.s 7
-			IL_025a: ldloc.s 7
-			IL_025c: ldstr " done: "
-			IL_0261: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0266: stloc.s 7
-			IL_0268: ldloc.3
-			IL_0269: ldstr "done"
-			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0273: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0278: stloc.s 6
-			IL_027a: ldloc.s 7
-			IL_027c: ldloc.s 6
-			IL_027e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0283: stloc.s 6
-			IL_0285: ldloc.s 5
-			IL_0287: ldstr "log"
-			IL_028c: ldloc.s 6
-			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0293: pop
-			IL_0294: ldloc.1
-			IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_029a: stloc.s 5
-			IL_029c: ldloc.s 5
-			IL_029e: ldstr "next"
-			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_02a8: stloc.s 5
-			IL_02aa: ldloc.0
-			IL_02ab: ldc.i4.3
-			IL_02ac: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02b1: ldloc.0
-			IL_02b2: ldloc.s 5
-			IL_02b4: ldarg.0
-			IL_02b5: ldc.i4.3
-			IL_02b6: ldloc.0
-			IL_02b7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02c1: ldloc.0
-			IL_02c2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02c7: dup
-			IL_02c8: ldc.i4.0
-			IL_02c9: ldloc.1
+			IL_0208: ldloc.0
+			IL_0209: ldfld object Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope::_awaited2
+			IL_020e: stloc.s 5
+			IL_0210: ldloc.s 5
+			IL_0212: stloc.3
+			IL_0213: ldstr "console"
+			IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_021d: stloc.s 5
+			IL_021f: ldloc.s 5
+			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0226: stloc.s 5
+			IL_0228: ldloc.3
+			IL_0229: ldstr "value"
+			IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0233: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0238: stloc.s 7
+			IL_023a: ldstr "v2: "
+			IL_023f: ldloc.s 7
+			IL_0241: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0246: stloc.s 7
+			IL_0248: ldloc.s 7
+			IL_024a: ldstr " done: "
+			IL_024f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0254: stloc.s 7
+			IL_0256: ldloc.3
+			IL_0257: ldstr "done"
+			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0261: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0266: stloc.s 6
+			IL_0268: ldloc.s 7
+			IL_026a: ldloc.s 6
+			IL_026c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0271: stloc.s 6
+			IL_0273: ldloc.s 5
+			IL_0275: ldstr "log"
+			IL_027a: ldloc.s 6
+			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0281: pop
+			IL_0282: ldloc.1
+			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0288: stloc.s 5
+			IL_028a: ldloc.s 5
+			IL_028c: ldstr "next"
+			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0296: stloc.s 5
+			IL_0298: ldloc.0
+			IL_0299: ldc.i4.3
+			IL_029a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_029f: ldloc.0
+			IL_02a0: ldloc.s 5
+			IL_02a2: ldarg.0
+			IL_02a3: ldc.i4.3
+			IL_02a4: ldloc.0
+			IL_02a5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02af: ldloc.0
+			IL_02b0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02b5: dup
+			IL_02b6: ldc.i4.0
+			IL_02b7: ldloc.1
+			IL_02b8: stelem.ref
+			IL_02b9: dup
+			IL_02ba: ldc.i4.1
+			IL_02bb: ldloc.2
+			IL_02bc: stelem.ref
+			IL_02bd: dup
+			IL_02be: ldc.i4.2
+			IL_02bf: ldloc.3
+			IL_02c0: stelem.ref
+			IL_02c1: dup
+			IL_02c2: ldc.i4.3
+			IL_02c3: ldloc.s 4
+			IL_02c5: stelem.ref
+			IL_02c6: dup
+			IL_02c7: ldc.i4.4
+			IL_02c8: ldloc.s 5
 			IL_02ca: stelem.ref
 			IL_02cb: dup
-			IL_02cc: ldc.i4.1
-			IL_02cd: ldloc.2
-			IL_02ce: stelem.ref
-			IL_02cf: dup
-			IL_02d0: ldc.i4.2
-			IL_02d1: ldloc.3
-			IL_02d2: stelem.ref
-			IL_02d3: dup
-			IL_02d4: ldc.i4.3
-			IL_02d5: ldloc.s 4
-			IL_02d7: stelem.ref
-			IL_02d8: dup
-			IL_02d9: ldc.i4.4
-			IL_02da: ldloc.s 5
-			IL_02dc: stelem.ref
-			IL_02dd: dup
-			IL_02de: ldc.i4.5
-			IL_02df: ldloc.s 6
-			IL_02e1: stelem.ref
-			IL_02e2: dup
-			IL_02e3: ldc.i4.6
-			IL_02e4: ldloc.s 7
-			IL_02e6: stelem.ref
-			IL_02e7: pop
-			IL_02e8: ldloc.0
-			IL_02e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02ee: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02f3: ret
+			IL_02cc: ldc.i4.5
+			IL_02cd: ldloc.s 6
+			IL_02cf: stelem.ref
+			IL_02d0: dup
+			IL_02d1: ldc.i4.6
+			IL_02d2: ldloc.s 7
+			IL_02d4: stelem.ref
+			IL_02d5: pop
+			IL_02d6: ldloc.0
+			IL_02d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02dc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02e1: ret
 
-			IL_02f4: ldloc.0
-			IL_02f5: ldfld object Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope::_awaited3
-			IL_02fa: stloc.s 5
-			IL_02fc: ldloc.s 5
-			IL_02fe: stloc.s 4
-			IL_0300: ldstr "console"
-			IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_030a: stloc.s 5
-			IL_030c: ldloc.s 5
-			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0313: stloc.s 5
-			IL_0315: ldloc.s 4
-			IL_0317: ldstr "value"
-			IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0321: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0326: stloc.s 6
-			IL_0328: ldstr "v3: "
-			IL_032d: ldloc.s 6
-			IL_032f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0334: stloc.s 6
-			IL_0336: ldloc.s 6
-			IL_0338: ldstr " done: "
-			IL_033d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0342: stloc.s 6
-			IL_0344: ldloc.s 4
-			IL_0346: ldstr "done"
-			IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0350: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0355: stloc.s 7
-			IL_0357: ldloc.s 6
-			IL_0359: ldloc.s 7
-			IL_035b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0360: stloc.s 7
-			IL_0362: ldloc.s 5
-			IL_0364: ldstr "log"
-			IL_0369: ldloc.s 7
-			IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0370: pop
-			IL_0371: ldloc.0
-			IL_0372: ldc.i4.m1
-			IL_0373: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0378: ldloc.0
-			IL_0379: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_037e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0383: ldarg.0
-			IL_0384: ldc.i4.1
-			IL_0385: newarr [System.Runtime]System.Object
-			IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_038f: pop
-			IL_0390: ldloc.0
-			IL_0391: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0396: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_039b: ret
+			IL_02e2: ldloc.0
+			IL_02e3: ldfld object Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope::_awaited3
+			IL_02e8: stloc.s 5
+			IL_02ea: ldloc.s 5
+			IL_02ec: stloc.s 4
+			IL_02ee: ldstr "console"
+			IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02f8: stloc.s 5
+			IL_02fa: ldloc.s 5
+			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0301: stloc.s 5
+			IL_0303: ldloc.s 4
+			IL_0305: ldstr "value"
+			IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_030f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0314: stloc.s 6
+			IL_0316: ldstr "v3: "
+			IL_031b: ldloc.s 6
+			IL_031d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0322: stloc.s 6
+			IL_0324: ldloc.s 6
+			IL_0326: ldstr " done: "
+			IL_032b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0330: stloc.s 6
+			IL_0332: ldloc.s 4
+			IL_0334: ldstr "done"
+			IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_033e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0343: stloc.s 7
+			IL_0345: ldloc.s 6
+			IL_0347: ldloc.s 7
+			IL_0349: call string [System.Runtime]System.String::Concat(string, string)
+			IL_034e: stloc.s 7
+			IL_0350: ldloc.s 5
+			IL_0352: ldstr "log"
+			IL_0357: ldloc.s 7
+			IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_035e: pop
+			IL_035f: ldloc.0
+			IL_0360: ldc.i4.m1
+			IL_0361: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0366: ldloc.0
+			IL_0367: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_036c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0371: ldarg.0
+			IL_0372: ldc.i4.1
+			IL_0373: newarr [System.Runtime]System.Object
+			IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_037d: pop
+			IL_037e: ldloc.0
+			IL_037f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0384: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0389: ret
 		} // end of method ArrowFunction_L9C2::__js_call__
 
 	} // end of class ArrowFunction_L9C2
@@ -783,7 +777,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2700
+			// Method begins at RVA 0x26ee
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -878,7 +872,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x271b
+		// Method begins at RVA 0x2709
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_ForAwaitOf.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_ForAwaitOf.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2793
+				// Method begins at RVA 0x2781
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -306,7 +306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x279c
+				// Method begins at RVA 0x278a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -330,7 +330,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27ae
+					// Method begins at RVA 0x279c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -348,7 +348,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27a5
+				// Method begins at RVA 0x2793
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -374,7 +374,7 @@
 			)
 			// Method begins at RVA 0x233c
 			// Header size: 12
-			// Code size: 1090 (0x442)
+			// Code size: 1072 (0x430)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope,
@@ -500,7 +500,7 @@
 
 			IL_00db: ldloc.0
 			IL_00dc: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00e1: switch (IL_00fa, IL_02af, IL_0376, IL_0201, IL_036a)
+			IL_00e1: switch (IL_00fa, IL_029d, IL_0364, IL_01ef, IL_0358)
 
 			IL_00fa: ldc.r8 0.0
 			IL_0103: stloc.1
@@ -509,369 +509,363 @@
 			IL_0106: ldelem.ref
 			IL_0107: castclass Modules.AsyncGenerator_ForAwaitOf/Scope
 			IL_010c: ldfld object Modules.AsyncGenerator_ForAwaitOf/Scope::g
-			IL_0111: stloc.s 9
-			IL_0113: ldstr "g"
-			IL_0118: ldloc.s 9
-			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_011f: stloc.s 9
-			IL_0121: ldloc.s 9
-			IL_0123: ldc.i4.1
-			IL_0124: newarr [System.Runtime]System.Object
-			IL_0129: dup
-			IL_012a: ldc.i4.0
-			IL_012b: ldarg.0
-			IL_012c: ldc.i4.1
-			IL_012d: ldelem.ref
-			IL_012e: stelem.ref
-			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0134: stloc.s 9
-			IL_0136: ldloc.s 9
-			IL_0138: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-			IL_013d: stloc.2
+			IL_0111: ldc.i4.1
+			IL_0112: newarr [System.Runtime]System.Object
+			IL_0117: dup
+			IL_0118: ldc.i4.0
+			IL_0119: ldarg.0
+			IL_011a: ldc.i4.1
+			IL_011b: ldelem.ref
+			IL_011c: stelem.ref
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0122: stloc.s 9
+			IL_0124: ldloc.s 9
+			IL_0126: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+			IL_012b: stloc.2
+			IL_012c: ldc.i4.0
+			IL_012d: stloc.3
+			IL_012e: ldc.i4.0
+			IL_012f: stloc.s 4
+			IL_0131: ldloc.0
+			IL_0132: ldc.i4.0
+			IL_0133: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0138: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_013d: ldloc.0
 			IL_013e: ldc.i4.0
-			IL_013f: stloc.3
-			IL_0140: ldc.i4.0
-			IL_0141: stloc.s 4
-			IL_0143: ldloc.0
-			IL_0144: ldc.i4.0
-			IL_0145: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_014a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_014f: ldloc.0
-			IL_0150: ldc.i4.0
-			IL_0151: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0156: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_015b: ldloc.0
-			IL_015c: ldc.i4.0
-			IL_015d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0162: ldloc.0
-			IL_0163: ldc.i4.0
-			IL_0164: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_013f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0144: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0149: ldloc.0
+			IL_014a: ldc.i4.0
+			IL_014b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0150: ldloc.0
+			IL_0151: ldc.i4.0
+			IL_0152: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-			IL_0169: ldloc.2
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-			IL_016f: stloc.s 9
-			IL_0171: ldloc.0
-			IL_0172: ldc.i4.3
-			IL_0173: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0178: ldloc.0
-			IL_0179: ldloc.s 9
-			IL_017b: ldarg.0
-			IL_017c: ldc.i4.1
-			IL_017d: ldloc.0
-			IL_017e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0183: ldc.i4.1
-			IL_0184: ldstr "_pendingException"
-			IL_0189: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_018e: ldloc.0
-			IL_018f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0194: dup
-			IL_0195: ldc.i4.0
-			IL_0196: ldloc.1
-			IL_0197: box [System.Runtime]System.Double
-			IL_019c: stelem.ref
-			IL_019d: dup
-			IL_019e: ldc.i4.1
-			IL_019f: ldloc.2
-			IL_01a0: stelem.ref
-			IL_01a1: dup
-			IL_01a2: ldc.i4.2
-			IL_01a3: ldloc.3
-			IL_01a4: box [System.Runtime]System.Boolean
-			IL_01a9: stelem.ref
-			IL_01aa: dup
-			IL_01ab: ldc.i4.3
-			IL_01ac: ldloc.s 4
-			IL_01ae: box [System.Runtime]System.Boolean
-			IL_01b3: stelem.ref
-			IL_01b4: dup
-			IL_01b5: ldc.i4.4
-			IL_01b6: ldloc.s 5
-			IL_01b8: stelem.ref
-			IL_01b9: dup
-			IL_01ba: ldc.i4.5
-			IL_01bb: ldloc.s 6
-			IL_01bd: stelem.ref
-			IL_01be: dup
-			IL_01bf: ldc.i4.6
-			IL_01c0: ldloc.s 7
-			IL_01c2: box [System.Runtime]System.Boolean
-			IL_01c7: stelem.ref
-			IL_01c8: dup
-			IL_01c9: ldc.i4.7
-			IL_01ca: ldloc.s 8
-			IL_01cc: box [System.Runtime]System.Boolean
-			IL_01d1: stelem.ref
-			IL_01d2: dup
-			IL_01d3: ldc.i4.8
-			IL_01d4: ldloc.s 9
-			IL_01d6: stelem.ref
-			IL_01d7: dup
-			IL_01d8: ldc.i4.s 9
-			IL_01da: ldloc.s 10
-			IL_01dc: box [System.Runtime]System.Boolean
+			IL_0157: ldloc.2
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+			IL_015d: stloc.s 9
+			IL_015f: ldloc.0
+			IL_0160: ldc.i4.3
+			IL_0161: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0166: ldloc.0
+			IL_0167: ldloc.s 9
+			IL_0169: ldarg.0
+			IL_016a: ldc.i4.1
+			IL_016b: ldloc.0
+			IL_016c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0171: ldc.i4.1
+			IL_0172: ldstr "_pendingException"
+			IL_0177: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_017c: ldloc.0
+			IL_017d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0182: dup
+			IL_0183: ldc.i4.0
+			IL_0184: ldloc.1
+			IL_0185: box [System.Runtime]System.Double
+			IL_018a: stelem.ref
+			IL_018b: dup
+			IL_018c: ldc.i4.1
+			IL_018d: ldloc.2
+			IL_018e: stelem.ref
+			IL_018f: dup
+			IL_0190: ldc.i4.2
+			IL_0191: ldloc.3
+			IL_0192: box [System.Runtime]System.Boolean
+			IL_0197: stelem.ref
+			IL_0198: dup
+			IL_0199: ldc.i4.3
+			IL_019a: ldloc.s 4
+			IL_019c: box [System.Runtime]System.Boolean
+			IL_01a1: stelem.ref
+			IL_01a2: dup
+			IL_01a3: ldc.i4.4
+			IL_01a4: ldloc.s 5
+			IL_01a6: stelem.ref
+			IL_01a7: dup
+			IL_01a8: ldc.i4.5
+			IL_01a9: ldloc.s 6
+			IL_01ab: stelem.ref
+			IL_01ac: dup
+			IL_01ad: ldc.i4.6
+			IL_01ae: ldloc.s 7
+			IL_01b0: box [System.Runtime]System.Boolean
+			IL_01b5: stelem.ref
+			IL_01b6: dup
+			IL_01b7: ldc.i4.7
+			IL_01b8: ldloc.s 8
+			IL_01ba: box [System.Runtime]System.Boolean
+			IL_01bf: stelem.ref
+			IL_01c0: dup
+			IL_01c1: ldc.i4.8
+			IL_01c2: ldloc.s 9
+			IL_01c4: stelem.ref
+			IL_01c5: dup
+			IL_01c6: ldc.i4.s 9
+			IL_01c8: ldloc.s 10
+			IL_01ca: box [System.Runtime]System.Boolean
+			IL_01cf: stelem.ref
+			IL_01d0: dup
+			IL_01d1: ldc.i4.s 10
+			IL_01d3: ldloc.s 11
+			IL_01d5: stelem.ref
+			IL_01d6: dup
+			IL_01d7: ldc.i4.s 11
+			IL_01d9: ldloc.s 12
+			IL_01db: stelem.ref
+			IL_01dc: dup
+			IL_01dd: ldc.i4.s 12
+			IL_01df: ldloc.s 13
 			IL_01e1: stelem.ref
-			IL_01e2: dup
-			IL_01e3: ldc.i4.s 10
-			IL_01e5: ldloc.s 11
-			IL_01e7: stelem.ref
-			IL_01e8: dup
-			IL_01e9: ldc.i4.s 11
-			IL_01eb: ldloc.s 12
-			IL_01ed: stelem.ref
-			IL_01ee: dup
-			IL_01ef: ldc.i4.s 12
-			IL_01f1: ldloc.s 13
-			IL_01f3: stelem.ref
-			IL_01f4: pop
-			IL_01f5: ldloc.0
-			IL_01f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01fb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0200: ret
+			IL_01e2: pop
+			IL_01e3: ldloc.0
+			IL_01e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01e9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01ee: ret
 
-			IL_0201: ldloc.0
-			IL_0202: ldfld object Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope::_awaited1
-			IL_0207: stloc.s 9
-			IL_0209: ldloc.s 9
-			IL_020b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_0210: stloc.s 10
-			IL_0212: ldloc.s 10
-			IL_0214: brtrue IL_02a8
+			IL_01ef: ldloc.0
+			IL_01f0: ldfld object Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope::_awaited1
+			IL_01f5: stloc.s 9
+			IL_01f7: ldloc.s 9
+			IL_01f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_01fe: stloc.s 10
+			IL_0200: ldloc.s 10
+			IL_0202: brtrue IL_0296
 
-			IL_0219: ldloc.s 9
-			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_0220: stloc.s 9
-			IL_0222: ldloc.s 9
-			IL_0224: stloc.s 5
-			IL_0226: newobj instance void Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope_ForOf_L10C13/Block_L10C29::.ctor()
-			IL_022b: stloc.s 6
-			IL_022d: ldstr "console"
-			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0237: stloc.s 9
-			IL_0239: ldloc.s 9
-			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0240: stloc.s 9
-			IL_0242: ldloc.1
-			IL_0243: ldc.r8 1
-			IL_024c: add
-			IL_024d: stloc.1
-			IL_024e: ldloc.1
-			IL_024f: box [System.Runtime]System.Double
-			IL_0254: stloc.s 11
-			IL_0256: ldloc.s 11
-			IL_0258: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_025d: stloc.s 12
-			IL_025f: ldstr "x"
-			IL_0264: ldloc.s 12
-			IL_0266: call string [System.Runtime]System.String::Concat(string, string)
-			IL_026b: stloc.s 12
-			IL_026d: ldloc.s 12
-			IL_026f: ldstr ": "
-			IL_0274: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0279: stloc.s 12
-			IL_027b: ldloc.s 5
-			IL_027d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0282: stloc.s 13
-			IL_0284: ldloc.s 12
-			IL_0286: ldloc.s 13
-			IL_0288: call string [System.Runtime]System.String::Concat(string, string)
-			IL_028d: stloc.s 13
-			IL_028f: ldloc.s 9
-			IL_0291: ldstr "log"
-			IL_0296: ldloc.s 13
-			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_029d: pop
-			IL_029e: br IL_0169
+			IL_0207: ldloc.s 9
+			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_020e: stloc.s 9
+			IL_0210: ldloc.s 9
+			IL_0212: stloc.s 5
+			IL_0214: newobj instance void Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope_ForOf_L10C13/Block_L10C29::.ctor()
+			IL_0219: stloc.s 6
+			IL_021b: ldstr "console"
+			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0225: stloc.s 9
+			IL_0227: ldloc.s 9
+			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_022e: stloc.s 9
+			IL_0230: ldloc.1
+			IL_0231: ldc.r8 1
+			IL_023a: add
+			IL_023b: stloc.1
+			IL_023c: ldloc.1
+			IL_023d: box [System.Runtime]System.Double
+			IL_0242: stloc.s 11
+			IL_0244: ldloc.s 11
+			IL_0246: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_024b: stloc.s 12
+			IL_024d: ldstr "x"
+			IL_0252: ldloc.s 12
+			IL_0254: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0259: stloc.s 12
+			IL_025b: ldloc.s 12
+			IL_025d: ldstr ": "
+			IL_0262: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0267: stloc.s 12
+			IL_0269: ldloc.s 5
+			IL_026b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0270: stloc.s 13
+			IL_0272: ldloc.s 12
+			IL_0274: ldloc.s 13
+			IL_0276: call string [System.Runtime]System.String::Concat(string, string)
+			IL_027b: stloc.s 13
+			IL_027d: ldloc.s 9
+			IL_027f: ldstr "log"
+			IL_0284: ldloc.s 13
+			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_028b: pop
+			IL_028c: br IL_0157
 
-			IL_02a3: br IL_02c2
+			IL_0291: br IL_02b0
 
-			IL_02a8: ldc.i4.1
-			IL_02a9: stloc.3
-			IL_02aa: br IL_02c2
+			IL_0296: ldc.i4.1
+			IL_0297: stloc.3
+			IL_0298: br IL_02b0
 
-			IL_02af: ldloc.0
-			IL_02b0: ldc.i4.1
-			IL_02b1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02b6: ldloc.0
-			IL_02b7: ldc.i4.0
-			IL_02b8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02bd: br IL_02c2
+			IL_029d: ldloc.0
+			IL_029e: ldc.i4.1
+			IL_029f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02a4: ldloc.0
+			IL_02a5: ldc.i4.0
+			IL_02a6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02ab: br IL_02b0
 
-			IL_02c2: ldloc.3
-			IL_02c3: brtrue IL_0371
+			IL_02b0: ldloc.3
+			IL_02b1: brtrue IL_035f
 
-			IL_02c8: ldloc.s 4
-			IL_02ca: brtrue IL_0371
+			IL_02b6: ldloc.s 4
+			IL_02b8: brtrue IL_035f
 
-			IL_02cf: ldc.i4.1
-			IL_02d0: stloc.s 4
-			IL_02d2: ldloc.2
-			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-			IL_02d8: stloc.s 9
-			IL_02da: ldloc.0
-			IL_02db: ldc.i4.4
-			IL_02dc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02e1: ldloc.0
-			IL_02e2: ldloc.s 9
-			IL_02e4: ldarg.0
-			IL_02e5: ldc.i4.2
-			IL_02e6: ldloc.0
-			IL_02e7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02ec: ldc.i4.2
-			IL_02ed: ldstr "_pendingException"
-			IL_02f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_02f7: ldloc.0
-			IL_02f8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02fd: dup
-			IL_02fe: ldc.i4.0
-			IL_02ff: ldloc.1
-			IL_0300: box [System.Runtime]System.Double
-			IL_0305: stelem.ref
-			IL_0306: dup
-			IL_0307: ldc.i4.1
-			IL_0308: ldloc.2
-			IL_0309: stelem.ref
-			IL_030a: dup
-			IL_030b: ldc.i4.2
-			IL_030c: ldloc.3
-			IL_030d: box [System.Runtime]System.Boolean
-			IL_0312: stelem.ref
-			IL_0313: dup
-			IL_0314: ldc.i4.3
-			IL_0315: ldloc.s 4
-			IL_0317: box [System.Runtime]System.Boolean
-			IL_031c: stelem.ref
-			IL_031d: dup
-			IL_031e: ldc.i4.4
-			IL_031f: ldloc.s 5
-			IL_0321: stelem.ref
-			IL_0322: dup
-			IL_0323: ldc.i4.5
-			IL_0324: ldloc.s 6
-			IL_0326: stelem.ref
-			IL_0327: dup
-			IL_0328: ldc.i4.6
-			IL_0329: ldloc.s 7
-			IL_032b: box [System.Runtime]System.Boolean
-			IL_0330: stelem.ref
-			IL_0331: dup
-			IL_0332: ldc.i4.7
-			IL_0333: ldloc.s 8
-			IL_0335: box [System.Runtime]System.Boolean
-			IL_033a: stelem.ref
-			IL_033b: dup
-			IL_033c: ldc.i4.8
-			IL_033d: ldloc.s 9
-			IL_033f: stelem.ref
-			IL_0340: dup
-			IL_0341: ldc.i4.s 9
-			IL_0343: ldloc.s 10
-			IL_0345: box [System.Runtime]System.Boolean
+			IL_02bd: ldc.i4.1
+			IL_02be: stloc.s 4
+			IL_02c0: ldloc.2
+			IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+			IL_02c6: stloc.s 9
+			IL_02c8: ldloc.0
+			IL_02c9: ldc.i4.4
+			IL_02ca: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02cf: ldloc.0
+			IL_02d0: ldloc.s 9
+			IL_02d2: ldarg.0
+			IL_02d3: ldc.i4.2
+			IL_02d4: ldloc.0
+			IL_02d5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02da: ldc.i4.2
+			IL_02db: ldstr "_pendingException"
+			IL_02e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_02e5: ldloc.0
+			IL_02e6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02eb: dup
+			IL_02ec: ldc.i4.0
+			IL_02ed: ldloc.1
+			IL_02ee: box [System.Runtime]System.Double
+			IL_02f3: stelem.ref
+			IL_02f4: dup
+			IL_02f5: ldc.i4.1
+			IL_02f6: ldloc.2
+			IL_02f7: stelem.ref
+			IL_02f8: dup
+			IL_02f9: ldc.i4.2
+			IL_02fa: ldloc.3
+			IL_02fb: box [System.Runtime]System.Boolean
+			IL_0300: stelem.ref
+			IL_0301: dup
+			IL_0302: ldc.i4.3
+			IL_0303: ldloc.s 4
+			IL_0305: box [System.Runtime]System.Boolean
+			IL_030a: stelem.ref
+			IL_030b: dup
+			IL_030c: ldc.i4.4
+			IL_030d: ldloc.s 5
+			IL_030f: stelem.ref
+			IL_0310: dup
+			IL_0311: ldc.i4.5
+			IL_0312: ldloc.s 6
+			IL_0314: stelem.ref
+			IL_0315: dup
+			IL_0316: ldc.i4.6
+			IL_0317: ldloc.s 7
+			IL_0319: box [System.Runtime]System.Boolean
+			IL_031e: stelem.ref
+			IL_031f: dup
+			IL_0320: ldc.i4.7
+			IL_0321: ldloc.s 8
+			IL_0323: box [System.Runtime]System.Boolean
+			IL_0328: stelem.ref
+			IL_0329: dup
+			IL_032a: ldc.i4.8
+			IL_032b: ldloc.s 9
+			IL_032d: stelem.ref
+			IL_032e: dup
+			IL_032f: ldc.i4.s 9
+			IL_0331: ldloc.s 10
+			IL_0333: box [System.Runtime]System.Boolean
+			IL_0338: stelem.ref
+			IL_0339: dup
+			IL_033a: ldc.i4.s 10
+			IL_033c: ldloc.s 11
+			IL_033e: stelem.ref
+			IL_033f: dup
+			IL_0340: ldc.i4.s 11
+			IL_0342: ldloc.s 12
+			IL_0344: stelem.ref
+			IL_0345: dup
+			IL_0346: ldc.i4.s 12
+			IL_0348: ldloc.s 13
 			IL_034a: stelem.ref
-			IL_034b: dup
-			IL_034c: ldc.i4.s 10
-			IL_034e: ldloc.s 11
-			IL_0350: stelem.ref
-			IL_0351: dup
-			IL_0352: ldc.i4.s 11
-			IL_0354: ldloc.s 12
-			IL_0356: stelem.ref
-			IL_0357: dup
-			IL_0358: ldc.i4.s 12
-			IL_035a: ldloc.s 13
-			IL_035c: stelem.ref
-			IL_035d: pop
-			IL_035e: ldloc.0
-			IL_035f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0364: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0369: ret
+			IL_034b: pop
+			IL_034c: ldloc.0
+			IL_034d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0352: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0357: ret
 
-			IL_036a: ldloc.0
-			IL_036b: ldfld object Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope::_awaited2
-			IL_0370: pop
+			IL_0358: ldloc.0
+			IL_0359: ldfld object Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope::_awaited2
+			IL_035e: pop
 
-			IL_0371: br IL_0389
+			IL_035f: br IL_0377
 
-			IL_0376: ldloc.0
-			IL_0377: ldc.i4.1
-			IL_0378: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_037d: ldloc.0
-			IL_037e: ldc.i4.0
-			IL_037f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0384: br IL_0389
+			IL_0364: ldloc.0
+			IL_0365: ldc.i4.1
+			IL_0366: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_036b: ldloc.0
+			IL_036c: ldc.i4.0
+			IL_036d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0372: br IL_0377
 
-			IL_0389: ldloc.0
-			IL_038a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_038f: stloc.s 7
-			IL_0391: ldloc.s 7
-			IL_0393: brfalse IL_03d0
+			IL_0377: ldloc.0
+			IL_0378: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_037d: stloc.s 7
+			IL_037f: ldloc.s 7
+			IL_0381: brfalse IL_03be
 
-			IL_0398: ldloc.0
-			IL_0399: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_039e: stloc.s 9
-			IL_03a0: ldloc.0
-			IL_03a1: ldc.i4.m1
-			IL_03a2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03a7: ldloc.0
-			IL_03a8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_03b2: ldarg.0
-			IL_03b3: ldc.i4.1
-			IL_03b4: newarr [System.Runtime]System.Object
-			IL_03b9: dup
-			IL_03ba: ldc.i4.0
-			IL_03bb: ldloc.s 9
-			IL_03bd: stelem.ref
-			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03c3: pop
-			IL_03c4: ldloc.0
-			IL_03c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03ca: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03cf: ret
+			IL_0386: ldloc.0
+			IL_0387: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_038c: stloc.s 9
+			IL_038e: ldloc.0
+			IL_038f: ldc.i4.m1
+			IL_0390: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0395: ldloc.0
+			IL_0396: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_039b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_03a0: ldarg.0
+			IL_03a1: ldc.i4.1
+			IL_03a2: newarr [System.Runtime]System.Object
+			IL_03a7: dup
+			IL_03a8: ldc.i4.0
+			IL_03a9: ldloc.s 9
+			IL_03ab: stelem.ref
+			IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03b1: pop
+			IL_03b2: ldloc.0
+			IL_03b3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03b8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03bd: ret
 
-			IL_03d0: ldloc.0
-			IL_03d1: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_03d6: stloc.s 8
-			IL_03d8: ldloc.s 8
-			IL_03da: brfalse IL_0417
+			IL_03be: ldloc.0
+			IL_03bf: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_03c4: stloc.s 8
+			IL_03c6: ldloc.s 8
+			IL_03c8: brfalse IL_0405
 
-			IL_03df: ldloc.0
-			IL_03e0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_03e5: stloc.s 9
-			IL_03e7: ldloc.0
-			IL_03e8: ldc.i4.m1
-			IL_03e9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03ee: ldloc.0
-			IL_03ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_03f9: ldarg.0
-			IL_03fa: ldc.i4.1
-			IL_03fb: newarr [System.Runtime]System.Object
-			IL_0400: dup
-			IL_0401: ldc.i4.0
-			IL_0402: ldloc.s 9
-			IL_0404: stelem.ref
-			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_040a: pop
-			IL_040b: ldloc.0
-			IL_040c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0411: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0416: ret
+			IL_03cd: ldloc.0
+			IL_03ce: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_03d3: stloc.s 9
+			IL_03d5: ldloc.0
+			IL_03d6: ldc.i4.m1
+			IL_03d7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03dc: ldloc.0
+			IL_03dd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_03e7: ldarg.0
+			IL_03e8: ldc.i4.1
+			IL_03e9: newarr [System.Runtime]System.Object
+			IL_03ee: dup
+			IL_03ef: ldc.i4.0
+			IL_03f0: ldloc.s 9
+			IL_03f2: stelem.ref
+			IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03f8: pop
+			IL_03f9: ldloc.0
+			IL_03fa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03ff: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0404: ret
 
-			IL_0417: ldloc.0
-			IL_0418: ldc.i4.m1
-			IL_0419: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_041e: ldloc.0
-			IL_041f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0424: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0429: ldarg.0
-			IL_042a: ldc.i4.1
-			IL_042b: newarr [System.Runtime]System.Object
-			IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0435: pop
-			IL_0436: ldloc.0
-			IL_0437: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_043c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0441: ret
+			IL_0405: ldloc.0
+			IL_0406: ldc.i4.m1
+			IL_0407: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_040c: ldloc.0
+			IL_040d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0412: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0417: ldarg.0
+			IL_0418: ldc.i4.1
+			IL_0419: newarr [System.Runtime]System.Object
+			IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0423: pop
+			IL_0424: ldloc.0
+			IL_0425: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_042a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_042f: ret
 		} // end of method ArrowFunction_L8C2::__js_call__
 
 	} // end of class ArrowFunction_L8C2
@@ -889,7 +883,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x278a
+			// Method begins at RVA 0x2778
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -984,7 +978,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27b7
+		// Method begins at RVA 0x27a5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Return.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Return.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x286f
+					// Method begins at RVA 0x285d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2878
+					// Method begins at RVA 0x2866
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2866
+				// Method begins at RVA 0x2854
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -494,7 +494,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2881
+				// Method begins at RVA 0x286f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -520,7 +520,7 @@
 			)
 			// Method begins at RVA 0x24b0
 			// Header size: 12
-			// Code size: 929 (0x3a1)
+			// Code size: 911 (0x38f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope,
@@ -601,312 +601,306 @@
 
 			IL_0081: ldloc.0
 			IL_0082: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0087: switch (IL_009c, IL_012c, IL_0216, IL_02f2)
+			IL_0087: switch (IL_009c, IL_011a, IL_0204, IL_02e0)
 
 			IL_009c: ldarg.0
 			IL_009d: ldc.i4.1
 			IL_009e: ldelem.ref
 			IL_009f: castclass Modules.AsyncGenerator_Return/Scope
 			IL_00a4: ldfld object Modules.AsyncGenerator_Return/Scope::g
-			IL_00a9: stloc.s 5
-			IL_00ab: ldstr "g"
-			IL_00b0: ldloc.s 5
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00b7: stloc.s 5
-			IL_00b9: ldloc.s 5
-			IL_00bb: ldc.i4.1
-			IL_00bc: newarr [System.Runtime]System.Object
-			IL_00c1: dup
-			IL_00c2: ldc.i4.0
-			IL_00c3: ldarg.0
-			IL_00c4: ldc.i4.1
-			IL_00c5: ldelem.ref
-			IL_00c6: stelem.ref
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00cc: stloc.s 5
-			IL_00ce: ldloc.s 5
-			IL_00d0: stloc.1
-			IL_00d1: ldloc.1
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d7: stloc.s 5
-			IL_00d9: ldloc.s 5
-			IL_00db: ldstr "next"
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00e5: stloc.s 5
-			IL_00e7: ldloc.0
-			IL_00e8: ldc.i4.1
-			IL_00e9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00ee: ldloc.0
-			IL_00ef: ldloc.s 5
-			IL_00f1: ldarg.0
-			IL_00f2: ldc.i4.1
-			IL_00f3: ldloc.0
-			IL_00f4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_00fe: ldloc.0
-			IL_00ff: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0104: dup
-			IL_0105: ldc.i4.0
-			IL_0106: ldloc.1
+			IL_00a9: ldc.i4.1
+			IL_00aa: newarr [System.Runtime]System.Object
+			IL_00af: dup
+			IL_00b0: ldc.i4.0
+			IL_00b1: ldarg.0
+			IL_00b2: ldc.i4.1
+			IL_00b3: ldelem.ref
+			IL_00b4: stelem.ref
+			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00ba: stloc.s 5
+			IL_00bc: ldloc.s 5
+			IL_00be: stloc.1
+			IL_00bf: ldloc.1
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c5: stloc.s 5
+			IL_00c7: ldloc.s 5
+			IL_00c9: ldstr "next"
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00d3: stloc.s 5
+			IL_00d5: ldloc.0
+			IL_00d6: ldc.i4.1
+			IL_00d7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00dc: ldloc.0
+			IL_00dd: ldloc.s 5
+			IL_00df: ldarg.0
+			IL_00e0: ldc.i4.1
+			IL_00e1: ldloc.0
+			IL_00e2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00ec: ldloc.0
+			IL_00ed: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00f2: dup
+			IL_00f3: ldc.i4.0
+			IL_00f4: ldloc.1
+			IL_00f5: stelem.ref
+			IL_00f6: dup
+			IL_00f7: ldc.i4.1
+			IL_00f8: ldloc.2
+			IL_00f9: stelem.ref
+			IL_00fa: dup
+			IL_00fb: ldc.i4.2
+			IL_00fc: ldloc.3
+			IL_00fd: stelem.ref
+			IL_00fe: dup
+			IL_00ff: ldc.i4.3
+			IL_0100: ldloc.s 4
+			IL_0102: stelem.ref
+			IL_0103: dup
+			IL_0104: ldc.i4.4
+			IL_0105: ldloc.s 5
 			IL_0107: stelem.ref
 			IL_0108: dup
-			IL_0109: ldc.i4.1
-			IL_010a: ldloc.2
-			IL_010b: stelem.ref
-			IL_010c: dup
-			IL_010d: ldc.i4.2
-			IL_010e: ldloc.3
-			IL_010f: stelem.ref
-			IL_0110: dup
-			IL_0111: ldc.i4.3
-			IL_0112: ldloc.s 4
-			IL_0114: stelem.ref
-			IL_0115: dup
-			IL_0116: ldc.i4.4
-			IL_0117: ldloc.s 5
-			IL_0119: stelem.ref
-			IL_011a: dup
-			IL_011b: ldc.i4.5
-			IL_011c: ldloc.s 6
-			IL_011e: stelem.ref
-			IL_011f: pop
-			IL_0120: ldloc.0
-			IL_0121: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0126: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_012b: ret
+			IL_0109: ldc.i4.5
+			IL_010a: ldloc.s 6
+			IL_010c: stelem.ref
+			IL_010d: pop
+			IL_010e: ldloc.0
+			IL_010f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0114: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0119: ret
 
-			IL_012c: ldloc.0
-			IL_012d: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited1
-			IL_0132: stloc.s 5
-			IL_0134: ldloc.s 5
-			IL_0136: stloc.2
-			IL_0137: ldstr "console"
-			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0141: stloc.s 5
-			IL_0143: ldloc.s 5
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014a: stloc.s 5
-			IL_014c: ldstr "r1.value="
-			IL_0151: ldloc.2
-			IL_0152: ldstr "value"
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0161: stloc.s 6
-			IL_0163: ldloc.s 5
-			IL_0165: ldstr "log"
-			IL_016a: ldloc.s 6
-			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0171: pop
-			IL_0172: ldstr "console"
-			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_017c: stloc.s 5
-			IL_017e: ldloc.s 5
-			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0185: stloc.s 5
-			IL_0187: ldstr "r1.done="
-			IL_018c: ldloc.2
-			IL_018d: ldstr "done"
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_019c: stloc.s 6
-			IL_019e: ldloc.s 5
-			IL_01a0: ldstr "log"
-			IL_01a5: ldloc.s 6
-			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01ac: pop
-			IL_01ad: ldloc.1
-			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b3: stloc.s 5
-			IL_01b5: ldloc.s 5
-			IL_01b7: ldstr "return"
-			IL_01bc: ldc.r8 99
-			IL_01c5: box [System.Runtime]System.Double
-			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01cf: stloc.s 5
-			IL_01d1: ldloc.0
-			IL_01d2: ldc.i4.2
-			IL_01d3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01d8: ldloc.0
-			IL_01d9: ldloc.s 5
-			IL_01db: ldarg.0
-			IL_01dc: ldc.i4.2
-			IL_01dd: ldloc.0
-			IL_01de: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01e8: ldloc.0
-			IL_01e9: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01ee: dup
-			IL_01ef: ldc.i4.0
-			IL_01f0: ldloc.1
+			IL_011a: ldloc.0
+			IL_011b: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited1
+			IL_0120: stloc.s 5
+			IL_0122: ldloc.s 5
+			IL_0124: stloc.2
+			IL_0125: ldstr "console"
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_012f: stloc.s 5
+			IL_0131: ldloc.s 5
+			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0138: stloc.s 5
+			IL_013a: ldstr "r1.value="
+			IL_013f: ldloc.2
+			IL_0140: ldstr "value"
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_014f: stloc.s 6
+			IL_0151: ldloc.s 5
+			IL_0153: ldstr "log"
+			IL_0158: ldloc.s 6
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_015f: pop
+			IL_0160: ldstr "console"
+			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_016a: stloc.s 5
+			IL_016c: ldloc.s 5
+			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0173: stloc.s 5
+			IL_0175: ldstr "r1.done="
+			IL_017a: ldloc.2
+			IL_017b: ldstr "done"
+			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_018a: stloc.s 6
+			IL_018c: ldloc.s 5
+			IL_018e: ldstr "log"
+			IL_0193: ldloc.s 6
+			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_019a: pop
+			IL_019b: ldloc.1
+			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a1: stloc.s 5
+			IL_01a3: ldloc.s 5
+			IL_01a5: ldstr "return"
+			IL_01aa: ldc.r8 99
+			IL_01b3: box [System.Runtime]System.Double
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01bd: stloc.s 5
+			IL_01bf: ldloc.0
+			IL_01c0: ldc.i4.2
+			IL_01c1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01c6: ldloc.0
+			IL_01c7: ldloc.s 5
+			IL_01c9: ldarg.0
+			IL_01ca: ldc.i4.2
+			IL_01cb: ldloc.0
+			IL_01cc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01d6: ldloc.0
+			IL_01d7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01dc: dup
+			IL_01dd: ldc.i4.0
+			IL_01de: ldloc.1
+			IL_01df: stelem.ref
+			IL_01e0: dup
+			IL_01e1: ldc.i4.1
+			IL_01e2: ldloc.2
+			IL_01e3: stelem.ref
+			IL_01e4: dup
+			IL_01e5: ldc.i4.2
+			IL_01e6: ldloc.3
+			IL_01e7: stelem.ref
+			IL_01e8: dup
+			IL_01e9: ldc.i4.3
+			IL_01ea: ldloc.s 4
+			IL_01ec: stelem.ref
+			IL_01ed: dup
+			IL_01ee: ldc.i4.4
+			IL_01ef: ldloc.s 5
 			IL_01f1: stelem.ref
 			IL_01f2: dup
-			IL_01f3: ldc.i4.1
-			IL_01f4: ldloc.2
-			IL_01f5: stelem.ref
-			IL_01f6: dup
-			IL_01f7: ldc.i4.2
-			IL_01f8: ldloc.3
-			IL_01f9: stelem.ref
-			IL_01fa: dup
-			IL_01fb: ldc.i4.3
-			IL_01fc: ldloc.s 4
-			IL_01fe: stelem.ref
-			IL_01ff: dup
-			IL_0200: ldc.i4.4
-			IL_0201: ldloc.s 5
-			IL_0203: stelem.ref
-			IL_0204: dup
-			IL_0205: ldc.i4.5
-			IL_0206: ldloc.s 6
-			IL_0208: stelem.ref
-			IL_0209: pop
-			IL_020a: ldloc.0
-			IL_020b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0210: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0215: ret
+			IL_01f3: ldc.i4.5
+			IL_01f4: ldloc.s 6
+			IL_01f6: stelem.ref
+			IL_01f7: pop
+			IL_01f8: ldloc.0
+			IL_01f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01fe: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0203: ret
 
-			IL_0216: ldloc.0
-			IL_0217: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited2
-			IL_021c: stloc.s 5
-			IL_021e: ldloc.s 5
-			IL_0220: stloc.3
-			IL_0221: ldstr "console"
-			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_022b: stloc.s 5
-			IL_022d: ldloc.s 5
-			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0234: stloc.s 5
-			IL_0236: ldstr "r2.value="
-			IL_023b: ldloc.3
-			IL_023c: ldstr "value"
-			IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_024b: stloc.s 6
-			IL_024d: ldloc.s 5
-			IL_024f: ldstr "log"
-			IL_0254: ldloc.s 6
-			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_025b: pop
-			IL_025c: ldstr "console"
-			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0266: stloc.s 5
-			IL_0268: ldloc.s 5
-			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_026f: stloc.s 5
-			IL_0271: ldstr "r2.done="
-			IL_0276: ldloc.3
-			IL_0277: ldstr "done"
-			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0286: stloc.s 6
-			IL_0288: ldloc.s 5
-			IL_028a: ldstr "log"
-			IL_028f: ldloc.s 6
-			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0296: pop
-			IL_0297: ldloc.1
-			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_029d: stloc.s 5
-			IL_029f: ldloc.s 5
-			IL_02a1: ldstr "next"
-			IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_02ab: stloc.s 5
-			IL_02ad: ldloc.0
-			IL_02ae: ldc.i4.3
-			IL_02af: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02b4: ldloc.0
-			IL_02b5: ldloc.s 5
-			IL_02b7: ldarg.0
-			IL_02b8: ldc.i4.3
-			IL_02b9: ldloc.0
-			IL_02ba: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02c4: ldloc.0
-			IL_02c5: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02ca: dup
-			IL_02cb: ldc.i4.0
-			IL_02cc: ldloc.1
+			IL_0204: ldloc.0
+			IL_0205: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited2
+			IL_020a: stloc.s 5
+			IL_020c: ldloc.s 5
+			IL_020e: stloc.3
+			IL_020f: ldstr "console"
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0219: stloc.s 5
+			IL_021b: ldloc.s 5
+			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0222: stloc.s 5
+			IL_0224: ldstr "r2.value="
+			IL_0229: ldloc.3
+			IL_022a: ldstr "value"
+			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0239: stloc.s 6
+			IL_023b: ldloc.s 5
+			IL_023d: ldstr "log"
+			IL_0242: ldloc.s 6
+			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0249: pop
+			IL_024a: ldstr "console"
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0254: stloc.s 5
+			IL_0256: ldloc.s 5
+			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_025d: stloc.s 5
+			IL_025f: ldstr "r2.done="
+			IL_0264: ldloc.3
+			IL_0265: ldstr "done"
+			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0274: stloc.s 6
+			IL_0276: ldloc.s 5
+			IL_0278: ldstr "log"
+			IL_027d: ldloc.s 6
+			IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0284: pop
+			IL_0285: ldloc.1
+			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_028b: stloc.s 5
+			IL_028d: ldloc.s 5
+			IL_028f: ldstr "next"
+			IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0299: stloc.s 5
+			IL_029b: ldloc.0
+			IL_029c: ldc.i4.3
+			IL_029d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02a2: ldloc.0
+			IL_02a3: ldloc.s 5
+			IL_02a5: ldarg.0
+			IL_02a6: ldc.i4.3
+			IL_02a7: ldloc.0
+			IL_02a8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02b2: ldloc.0
+			IL_02b3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02b8: dup
+			IL_02b9: ldc.i4.0
+			IL_02ba: ldloc.1
+			IL_02bb: stelem.ref
+			IL_02bc: dup
+			IL_02bd: ldc.i4.1
+			IL_02be: ldloc.2
+			IL_02bf: stelem.ref
+			IL_02c0: dup
+			IL_02c1: ldc.i4.2
+			IL_02c2: ldloc.3
+			IL_02c3: stelem.ref
+			IL_02c4: dup
+			IL_02c5: ldc.i4.3
+			IL_02c6: ldloc.s 4
+			IL_02c8: stelem.ref
+			IL_02c9: dup
+			IL_02ca: ldc.i4.4
+			IL_02cb: ldloc.s 5
 			IL_02cd: stelem.ref
 			IL_02ce: dup
-			IL_02cf: ldc.i4.1
-			IL_02d0: ldloc.2
-			IL_02d1: stelem.ref
-			IL_02d2: dup
-			IL_02d3: ldc.i4.2
-			IL_02d4: ldloc.3
-			IL_02d5: stelem.ref
-			IL_02d6: dup
-			IL_02d7: ldc.i4.3
-			IL_02d8: ldloc.s 4
-			IL_02da: stelem.ref
-			IL_02db: dup
-			IL_02dc: ldc.i4.4
-			IL_02dd: ldloc.s 5
-			IL_02df: stelem.ref
-			IL_02e0: dup
-			IL_02e1: ldc.i4.5
-			IL_02e2: ldloc.s 6
-			IL_02e4: stelem.ref
-			IL_02e5: pop
-			IL_02e6: ldloc.0
-			IL_02e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02ec: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02f1: ret
+			IL_02cf: ldc.i4.5
+			IL_02d0: ldloc.s 6
+			IL_02d2: stelem.ref
+			IL_02d3: pop
+			IL_02d4: ldloc.0
+			IL_02d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02da: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02df: ret
 
-			IL_02f2: ldloc.0
-			IL_02f3: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited3
-			IL_02f8: stloc.s 5
-			IL_02fa: ldloc.s 5
-			IL_02fc: stloc.s 4
-			IL_02fe: ldstr "console"
-			IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0308: stloc.s 5
-			IL_030a: ldloc.s 5
-			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0311: stloc.s 5
-			IL_0313: ldstr "r3.value="
-			IL_0318: ldloc.s 4
-			IL_031a: ldstr "value"
-			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0329: stloc.s 6
-			IL_032b: ldloc.s 5
-			IL_032d: ldstr "log"
-			IL_0332: ldloc.s 6
-			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0339: pop
-			IL_033a: ldstr "console"
-			IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0344: stloc.s 5
-			IL_0346: ldloc.s 5
-			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_034d: stloc.s 5
-			IL_034f: ldstr "r3.done="
-			IL_0354: ldloc.s 4
-			IL_0356: ldstr "done"
-			IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0365: stloc.s 6
-			IL_0367: ldloc.s 5
-			IL_0369: ldstr "log"
-			IL_036e: ldloc.s 6
-			IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0375: pop
-			IL_0376: ldloc.0
-			IL_0377: ldc.i4.m1
-			IL_0378: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_037d: ldloc.0
-			IL_037e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0383: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0388: ldarg.0
-			IL_0389: ldc.i4.1
-			IL_038a: newarr [System.Runtime]System.Object
-			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0394: pop
-			IL_0395: ldloc.0
-			IL_0396: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_039b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03a0: ret
+			IL_02e0: ldloc.0
+			IL_02e1: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited3
+			IL_02e6: stloc.s 5
+			IL_02e8: ldloc.s 5
+			IL_02ea: stloc.s 4
+			IL_02ec: ldstr "console"
+			IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02f6: stloc.s 5
+			IL_02f8: ldloc.s 5
+			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ff: stloc.s 5
+			IL_0301: ldstr "r3.value="
+			IL_0306: ldloc.s 4
+			IL_0308: ldstr "value"
+			IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0317: stloc.s 6
+			IL_0319: ldloc.s 5
+			IL_031b: ldstr "log"
+			IL_0320: ldloc.s 6
+			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0327: pop
+			IL_0328: ldstr "console"
+			IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0332: stloc.s 5
+			IL_0334: ldloc.s 5
+			IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_033b: stloc.s 5
+			IL_033d: ldstr "r3.done="
+			IL_0342: ldloc.s 4
+			IL_0344: ldstr "done"
+			IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0353: stloc.s 6
+			IL_0355: ldloc.s 5
+			IL_0357: ldstr "log"
+			IL_035c: ldloc.s 6
+			IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0363: pop
+			IL_0364: ldloc.0
+			IL_0365: ldc.i4.m1
+			IL_0366: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_036b: ldloc.0
+			IL_036c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0371: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0376: ldarg.0
+			IL_0377: ldc.i4.1
+			IL_0378: newarr [System.Runtime]System.Object
+			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0382: pop
+			IL_0383: ldloc.0
+			IL_0384: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0389: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_038e: ret
 		} // end of method ArrowFunction_L14C2::__js_call__
 
 	} // end of class ArrowFunction_L14C2
@@ -924,7 +918,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x285d
+			// Method begins at RVA 0x284b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1019,7 +1013,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x288a
+		// Method begins at RVA 0x2878
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x289e
+					// Method begins at RVA 0x288c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x28a7
+					// Method begins at RVA 0x2895
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x28b0
+					// Method begins at RVA 0x289e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2895
+				// Method begins at RVA 0x2883
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -537,7 +537,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28b9
+				// Method begins at RVA 0x28a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -563,7 +563,7 @@
 			)
 			// Method begins at RVA 0x24e8
 			// Header size: 12
-			// Code size: 920 (0x398)
+			// Code size: 902 (0x386)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope,
@@ -644,311 +644,305 @@
 
 			IL_0081: ldloc.0
 			IL_0082: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0087: switch (IL_009c, IL_012c, IL_020d, IL_02e9)
+			IL_0087: switch (IL_009c, IL_011a, IL_01fb, IL_02d7)
 
 			IL_009c: ldarg.0
 			IL_009d: ldc.i4.1
 			IL_009e: ldelem.ref
 			IL_009f: castclass Modules.AsyncGenerator_Throw/Scope
 			IL_00a4: ldfld object Modules.AsyncGenerator_Throw/Scope::g
-			IL_00a9: stloc.s 5
-			IL_00ab: ldstr "g"
-			IL_00b0: ldloc.s 5
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00b7: stloc.s 5
-			IL_00b9: ldloc.s 5
-			IL_00bb: ldc.i4.1
-			IL_00bc: newarr [System.Runtime]System.Object
-			IL_00c1: dup
-			IL_00c2: ldc.i4.0
-			IL_00c3: ldarg.0
-			IL_00c4: ldc.i4.1
-			IL_00c5: ldelem.ref
-			IL_00c6: stelem.ref
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00cc: stloc.s 5
-			IL_00ce: ldloc.s 5
-			IL_00d0: stloc.1
-			IL_00d1: ldloc.1
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d7: stloc.s 5
-			IL_00d9: ldloc.s 5
-			IL_00db: ldstr "next"
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00e5: stloc.s 5
-			IL_00e7: ldloc.0
-			IL_00e8: ldc.i4.1
-			IL_00e9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00ee: ldloc.0
-			IL_00ef: ldloc.s 5
-			IL_00f1: ldarg.0
-			IL_00f2: ldc.i4.1
-			IL_00f3: ldloc.0
-			IL_00f4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_00fe: ldloc.0
-			IL_00ff: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0104: dup
-			IL_0105: ldc.i4.0
-			IL_0106: ldloc.1
+			IL_00a9: ldc.i4.1
+			IL_00aa: newarr [System.Runtime]System.Object
+			IL_00af: dup
+			IL_00b0: ldc.i4.0
+			IL_00b1: ldarg.0
+			IL_00b2: ldc.i4.1
+			IL_00b3: ldelem.ref
+			IL_00b4: stelem.ref
+			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00ba: stloc.s 5
+			IL_00bc: ldloc.s 5
+			IL_00be: stloc.1
+			IL_00bf: ldloc.1
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c5: stloc.s 5
+			IL_00c7: ldloc.s 5
+			IL_00c9: ldstr "next"
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00d3: stloc.s 5
+			IL_00d5: ldloc.0
+			IL_00d6: ldc.i4.1
+			IL_00d7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00dc: ldloc.0
+			IL_00dd: ldloc.s 5
+			IL_00df: ldarg.0
+			IL_00e0: ldc.i4.1
+			IL_00e1: ldloc.0
+			IL_00e2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00ec: ldloc.0
+			IL_00ed: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00f2: dup
+			IL_00f3: ldc.i4.0
+			IL_00f4: ldloc.1
+			IL_00f5: stelem.ref
+			IL_00f6: dup
+			IL_00f7: ldc.i4.1
+			IL_00f8: ldloc.2
+			IL_00f9: stelem.ref
+			IL_00fa: dup
+			IL_00fb: ldc.i4.2
+			IL_00fc: ldloc.3
+			IL_00fd: stelem.ref
+			IL_00fe: dup
+			IL_00ff: ldc.i4.3
+			IL_0100: ldloc.s 4
+			IL_0102: stelem.ref
+			IL_0103: dup
+			IL_0104: ldc.i4.4
+			IL_0105: ldloc.s 5
 			IL_0107: stelem.ref
 			IL_0108: dup
-			IL_0109: ldc.i4.1
-			IL_010a: ldloc.2
-			IL_010b: stelem.ref
-			IL_010c: dup
-			IL_010d: ldc.i4.2
-			IL_010e: ldloc.3
-			IL_010f: stelem.ref
-			IL_0110: dup
-			IL_0111: ldc.i4.3
-			IL_0112: ldloc.s 4
-			IL_0114: stelem.ref
-			IL_0115: dup
-			IL_0116: ldc.i4.4
-			IL_0117: ldloc.s 5
-			IL_0119: stelem.ref
-			IL_011a: dup
-			IL_011b: ldc.i4.5
-			IL_011c: ldloc.s 6
-			IL_011e: stelem.ref
-			IL_011f: pop
-			IL_0120: ldloc.0
-			IL_0121: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0126: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_012b: ret
+			IL_0109: ldc.i4.5
+			IL_010a: ldloc.s 6
+			IL_010c: stelem.ref
+			IL_010d: pop
+			IL_010e: ldloc.0
+			IL_010f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0114: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0119: ret
 
-			IL_012c: ldloc.0
-			IL_012d: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited1
-			IL_0132: stloc.s 5
-			IL_0134: ldloc.s 5
-			IL_0136: stloc.2
-			IL_0137: ldstr "console"
-			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0141: stloc.s 5
-			IL_0143: ldloc.s 5
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014a: stloc.s 5
-			IL_014c: ldstr "r1.value="
-			IL_0151: ldloc.2
-			IL_0152: ldstr "value"
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0161: stloc.s 6
-			IL_0163: ldloc.s 5
-			IL_0165: ldstr "log"
-			IL_016a: ldloc.s 6
-			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0171: pop
-			IL_0172: ldstr "console"
-			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_017c: stloc.s 5
-			IL_017e: ldloc.s 5
-			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0185: stloc.s 5
-			IL_0187: ldstr "r1.done="
-			IL_018c: ldloc.2
-			IL_018d: ldstr "done"
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_019c: stloc.s 6
-			IL_019e: ldloc.s 5
-			IL_01a0: ldstr "log"
-			IL_01a5: ldloc.s 6
-			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01ac: pop
-			IL_01ad: ldloc.1
-			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b3: stloc.s 5
-			IL_01b5: ldloc.s 5
-			IL_01b7: ldstr "throw"
-			IL_01bc: ldstr "boom"
-			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01c6: stloc.s 5
-			IL_01c8: ldloc.0
-			IL_01c9: ldc.i4.2
-			IL_01ca: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01cf: ldloc.0
-			IL_01d0: ldloc.s 5
-			IL_01d2: ldarg.0
-			IL_01d3: ldc.i4.2
-			IL_01d4: ldloc.0
-			IL_01d5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01df: ldloc.0
-			IL_01e0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01e5: dup
-			IL_01e6: ldc.i4.0
-			IL_01e7: ldloc.1
+			IL_011a: ldloc.0
+			IL_011b: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited1
+			IL_0120: stloc.s 5
+			IL_0122: ldloc.s 5
+			IL_0124: stloc.2
+			IL_0125: ldstr "console"
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_012f: stloc.s 5
+			IL_0131: ldloc.s 5
+			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0138: stloc.s 5
+			IL_013a: ldstr "r1.value="
+			IL_013f: ldloc.2
+			IL_0140: ldstr "value"
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_014f: stloc.s 6
+			IL_0151: ldloc.s 5
+			IL_0153: ldstr "log"
+			IL_0158: ldloc.s 6
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_015f: pop
+			IL_0160: ldstr "console"
+			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_016a: stloc.s 5
+			IL_016c: ldloc.s 5
+			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0173: stloc.s 5
+			IL_0175: ldstr "r1.done="
+			IL_017a: ldloc.2
+			IL_017b: ldstr "done"
+			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_018a: stloc.s 6
+			IL_018c: ldloc.s 5
+			IL_018e: ldstr "log"
+			IL_0193: ldloc.s 6
+			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_019a: pop
+			IL_019b: ldloc.1
+			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a1: stloc.s 5
+			IL_01a3: ldloc.s 5
+			IL_01a5: ldstr "throw"
+			IL_01aa: ldstr "boom"
+			IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01b4: stloc.s 5
+			IL_01b6: ldloc.0
+			IL_01b7: ldc.i4.2
+			IL_01b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01bd: ldloc.0
+			IL_01be: ldloc.s 5
+			IL_01c0: ldarg.0
+			IL_01c1: ldc.i4.2
+			IL_01c2: ldloc.0
+			IL_01c3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01cd: ldloc.0
+			IL_01ce: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01d3: dup
+			IL_01d4: ldc.i4.0
+			IL_01d5: ldloc.1
+			IL_01d6: stelem.ref
+			IL_01d7: dup
+			IL_01d8: ldc.i4.1
+			IL_01d9: ldloc.2
+			IL_01da: stelem.ref
+			IL_01db: dup
+			IL_01dc: ldc.i4.2
+			IL_01dd: ldloc.3
+			IL_01de: stelem.ref
+			IL_01df: dup
+			IL_01e0: ldc.i4.3
+			IL_01e1: ldloc.s 4
+			IL_01e3: stelem.ref
+			IL_01e4: dup
+			IL_01e5: ldc.i4.4
+			IL_01e6: ldloc.s 5
 			IL_01e8: stelem.ref
 			IL_01e9: dup
-			IL_01ea: ldc.i4.1
-			IL_01eb: ldloc.2
-			IL_01ec: stelem.ref
-			IL_01ed: dup
-			IL_01ee: ldc.i4.2
-			IL_01ef: ldloc.3
-			IL_01f0: stelem.ref
-			IL_01f1: dup
-			IL_01f2: ldc.i4.3
-			IL_01f3: ldloc.s 4
-			IL_01f5: stelem.ref
-			IL_01f6: dup
-			IL_01f7: ldc.i4.4
-			IL_01f8: ldloc.s 5
-			IL_01fa: stelem.ref
-			IL_01fb: dup
-			IL_01fc: ldc.i4.5
-			IL_01fd: ldloc.s 6
-			IL_01ff: stelem.ref
-			IL_0200: pop
-			IL_0201: ldloc.0
-			IL_0202: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0207: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_020c: ret
+			IL_01ea: ldc.i4.5
+			IL_01eb: ldloc.s 6
+			IL_01ed: stelem.ref
+			IL_01ee: pop
+			IL_01ef: ldloc.0
+			IL_01f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01f5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01fa: ret
 
-			IL_020d: ldloc.0
-			IL_020e: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited2
-			IL_0213: stloc.s 5
-			IL_0215: ldloc.s 5
-			IL_0217: stloc.3
-			IL_0218: ldstr "console"
-			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0222: stloc.s 5
-			IL_0224: ldloc.s 5
-			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_022b: stloc.s 5
-			IL_022d: ldstr "r2.value="
-			IL_0232: ldloc.3
-			IL_0233: ldstr "value"
-			IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0242: stloc.s 6
-			IL_0244: ldloc.s 5
-			IL_0246: ldstr "log"
-			IL_024b: ldloc.s 6
-			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0252: pop
-			IL_0253: ldstr "console"
-			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_025d: stloc.s 5
-			IL_025f: ldloc.s 5
-			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0266: stloc.s 5
-			IL_0268: ldstr "r2.done="
-			IL_026d: ldloc.3
-			IL_026e: ldstr "done"
-			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_027d: stloc.s 6
-			IL_027f: ldloc.s 5
-			IL_0281: ldstr "log"
-			IL_0286: ldloc.s 6
-			IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_028d: pop
-			IL_028e: ldloc.1
-			IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0294: stloc.s 5
-			IL_0296: ldloc.s 5
-			IL_0298: ldstr "next"
-			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_02a2: stloc.s 5
-			IL_02a4: ldloc.0
-			IL_02a5: ldc.i4.3
-			IL_02a6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02ab: ldloc.0
-			IL_02ac: ldloc.s 5
-			IL_02ae: ldarg.0
-			IL_02af: ldc.i4.3
-			IL_02b0: ldloc.0
-			IL_02b1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02bb: ldloc.0
-			IL_02bc: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02c1: dup
-			IL_02c2: ldc.i4.0
-			IL_02c3: ldloc.1
+			IL_01fb: ldloc.0
+			IL_01fc: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited2
+			IL_0201: stloc.s 5
+			IL_0203: ldloc.s 5
+			IL_0205: stloc.3
+			IL_0206: ldstr "console"
+			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0210: stloc.s 5
+			IL_0212: ldloc.s 5
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0219: stloc.s 5
+			IL_021b: ldstr "r2.value="
+			IL_0220: ldloc.3
+			IL_0221: ldstr "value"
+			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0230: stloc.s 6
+			IL_0232: ldloc.s 5
+			IL_0234: ldstr "log"
+			IL_0239: ldloc.s 6
+			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0240: pop
+			IL_0241: ldstr "console"
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_024b: stloc.s 5
+			IL_024d: ldloc.s 5
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0254: stloc.s 5
+			IL_0256: ldstr "r2.done="
+			IL_025b: ldloc.3
+			IL_025c: ldstr "done"
+			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_026b: stloc.s 6
+			IL_026d: ldloc.s 5
+			IL_026f: ldstr "log"
+			IL_0274: ldloc.s 6
+			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_027b: pop
+			IL_027c: ldloc.1
+			IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0282: stloc.s 5
+			IL_0284: ldloc.s 5
+			IL_0286: ldstr "next"
+			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0290: stloc.s 5
+			IL_0292: ldloc.0
+			IL_0293: ldc.i4.3
+			IL_0294: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0299: ldloc.0
+			IL_029a: ldloc.s 5
+			IL_029c: ldarg.0
+			IL_029d: ldc.i4.3
+			IL_029e: ldloc.0
+			IL_029f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02a9: ldloc.0
+			IL_02aa: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02af: dup
+			IL_02b0: ldc.i4.0
+			IL_02b1: ldloc.1
+			IL_02b2: stelem.ref
+			IL_02b3: dup
+			IL_02b4: ldc.i4.1
+			IL_02b5: ldloc.2
+			IL_02b6: stelem.ref
+			IL_02b7: dup
+			IL_02b8: ldc.i4.2
+			IL_02b9: ldloc.3
+			IL_02ba: stelem.ref
+			IL_02bb: dup
+			IL_02bc: ldc.i4.3
+			IL_02bd: ldloc.s 4
+			IL_02bf: stelem.ref
+			IL_02c0: dup
+			IL_02c1: ldc.i4.4
+			IL_02c2: ldloc.s 5
 			IL_02c4: stelem.ref
 			IL_02c5: dup
-			IL_02c6: ldc.i4.1
-			IL_02c7: ldloc.2
-			IL_02c8: stelem.ref
-			IL_02c9: dup
-			IL_02ca: ldc.i4.2
-			IL_02cb: ldloc.3
-			IL_02cc: stelem.ref
-			IL_02cd: dup
-			IL_02ce: ldc.i4.3
-			IL_02cf: ldloc.s 4
-			IL_02d1: stelem.ref
-			IL_02d2: dup
-			IL_02d3: ldc.i4.4
-			IL_02d4: ldloc.s 5
-			IL_02d6: stelem.ref
-			IL_02d7: dup
-			IL_02d8: ldc.i4.5
-			IL_02d9: ldloc.s 6
-			IL_02db: stelem.ref
-			IL_02dc: pop
-			IL_02dd: ldloc.0
-			IL_02de: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02e3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02e8: ret
+			IL_02c6: ldc.i4.5
+			IL_02c7: ldloc.s 6
+			IL_02c9: stelem.ref
+			IL_02ca: pop
+			IL_02cb: ldloc.0
+			IL_02cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02d1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02d6: ret
 
-			IL_02e9: ldloc.0
-			IL_02ea: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited3
-			IL_02ef: stloc.s 5
-			IL_02f1: ldloc.s 5
-			IL_02f3: stloc.s 4
-			IL_02f5: ldstr "console"
-			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02ff: stloc.s 5
-			IL_0301: ldloc.s 5
-			IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0308: stloc.s 5
-			IL_030a: ldstr "r3.value="
-			IL_030f: ldloc.s 4
-			IL_0311: ldstr "value"
-			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0320: stloc.s 6
-			IL_0322: ldloc.s 5
-			IL_0324: ldstr "log"
-			IL_0329: ldloc.s 6
-			IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0330: pop
-			IL_0331: ldstr "console"
-			IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_033b: stloc.s 5
-			IL_033d: ldloc.s 5
-			IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0344: stloc.s 5
-			IL_0346: ldstr "r3.done="
-			IL_034b: ldloc.s 4
-			IL_034d: ldstr "done"
-			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_035c: stloc.s 6
-			IL_035e: ldloc.s 5
-			IL_0360: ldstr "log"
-			IL_0365: ldloc.s 6
-			IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_036c: pop
-			IL_036d: ldloc.0
-			IL_036e: ldc.i4.m1
-			IL_036f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0374: ldloc.0
-			IL_0375: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_037a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_037f: ldarg.0
-			IL_0380: ldc.i4.1
-			IL_0381: newarr [System.Runtime]System.Object
-			IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_038b: pop
-			IL_038c: ldloc.0
-			IL_038d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0392: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0397: ret
+			IL_02d7: ldloc.0
+			IL_02d8: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited3
+			IL_02dd: stloc.s 5
+			IL_02df: ldloc.s 5
+			IL_02e1: stloc.s 4
+			IL_02e3: ldstr "console"
+			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02ed: stloc.s 5
+			IL_02ef: ldloc.s 5
+			IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02f6: stloc.s 5
+			IL_02f8: ldstr "r3.value="
+			IL_02fd: ldloc.s 4
+			IL_02ff: ldstr "value"
+			IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_030e: stloc.s 6
+			IL_0310: ldloc.s 5
+			IL_0312: ldstr "log"
+			IL_0317: ldloc.s 6
+			IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_031e: pop
+			IL_031f: ldstr "console"
+			IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0329: stloc.s 5
+			IL_032b: ldloc.s 5
+			IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0332: stloc.s 5
+			IL_0334: ldstr "r3.done="
+			IL_0339: ldloc.s 4
+			IL_033b: ldstr "done"
+			IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_034a: stloc.s 6
+			IL_034c: ldloc.s 5
+			IL_034e: ldstr "log"
+			IL_0353: ldloc.s 6
+			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_035a: pop
+			IL_035b: ldloc.0
+			IL_035c: ldc.i4.m1
+			IL_035d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0362: ldloc.0
+			IL_0363: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0368: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_036d: ldarg.0
+			IL_036e: ldc.i4.1
+			IL_036f: newarr [System.Runtime]System.Object
+			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0379: pop
+			IL_037a: ldloc.0
+			IL_037b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0380: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0385: ret
 		} // end of method ArrowFunction_L15C2::__js_call__
 
 	} // end of class ArrowFunction_L15C2
@@ -966,7 +960,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x288c
+			// Method begins at RVA 0x287a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1061,7 +1055,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x28c2
+		// Method begins at RVA 0x28b0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_TryCatchFinally.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_TryCatchFinally.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ab6
+					// Method begins at RVA 0x2aa4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2abf
+					// Method begins at RVA 0x2aad
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ac8
+					// Method begins at RVA 0x2ab6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -105,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aad
+				// Method begins at RVA 0x2a9b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -743,7 +743,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad1
+				// Method begins at RVA 0x2abf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -769,7 +769,7 @@
 			)
 			// Method begins at RVA 0x26d4
 			// Header size: 12
-			// Code size: 964 (0x3c4)
+			// Code size: 946 (0x3b2)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope,
@@ -855,356 +855,350 @@
 
 			IL_0086: ldloc.0
 			IL_0087: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_008c: switch (IL_00a5, IL_013a, IL_01e0, IL_0286, IL_032e)
+			IL_008c: switch (IL_00a5, IL_0128, IL_01ce, IL_0274, IL_031c)
 
 			IL_00a5: ldarg.0
 			IL_00a6: ldc.i4.1
 			IL_00a7: ldelem.ref
 			IL_00a8: castclass Modules.AsyncGenerator_TryCatchFinally/Scope
 			IL_00ad: ldfld object Modules.AsyncGenerator_TryCatchFinally/Scope::g
-			IL_00b2: stloc.s 6
-			IL_00b4: ldstr "g"
-			IL_00b9: ldloc.s 6
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c0: stloc.s 6
-			IL_00c2: ldloc.s 6
-			IL_00c4: ldc.i4.1
-			IL_00c5: newarr [System.Runtime]System.Object
-			IL_00ca: dup
-			IL_00cb: ldc.i4.0
-			IL_00cc: ldarg.0
-			IL_00cd: ldc.i4.1
-			IL_00ce: ldelem.ref
-			IL_00cf: stelem.ref
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00d5: stloc.s 6
-			IL_00d7: ldloc.s 6
-			IL_00d9: stloc.1
-			IL_00da: ldloc.1
-			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e0: stloc.s 6
-			IL_00e2: ldloc.s 6
-			IL_00e4: ldstr "next"
-			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00ee: stloc.s 6
-			IL_00f0: ldloc.0
-			IL_00f1: ldc.i4.1
-			IL_00f2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00f7: ldloc.0
-			IL_00f8: ldloc.s 6
-			IL_00fa: ldarg.0
-			IL_00fb: ldc.i4.1
-			IL_00fc: ldloc.0
-			IL_00fd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0102: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0107: ldloc.0
-			IL_0108: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_010d: dup
-			IL_010e: ldc.i4.0
-			IL_010f: ldloc.1
+			IL_00b2: ldc.i4.1
+			IL_00b3: newarr [System.Runtime]System.Object
+			IL_00b8: dup
+			IL_00b9: ldc.i4.0
+			IL_00ba: ldarg.0
+			IL_00bb: ldc.i4.1
+			IL_00bc: ldelem.ref
+			IL_00bd: stelem.ref
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00c3: stloc.s 6
+			IL_00c5: ldloc.s 6
+			IL_00c7: stloc.1
+			IL_00c8: ldloc.1
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ce: stloc.s 6
+			IL_00d0: ldloc.s 6
+			IL_00d2: ldstr "next"
+			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00dc: stloc.s 6
+			IL_00de: ldloc.0
+			IL_00df: ldc.i4.1
+			IL_00e0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00e5: ldloc.0
+			IL_00e6: ldloc.s 6
+			IL_00e8: ldarg.0
+			IL_00e9: ldc.i4.1
+			IL_00ea: ldloc.0
+			IL_00eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00f5: ldloc.0
+			IL_00f6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00fb: dup
+			IL_00fc: ldc.i4.0
+			IL_00fd: ldloc.1
+			IL_00fe: stelem.ref
+			IL_00ff: dup
+			IL_0100: ldc.i4.1
+			IL_0101: ldloc.2
+			IL_0102: stelem.ref
+			IL_0103: dup
+			IL_0104: ldc.i4.2
+			IL_0105: ldloc.3
+			IL_0106: stelem.ref
+			IL_0107: dup
+			IL_0108: ldc.i4.3
+			IL_0109: ldloc.s 4
+			IL_010b: stelem.ref
+			IL_010c: dup
+			IL_010d: ldc.i4.4
+			IL_010e: ldloc.s 5
 			IL_0110: stelem.ref
 			IL_0111: dup
-			IL_0112: ldc.i4.1
-			IL_0113: ldloc.2
-			IL_0114: stelem.ref
-			IL_0115: dup
-			IL_0116: ldc.i4.2
-			IL_0117: ldloc.3
-			IL_0118: stelem.ref
-			IL_0119: dup
-			IL_011a: ldc.i4.3
-			IL_011b: ldloc.s 4
-			IL_011d: stelem.ref
-			IL_011e: dup
-			IL_011f: ldc.i4.4
-			IL_0120: ldloc.s 5
-			IL_0122: stelem.ref
-			IL_0123: dup
-			IL_0124: ldc.i4.5
-			IL_0125: ldloc.s 6
-			IL_0127: stelem.ref
-			IL_0128: dup
-			IL_0129: ldc.i4.6
-			IL_012a: ldloc.s 7
-			IL_012c: stelem.ref
-			IL_012d: pop
-			IL_012e: ldloc.0
-			IL_012f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0134: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0139: ret
+			IL_0112: ldc.i4.5
+			IL_0113: ldloc.s 6
+			IL_0115: stelem.ref
+			IL_0116: dup
+			IL_0117: ldc.i4.6
+			IL_0118: ldloc.s 7
+			IL_011a: stelem.ref
+			IL_011b: pop
+			IL_011c: ldloc.0
+			IL_011d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0122: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0127: ret
 
-			IL_013a: ldloc.0
-			IL_013b: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited1
-			IL_0140: stloc.s 6
-			IL_0142: ldloc.s 6
-			IL_0144: stloc.2
-			IL_0145: ldstr "console"
-			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_014f: stloc.s 6
-			IL_0151: ldloc.s 6
-			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0158: stloc.s 6
-			IL_015a: ldstr "r1="
-			IL_015f: ldloc.2
-			IL_0160: ldstr "value"
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_016f: stloc.s 7
-			IL_0171: ldloc.s 6
-			IL_0173: ldstr "log"
-			IL_0178: ldloc.s 7
-			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_017f: pop
-			IL_0180: ldloc.1
-			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0186: stloc.s 6
-			IL_0188: ldloc.s 6
-			IL_018a: ldstr "next"
-			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0194: stloc.s 6
-			IL_0196: ldloc.0
-			IL_0197: ldc.i4.2
-			IL_0198: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_019d: ldloc.0
-			IL_019e: ldloc.s 6
-			IL_01a0: ldarg.0
-			IL_01a1: ldc.i4.2
-			IL_01a2: ldloc.0
-			IL_01a3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01ad: ldloc.0
-			IL_01ae: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01b3: dup
-			IL_01b4: ldc.i4.0
-			IL_01b5: ldloc.1
+			IL_0128: ldloc.0
+			IL_0129: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited1
+			IL_012e: stloc.s 6
+			IL_0130: ldloc.s 6
+			IL_0132: stloc.2
+			IL_0133: ldstr "console"
+			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_013d: stloc.s 6
+			IL_013f: ldloc.s 6
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0146: stloc.s 6
+			IL_0148: ldstr "r1="
+			IL_014d: ldloc.2
+			IL_014e: ldstr "value"
+			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_015d: stloc.s 7
+			IL_015f: ldloc.s 6
+			IL_0161: ldstr "log"
+			IL_0166: ldloc.s 7
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_016d: pop
+			IL_016e: ldloc.1
+			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0174: stloc.s 6
+			IL_0176: ldloc.s 6
+			IL_0178: ldstr "next"
+			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0182: stloc.s 6
+			IL_0184: ldloc.0
+			IL_0185: ldc.i4.2
+			IL_0186: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_018b: ldloc.0
+			IL_018c: ldloc.s 6
+			IL_018e: ldarg.0
+			IL_018f: ldc.i4.2
+			IL_0190: ldloc.0
+			IL_0191: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0196: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_019b: ldloc.0
+			IL_019c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01a1: dup
+			IL_01a2: ldc.i4.0
+			IL_01a3: ldloc.1
+			IL_01a4: stelem.ref
+			IL_01a5: dup
+			IL_01a6: ldc.i4.1
+			IL_01a7: ldloc.2
+			IL_01a8: stelem.ref
+			IL_01a9: dup
+			IL_01aa: ldc.i4.2
+			IL_01ab: ldloc.3
+			IL_01ac: stelem.ref
+			IL_01ad: dup
+			IL_01ae: ldc.i4.3
+			IL_01af: ldloc.s 4
+			IL_01b1: stelem.ref
+			IL_01b2: dup
+			IL_01b3: ldc.i4.4
+			IL_01b4: ldloc.s 5
 			IL_01b6: stelem.ref
 			IL_01b7: dup
-			IL_01b8: ldc.i4.1
-			IL_01b9: ldloc.2
-			IL_01ba: stelem.ref
-			IL_01bb: dup
-			IL_01bc: ldc.i4.2
-			IL_01bd: ldloc.3
-			IL_01be: stelem.ref
-			IL_01bf: dup
-			IL_01c0: ldc.i4.3
-			IL_01c1: ldloc.s 4
-			IL_01c3: stelem.ref
-			IL_01c4: dup
-			IL_01c5: ldc.i4.4
-			IL_01c6: ldloc.s 5
-			IL_01c8: stelem.ref
-			IL_01c9: dup
-			IL_01ca: ldc.i4.5
-			IL_01cb: ldloc.s 6
-			IL_01cd: stelem.ref
-			IL_01ce: dup
-			IL_01cf: ldc.i4.6
-			IL_01d0: ldloc.s 7
-			IL_01d2: stelem.ref
-			IL_01d3: pop
-			IL_01d4: ldloc.0
-			IL_01d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01da: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01df: ret
+			IL_01b8: ldc.i4.5
+			IL_01b9: ldloc.s 6
+			IL_01bb: stelem.ref
+			IL_01bc: dup
+			IL_01bd: ldc.i4.6
+			IL_01be: ldloc.s 7
+			IL_01c0: stelem.ref
+			IL_01c1: pop
+			IL_01c2: ldloc.0
+			IL_01c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01c8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01cd: ret
 
-			IL_01e0: ldloc.0
-			IL_01e1: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited2
-			IL_01e6: stloc.s 6
-			IL_01e8: ldloc.s 6
-			IL_01ea: stloc.3
-			IL_01eb: ldstr "console"
-			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01f5: stloc.s 6
-			IL_01f7: ldloc.s 6
-			IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01fe: stloc.s 6
-			IL_0200: ldstr "r2="
-			IL_0205: ldloc.3
-			IL_0206: ldstr "value"
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0215: stloc.s 7
-			IL_0217: ldloc.s 6
-			IL_0219: ldstr "log"
-			IL_021e: ldloc.s 7
-			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0225: pop
-			IL_0226: ldloc.1
-			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_022c: stloc.s 6
-			IL_022e: ldloc.s 6
-			IL_0230: ldstr "next"
-			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_023a: stloc.s 6
-			IL_023c: ldloc.0
-			IL_023d: ldc.i4.3
-			IL_023e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0243: ldloc.0
-			IL_0244: ldloc.s 6
-			IL_0246: ldarg.0
-			IL_0247: ldc.i4.3
-			IL_0248: ldloc.0
-			IL_0249: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_024e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0253: ldloc.0
-			IL_0254: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0259: dup
-			IL_025a: ldc.i4.0
-			IL_025b: ldloc.1
+			IL_01ce: ldloc.0
+			IL_01cf: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited2
+			IL_01d4: stloc.s 6
+			IL_01d6: ldloc.s 6
+			IL_01d8: stloc.3
+			IL_01d9: ldstr "console"
+			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01e3: stloc.s 6
+			IL_01e5: ldloc.s 6
+			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ec: stloc.s 6
+			IL_01ee: ldstr "r2="
+			IL_01f3: ldloc.3
+			IL_01f4: ldstr "value"
+			IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0203: stloc.s 7
+			IL_0205: ldloc.s 6
+			IL_0207: ldstr "log"
+			IL_020c: ldloc.s 7
+			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0213: pop
+			IL_0214: ldloc.1
+			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021a: stloc.s 6
+			IL_021c: ldloc.s 6
+			IL_021e: ldstr "next"
+			IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0228: stloc.s 6
+			IL_022a: ldloc.0
+			IL_022b: ldc.i4.3
+			IL_022c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0231: ldloc.0
+			IL_0232: ldloc.s 6
+			IL_0234: ldarg.0
+			IL_0235: ldc.i4.3
+			IL_0236: ldloc.0
+			IL_0237: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_023c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0241: ldloc.0
+			IL_0242: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0247: dup
+			IL_0248: ldc.i4.0
+			IL_0249: ldloc.1
+			IL_024a: stelem.ref
+			IL_024b: dup
+			IL_024c: ldc.i4.1
+			IL_024d: ldloc.2
+			IL_024e: stelem.ref
+			IL_024f: dup
+			IL_0250: ldc.i4.2
+			IL_0251: ldloc.3
+			IL_0252: stelem.ref
+			IL_0253: dup
+			IL_0254: ldc.i4.3
+			IL_0255: ldloc.s 4
+			IL_0257: stelem.ref
+			IL_0258: dup
+			IL_0259: ldc.i4.4
+			IL_025a: ldloc.s 5
 			IL_025c: stelem.ref
 			IL_025d: dup
-			IL_025e: ldc.i4.1
-			IL_025f: ldloc.2
-			IL_0260: stelem.ref
-			IL_0261: dup
-			IL_0262: ldc.i4.2
-			IL_0263: ldloc.3
-			IL_0264: stelem.ref
-			IL_0265: dup
-			IL_0266: ldc.i4.3
-			IL_0267: ldloc.s 4
-			IL_0269: stelem.ref
-			IL_026a: dup
-			IL_026b: ldc.i4.4
-			IL_026c: ldloc.s 5
-			IL_026e: stelem.ref
-			IL_026f: dup
-			IL_0270: ldc.i4.5
-			IL_0271: ldloc.s 6
-			IL_0273: stelem.ref
-			IL_0274: dup
-			IL_0275: ldc.i4.6
-			IL_0276: ldloc.s 7
-			IL_0278: stelem.ref
-			IL_0279: pop
-			IL_027a: ldloc.0
-			IL_027b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0280: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0285: ret
+			IL_025e: ldc.i4.5
+			IL_025f: ldloc.s 6
+			IL_0261: stelem.ref
+			IL_0262: dup
+			IL_0263: ldc.i4.6
+			IL_0264: ldloc.s 7
+			IL_0266: stelem.ref
+			IL_0267: pop
+			IL_0268: ldloc.0
+			IL_0269: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_026e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0273: ret
 
-			IL_0286: ldloc.0
-			IL_0287: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited3
-			IL_028c: stloc.s 6
-			IL_028e: ldloc.s 6
-			IL_0290: stloc.s 4
-			IL_0292: ldstr "console"
-			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_029c: stloc.s 6
-			IL_029e: ldloc.s 6
-			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a5: stloc.s 6
-			IL_02a7: ldstr "r3="
-			IL_02ac: ldloc.s 4
-			IL_02ae: ldstr "value"
-			IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02bd: stloc.s 7
-			IL_02bf: ldloc.s 6
-			IL_02c1: ldstr "log"
-			IL_02c6: ldloc.s 7
-			IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02cd: pop
-			IL_02ce: ldloc.1
-			IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02d4: stloc.s 6
-			IL_02d6: ldloc.s 6
-			IL_02d8: ldstr "next"
-			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_02e2: stloc.s 6
-			IL_02e4: ldloc.0
-			IL_02e5: ldc.i4.4
-			IL_02e6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02eb: ldloc.0
-			IL_02ec: ldloc.s 6
-			IL_02ee: ldarg.0
-			IL_02ef: ldc.i4.4
-			IL_02f0: ldloc.0
-			IL_02f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02fb: ldloc.0
-			IL_02fc: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0301: dup
-			IL_0302: ldc.i4.0
-			IL_0303: ldloc.1
+			IL_0274: ldloc.0
+			IL_0275: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited3
+			IL_027a: stloc.s 6
+			IL_027c: ldloc.s 6
+			IL_027e: stloc.s 4
+			IL_0280: ldstr "console"
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_028a: stloc.s 6
+			IL_028c: ldloc.s 6
+			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0293: stloc.s 6
+			IL_0295: ldstr "r3="
+			IL_029a: ldloc.s 4
+			IL_029c: ldstr "value"
+			IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ab: stloc.s 7
+			IL_02ad: ldloc.s 6
+			IL_02af: ldstr "log"
+			IL_02b4: ldloc.s 7
+			IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02bb: pop
+			IL_02bc: ldloc.1
+			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c2: stloc.s 6
+			IL_02c4: ldloc.s 6
+			IL_02c6: ldstr "next"
+			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_02d0: stloc.s 6
+			IL_02d2: ldloc.0
+			IL_02d3: ldc.i4.4
+			IL_02d4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02d9: ldloc.0
+			IL_02da: ldloc.s 6
+			IL_02dc: ldarg.0
+			IL_02dd: ldc.i4.4
+			IL_02de: ldloc.0
+			IL_02df: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02e9: ldloc.0
+			IL_02ea: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02ef: dup
+			IL_02f0: ldc.i4.0
+			IL_02f1: ldloc.1
+			IL_02f2: stelem.ref
+			IL_02f3: dup
+			IL_02f4: ldc.i4.1
+			IL_02f5: ldloc.2
+			IL_02f6: stelem.ref
+			IL_02f7: dup
+			IL_02f8: ldc.i4.2
+			IL_02f9: ldloc.3
+			IL_02fa: stelem.ref
+			IL_02fb: dup
+			IL_02fc: ldc.i4.3
+			IL_02fd: ldloc.s 4
+			IL_02ff: stelem.ref
+			IL_0300: dup
+			IL_0301: ldc.i4.4
+			IL_0302: ldloc.s 5
 			IL_0304: stelem.ref
 			IL_0305: dup
-			IL_0306: ldc.i4.1
-			IL_0307: ldloc.2
-			IL_0308: stelem.ref
-			IL_0309: dup
-			IL_030a: ldc.i4.2
-			IL_030b: ldloc.3
-			IL_030c: stelem.ref
-			IL_030d: dup
-			IL_030e: ldc.i4.3
-			IL_030f: ldloc.s 4
-			IL_0311: stelem.ref
-			IL_0312: dup
-			IL_0313: ldc.i4.4
-			IL_0314: ldloc.s 5
-			IL_0316: stelem.ref
-			IL_0317: dup
-			IL_0318: ldc.i4.5
-			IL_0319: ldloc.s 6
-			IL_031b: stelem.ref
-			IL_031c: dup
-			IL_031d: ldc.i4.6
-			IL_031e: ldloc.s 7
-			IL_0320: stelem.ref
-			IL_0321: pop
-			IL_0322: ldloc.0
-			IL_0323: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0328: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_032d: ret
+			IL_0306: ldc.i4.5
+			IL_0307: ldloc.s 6
+			IL_0309: stelem.ref
+			IL_030a: dup
+			IL_030b: ldc.i4.6
+			IL_030c: ldloc.s 7
+			IL_030e: stelem.ref
+			IL_030f: pop
+			IL_0310: ldloc.0
+			IL_0311: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0316: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_031b: ret
 
-			IL_032e: ldloc.0
-			IL_032f: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited4
-			IL_0334: stloc.s 6
-			IL_0336: ldloc.s 6
-			IL_0338: stloc.s 5
-			IL_033a: ldstr "console"
-			IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0344: stloc.s 6
-			IL_0346: ldloc.s 6
-			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_034d: stloc.s 6
-			IL_034f: ldstr "r4="
-			IL_0354: ldloc.s 5
-			IL_0356: ldstr "value"
-			IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0365: stloc.s 7
-			IL_0367: ldloc.s 7
-			IL_0369: ldstr " done="
-			IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0373: stloc.s 7
-			IL_0375: ldloc.s 7
-			IL_0377: ldloc.s 5
-			IL_0379: ldstr "done"
-			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0388: stloc.s 7
-			IL_038a: ldloc.s 6
-			IL_038c: ldstr "log"
-			IL_0391: ldloc.s 7
-			IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0398: pop
-			IL_0399: ldloc.0
-			IL_039a: ldc.i4.m1
-			IL_039b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03a0: ldloc.0
-			IL_03a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_03ab: ldarg.0
-			IL_03ac: ldc.i4.1
-			IL_03ad: newarr [System.Runtime]System.Object
-			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03b7: pop
-			IL_03b8: ldloc.0
-			IL_03b9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03be: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03c3: ret
+			IL_031c: ldloc.0
+			IL_031d: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited4
+			IL_0322: stloc.s 6
+			IL_0324: ldloc.s 6
+			IL_0326: stloc.s 5
+			IL_0328: ldstr "console"
+			IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0332: stloc.s 6
+			IL_0334: ldloc.s 6
+			IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_033b: stloc.s 6
+			IL_033d: ldstr "r4="
+			IL_0342: ldloc.s 5
+			IL_0344: ldstr "value"
+			IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0353: stloc.s 7
+			IL_0355: ldloc.s 7
+			IL_0357: ldstr " done="
+			IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0361: stloc.s 7
+			IL_0363: ldloc.s 7
+			IL_0365: ldloc.s 5
+			IL_0367: ldstr "done"
+			IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0376: stloc.s 7
+			IL_0378: ldloc.s 6
+			IL_037a: ldstr "log"
+			IL_037f: ldloc.s 7
+			IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0386: pop
+			IL_0387: ldloc.0
+			IL_0388: ldc.i4.m1
+			IL_0389: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_038e: ldloc.0
+			IL_038f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0394: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0399: ldarg.0
+			IL_039a: ldc.i4.1
+			IL_039b: newarr [System.Runtime]System.Object
+			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03a5: pop
+			IL_03a6: ldloc.0
+			IL_03a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03ac: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03b1: ret
 		} // end of method ArrowFunction_L19C2::__js_call__
 
 	} // end of class ArrowFunction_L19C2
@@ -1222,7 +1216,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2aa4
+			// Method begins at RVA 0x2a92
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1317,7 +1311,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2ada
+		// Method begins at RVA 0x2ac8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_YieldAwait.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_YieldAwait.verified.txt
@@ -30,7 +30,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29b4
+				// Method begins at RVA 0x29a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -535,7 +535,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29bd
+				// Method begins at RVA 0x29ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -561,7 +561,7 @@
 			)
 			// Method begins at RVA 0x2510
 			// Header size: 12
-			// Code size: 1167 (0x48f)
+			// Code size: 1149 (0x47d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope,
@@ -647,414 +647,408 @@
 
 			IL_0086: ldloc.0
 			IL_0087: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_008c: switch (IL_00a5, IL_013a, IL_021b, IL_02fc, IL_03e0)
+			IL_008c: switch (IL_00a5, IL_0128, IL_0209, IL_02ea, IL_03ce)
 
 			IL_00a5: ldarg.0
 			IL_00a6: ldc.i4.1
 			IL_00a7: ldelem.ref
 			IL_00a8: castclass Modules.AsyncGenerator_YieldAwait/Scope
 			IL_00ad: ldfld object Modules.AsyncGenerator_YieldAwait/Scope::g
-			IL_00b2: stloc.s 6
-			IL_00b4: ldstr "g"
-			IL_00b9: ldloc.s 6
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c0: stloc.s 6
-			IL_00c2: ldloc.s 6
-			IL_00c4: ldc.i4.1
-			IL_00c5: newarr [System.Runtime]System.Object
-			IL_00ca: dup
-			IL_00cb: ldc.i4.0
-			IL_00cc: ldarg.0
-			IL_00cd: ldc.i4.1
-			IL_00ce: ldelem.ref
-			IL_00cf: stelem.ref
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00d5: stloc.s 6
-			IL_00d7: ldloc.s 6
-			IL_00d9: stloc.1
-			IL_00da: ldloc.1
-			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e0: stloc.s 6
-			IL_00e2: ldloc.s 6
-			IL_00e4: ldstr "next"
-			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00ee: stloc.s 6
-			IL_00f0: ldloc.0
-			IL_00f1: ldc.i4.1
-			IL_00f2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00f7: ldloc.0
-			IL_00f8: ldloc.s 6
-			IL_00fa: ldarg.0
-			IL_00fb: ldc.i4.1
-			IL_00fc: ldloc.0
-			IL_00fd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0102: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0107: ldloc.0
-			IL_0108: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_010d: dup
-			IL_010e: ldc.i4.0
-			IL_010f: ldloc.1
+			IL_00b2: ldc.i4.1
+			IL_00b3: newarr [System.Runtime]System.Object
+			IL_00b8: dup
+			IL_00b9: ldc.i4.0
+			IL_00ba: ldarg.0
+			IL_00bb: ldc.i4.1
+			IL_00bc: ldelem.ref
+			IL_00bd: stelem.ref
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00c3: stloc.s 6
+			IL_00c5: ldloc.s 6
+			IL_00c7: stloc.1
+			IL_00c8: ldloc.1
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ce: stloc.s 6
+			IL_00d0: ldloc.s 6
+			IL_00d2: ldstr "next"
+			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00dc: stloc.s 6
+			IL_00de: ldloc.0
+			IL_00df: ldc.i4.1
+			IL_00e0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00e5: ldloc.0
+			IL_00e6: ldloc.s 6
+			IL_00e8: ldarg.0
+			IL_00e9: ldc.i4.1
+			IL_00ea: ldloc.0
+			IL_00eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00f5: ldloc.0
+			IL_00f6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00fb: dup
+			IL_00fc: ldc.i4.0
+			IL_00fd: ldloc.1
+			IL_00fe: stelem.ref
+			IL_00ff: dup
+			IL_0100: ldc.i4.1
+			IL_0101: ldloc.2
+			IL_0102: stelem.ref
+			IL_0103: dup
+			IL_0104: ldc.i4.2
+			IL_0105: ldloc.3
+			IL_0106: stelem.ref
+			IL_0107: dup
+			IL_0108: ldc.i4.3
+			IL_0109: ldloc.s 4
+			IL_010b: stelem.ref
+			IL_010c: dup
+			IL_010d: ldc.i4.4
+			IL_010e: ldloc.s 5
 			IL_0110: stelem.ref
 			IL_0111: dup
-			IL_0112: ldc.i4.1
-			IL_0113: ldloc.2
-			IL_0114: stelem.ref
-			IL_0115: dup
-			IL_0116: ldc.i4.2
-			IL_0117: ldloc.3
-			IL_0118: stelem.ref
-			IL_0119: dup
-			IL_011a: ldc.i4.3
-			IL_011b: ldloc.s 4
-			IL_011d: stelem.ref
-			IL_011e: dup
-			IL_011f: ldc.i4.4
-			IL_0120: ldloc.s 5
-			IL_0122: stelem.ref
-			IL_0123: dup
-			IL_0124: ldc.i4.5
-			IL_0125: ldloc.s 6
-			IL_0127: stelem.ref
-			IL_0128: dup
-			IL_0129: ldc.i4.6
-			IL_012a: ldloc.s 7
-			IL_012c: stelem.ref
-			IL_012d: pop
-			IL_012e: ldloc.0
-			IL_012f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0134: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0139: ret
+			IL_0112: ldc.i4.5
+			IL_0113: ldloc.s 6
+			IL_0115: stelem.ref
+			IL_0116: dup
+			IL_0117: ldc.i4.6
+			IL_0118: ldloc.s 7
+			IL_011a: stelem.ref
+			IL_011b: pop
+			IL_011c: ldloc.0
+			IL_011d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0122: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0127: ret
 
-			IL_013a: ldloc.0
-			IL_013b: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited1
-			IL_0140: stloc.s 6
-			IL_0142: ldloc.s 6
-			IL_0144: stloc.2
-			IL_0145: ldstr "console"
-			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_014f: stloc.s 6
-			IL_0151: ldloc.s 6
-			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0158: stloc.s 6
-			IL_015a: ldstr "r1.value="
-			IL_015f: ldloc.2
-			IL_0160: ldstr "value"
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_016f: stloc.s 7
-			IL_0171: ldloc.s 6
-			IL_0173: ldstr "log"
-			IL_0178: ldloc.s 7
-			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_017f: pop
-			IL_0180: ldstr "console"
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_018a: stloc.s 6
-			IL_018c: ldloc.s 6
-			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0193: stloc.s 6
-			IL_0195: ldstr "r1.done="
-			IL_019a: ldloc.2
-			IL_019b: ldstr "done"
-			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01aa: stloc.s 7
-			IL_01ac: ldloc.s 6
-			IL_01ae: ldstr "log"
-			IL_01b3: ldloc.s 7
-			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01ba: pop
-			IL_01bb: ldloc.1
-			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c1: stloc.s 6
-			IL_01c3: ldloc.s 6
-			IL_01c5: ldstr "next"
-			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01cf: stloc.s 6
-			IL_01d1: ldloc.0
-			IL_01d2: ldc.i4.2
-			IL_01d3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01d8: ldloc.0
-			IL_01d9: ldloc.s 6
-			IL_01db: ldarg.0
-			IL_01dc: ldc.i4.2
-			IL_01dd: ldloc.0
-			IL_01de: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01e8: ldloc.0
-			IL_01e9: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01ee: dup
-			IL_01ef: ldc.i4.0
-			IL_01f0: ldloc.1
+			IL_0128: ldloc.0
+			IL_0129: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited1
+			IL_012e: stloc.s 6
+			IL_0130: ldloc.s 6
+			IL_0132: stloc.2
+			IL_0133: ldstr "console"
+			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_013d: stloc.s 6
+			IL_013f: ldloc.s 6
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0146: stloc.s 6
+			IL_0148: ldstr "r1.value="
+			IL_014d: ldloc.2
+			IL_014e: ldstr "value"
+			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_015d: stloc.s 7
+			IL_015f: ldloc.s 6
+			IL_0161: ldstr "log"
+			IL_0166: ldloc.s 7
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_016d: pop
+			IL_016e: ldstr "console"
+			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0178: stloc.s 6
+			IL_017a: ldloc.s 6
+			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0181: stloc.s 6
+			IL_0183: ldstr "r1.done="
+			IL_0188: ldloc.2
+			IL_0189: ldstr "done"
+			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0198: stloc.s 7
+			IL_019a: ldloc.s 6
+			IL_019c: ldstr "log"
+			IL_01a1: ldloc.s 7
+			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01a8: pop
+			IL_01a9: ldloc.1
+			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01af: stloc.s 6
+			IL_01b1: ldloc.s 6
+			IL_01b3: ldstr "next"
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01bd: stloc.s 6
+			IL_01bf: ldloc.0
+			IL_01c0: ldc.i4.2
+			IL_01c1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01c6: ldloc.0
+			IL_01c7: ldloc.s 6
+			IL_01c9: ldarg.0
+			IL_01ca: ldc.i4.2
+			IL_01cb: ldloc.0
+			IL_01cc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01d6: ldloc.0
+			IL_01d7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01dc: dup
+			IL_01dd: ldc.i4.0
+			IL_01de: ldloc.1
+			IL_01df: stelem.ref
+			IL_01e0: dup
+			IL_01e1: ldc.i4.1
+			IL_01e2: ldloc.2
+			IL_01e3: stelem.ref
+			IL_01e4: dup
+			IL_01e5: ldc.i4.2
+			IL_01e6: ldloc.3
+			IL_01e7: stelem.ref
+			IL_01e8: dup
+			IL_01e9: ldc.i4.3
+			IL_01ea: ldloc.s 4
+			IL_01ec: stelem.ref
+			IL_01ed: dup
+			IL_01ee: ldc.i4.4
+			IL_01ef: ldloc.s 5
 			IL_01f1: stelem.ref
 			IL_01f2: dup
-			IL_01f3: ldc.i4.1
-			IL_01f4: ldloc.2
-			IL_01f5: stelem.ref
-			IL_01f6: dup
-			IL_01f7: ldc.i4.2
-			IL_01f8: ldloc.3
-			IL_01f9: stelem.ref
-			IL_01fa: dup
-			IL_01fb: ldc.i4.3
-			IL_01fc: ldloc.s 4
-			IL_01fe: stelem.ref
-			IL_01ff: dup
-			IL_0200: ldc.i4.4
-			IL_0201: ldloc.s 5
-			IL_0203: stelem.ref
-			IL_0204: dup
-			IL_0205: ldc.i4.5
-			IL_0206: ldloc.s 6
-			IL_0208: stelem.ref
-			IL_0209: dup
-			IL_020a: ldc.i4.6
-			IL_020b: ldloc.s 7
-			IL_020d: stelem.ref
-			IL_020e: pop
-			IL_020f: ldloc.0
-			IL_0210: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0215: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_021a: ret
+			IL_01f3: ldc.i4.5
+			IL_01f4: ldloc.s 6
+			IL_01f6: stelem.ref
+			IL_01f7: dup
+			IL_01f8: ldc.i4.6
+			IL_01f9: ldloc.s 7
+			IL_01fb: stelem.ref
+			IL_01fc: pop
+			IL_01fd: ldloc.0
+			IL_01fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0203: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0208: ret
 
-			IL_021b: ldloc.0
-			IL_021c: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited2
-			IL_0221: stloc.s 6
-			IL_0223: ldloc.s 6
-			IL_0225: stloc.3
-			IL_0226: ldstr "console"
-			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0230: stloc.s 6
-			IL_0232: ldloc.s 6
-			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0239: stloc.s 6
-			IL_023b: ldstr "r2.value="
-			IL_0240: ldloc.3
-			IL_0241: ldstr "value"
-			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0250: stloc.s 7
-			IL_0252: ldloc.s 6
-			IL_0254: ldstr "log"
-			IL_0259: ldloc.s 7
-			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0260: pop
-			IL_0261: ldstr "console"
-			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_026b: stloc.s 6
-			IL_026d: ldloc.s 6
-			IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0274: stloc.s 6
-			IL_0276: ldstr "r2.done="
-			IL_027b: ldloc.3
-			IL_027c: ldstr "done"
-			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_028b: stloc.s 7
-			IL_028d: ldloc.s 6
-			IL_028f: ldstr "log"
-			IL_0294: ldloc.s 7
-			IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_029b: pop
-			IL_029c: ldloc.1
-			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a2: stloc.s 6
-			IL_02a4: ldloc.s 6
-			IL_02a6: ldstr "next"
-			IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_02b0: stloc.s 6
-			IL_02b2: ldloc.0
-			IL_02b3: ldc.i4.3
-			IL_02b4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02b9: ldloc.0
-			IL_02ba: ldloc.s 6
-			IL_02bc: ldarg.0
-			IL_02bd: ldc.i4.3
-			IL_02be: ldloc.0
-			IL_02bf: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02c9: ldloc.0
-			IL_02ca: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02cf: dup
-			IL_02d0: ldc.i4.0
-			IL_02d1: ldloc.1
+			IL_0209: ldloc.0
+			IL_020a: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited2
+			IL_020f: stloc.s 6
+			IL_0211: ldloc.s 6
+			IL_0213: stloc.3
+			IL_0214: ldstr "console"
+			IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_021e: stloc.s 6
+			IL_0220: ldloc.s 6
+			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0227: stloc.s 6
+			IL_0229: ldstr "r2.value="
+			IL_022e: ldloc.3
+			IL_022f: ldstr "value"
+			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_023e: stloc.s 7
+			IL_0240: ldloc.s 6
+			IL_0242: ldstr "log"
+			IL_0247: ldloc.s 7
+			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_024e: pop
+			IL_024f: ldstr "console"
+			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0259: stloc.s 6
+			IL_025b: ldloc.s 6
+			IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0262: stloc.s 6
+			IL_0264: ldstr "r2.done="
+			IL_0269: ldloc.3
+			IL_026a: ldstr "done"
+			IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0279: stloc.s 7
+			IL_027b: ldloc.s 6
+			IL_027d: ldstr "log"
+			IL_0282: ldloc.s 7
+			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0289: pop
+			IL_028a: ldloc.1
+			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0290: stloc.s 6
+			IL_0292: ldloc.s 6
+			IL_0294: ldstr "next"
+			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_029e: stloc.s 6
+			IL_02a0: ldloc.0
+			IL_02a1: ldc.i4.3
+			IL_02a2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02a7: ldloc.0
+			IL_02a8: ldloc.s 6
+			IL_02aa: ldarg.0
+			IL_02ab: ldc.i4.3
+			IL_02ac: ldloc.0
+			IL_02ad: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02b7: ldloc.0
+			IL_02b8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02bd: dup
+			IL_02be: ldc.i4.0
+			IL_02bf: ldloc.1
+			IL_02c0: stelem.ref
+			IL_02c1: dup
+			IL_02c2: ldc.i4.1
+			IL_02c3: ldloc.2
+			IL_02c4: stelem.ref
+			IL_02c5: dup
+			IL_02c6: ldc.i4.2
+			IL_02c7: ldloc.3
+			IL_02c8: stelem.ref
+			IL_02c9: dup
+			IL_02ca: ldc.i4.3
+			IL_02cb: ldloc.s 4
+			IL_02cd: stelem.ref
+			IL_02ce: dup
+			IL_02cf: ldc.i4.4
+			IL_02d0: ldloc.s 5
 			IL_02d2: stelem.ref
 			IL_02d3: dup
-			IL_02d4: ldc.i4.1
-			IL_02d5: ldloc.2
-			IL_02d6: stelem.ref
-			IL_02d7: dup
-			IL_02d8: ldc.i4.2
-			IL_02d9: ldloc.3
-			IL_02da: stelem.ref
-			IL_02db: dup
-			IL_02dc: ldc.i4.3
-			IL_02dd: ldloc.s 4
-			IL_02df: stelem.ref
-			IL_02e0: dup
-			IL_02e1: ldc.i4.4
-			IL_02e2: ldloc.s 5
-			IL_02e4: stelem.ref
-			IL_02e5: dup
-			IL_02e6: ldc.i4.5
-			IL_02e7: ldloc.s 6
-			IL_02e9: stelem.ref
-			IL_02ea: dup
-			IL_02eb: ldc.i4.6
-			IL_02ec: ldloc.s 7
-			IL_02ee: stelem.ref
-			IL_02ef: pop
-			IL_02f0: ldloc.0
-			IL_02f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02f6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02fb: ret
+			IL_02d4: ldc.i4.5
+			IL_02d5: ldloc.s 6
+			IL_02d7: stelem.ref
+			IL_02d8: dup
+			IL_02d9: ldc.i4.6
+			IL_02da: ldloc.s 7
+			IL_02dc: stelem.ref
+			IL_02dd: pop
+			IL_02de: ldloc.0
+			IL_02df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02e4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02e9: ret
 
-			IL_02fc: ldloc.0
-			IL_02fd: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited3
-			IL_0302: stloc.s 6
-			IL_0304: ldloc.s 6
-			IL_0306: stloc.s 4
-			IL_0308: ldstr "console"
-			IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0312: stloc.s 6
-			IL_0314: ldloc.s 6
-			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_031b: stloc.s 6
-			IL_031d: ldstr "r3.value="
-			IL_0322: ldloc.s 4
-			IL_0324: ldstr "value"
-			IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0333: stloc.s 7
-			IL_0335: ldloc.s 6
-			IL_0337: ldstr "log"
-			IL_033c: ldloc.s 7
-			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0343: pop
-			IL_0344: ldstr "console"
-			IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_034e: stloc.s 6
-			IL_0350: ldloc.s 6
-			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0357: stloc.s 6
-			IL_0359: ldstr "r3.done="
-			IL_035e: ldloc.s 4
-			IL_0360: ldstr "done"
-			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_036f: stloc.s 7
-			IL_0371: ldloc.s 6
-			IL_0373: ldstr "log"
-			IL_0378: ldloc.s 7
-			IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_037f: pop
-			IL_0380: ldloc.1
-			IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0386: stloc.s 6
-			IL_0388: ldloc.s 6
-			IL_038a: ldstr "next"
-			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0394: stloc.s 6
-			IL_0396: ldloc.0
-			IL_0397: ldc.i4.4
-			IL_0398: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_039d: ldloc.0
-			IL_039e: ldloc.s 6
-			IL_03a0: ldarg.0
-			IL_03a1: ldc.i4.4
-			IL_03a2: ldloc.0
-			IL_03a3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_03ad: ldloc.0
-			IL_03ae: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03b3: dup
-			IL_03b4: ldc.i4.0
-			IL_03b5: ldloc.1
+			IL_02ea: ldloc.0
+			IL_02eb: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited3
+			IL_02f0: stloc.s 6
+			IL_02f2: ldloc.s 6
+			IL_02f4: stloc.s 4
+			IL_02f6: ldstr "console"
+			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0300: stloc.s 6
+			IL_0302: ldloc.s 6
+			IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0309: stloc.s 6
+			IL_030b: ldstr "r3.value="
+			IL_0310: ldloc.s 4
+			IL_0312: ldstr "value"
+			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0321: stloc.s 7
+			IL_0323: ldloc.s 6
+			IL_0325: ldstr "log"
+			IL_032a: ldloc.s 7
+			IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0331: pop
+			IL_0332: ldstr "console"
+			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_033c: stloc.s 6
+			IL_033e: ldloc.s 6
+			IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0345: stloc.s 6
+			IL_0347: ldstr "r3.done="
+			IL_034c: ldloc.s 4
+			IL_034e: ldstr "done"
+			IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_035d: stloc.s 7
+			IL_035f: ldloc.s 6
+			IL_0361: ldstr "log"
+			IL_0366: ldloc.s 7
+			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_036d: pop
+			IL_036e: ldloc.1
+			IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0374: stloc.s 6
+			IL_0376: ldloc.s 6
+			IL_0378: ldstr "next"
+			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0382: stloc.s 6
+			IL_0384: ldloc.0
+			IL_0385: ldc.i4.4
+			IL_0386: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_038b: ldloc.0
+			IL_038c: ldloc.s 6
+			IL_038e: ldarg.0
+			IL_038f: ldc.i4.4
+			IL_0390: ldloc.0
+			IL_0391: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0396: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_039b: ldloc.0
+			IL_039c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03a1: dup
+			IL_03a2: ldc.i4.0
+			IL_03a3: ldloc.1
+			IL_03a4: stelem.ref
+			IL_03a5: dup
+			IL_03a6: ldc.i4.1
+			IL_03a7: ldloc.2
+			IL_03a8: stelem.ref
+			IL_03a9: dup
+			IL_03aa: ldc.i4.2
+			IL_03ab: ldloc.3
+			IL_03ac: stelem.ref
+			IL_03ad: dup
+			IL_03ae: ldc.i4.3
+			IL_03af: ldloc.s 4
+			IL_03b1: stelem.ref
+			IL_03b2: dup
+			IL_03b3: ldc.i4.4
+			IL_03b4: ldloc.s 5
 			IL_03b6: stelem.ref
 			IL_03b7: dup
-			IL_03b8: ldc.i4.1
-			IL_03b9: ldloc.2
-			IL_03ba: stelem.ref
-			IL_03bb: dup
-			IL_03bc: ldc.i4.2
-			IL_03bd: ldloc.3
-			IL_03be: stelem.ref
-			IL_03bf: dup
-			IL_03c0: ldc.i4.3
-			IL_03c1: ldloc.s 4
-			IL_03c3: stelem.ref
-			IL_03c4: dup
-			IL_03c5: ldc.i4.4
-			IL_03c6: ldloc.s 5
-			IL_03c8: stelem.ref
-			IL_03c9: dup
-			IL_03ca: ldc.i4.5
-			IL_03cb: ldloc.s 6
-			IL_03cd: stelem.ref
-			IL_03ce: dup
-			IL_03cf: ldc.i4.6
-			IL_03d0: ldloc.s 7
-			IL_03d2: stelem.ref
-			IL_03d3: pop
-			IL_03d4: ldloc.0
-			IL_03d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03da: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03df: ret
+			IL_03b8: ldc.i4.5
+			IL_03b9: ldloc.s 6
+			IL_03bb: stelem.ref
+			IL_03bc: dup
+			IL_03bd: ldc.i4.6
+			IL_03be: ldloc.s 7
+			IL_03c0: stelem.ref
+			IL_03c1: pop
+			IL_03c2: ldloc.0
+			IL_03c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03c8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03cd: ret
 
-			IL_03e0: ldloc.0
-			IL_03e1: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited4
-			IL_03e6: stloc.s 6
-			IL_03e8: ldloc.s 6
-			IL_03ea: stloc.s 5
-			IL_03ec: ldstr "console"
-			IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03f6: stloc.s 6
-			IL_03f8: ldloc.s 6
-			IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03ff: stloc.s 6
-			IL_0401: ldstr "r4.value="
-			IL_0406: ldloc.s 5
-			IL_0408: ldstr "value"
-			IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0417: stloc.s 7
-			IL_0419: ldloc.s 6
-			IL_041b: ldstr "log"
-			IL_0420: ldloc.s 7
-			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0427: pop
-			IL_0428: ldstr "console"
-			IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0432: stloc.s 6
-			IL_0434: ldloc.s 6
-			IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_043b: stloc.s 6
-			IL_043d: ldstr "r4.done="
-			IL_0442: ldloc.s 5
-			IL_0444: ldstr "done"
-			IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0453: stloc.s 7
-			IL_0455: ldloc.s 6
-			IL_0457: ldstr "log"
-			IL_045c: ldloc.s 7
-			IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0463: pop
-			IL_0464: ldloc.0
-			IL_0465: ldc.i4.m1
-			IL_0466: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_046b: ldloc.0
-			IL_046c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0471: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0476: ldarg.0
-			IL_0477: ldc.i4.1
-			IL_0478: newarr [System.Runtime]System.Object
-			IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0482: pop
-			IL_0483: ldloc.0
-			IL_0484: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0489: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_048e: ret
+			IL_03ce: ldloc.0
+			IL_03cf: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited4
+			IL_03d4: stloc.s 6
+			IL_03d6: ldloc.s 6
+			IL_03d8: stloc.s 5
+			IL_03da: ldstr "console"
+			IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03e4: stloc.s 6
+			IL_03e6: ldloc.s 6
+			IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03ed: stloc.s 6
+			IL_03ef: ldstr "r4.value="
+			IL_03f4: ldloc.s 5
+			IL_03f6: ldstr "value"
+			IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0405: stloc.s 7
+			IL_0407: ldloc.s 6
+			IL_0409: ldstr "log"
+			IL_040e: ldloc.s 7
+			IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0415: pop
+			IL_0416: ldstr "console"
+			IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0420: stloc.s 6
+			IL_0422: ldloc.s 6
+			IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0429: stloc.s 6
+			IL_042b: ldstr "r4.done="
+			IL_0430: ldloc.s 5
+			IL_0432: ldstr "done"
+			IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0441: stloc.s 7
+			IL_0443: ldloc.s 6
+			IL_0445: ldstr "log"
+			IL_044a: ldloc.s 7
+			IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0451: pop
+			IL_0452: ldloc.0
+			IL_0453: ldc.i4.m1
+			IL_0454: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0459: ldloc.0
+			IL_045a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_045f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0464: ldarg.0
+			IL_0465: ldc.i4.1
+			IL_0466: newarr [System.Runtime]System.Object
+			IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0470: pop
+			IL_0471: ldloc.0
+			IL_0472: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0477: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_047c: ret
 		} // end of method ArrowFunction_L10C2::__js_call__
 
 	} // end of class ArrowFunction_L10C2
@@ -1072,7 +1066,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29ab
+			// Method begins at RVA 0x2999
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1167,7 +1161,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29c6
+		// Method begins at RVA 0x29b4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalAnd_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalAnd_ShortCircuit.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2142
+				// Method begins at RVA 0x2134
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,30 +46,23 @@
 			)
 			// Method begins at RVA 0x20fc
 			// Header size: 12
-			// Code size: 49 (0x31)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope::x
-			IL_0006: stloc.0
-			IL_0007: ldstr "x"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.r8 1
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0022: stloc.1
-			IL_0023: ldarg.0
-			IL_0024: ldloc.1
-			IL_0025: stfld object Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope::x
-			IL_002a: ldc.i4.1
-			IL_002b: box [System.Runtime]System.Boolean
-			IL_0030: ret
+			IL_0006: ldc.r8 1
+			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0014: stloc.0
+			IL_0015: ldarg.0
+			IL_0016: ldloc.0
+			IL_0017: stfld object Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope::x
+			IL_001c: ldc.i4.1
+			IL_001d: box [System.Runtime]System.Boolean
+			IL_0022: ret
 		} // end of method inc::__js_call__
 
 	} // end of class inc
@@ -89,7 +82,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2139
+			// Method begins at RVA 0x212b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -198,7 +191,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x214b
+		// Method begins at RVA 0x213d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ShortCircuit.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2142
+				// Method begins at RVA 0x2134
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,30 +46,23 @@
 			)
 			// Method begins at RVA 0x20fc
 			// Header size: 12
-			// Code size: 49 (0x31)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope::x
-			IL_0006: stloc.0
-			IL_0007: ldstr "x"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.r8 1
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0022: stloc.1
-			IL_0023: ldarg.0
-			IL_0024: ldloc.1
-			IL_0025: stfld object Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope::x
-			IL_002a: ldc.i4.1
-			IL_002b: box [System.Runtime]System.Boolean
-			IL_0030: ret
+			IL_0006: ldc.r8 1
+			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0014: stloc.0
+			IL_0015: ldarg.0
+			IL_0016: ldloc.0
+			IL_0017: stfld object Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope::x
+			IL_001c: ldc.i4.1
+			IL_001d: box [System.Runtime]System.Boolean
+			IL_0022: ret
 		} // end of method inc::__js_call__
 
 	} // end of class inc
@@ -89,7 +82,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2139
+			// Method begins at RVA 0x212b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -198,7 +191,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x214b
+		// Method begins at RVA 0x213d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2173
+				// Method begins at RVA 0x2153
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,38 +44,21 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2124
-			// Header size: 12
-			// Code size: 58 (0x3a)
+			// Method begins at RVA 0x2123
+			// Header size: 1
+			// Code size: 38 (0x26)
 			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] float64,
-				[2] object
-			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope::called
-			IL_0006: stloc.0
-			IL_0007: ldstr "called"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldc.r8 1
-			IL_0024: add
-			IL_0025: stloc.1
-			IL_0026: ldloc.1
-			IL_0027: box [System.Runtime]System.Double
-			IL_002c: stloc.2
-			IL_002d: ldarg.0
-			IL_002e: ldloc.2
-			IL_002f: stfld object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope::called
-			IL_0034: ldstr "x"
-			IL_0039: ret
+			IL_0001: ldarg.0
+			IL_0002: ldfld object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope::called
+			IL_0007: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000c: ldc.r8 1
+			IL_0015: add
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: stfld object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope::called
+			IL_0020: ldstr "x"
+			IL_0025: ret
 		} // end of method key::__js_call__
 
 	} // end of class key
@@ -96,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x216a
+			// Method begins at RVA 0x214a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -216,7 +199,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x217c
+		// Method begins at RVA 0x215c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_AccessorMethods_InstanceAndStatic.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_AccessorMethods_InstanceAndStatic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2695
+				// Method begins at RVA 0x2689
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x269e
+				// Method begins at RVA 0x2692
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26a7
+				// Method begins at RVA 0x269b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26b0
+				// Method begins at RVA 0x26a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26b9
+				// Method begins at RVA 0x26ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +250,7 @@
 			)
 			// Method begins at RVA 0x2630
 			// Header size: 12
-			// Code size: 69 (0x45)
+			// Code size: 57 (0x39)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -265,23 +265,19 @@
 			IL_000d: ldstr "Cannot access 'Counter' before initialization"
 			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0017: stloc.0
-			IL_0018: ldstr "Counter"
-			IL_001d: ldloc.0
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0023: stloc.0
-			IL_0024: ldarg.2
-			IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002a: ldc.r8 2
-			IL_0033: mul
-			IL_0034: stloc.1
-			IL_0035: ldloc.0
-			IL_0036: ldstr "_total"
-			IL_003b: ldloc.1
-			IL_003c: ldc.i4.1
-			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0042: pop
-			IL_0043: ldnull
-			IL_0044: ret
+			IL_0018: ldarg.2
+			IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_001e: ldc.r8 2
+			IL_0027: mul
+			IL_0028: stloc.1
+			IL_0029: ldloc.0
+			IL_002a: ldstr "_total"
+			IL_002f: ldloc.1
+			IL_0030: ldc.i4.1
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0036: pop
+			IL_0037: ldnull
+			IL_0038: ret
 		} // end of method Counter::set_total
 
 		.method private hidebysig specialname rtspecialname static 
@@ -311,7 +307,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2681
+			// Method begins at RVA 0x2675
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -889,7 +885,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26c2
+		// Method begins at RVA 0x26b6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
@@ -24,30 +24,21 @@
 			)
 			// Method begins at RVA 0x2238
 			// Header size: 12
-			// Code size: 49 (0x31)
+			// Code size: 33 (0x21)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
-			IL_0006: stloc.0
-			IL_0007: ldstr "fieldKey"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0018: ldloc.0
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldarg.0
+			IL_0006: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_0010: ldc.r8 1
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
 			IL_001e: stloc.0
 			IL_001f: ldloc.0
-			IL_0020: ldc.r8 1
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_002e: stloc.1
-			IL_002f: ldloc.1
-			IL_0030: ret
+			IL_0020: ret
 		} // end of method methodKey::__js_call__
 
 	} // end of class methodKey
@@ -63,7 +54,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22cd
+				// Method begins at RVA 0x22b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +74,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d6
+				// Method begins at RVA 0x22ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -109,9 +100,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2278
+			// Method begins at RVA 0x2268
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 52 (0x34)
 			.maxstack 8
 			.locals init (
 				[0] object[],
@@ -131,17 +122,13 @@
 			IL_0012: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
 			IL_0017: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
 			IL_001c: stloc.1
-			IL_001d: ldstr "fieldKey"
-			IL_0022: ldloc.1
-			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0028: stloc.1
-			IL_0029: ldarg.0
-			IL_002a: ldloc.1
-			IL_002b: ldc.r8 41
-			IL_0034: box [System.Runtime]System.Double
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassFieldDataProperty(object, object, object)
-			IL_003e: pop
-			IL_003f: ret
+			IL_001d: ldarg.0
+			IL_001e: ldloc.1
+			IL_001f: ldc.r8 41
+			IL_0028: box [System.Runtime]System.Double
+			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassFieldDataProperty(object, object, object)
+			IL_0032: pop
+			IL_0033: ret
 		} // end of method Example::.ctor
 
 	} // end of class Example
@@ -163,7 +150,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22c4
+			// Method begins at RVA 0x22a8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -370,7 +357,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22df
+		// Method begins at RVA 0x22c3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d3
+					// Method begins at RVA 0x21b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21dc
+					// Method begins at RVA 0x21c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -71,12 +71,11 @@
 				)
 				// Method begins at RVA 0x2114
 				// Header size: 12
-				// Code size: 161 (0xa1)
+				// Code size: 133 (0x85)
 				.maxstack 8
 				.locals init (
 					[0] object[],
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: ldarg.0
@@ -92,54 +91,42 @@
 				IL_001a: ldloc.1
 				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0020: stloc.1
-				IL_0021: ldarg.1
-				IL_0022: ldc.i4.0
-				IL_0023: ldelem.ref
-				IL_0024: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope
-				IL_0029: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
-				IL_002e: stloc.2
-				IL_002f: ldstr "GLOBAL_VALUE"
-				IL_0034: ldloc.2
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003a: stloc.2
-				IL_003b: ldloc.1
-				IL_003c: ldstr "log"
-				IL_0041: ldloc.2
-				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0047: pop
-				IL_0048: ldstr "console"
-				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0052: stloc.2
-				IL_0053: ldloc.2
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0059: stloc.2
-				IL_005a: ldarg.1
-				IL_005b: ldc.i4.1
-				IL_005c: ldelem.ref
-				IL_005d: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope
-				IL_0062: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0067: stloc.1
-				IL_0068: ldstr "FUNCTION_VALUE"
-				IL_006d: ldloc.1
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0073: stloc.1
-				IL_0074: ldloc.2
-				IL_0075: ldstr "log"
-				IL_007a: ldloc.1
-				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0080: pop
-				IL_0081: ldstr "console"
-				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_008b: stloc.1
-				IL_008c: ldloc.1
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0092: stloc.1
-				IL_0093: ldloc.1
-				IL_0094: ldstr "log"
-				IL_0099: ldarg.2
-				IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_009f: pop
-				IL_00a0: ret
+				IL_0021: ldloc.1
+				IL_0022: ldstr "log"
+				IL_0027: ldarg.1
+				IL_0028: ldc.i4.0
+				IL_0029: ldelem.ref
+				IL_002a: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope
+				IL_002f: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
+				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0039: pop
+				IL_003a: ldstr "console"
+				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0044: stloc.1
+				IL_0045: ldloc.1
+				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_004b: stloc.1
+				IL_004c: ldloc.1
+				IL_004d: ldstr "log"
+				IL_0052: ldarg.1
+				IL_0053: ldc.i4.1
+				IL_0054: ldelem.ref
+				IL_0055: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope
+				IL_005a: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
+				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0064: pop
+				IL_0065: ldstr "console"
+				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_006f: stloc.1
+				IL_0070: ldloc.1
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0076: stloc.1
+				IL_0077: ldloc.1
+				IL_0078: ldstr "log"
+				IL_007d: ldarg.2
+				IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0083: pop
+				IL_0084: ret
 			} // end of method MyClass::.ctor
 
 		} // end of class MyClass
@@ -159,7 +146,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ca
+				// Method begins at RVA 0x21ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -253,7 +240,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c1
+			// Method begins at RVA 0x21a5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -328,7 +315,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e5
+		// Method begins at RVA 0x21c9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21a8
+					// Method begins at RVA 0x218c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b1
+					// Method begins at RVA 0x2195
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -70,12 +70,11 @@
 				)
 				// Method begins at RVA 0x2108
 				// Header size: 12
-				// Code size: 130 (0x82)
+				// Code size: 102 (0x66)
 				.maxstack 8
 				.locals init (
 					[0] object[],
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: ldarg.0
@@ -91,43 +90,31 @@
 				IL_001a: ldloc.1
 				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0020: stloc.1
-				IL_0021: ldarg.1
-				IL_0022: ldc.i4.0
-				IL_0023: ldelem.ref
-				IL_0024: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope
-				IL_0029: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-				IL_002e: stloc.2
-				IL_002f: ldstr "GLOBAL_VALUE"
-				IL_0034: ldloc.2
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003a: stloc.2
-				IL_003b: ldloc.1
-				IL_003c: ldstr "log"
-				IL_0041: ldloc.2
-				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0047: pop
-				IL_0048: ldstr "console"
-				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0052: stloc.2
-				IL_0053: ldloc.2
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0059: stloc.2
-				IL_005a: ldarg.1
-				IL_005b: ldc.i4.1
-				IL_005c: ldelem.ref
-				IL_005d: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope
-				IL_0062: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0067: stloc.1
-				IL_0068: ldstr "FUNCTION_VALUE"
-				IL_006d: ldloc.1
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0073: stloc.1
-				IL_0074: ldloc.2
-				IL_0075: ldstr "log"
-				IL_007a: ldloc.1
-				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0080: pop
-				IL_0081: ret
+				IL_0021: ldloc.1
+				IL_0022: ldstr "log"
+				IL_0027: ldarg.1
+				IL_0028: ldc.i4.0
+				IL_0029: ldelem.ref
+				IL_002a: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope
+				IL_002f: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
+				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0039: pop
+				IL_003a: ldstr "console"
+				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0044: stloc.1
+				IL_0045: ldloc.1
+				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_004b: stloc.1
+				IL_004c: ldloc.1
+				IL_004d: ldstr "log"
+				IL_0052: ldarg.1
+				IL_0053: ldc.i4.1
+				IL_0054: ldelem.ref
+				IL_0055: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope
+				IL_005a: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
+				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0064: pop
+				IL_0065: ret
 			} // end of method MyClass::.ctor
 
 		} // end of class MyClass
@@ -147,7 +134,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x219f
+				// Method begins at RVA 0x2183
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -236,7 +223,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2196
+			// Method begins at RVA 0x217a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -311,7 +298,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ba
+		// Method begins at RVA 0x219e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x218e
+					// Method begins at RVA 0x2180
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2197
+					// Method begins at RVA 0x2189
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -71,12 +71,11 @@
 				)
 				// Method begins at RVA 0x2108
 				// Header size: 12
-				// Code size: 104 (0x68)
+				// Code size: 90 (0x5a)
 				.maxstack 8
 				.locals init (
 					[0] object[],
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: ldarg.0
@@ -92,33 +91,27 @@
 				IL_001a: ldloc.1
 				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0020: stloc.1
-				IL_0021: ldarg.1
-				IL_0022: ldc.i4.1
-				IL_0023: ldelem.ref
-				IL_0024: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope
-				IL_0029: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_002e: stloc.2
-				IL_002f: ldstr "FUNCTION_VALUE"
-				IL_0034: ldloc.2
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003a: stloc.2
-				IL_003b: ldloc.1
-				IL_003c: ldstr "log"
-				IL_0041: ldloc.2
-				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0047: pop
-				IL_0048: ldstr "console"
-				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0052: stloc.2
-				IL_0053: ldloc.2
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0059: stloc.2
-				IL_005a: ldloc.2
-				IL_005b: ldstr "log"
-				IL_0060: ldarg.2
-				IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0066: pop
-				IL_0067: ret
+				IL_0021: ldloc.1
+				IL_0022: ldstr "log"
+				IL_0027: ldarg.1
+				IL_0028: ldc.i4.1
+				IL_0029: ldelem.ref
+				IL_002a: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope
+				IL_002f: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
+				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0039: pop
+				IL_003a: ldstr "console"
+				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0044: stloc.1
+				IL_0045: ldloc.1
+				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_004b: stloc.1
+				IL_004c: ldloc.1
+				IL_004d: ldstr "log"
+				IL_0052: ldarg.2
+				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0058: pop
+				IL_0059: ret
 			} // end of method MyClass::.ctor
 
 		} // end of class MyClass
@@ -138,7 +131,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2185
+				// Method begins at RVA 0x2177
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -229,7 +222,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217c
+			// Method begins at RVA 0x216e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -301,7 +294,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21a0
+		// Method begins at RVA 0x2192
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2163
+					// Method begins at RVA 0x2155
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x216c
+					// Method begins at RVA 0x215e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -70,12 +70,11 @@
 				)
 				// Method begins at RVA 0x20fc
 				// Header size: 12
-				// Code size: 73 (0x49)
+				// Code size: 59 (0x3b)
 				.maxstack 8
 				.locals init (
 					[0] object[],
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: ldarg.0
@@ -91,22 +90,16 @@
 				IL_001a: ldloc.1
 				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0020: stloc.1
-				IL_0021: ldarg.1
-				IL_0022: ldc.i4.1
-				IL_0023: ldelem.ref
-				IL_0024: castclass Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope
-				IL_0029: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_002e: stloc.2
-				IL_002f: ldstr "FUNCTION_VALUE"
-				IL_0034: ldloc.2
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003a: stloc.2
-				IL_003b: ldloc.1
-				IL_003c: ldstr "log"
-				IL_0041: ldloc.2
-				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0047: pop
-				IL_0048: ret
+				IL_0021: ldloc.1
+				IL_0022: ldstr "log"
+				IL_0027: ldarg.1
+				IL_0028: ldc.i4.1
+				IL_0029: ldelem.ref
+				IL_002a: castclass Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope
+				IL_002f: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
+				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0039: pop
+				IL_003a: ret
 			} // end of method MyClass::.ctor
 
 		} // end of class MyClass
@@ -126,7 +119,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x215a
+				// Method begins at RVA 0x214c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -212,7 +205,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2151
+			// Method begins at RVA 0x2143
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -284,7 +277,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2175
+		// Method begins at RVA 0x2167
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2135
+				// Method begins at RVA 0x2127
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x213e
+				// Method begins at RVA 0x2130
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -67,12 +67,11 @@
 			)
 			// Method begins at RVA 0x20b8
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 90 (0x5a)
 			.maxstack 8
 			.locals init (
 				[0] object[],
-				[1] object,
-				[2] object
+				[1] object
 			)
 
 			IL_0000: ldarg.0
@@ -88,33 +87,27 @@
 			IL_001a: ldloc.1
 			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0020: stloc.1
-			IL_0021: ldarg.1
-			IL_0022: ldc.i4.0
-			IL_0023: ldelem.ref
-			IL_0024: castclass Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope
-			IL_0029: ldfld string Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
-			IL_002e: stloc.2
-			IL_002f: ldstr "GLOBAL_VALUE"
-			IL_0034: ldloc.2
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003a: stloc.2
-			IL_003b: ldloc.1
-			IL_003c: ldstr "log"
-			IL_0041: ldloc.2
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0047: pop
-			IL_0048: ldstr "console"
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0052: stloc.2
-			IL_0053: ldloc.2
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0059: stloc.2
-			IL_005a: ldloc.2
-			IL_005b: ldstr "log"
-			IL_0060: ldarg.2
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0066: pop
-			IL_0067: ret
+			IL_0021: ldloc.1
+			IL_0022: ldstr "log"
+			IL_0027: ldarg.1
+			IL_0028: ldc.i4.0
+			IL_0029: ldelem.ref
+			IL_002a: castclass Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope
+			IL_002f: ldfld string Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0039: pop
+			IL_003a: ldstr "console"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0044: stloc.1
+			IL_0045: ldloc.1
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_004b: stloc.1
+			IL_004c: ldloc.1
+			IL_004d: ldstr "log"
+			IL_0052: ldarg.2
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0058: pop
+			IL_0059: ret
 		} // end of method MyClass::.ctor
 
 	} // end of class MyClass
@@ -134,7 +127,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x212c
+			// Method begins at RVA 0x211e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -210,7 +203,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2147
+		// Method begins at RVA 0x2139
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariable_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x210a
+				// Method begins at RVA 0x20fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2113
+				// Method begins at RVA 0x2105
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,12 +66,11 @@
 			)
 			// Method begins at RVA 0x20ac
 			// Header size: 12
-			// Code size: 73 (0x49)
+			// Code size: 59 (0x3b)
 			.maxstack 8
 			.locals init (
 				[0] object[],
-				[1] object,
-				[2] object
+				[1] object
 			)
 
 			IL_0000: ldarg.0
@@ -87,22 +86,16 @@
 			IL_001a: ldloc.1
 			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0020: stloc.1
-			IL_0021: ldarg.1
-			IL_0022: ldc.i4.0
-			IL_0023: ldelem.ref
-			IL_0024: castclass Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope
-			IL_0029: ldfld string Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
-			IL_002e: stloc.2
-			IL_002f: ldstr "GLOBAL_VALUE"
-			IL_0034: ldloc.2
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003a: stloc.2
-			IL_003b: ldloc.1
-			IL_003c: ldstr "log"
-			IL_0041: ldloc.2
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0047: pop
-			IL_0048: ret
+			IL_0021: ldloc.1
+			IL_0022: ldstr "log"
+			IL_0027: ldarg.1
+			IL_0028: ldc.i4.0
+			IL_0029: ldelem.ref
+			IL_002a: castclass Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope
+			IL_002f: ldfld string Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0039: pop
+			IL_003a: ret
 		} // end of method MyClass::.ctor
 
 	} // end of class MyClass
@@ -122,7 +115,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2101
+			// Method begins at RVA 0x20f3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -193,7 +186,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x211c
+		// Method begins at RVA 0x210e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21dd
+				// Method begins at RVA 0x21d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e6
+				// Method begins at RVA 0x21da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -67,11 +67,10 @@
 			)
 			// Method begins at RVA 0x2194
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 40 (0x28)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -81,19 +80,15 @@
 			IL_0008: ldarg.0
 			IL_0009: ldloc.0
 			IL_000a: stfld object[] Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner::_scopes
-			IL_000f: ldstr "GLOBAL_VALUE"
-			IL_0014: ldarg.1
-			IL_0015: ldc.i4.0
-			IL_0016: ldelem.ref
-			IL_0017: castclass Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope
-			IL_001c: ldfld float64 Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::GLOBAL_VALUE
-			IL_0021: box [System.Runtime]System.Double
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_002b: stloc.1
-			IL_002c: ldarg.0
-			IL_002d: ldloc.1
-			IL_002e: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner::'value'
-			IL_0033: ret
+			IL_000f: ldarg.0
+			IL_0010: ldarg.1
+			IL_0011: ldc.i4.0
+			IL_0012: ldelem.ref
+			IL_0013: castclass Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope
+			IL_0018: ldfld float64 Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::GLOBAL_VALUE
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner::'value'
+			IL_0027: ret
 		} // end of method Inner::.ctor
 
 	} // end of class Inner
@@ -109,7 +104,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ef
+				// Method begins at RVA 0x21e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -129,7 +124,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f8
+				// Method begins at RVA 0x21ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -200,7 +195,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d4
+			// Method begins at RVA 0x21c8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -331,7 +326,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2201
+		// Method begins at RVA 0x21f5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2214
+					// Method begins at RVA 0x21f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x221d
+					// Method begins at RVA 0x2201
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -94,11 +94,10 @@
 				)
 				// Method begins at RVA 0x2178
 				// Header size: 12
-				// Code size: 126 (0x7e)
+				// Code size: 98 (0x62)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldstr "console"
@@ -107,46 +106,34 @@
 				IL_000b: ldloc.0
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0011: stloc.0
-				IL_0012: ldarg.0
-				IL_0013: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::_scopes
-				IL_0018: ldc.i4.0
-				IL_0019: ldelem.ref
-				IL_001a: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
-				IL_001f: ldfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-				IL_0024: stloc.1
-				IL_0025: ldstr "GLOBAL_VALUE"
-				IL_002a: ldloc.1
-				IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0030: stloc.1
-				IL_0031: ldloc.0
-				IL_0032: ldstr "log"
-				IL_0037: ldloc.1
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_003d: pop
-				IL_003e: ldstr "console"
-				IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0048: stloc.1
-				IL_0049: ldloc.1
-				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004f: stloc.1
-				IL_0050: ldarg.0
-				IL_0051: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::_scopes
-				IL_0056: ldc.i4.1
-				IL_0057: ldelem.ref
-				IL_0058: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope
-				IL_005d: ldfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope::FUNCTION_VALUE
-				IL_0062: stloc.0
-				IL_0063: ldstr "FUNCTION_VALUE"
-				IL_0068: ldloc.0
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006e: stloc.0
-				IL_006f: ldloc.1
-				IL_0070: ldstr "log"
-				IL_0075: ldloc.0
-				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_007b: pop
-				IL_007c: ldnull
-				IL_007d: ret
+				IL_0012: ldloc.0
+				IL_0013: ldstr "log"
+				IL_0018: ldarg.0
+				IL_0019: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::_scopes
+				IL_001e: ldc.i4.0
+				IL_001f: ldelem.ref
+				IL_0020: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
+				IL_0025: ldfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_002f: pop
+				IL_0030: ldstr "console"
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_003a: stloc.0
+				IL_003b: ldloc.0
+				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0041: stloc.0
+				IL_0042: ldloc.0
+				IL_0043: ldstr "log"
+				IL_0048: ldarg.0
+				IL_0049: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::_scopes
+				IL_004e: ldc.i4.1
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope
+				IL_0055: ldfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope::FUNCTION_VALUE
+				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_005f: pop
+				IL_0060: ldnull
+				IL_0061: ret
 			} // end of method MyClass::logValues
 
 		} // end of class MyClass
@@ -166,7 +153,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x220b
+				// Method begins at RVA 0x21ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -271,7 +258,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2202
+			// Method begins at RVA 0x21e6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -360,7 +347,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2226
+		// Method begins at RVA 0x220a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ca
+					// Method begins at RVA 0x21bc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d3
+					// Method begins at RVA 0x21c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -94,11 +94,10 @@
 				)
 				// Method begins at RVA 0x216c
 				// Header size: 12
-				// Code size: 64 (0x40)
+				// Code size: 50 (0x32)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldstr "console"
@@ -107,24 +106,18 @@
 				IL_000b: ldloc.0
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0011: stloc.0
-				IL_0012: ldarg.0
-				IL_0013: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::_scopes
-				IL_0018: ldc.i4.1
-				IL_0019: ldelem.ref
-				IL_001a: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope
-				IL_001f: ldfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope::FUNCTION_VALUE
-				IL_0024: stloc.1
-				IL_0025: ldstr "FUNCTION_VALUE"
-				IL_002a: ldloc.1
-				IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0030: stloc.1
-				IL_0031: ldloc.0
-				IL_0032: ldstr "log"
-				IL_0037: ldloc.1
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_003d: pop
-				IL_003e: ldnull
-				IL_003f: ret
+				IL_0012: ldloc.0
+				IL_0013: ldstr "log"
+				IL_0018: ldarg.0
+				IL_0019: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::_scopes
+				IL_001e: ldc.i4.1
+				IL_001f: ldelem.ref
+				IL_0020: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope
+				IL_0025: ldfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope::FUNCTION_VALUE
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_002f: pop
+				IL_0030: ldnull
+				IL_0031: ret
 			} // end of method MyClass::logValue
 
 		} // end of class MyClass
@@ -144,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c1
+				// Method begins at RVA 0x21b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -241,7 +234,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b8
+			// Method begins at RVA 0x21aa
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -327,7 +320,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21dc
+		// Method begins at RVA 0x21ce
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ec
+					// Method begins at RVA 0x21d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21f5
+					// Method begins at RVA 0x21d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -94,11 +94,10 @@
 				)
 				// Method begins at RVA 0x2150
 				// Header size: 12
-				// Code size: 126 (0x7e)
+				// Code size: 98 (0x62)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldstr "console"
@@ -107,46 +106,34 @@
 				IL_000b: ldloc.0
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0011: stloc.0
-				IL_0012: ldarg.0
-				IL_0013: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::_scopes
-				IL_0018: ldc.i4.0
-				IL_0019: ldelem.ref
-				IL_001a: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope
-				IL_001f: ldfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-				IL_0024: stloc.1
-				IL_0025: ldstr "GLOBAL_VALUE"
-				IL_002a: ldloc.1
-				IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0030: stloc.1
-				IL_0031: ldloc.0
-				IL_0032: ldstr "log"
-				IL_0037: ldloc.1
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_003d: pop
-				IL_003e: ldstr "console"
-				IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0048: stloc.1
-				IL_0049: ldloc.1
-				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004f: stloc.1
-				IL_0050: ldarg.0
-				IL_0051: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::_scopes
-				IL_0056: ldc.i4.1
-				IL_0057: ldelem.ref
-				IL_0058: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope
-				IL_005d: ldfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0062: stloc.0
-				IL_0063: ldstr "FUNCTION_VALUE"
-				IL_0068: ldloc.0
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006e: stloc.0
-				IL_006f: ldloc.1
-				IL_0070: ldstr "log"
-				IL_0075: ldloc.0
-				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_007b: pop
-				IL_007c: ldnull
-				IL_007d: ret
+				IL_0012: ldloc.0
+				IL_0013: ldstr "log"
+				IL_0018: ldarg.0
+				IL_0019: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::_scopes
+				IL_001e: ldc.i4.0
+				IL_001f: ldelem.ref
+				IL_0020: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope
+				IL_0025: ldfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_002f: pop
+				IL_0030: ldstr "console"
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_003a: stloc.0
+				IL_003b: ldloc.0
+				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0041: stloc.0
+				IL_0042: ldloc.0
+				IL_0043: ldstr "log"
+				IL_0048: ldarg.0
+				IL_0049: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::_scopes
+				IL_004e: ldc.i4.1
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope
+				IL_0055: ldfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
+				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_005f: pop
+				IL_0060: ldnull
+				IL_0061: ret
 			} // end of method MyClass::logValues
 
 		} // end of class MyClass
@@ -166,7 +153,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e3
+				// Method begins at RVA 0x21c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +261,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21da
+			// Method begins at RVA 0x21be
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -349,7 +336,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21fe
+		// Method begins at RVA 0x21e2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21a2
+					// Method begins at RVA 0x2194
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ab
+					// Method begins at RVA 0x219d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -94,11 +94,10 @@
 				)
 				// Method begins at RVA 0x2144
 				// Header size: 12
-				// Code size: 64 (0x40)
+				// Code size: 50 (0x32)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldstr "console"
@@ -107,24 +106,18 @@
 				IL_000b: ldloc.0
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0011: stloc.0
-				IL_0012: ldarg.0
-				IL_0013: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::_scopes
-				IL_0018: ldc.i4.1
-				IL_0019: ldelem.ref
-				IL_001a: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope
-				IL_001f: ldfld string Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0024: stloc.1
-				IL_0025: ldstr "FUNCTION_VALUE"
-				IL_002a: ldloc.1
-				IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0030: stloc.1
-				IL_0031: ldloc.0
-				IL_0032: ldstr "log"
-				IL_0037: ldloc.1
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_003d: pop
-				IL_003e: ldnull
-				IL_003f: ret
+				IL_0012: ldloc.0
+				IL_0013: ldstr "log"
+				IL_0018: ldarg.0
+				IL_0019: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::_scopes
+				IL_001e: ldc.i4.1
+				IL_001f: ldelem.ref
+				IL_0020: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope
+				IL_0025: ldfld string Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_002f: pop
+				IL_0030: ldnull
+				IL_0031: ret
 			} // end of method MyClass::logValue
 
 		} // end of class MyClass
@@ -144,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2199
+				// Method begins at RVA 0x218b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -249,7 +242,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2190
+			// Method begins at RVA 0x2182
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -321,7 +314,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b4
+		// Method begins at RVA 0x21a6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2149
+				// Method begins at RVA 0x213b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2152
+				// Method begins at RVA 0x2144
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -90,11 +90,10 @@
 			)
 			// Method begins at RVA 0x20f4
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 50 (0x32)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldstr "console"
@@ -103,24 +102,18 @@
 			IL_000b: ldloc.0
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
-			IL_0012: ldarg.0
-			IL_0013: ldfld object[] Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::_scopes
-			IL_0018: ldc.i4.0
-			IL_0019: ldelem.ref
-			IL_001a: castclass Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope
-			IL_001f: ldfld string Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
-			IL_0024: stloc.1
-			IL_0025: ldstr "GLOBAL_VALUE"
-			IL_002a: ldloc.1
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0030: stloc.1
-			IL_0031: ldloc.0
-			IL_0032: ldstr "log"
-			IL_0037: ldloc.1
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003d: pop
-			IL_003e: ldnull
-			IL_003f: ret
+			IL_0012: ldloc.0
+			IL_0013: ldstr "log"
+			IL_0018: ldarg.0
+			IL_0019: ldfld object[] Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::_scopes
+			IL_001e: ldc.i4.0
+			IL_001f: ldelem.ref
+			IL_0020: castclass Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope
+			IL_0025: ldfld string Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_002f: pop
+			IL_0030: ldnull
+			IL_0031: ret
 		} // end of method MyClass::logGlobal
 
 	} // end of class MyClass
@@ -140,7 +133,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2140
+			// Method begins at RVA 0x2132
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -230,7 +223,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x215b
+		// Method begins at RVA 0x214d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x248b
+				// Method begins at RVA 0x2493
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2494
+				// Method begins at RVA 0x249c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x249d
+				// Method begins at RVA 0x24a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24af
+					// Method begins at RVA 0x24b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24b8
+					// Method begins at RVA 0x24c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a6
+				// Method begins at RVA 0x24ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -177,7 +177,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2478
+			// Method begins at RVA 0x2480
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -197,7 +197,7 @@
 			)
 			// Method begins at RVA 0x22e8
 			// Header size: 12
-			// Code size: 372 (0x174)
+			// Code size: 377 (0x179)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_log/Block_L15C8,
@@ -209,8 +209,9 @@
 				[6] object,
 				[7] string,
 				[8] object,
-				[9] float64,
-				[10] object
+				[9] bool,
+				[10] float64,
+				[11] object
 			)
 
 			IL_0000: ldstr "console"
@@ -235,7 +236,7 @@
 				IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
 				IL_003c: throw
 
-				IL_003d: leave IL_00fc
+				IL_003d: leave IL_0101
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -294,56 +295,57 @@
 				IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_00d3: stloc.s 8
 				IL_00d5: ldloc.s 8
-				IL_00d7: ldstr "includes"
+				IL_00d7: castclass [System.Runtime]System.String
 				IL_00dc: ldstr "without a setter"
-				IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00e6: stloc.s 8
+				IL_00e1: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+				IL_00e6: stloc.s 9
 				IL_00e8: ldloc.s 6
 				IL_00ea: ldstr "log"
-				IL_00ef: ldloc.s 8
-				IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00f6: pop
-				IL_00f7: leave IL_00fc
+				IL_00ef: ldloc.s 9
+				IL_00f1: box [System.Runtime]System.Boolean
+				IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00fb: pop
+				IL_00fc: leave IL_0101
 			} // end handler
 
-			IL_00fc: ldarg.0
-			IL_00fd: ldc.r8 7
-			IL_0106: box [System.Runtime]System.Double
-			IL_010b: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_set_writeOnly(object)
-			IL_0110: pop
-			IL_0111: ldstr "console"
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_011b: stloc.s 8
-			IL_011d: ldloc.s 8
-			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0124: stloc.s 8
-			IL_0126: ldloc.s 8
-			IL_0128: ldstr "log"
-			IL_012d: ldarg.0
-			IL_012e: ldfld object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::saved
-			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0138: pop
-			IL_0139: ldstr "console"
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0143: stloc.s 8
-			IL_0145: ldloc.s 8
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014c: stloc.s 8
-			IL_014e: ldarg.0
-			IL_014f: callvirt instance float64 Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_get_readOnly()
-			IL_0154: stloc.s 9
-			IL_0156: ldloc.s 9
-			IL_0158: box [System.Runtime]System.Double
-			IL_015d: stloc.s 10
-			IL_015f: ldloc.s 8
-			IL_0161: ldstr "log"
-			IL_0166: ldloc.s 10
-			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_016d: pop
-			IL_016e: ldnull
-			IL_016f: stloc.s 5
-			IL_0171: ldloc.s 5
-			IL_0173: ret
+			IL_0101: ldarg.0
+			IL_0102: ldc.r8 7
+			IL_010b: box [System.Runtime]System.Double
+			IL_0110: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_set_writeOnly(object)
+			IL_0115: pop
+			IL_0116: ldstr "console"
+			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0120: stloc.s 6
+			IL_0122: ldloc.s 6
+			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0129: stloc.s 6
+			IL_012b: ldloc.s 6
+			IL_012d: ldstr "log"
+			IL_0132: ldarg.0
+			IL_0133: ldfld object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::saved
+			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_013d: pop
+			IL_013e: ldstr "console"
+			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0148: stloc.s 6
+			IL_014a: ldloc.s 6
+			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0151: stloc.s 6
+			IL_0153: ldarg.0
+			IL_0154: callvirt instance float64 Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_get_readOnly()
+			IL_0159: stloc.s 10
+			IL_015b: ldloc.s 10
+			IL_015d: box [System.Runtime]System.Double
+			IL_0162: stloc.s 11
+			IL_0164: ldloc.s 6
+			IL_0166: ldstr "log"
+			IL_016b: ldloc.s 11
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0172: pop
+			IL_0173: ldnull
+			IL_0174: stloc.s 5
+			IL_0176: ldloc.s 5
+			IL_0178: ret
 		} // end of method AccessorEdges::log
 
 	} // end of class AccessorEdges
@@ -355,7 +357,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2482
+			// Method begins at RVA 0x248a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -670,7 +672,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24c1
+		// Method begins at RVA 0x24c9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2382
+					// Method begins at RVA 0x2360
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x238b
+					// Method begins at RVA 0x2369
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -93,30 +93,19 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Method begins at RVA 0x2330
-				// Header size: 12
-				// Code size: 52 (0x34)
+				// Header size: 1
+				// Code size: 29 (0x1d)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] float64
-				)
 
-				IL_0000: ldstr "captured"
-				IL_0005: ldarg.0
-				IL_0006: ldfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base::_scopes
-				IL_000b: ldc.i4.1
-				IL_000c: ldelem.ref
-				IL_000d: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope
-				IL_0012: ldfld float64 Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::captured
-				IL_0017: box [System.Runtime]System.Double
-				IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0021: stloc.0
-				IL_0022: ldloc.0
-				IL_0023: ldc.r8 2
-				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, float64)
-				IL_0031: stloc.1
-				IL_0032: ldloc.1
-				IL_0033: ret
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base::_scopes
+				IL_0006: ldc.i4.1
+				IL_0007: ldelem.ref
+				IL_0008: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope
+				IL_000d: ldfld float64 Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::captured
+				IL_0012: ldc.r8 2
+				IL_001b: add
+				IL_001c: ret
 			} // end of method Base::m
 
 		} // end of class Base
@@ -132,7 +121,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2394
+					// Method begins at RVA 0x2372
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -152,7 +141,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x239d
+					// Method begins at RVA 0x237b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -240,7 +229,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2379
+				// Method begins at RVA 0x2357
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -529,7 +518,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2370
+			// Method begins at RVA 0x234e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -601,7 +590,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23a6
+		// Method begins at RVA 0x2384
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22f1
+			// Method begins at RVA 0x22c3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -145,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2303
+				// Method begins at RVA 0x22d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -174,36 +174,21 @@
 			)
 			// Method begins at RVA 0x2208
 			// Header size: 12
-			// Code size: 49 (0x31)
+			// Code size: 21 (0x15)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] float64,
-				[2] float64,
-				[3] object
+				[0] float64
 			)
 
-			IL_0000: ldstr "moduleFactor"
-			IL_0005: ldarg.0
-			IL_0006: ldfld float64 Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope::moduleFactor
-			IL_000b: box [System.Runtime]System.Double
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0015: stloc.0
-			IL_0016: ldarg.2
-			IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001c: stloc.1
-			IL_001d: ldloc.0
-			IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0023: stloc.2
-			IL_0024: ldloc.1
-			IL_0025: ldloc.2
-			IL_0026: mul
-			IL_0027: stloc.2
-			IL_0028: ldloc.2
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: stloc.3
-			IL_002f: ldloc.3
-			IL_0030: ret
+			IL_0000: ldarg.0
+			IL_0001: ldfld float64 Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope::moduleFactor
+			IL_0006: stloc.0
+			IL_0007: ldarg.2
+			IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000d: ldloc.0
+			IL_000e: mul
+			IL_000f: box [System.Runtime]System.Double
+			IL_0014: ret
 		} // end of method multiplyModuleFactor::__js_call__
 
 	} // end of class multiplyModuleFactor
@@ -223,7 +208,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2315
+					// Method begins at RVA 0x22e7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -248,15 +233,13 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22b0
+				// Method begins at RVA 0x2294
 				// Header size: 12
-				// Code size: 53 (0x35)
+				// Code size: 35 (0x23)
 				.maxstack 8
 				.locals init (
 					[0] object,
-					[1] float64,
-					[2] float64,
-					[3] object
+					[1] float64
 				)
 
 				IL_0000: ldarg.0
@@ -265,25 +248,15 @@
 				IL_0003: castclass Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope
 				IL_0008: ldfld object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope::factor
 				IL_000d: stloc.0
-				IL_000e: ldstr "factor"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldarg.2
-				IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.0
-				IL_0022: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0027: stloc.2
-				IL_0028: ldloc.1
-				IL_0029: ldloc.2
-				IL_002a: mul
-				IL_002b: stloc.2
-				IL_002c: ldloc.2
-				IL_002d: box [System.Runtime]System.Double
-				IL_0032: stloc.3
-				IL_0033: ldloc.3
-				IL_0034: ret
+				IL_000e: ldarg.2
+				IL_000f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0014: stloc.1
+				IL_0015: ldloc.1
+				IL_0016: ldloc.0
+				IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001c: mul
+				IL_001d: box [System.Runtime]System.Double
+				IL_0022: ret
 			} // end of method multiply::__js_call__
 
 		} // end of class multiply
@@ -304,7 +277,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230c
+				// Method begins at RVA 0x22de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -331,7 +304,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2248
+			// Method begins at RVA 0x222c
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -407,7 +380,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22fa
+			// Method begins at RVA 0x22cc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -516,7 +489,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x231e
+		// Method begins at RVA 0x22f0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2468
+				// Method begins at RVA 0x2432
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2483
+				// Method begins at RVA 0x244d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,12 +98,11 @@
 			)
 			// Method begins at RVA 0x228c
 			// Header size: 12
-			// Code size: 83 (0x53)
+			// Code size: 69 (0x45)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] string
+				[1] string
 			)
 
 			IL_0000: ldstr "console"
@@ -114,29 +113,23 @@
 			IL_0011: stloc.0
 			IL_0012: ldarg.0
 			IL_0013: ldfld string Modules.CommonJS_Require_Basic/Scope::moduleName
-			IL_0018: stloc.1
-			IL_0019: ldstr "moduleName"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: ldloc.1
-			IL_0026: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_002b: stloc.2
-			IL_002c: ldstr "Function from "
-			IL_0031: ldloc.2
-			IL_0032: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0037: stloc.2
-			IL_0038: ldloc.2
-			IL_0039: ldstr " has been called"
-			IL_003e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0043: stloc.2
-			IL_0044: ldloc.0
-			IL_0045: ldstr "log"
-			IL_004a: ldloc.2
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0050: pop
-			IL_0051: ldnull
-			IL_0052: ret
+			IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_001d: stloc.1
+			IL_001e: ldstr "Function from "
+			IL_0023: ldloc.1
+			IL_0024: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0029: stloc.1
+			IL_002a: ldloc.1
+			IL_002b: ldstr " has been called"
+			IL_0030: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0035: stloc.1
+			IL_0036: ldloc.0
+			IL_0037: ldstr "log"
+			IL_003c: ldloc.1
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0042: pop
+			IL_0043: ldnull
+			IL_0044: ret
 		} // end of method commonFunctionName::__js_call__
 
 	} // end of class commonFunctionName
@@ -152,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2471
+				// Method begins at RVA 0x243b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -172,7 +165,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x247a
+				// Method begins at RVA 0x2444
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -198,7 +191,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22ec
+			// Method begins at RVA 0x22e0
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -222,14 +215,13 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2308
+			// Method begins at RVA 0x22fc
 			// Header size: 12
-			// Code size: 95 (0x5f)
+			// Code size: 81 (0x51)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] string
+				[1] string
 			)
 
 			IL_0000: ldstr "console"
@@ -244,29 +236,23 @@
 			IL_0019: ldelem.ref
 			IL_001a: castclass Modules.CommonJS_Require_Basic/Scope
 			IL_001f: ldfld string Modules.CommonJS_Require_Basic/Scope::moduleName
-			IL_0024: stloc.1
-			IL_0025: ldstr "moduleName"
-			IL_002a: ldloc.1
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0030: stloc.1
-			IL_0031: ldloc.1
-			IL_0032: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0037: stloc.2
-			IL_0038: ldstr "class from "
-			IL_003d: ldloc.2
-			IL_003e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0043: stloc.2
-			IL_0044: ldloc.2
-			IL_0045: ldstr " has been loaded"
-			IL_004a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_004f: stloc.2
-			IL_0050: ldloc.0
-			IL_0051: ldstr "log"
-			IL_0056: ldloc.2
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005c: pop
-			IL_005d: ldnull
-			IL_005e: ret
+			IL_0024: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0029: stloc.1
+			IL_002a: ldstr "class from "
+			IL_002f: ldloc.1
+			IL_0030: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0035: stloc.1
+			IL_0036: ldloc.1
+			IL_0037: ldstr " has been loaded"
+			IL_003c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0041: stloc.1
+			IL_0042: ldloc.0
+			IL_0043: ldstr "log"
+			IL_0048: ldloc.1
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004e: pop
+			IL_004f: ldnull
+			IL_0050: ret
 		} // end of method CommonClassName::Log
 
 	} // end of class CommonClassName
@@ -289,7 +275,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x245f
+			// Method begins at RVA 0x2429
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -452,7 +438,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2495
+				// Method begins at RVA 0x245f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -476,7 +462,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2373
+			// Method begins at RVA 0x2359
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -498,7 +484,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b0
+				// Method begins at RVA 0x247a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -524,14 +510,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2378
+			// Method begins at RVA 0x235c
 			// Header size: 12
-			// Code size: 83 (0x53)
+			// Code size: 69 (0x45)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] string
+				[1] string
 			)
 
 			IL_0000: ldstr "console"
@@ -542,29 +527,23 @@
 			IL_0011: stloc.0
 			IL_0012: ldarg.0
 			IL_0013: ldfld string Modules.CommonJS_Require_Dependency/Scope::moduleName
-			IL_0018: stloc.1
-			IL_0019: ldstr "moduleName"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: ldloc.1
-			IL_0026: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_002b: stloc.2
-			IL_002c: ldstr "Function from "
-			IL_0031: ldloc.2
-			IL_0032: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0037: stloc.2
-			IL_0038: ldloc.2
-			IL_0039: ldstr " has been called"
-			IL_003e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0043: stloc.2
-			IL_0044: ldloc.0
-			IL_0045: ldstr "log"
-			IL_004a: ldloc.2
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0050: pop
-			IL_0051: ldnull
-			IL_0052: ret
+			IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_001d: stloc.1
+			IL_001e: ldstr "Function from "
+			IL_0023: ldloc.1
+			IL_0024: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0029: stloc.1
+			IL_002a: ldloc.1
+			IL_002b: ldstr " has been called"
+			IL_0030: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0035: stloc.1
+			IL_0036: ldloc.0
+			IL_0037: ldstr "log"
+			IL_003c: ldloc.1
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0042: pop
+			IL_0043: ldnull
+			IL_0044: ret
 		} // end of method commonFunctionName::__js_call__
 
 	} // end of class commonFunctionName
@@ -580,7 +559,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x249e
+				// Method begins at RVA 0x2468
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -600,7 +579,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a7
+				// Method begins at RVA 0x2471
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -626,7 +605,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23d8
+			// Method begins at RVA 0x23b0
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -650,14 +629,13 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f4
+			// Method begins at RVA 0x23cc
 			// Header size: 12
-			// Code size: 95 (0x5f)
+			// Code size: 81 (0x51)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] string
+				[1] string
 			)
 
 			IL_0000: ldstr "console"
@@ -672,29 +650,23 @@
 			IL_0019: ldelem.ref
 			IL_001a: castclass Modules.CommonJS_Require_Dependency/Scope
 			IL_001f: ldfld string Modules.CommonJS_Require_Dependency/Scope::moduleName
-			IL_0024: stloc.1
-			IL_0025: ldstr "moduleName"
-			IL_002a: ldloc.1
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0030: stloc.1
-			IL_0031: ldloc.1
-			IL_0032: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0037: stloc.2
-			IL_0038: ldstr "class from "
-			IL_003d: ldloc.2
-			IL_003e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0043: stloc.2
-			IL_0044: ldloc.2
-			IL_0045: ldstr " has been loaded"
-			IL_004a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_004f: stloc.2
-			IL_0050: ldloc.0
-			IL_0051: ldstr "log"
-			IL_0056: ldloc.2
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005c: pop
-			IL_005d: ldnull
-			IL_005e: ret
+			IL_0024: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0029: stloc.1
+			IL_002a: ldstr "class from "
+			IL_002f: ldloc.1
+			IL_0030: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0035: stloc.1
+			IL_0036: ldloc.1
+			IL_0037: ldstr " has been loaded"
+			IL_003c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0041: stloc.1
+			IL_0042: ldloc.0
+			IL_0043: ldstr "log"
+			IL_0048: ldloc.1
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004e: pop
+			IL_004f: ldnull
+			IL_0050: ret
 		} // end of method CommonClassName::Log
 
 	} // end of class CommonClassName
@@ -717,7 +689,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x248c
+			// Method begins at RVA 0x2456
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -851,7 +823,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24b9
+		// Method begins at RVA 0x2483
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fd
+				// Method begins at RVA 0x21f1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,7 +47,7 @@
 			)
 			// Method begins at RVA 0x2164
 			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Code size: 50 (0x32)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -56,29 +56,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope::URL
 			IL_0006: stloc.0
-			IL_0007: ldstr "URL"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldstr "base"
-			IL_0021: stelem.ref
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0027: stloc.0
-			IL_0028: ldloc.0
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002e: stloc.0
-			IL_002f: ldloc.0
-			IL_0030: ldstr "resolve"
-			IL_0035: ldarg.2
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003b: stloc.0
-			IL_003c: ldloc.0
-			IL_003d: ret
+			IL_0007: ldloc.0
+			IL_0008: ldc.i4.1
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldstr "base"
+			IL_0015: stelem.ref
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_001b: stloc.0
+			IL_001c: ldloc.0
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0022: stloc.0
+			IL_0023: ldloc.0
+			IL_0024: ldstr "resolve"
+			IL_0029: ldarg.2
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_002f: stloc.0
+			IL_0030: ldloc.0
+			IL_0031: ret
 		} // end of method FunctionExpression_descriptor::__js_call__
 
 	} // end of class FunctionExpression_descriptor
@@ -97,7 +93,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21f4
+			// Method begins at RVA 0x21e8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -207,7 +203,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x220f
+				// Method begins at RVA 0x2203
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -231,7 +227,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21ae
+			// Method begins at RVA 0x21a2
 			// Header size: 1
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -259,7 +255,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2218
+				// Method begins at RVA 0x220c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -283,7 +279,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21b8
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -321,7 +317,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2206
+			// Method begins at RVA 0x21fa
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -405,7 +401,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2221
+		// Method begins at RVA 0x2215
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x247f
+			// Method begins at RVA 0x2449
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -94,7 +94,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2491
+				// Method begins at RVA 0x245b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +140,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ac
+				// Method begins at RVA 0x2476
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -168,12 +168,11 @@
 			)
 			// Method begins at RVA 0x22ac
 			// Header size: 12
-			// Code size: 83 (0x53)
+			// Code size: 69 (0x45)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] string
+				[1] string
 			)
 
 			IL_0000: ldstr "console"
@@ -184,29 +183,23 @@
 			IL_0011: stloc.0
 			IL_0012: ldarg.0
 			IL_0013: ldfld string Modules.b/Scope::moduleName
-			IL_0018: stloc.1
-			IL_0019: ldstr "moduleName"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: ldloc.1
-			IL_0026: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_002b: stloc.2
-			IL_002c: ldstr "Function from "
-			IL_0031: ldloc.2
-			IL_0032: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0037: stloc.2
-			IL_0038: ldloc.2
-			IL_0039: ldstr " has been called"
-			IL_003e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0043: stloc.2
-			IL_0044: ldloc.0
-			IL_0045: ldstr "log"
-			IL_004a: ldloc.2
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0050: pop
-			IL_0051: ldnull
-			IL_0052: ret
+			IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_001d: stloc.1
+			IL_001e: ldstr "Function from "
+			IL_0023: ldloc.1
+			IL_0024: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0029: stloc.1
+			IL_002a: ldloc.1
+			IL_002b: ldstr " has been called"
+			IL_0030: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0035: stloc.1
+			IL_0036: ldloc.0
+			IL_0037: ldstr "log"
+			IL_003c: ldloc.1
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0042: pop
+			IL_0043: ldnull
+			IL_0044: ret
 		} // end of method commonFunctionName::__js_call__
 
 	} // end of class commonFunctionName
@@ -222,7 +215,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x249a
+				// Method begins at RVA 0x2464
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -242,7 +235,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a3
+				// Method begins at RVA 0x246d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -268,7 +261,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x230c
+			// Method begins at RVA 0x2300
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -292,14 +285,13 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2328
+			// Method begins at RVA 0x231c
 			// Header size: 12
-			// Code size: 95 (0x5f)
+			// Code size: 81 (0x51)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] string
+				[1] string
 			)
 
 			IL_0000: ldstr "console"
@@ -314,29 +306,23 @@
 			IL_0019: ldelem.ref
 			IL_001a: castclass Modules.b/Scope
 			IL_001f: ldfld string Modules.b/Scope::moduleName
-			IL_0024: stloc.1
-			IL_0025: ldstr "moduleName"
-			IL_002a: ldloc.1
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0030: stloc.1
-			IL_0031: ldloc.1
-			IL_0032: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0037: stloc.2
-			IL_0038: ldstr "class from "
-			IL_003d: ldloc.2
-			IL_003e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0043: stloc.2
-			IL_0044: ldloc.2
-			IL_0045: ldstr " has been loaded"
-			IL_004a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_004f: stloc.2
-			IL_0050: ldloc.0
-			IL_0051: ldstr "log"
-			IL_0056: ldloc.2
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005c: pop
-			IL_005d: ldnull
-			IL_005e: ret
+			IL_0024: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0029: stloc.1
+			IL_002a: ldstr "class from "
+			IL_002f: ldloc.1
+			IL_0030: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0035: stloc.1
+			IL_0036: ldloc.1
+			IL_0037: ldstr " has been loaded"
+			IL_003c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0041: stloc.1
+			IL_0042: ldloc.0
+			IL_0043: ldstr "log"
+			IL_0048: ldloc.1
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004e: pop
+			IL_004f: ldnull
+			IL_0050: ret
 		} // end of method CommonClassName::Log
 
 	} // end of class CommonClassName
@@ -359,7 +345,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2488
+			// Method begins at RVA 0x2452
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -507,7 +493,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24be
+				// Method begins at RVA 0x2488
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -531,7 +517,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2393
+			// Method begins at RVA 0x2379
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -553,7 +539,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d9
+				// Method begins at RVA 0x24a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -579,14 +565,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2398
+			// Method begins at RVA 0x237c
 			// Header size: 12
-			// Code size: 83 (0x53)
+			// Code size: 69 (0x45)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] string
+				[1] string
 			)
 
 			IL_0000: ldstr "console"
@@ -597,29 +582,23 @@
 			IL_0011: stloc.0
 			IL_0012: ldarg.0
 			IL_0013: ldfld string Modules.helpers_b/Scope::moduleName
-			IL_0018: stloc.1
-			IL_0019: ldstr "moduleName"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: ldloc.1
-			IL_0026: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_002b: stloc.2
-			IL_002c: ldstr "Function from "
-			IL_0031: ldloc.2
-			IL_0032: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0037: stloc.2
-			IL_0038: ldloc.2
-			IL_0039: ldstr " has been called"
-			IL_003e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0043: stloc.2
-			IL_0044: ldloc.0
-			IL_0045: ldstr "log"
-			IL_004a: ldloc.2
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0050: pop
-			IL_0051: ldnull
-			IL_0052: ret
+			IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_001d: stloc.1
+			IL_001e: ldstr "Function from "
+			IL_0023: ldloc.1
+			IL_0024: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0029: stloc.1
+			IL_002a: ldloc.1
+			IL_002b: ldstr " has been called"
+			IL_0030: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0035: stloc.1
+			IL_0036: ldloc.0
+			IL_0037: ldstr "log"
+			IL_003c: ldloc.1
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0042: pop
+			IL_0043: ldnull
+			IL_0044: ret
 		} // end of method commonFunctionName::__js_call__
 
 	} // end of class commonFunctionName
@@ -635,7 +614,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24c7
+				// Method begins at RVA 0x2491
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -655,7 +634,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d0
+				// Method begins at RVA 0x249a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -681,7 +660,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f8
+			// Method begins at RVA 0x23d0
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -705,14 +684,13 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2414
+			// Method begins at RVA 0x23ec
 			// Header size: 12
-			// Code size: 95 (0x5f)
+			// Code size: 81 (0x51)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] string
+				[1] string
 			)
 
 			IL_0000: ldstr "console"
@@ -727,29 +705,23 @@
 			IL_0019: ldelem.ref
 			IL_001a: castclass Modules.helpers_b/Scope
 			IL_001f: ldfld string Modules.helpers_b/Scope::moduleName
-			IL_0024: stloc.1
-			IL_0025: ldstr "moduleName"
-			IL_002a: ldloc.1
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0030: stloc.1
-			IL_0031: ldloc.1
-			IL_0032: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0037: stloc.2
-			IL_0038: ldstr "class from "
-			IL_003d: ldloc.2
-			IL_003e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0043: stloc.2
-			IL_0044: ldloc.2
-			IL_0045: ldstr " has been loaded"
-			IL_004a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_004f: stloc.2
-			IL_0050: ldloc.0
-			IL_0051: ldstr "log"
-			IL_0056: ldloc.2
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005c: pop
-			IL_005d: ldnull
-			IL_005e: ret
+			IL_0024: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0029: stloc.1
+			IL_002a: ldstr "class from "
+			IL_002f: ldloc.1
+			IL_0030: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0035: stloc.1
+			IL_0036: ldloc.1
+			IL_0037: ldstr " has been loaded"
+			IL_003c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0041: stloc.1
+			IL_0042: ldloc.0
+			IL_0043: ldstr "log"
+			IL_0048: ldloc.1
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004e: pop
+			IL_004f: ldnull
+			IL_0050: ret
 		} // end of method CommonClassName::Log
 
 	} // end of class CommonClassName
@@ -772,7 +744,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24b5
+			// Method begins at RVA 0x247f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -906,7 +878,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24e2
+		// Method begins at RVA 0x24ac
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21d7
+						// Method begins at RVA 0x21b7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ce
+					// Method begins at RVA 0x21ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21e0
+					// Method begins at RVA 0x21c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c5
+				// Method begins at RVA 0x21a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -110,7 +110,7 @@
 			)
 			// Method begins at RVA 0x2100
 			// Header size: 12
-			// Code size: 159 (0x9f)
+			// Code size: 127 (0x7f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/Scope/Block_L4C8,
@@ -119,10 +119,8 @@
 				[3] object,
 				[4] class [System.Runtime]System.Exception,
 				[5] class Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/Scope/Block_L9C12,
-				[6] class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate,
-				[7] object,
-				[8] object[],
-				[9] bool
+				[6] object,
+				[7] bool
 			)
 
 			.try
@@ -133,70 +131,56 @@
 				IL_0007: stloc.1
 				IL_0008: ldarg.0
 				IL_0009: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope::require
-				IL_000e: stloc.s 6
-				IL_0010: ldstr "require"
-				IL_0015: ldloc.s 6
-				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_001c: stloc.s 7
-				IL_001e: ldc.i4.1
-				IL_001f: newarr [System.Runtime]System.Object
-				IL_0024: dup
-				IL_0025: ldc.i4.0
-				IL_0026: ldarg.0
-				IL_0027: stelem.ref
-				IL_0028: stloc.s 8
-				IL_002a: ldloc.s 7
-				IL_002c: ldloc.s 8
-				IL_002e: ldstr "./CommonJS_Require_OptionalChain_Lib"
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0038: stloc.s 7
-				IL_003a: ldloc.s 7
-				IL_003c: brfalse IL_0060
+				IL_000e: ldstr "./CommonJS_Require_OptionalChain_Lib"
+				IL_0013: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+				IL_0018: stloc.s 6
+				IL_001a: ldloc.s 6
+				IL_001c: brfalse IL_0040
 
-				IL_0041: ldloc.s 7
-				IL_0043: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_0048: brtrue IL_0060
+				IL_0021: ldloc.s 6
+				IL_0023: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_0028: brtrue IL_0040
 
-				IL_004d: ldloc.s 7
-				IL_004f: ldstr "value"
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0059: stloc.s 7
-				IL_005b: br IL_0063
+				IL_002d: ldloc.s 6
+				IL_002f: ldstr "value"
+				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0039: stloc.s 6
+				IL_003b: br IL_0043
 
-				IL_0060: ldnull
-				IL_0061: stloc.s 7
+				IL_0040: ldnull
+				IL_0041: stloc.s 6
 
-				IL_0063: ldloc.s 7
-				IL_0065: stloc.1
-				IL_0066: ldloc.1
-				IL_0067: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_006c: stloc.s 9
-				IL_006e: ldloc.s 9
-				IL_0070: brfalse IL_0084
+				IL_0043: ldloc.s 6
+				IL_0045: stloc.1
+				IL_0046: ldloc.1
+				IL_0047: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_004c: stloc.s 7
+				IL_004e: ldloc.s 7
+				IL_0050: brfalse IL_0064
 
-				IL_0075: newobj instance void Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/Scope/Block_L4C8/Block_L6C76::.ctor()
-				IL_007a: stloc.2
-				IL_007b: ldnull
-				IL_007c: stloc.3
-				IL_007d: ldloc.1
-				IL_007e: stloc.3
-				IL_007f: leave IL_009d
+				IL_0055: newobj instance void Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/Scope/Block_L4C8/Block_L6C76::.ctor()
+				IL_005a: stloc.2
+				IL_005b: ldnull
+				IL_005c: stloc.3
+				IL_005d: ldloc.1
+				IL_005e: stloc.3
+				IL_005f: leave IL_007d
 
-				IL_0084: leave IL_0097
+				IL_0064: leave IL_0077
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0089: stloc.s 4
-				IL_008b: newobj instance void Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/Scope/Block_L9C12::.ctor()
-				IL_0090: stloc.s 5
-				IL_0092: leave IL_0097
+				IL_0069: stloc.s 4
+				IL_006b: newobj instance void Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/Scope/Block_L9C12::.ctor()
+				IL_0070: stloc.s 5
+				IL_0072: leave IL_0077
 			} // end handler
 
-			IL_0097: ldstr "missing"
-			IL_009c: ret
+			IL_0077: ldstr "missing"
+			IL_007c: ret
 
-			IL_009d: ldloc.3
-			IL_009e: ret
+			IL_007d: ldloc.3
+			IL_007e: ret
 		} // end of method loadValue::__js_call__
 
 	} // end of class loadValue
@@ -218,7 +202,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21bc
+			// Method begins at RVA 0x219c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -310,7 +294,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e9
+			// Method begins at RVA 0x21c9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -369,7 +353,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f2
+		// Method begins at RVA 0x21d2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_Conditional_Ternary_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_Conditional_Ternary_ShortCircuit.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2188
+				// Method begins at RVA 0x216c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,36 +46,23 @@
 			)
 			// Method begins at RVA 0x2134
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope::x
-			IL_0006: stloc.0
-			IL_0007: ldstr "x"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.r8 1
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0022: stloc.1
-			IL_0023: ldarg.0
-			IL_0024: ldloc.1
-			IL_0025: stfld object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope::x
-			IL_002a: ldarg.0
-			IL_002b: ldfld object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope::x
-			IL_0030: stloc.0
-			IL_0031: ldstr "x"
-			IL_0036: ldloc.0
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.0
-			IL_003d: ldloc.0
-			IL_003e: ret
+			IL_0006: ldc.r8 1
+			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0014: stloc.0
+			IL_0015: ldarg.0
+			IL_0016: ldloc.0
+			IL_0017: stfld object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope::x
+			IL_001c: ldarg.0
+			IL_001d: ldfld object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope::x
+			IL_0022: ret
 		} // end of method bump::__js_call__
 
 	} // end of class bump
@@ -95,7 +82,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217f
+			// Method begins at RVA 0x2163
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -217,7 +204,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2191
+		// Method begins at RVA 0x2175
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_Let_PerIterationBinding.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_Let_PerIterationBinding.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x223f
+				// Method begins at RVA 0x2226
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,25 +43,16 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Method begins at RVA 0x21fc
-			// Header size: 12
-			// Code size: 28 (0x1c)
+			// Header size: 1
+			// Code size: 14 (0xe)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldc.i4.1
 			IL_0002: ldelem.ref
 			IL_0003: castclass Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5
 			IL_0008: ldfld object Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5::k
-			IL_000d: stloc.0
-			IL_000e: ldstr "k"
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ret
+			IL_000d: ret
 		} // end of method FunctionExpression_L8C13::__js_call__
 
 	} // end of class FunctionExpression_L8C13
@@ -73,7 +64,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2224
+			// Method begins at RVA 0x220b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -101,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2236
+				// Method begins at RVA 0x221d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -122,7 +113,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x222d
+			// Method begins at RVA 0x2214
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -146,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2251
+				// Method begins at RVA 0x2238
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -164,7 +155,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2248
+			// Method begins at RVA 0x222f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -370,7 +361,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x225a
+		// Method begins at RVA 0x2241
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LetClosureCapture.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LetClosureCapture.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2297
+				// Method begins at RVA 0x226e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,26 +42,17 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2254
-			// Header size: 12
-			// Code size: 28 (0x1c)
+			// Method begins at RVA 0x2244
+			// Header size: 1
+			// Code size: 14 (0xe)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldc.i4.1
 			IL_0002: ldelem.ref
 			IL_0003: castclass Modules.ControlFlow_ForLoop_LetClosureCapture/Scope_For_L5C5
 			IL_0008: ldfld object Modules.ControlFlow_ForLoop_LetClosureCapture/Scope_For_L5C5::i
-			IL_000d: stloc.0
-			IL_000e: ldstr "i"
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ret
+			IL_000d: ret
 		} // end of method ArrowFunction_L6C12::__js_call__
 
 	} // end of class ArrowFunction_L6C12
@@ -73,7 +64,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x227c
+			// Method begins at RVA 0x2253
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -101,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228e
+				// Method begins at RVA 0x2265
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -122,7 +113,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2285
+			// Method begins at RVA 0x225c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -148,7 +139,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 502 (0x1f6)
+		// Code size: 488 (0x1e8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_LetClosureCapture/Scope,
@@ -186,7 +177,7 @@
 			IL_0042: ldloc.s 5
 			IL_0044: ldc.r8 3
 			IL_004d: clt
-			IL_004f: brfalse IL_010e
+			IL_004f: brfalse IL_0100
 
 			IL_0054: newobj instance void Modules.ControlFlow_ForLoop_LetClosureCapture/Scope_For_L5C5/Block_L5C28::.ctor()
 			IL_0059: stloc.3
@@ -233,97 +224,93 @@
 			IL_00c2: castclass Modules.ControlFlow_ForLoop_LetClosureCapture/Scope_For_L5C5
 			IL_00c7: ldfld object Modules.ControlFlow_ForLoop_LetClosureCapture/Scope_For_L5C5::i
 			IL_00cc: stloc.s 4
-			IL_00ce: ldstr "i"
-			IL_00d3: ldloc.s 4
-			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00da: stloc.s 4
-			IL_00dc: ldloc.s 4
-			IL_00de: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00ce: ldloc.s 4
+			IL_00d0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00d5: stloc.s 5
+			IL_00d7: ldloc.s 5
+			IL_00d9: ldc.r8 1
+			IL_00e2: add
 			IL_00e3: stloc.s 5
 			IL_00e5: ldloc.s 5
-			IL_00e7: ldc.r8 1
-			IL_00f0: add
-			IL_00f1: stloc.s 5
-			IL_00f3: ldloc.s 5
-			IL_00f5: box [System.Runtime]System.Double
-			IL_00fa: stloc.s 7
-			IL_00fc: ldloc.2
-			IL_00fd: castclass Modules.ControlFlow_ForLoop_LetClosureCapture/Scope_For_L5C5
-			IL_0102: ldloc.s 7
-			IL_0104: stfld object Modules.ControlFlow_ForLoop_LetClosureCapture/Scope_For_L5C5::i
-			IL_0109: br IL_002c
+			IL_00e7: box [System.Runtime]System.Double
+			IL_00ec: stloc.s 7
+			IL_00ee: ldloc.2
+			IL_00ef: castclass Modules.ControlFlow_ForLoop_LetClosureCapture/Scope_For_L5C5
+			IL_00f4: ldloc.s 7
+			IL_00f6: stfld object Modules.ControlFlow_ForLoop_LetClosureCapture/Scope_For_L5C5::i
+			IL_00fb: br IL_002c
 		// end loop
 
-		IL_010e: ldstr "console"
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0118: stloc.s 4
-		IL_011a: ldloc.s 4
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0121: stloc.s 4
-		IL_0123: ldloc.1
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0129: stloc.s 8
-		IL_012b: ldc.i4.0
-		IL_012c: newarr [System.Runtime]System.Object
-		IL_0131: stloc.s 9
-		IL_0133: ldloc.s 8
-		IL_0135: ldc.r8 0.0
-		IL_013e: box [System.Runtime]System.Double
-		IL_0143: ldloc.s 9
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
-		IL_014a: stloc.s 8
-		IL_014c: ldloc.s 4
-		IL_014e: ldstr "log"
-		IL_0153: ldloc.s 8
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_015a: pop
-		IL_015b: ldstr "console"
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0165: stloc.s 8
-		IL_0167: ldloc.s 8
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016e: stloc.s 8
-		IL_0170: ldloc.1
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0176: stloc.s 4
-		IL_0178: ldc.i4.0
-		IL_0179: newarr [System.Runtime]System.Object
-		IL_017e: stloc.s 9
-		IL_0180: ldloc.s 4
-		IL_0182: ldc.r8 1
-		IL_018b: box [System.Runtime]System.Double
-		IL_0190: ldloc.s 9
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
-		IL_0197: stloc.s 4
-		IL_0199: ldloc.s 8
-		IL_019b: ldstr "log"
-		IL_01a0: ldloc.s 4
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01a7: pop
-		IL_01a8: ldstr "console"
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b2: stloc.s 4
-		IL_01b4: ldloc.s 4
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bb: stloc.s 4
-		IL_01bd: ldloc.1
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c3: stloc.s 8
-		IL_01c5: ldc.i4.0
-		IL_01c6: newarr [System.Runtime]System.Object
-		IL_01cb: stloc.s 9
-		IL_01cd: ldloc.s 8
-		IL_01cf: ldc.r8 2
-		IL_01d8: box [System.Runtime]System.Double
-		IL_01dd: ldloc.s 9
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
-		IL_01e4: stloc.s 8
-		IL_01e6: ldloc.s 4
-		IL_01e8: ldstr "log"
-		IL_01ed: ldloc.s 8
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01f4: pop
-		IL_01f5: ret
+		IL_0100: ldstr "console"
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_010a: stloc.s 4
+		IL_010c: ldloc.s 4
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0113: stloc.s 4
+		IL_0115: ldloc.1
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011b: stloc.s 8
+		IL_011d: ldc.i4.0
+		IL_011e: newarr [System.Runtime]System.Object
+		IL_0123: stloc.s 9
+		IL_0125: ldloc.s 8
+		IL_0127: ldc.r8 0.0
+		IL_0130: box [System.Runtime]System.Double
+		IL_0135: ldloc.s 9
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
+		IL_013c: stloc.s 8
+		IL_013e: ldloc.s 4
+		IL_0140: ldstr "log"
+		IL_0145: ldloc.s 8
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_014c: pop
+		IL_014d: ldstr "console"
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0157: stloc.s 8
+		IL_0159: ldloc.s 8
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0160: stloc.s 8
+		IL_0162: ldloc.1
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0168: stloc.s 4
+		IL_016a: ldc.i4.0
+		IL_016b: newarr [System.Runtime]System.Object
+		IL_0170: stloc.s 9
+		IL_0172: ldloc.s 4
+		IL_0174: ldc.r8 1
+		IL_017d: box [System.Runtime]System.Double
+		IL_0182: ldloc.s 9
+		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
+		IL_0189: stloc.s 4
+		IL_018b: ldloc.s 8
+		IL_018d: ldstr "log"
+		IL_0192: ldloc.s 4
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0199: pop
+		IL_019a: ldstr "console"
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a4: stloc.s 4
+		IL_01a6: ldloc.s 4
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ad: stloc.s 4
+		IL_01af: ldloc.1
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b5: stloc.s 8
+		IL_01b7: ldc.i4.0
+		IL_01b8: newarr [System.Runtime]System.Object
+		IL_01bd: stloc.s 9
+		IL_01bf: ldloc.s 8
+		IL_01c1: ldc.r8 2
+		IL_01ca: box [System.Runtime]System.Double
+		IL_01cf: ldloc.s 9
+		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
+		IL_01d6: stloc.s 8
+		IL_01d8: ldloc.s 4
+		IL_01da: ldstr "log"
+		IL_01df: ldloc.s 8
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01e6: pop
+		IL_01e7: ret
 	} // end of method ControlFlow_ForLoop_LetClosureCapture::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_LetClosureCapture
@@ -335,7 +322,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22a0
+		// Method begins at RVA 0x2277
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LetClosureCapture_Continue.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LetClosureCapture_Continue.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22cf
+				// Method begins at RVA 0x22a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,26 +42,17 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x228c
-			// Header size: 12
-			// Code size: 28 (0x1c)
+			// Method begins at RVA 0x227b
+			// Header size: 1
+			// Code size: 14 (0xe)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldc.i4.1
 			IL_0002: ldelem.ref
 			IL_0003: castclass Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope_For_L5C5
 			IL_0008: ldfld object Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope_For_L5C5::i
-			IL_000d: stloc.0
-			IL_000e: ldstr "i"
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ret
+			IL_000d: ret
 		} // end of method ArrowFunction_L6C12::__js_call__
 
 	} // end of class ArrowFunction_L6C12
@@ -73,7 +64,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22b4
+			// Method begins at RVA 0x228a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -105,7 +96,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22d8
+					// Method begins at RVA 0x22ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -123,7 +114,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c6
+				// Method begins at RVA 0x229c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -144,7 +135,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22bd
+			// Method begins at RVA 0x2293
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -170,7 +161,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 557 (0x22d)
+		// Code size: 543 (0x21f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope,
@@ -210,7 +201,7 @@
 			IL_0042: ldloc.s 6
 			IL_0044: ldc.r8 3
 			IL_004d: clt
-			IL_004f: brfalse IL_0145
+			IL_004f: brfalse IL_0137
 
 			IL_0054: newobj instance void Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope_For_L5C5/Block_L5C28::.ctor()
 			IL_0059: stloc.3
@@ -273,97 +264,93 @@
 			IL_00f9: castclass Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope_For_L5C5
 			IL_00fe: ldfld object Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope_For_L5C5::i
 			IL_0103: stloc.s 5
-			IL_0105: ldstr "i"
-			IL_010a: ldloc.s 5
-			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0111: stloc.s 5
-			IL_0113: ldloc.s 5
-			IL_0115: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0105: ldloc.s 5
+			IL_0107: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_010c: stloc.s 6
+			IL_010e: ldloc.s 6
+			IL_0110: ldc.r8 1
+			IL_0119: add
 			IL_011a: stloc.s 6
 			IL_011c: ldloc.s 6
-			IL_011e: ldc.r8 1
-			IL_0127: add
-			IL_0128: stloc.s 6
-			IL_012a: ldloc.s 6
-			IL_012c: box [System.Runtime]System.Double
-			IL_0131: stloc.s 9
-			IL_0133: ldloc.2
-			IL_0134: castclass Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope_For_L5C5
-			IL_0139: ldloc.s 9
-			IL_013b: stfld object Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope_For_L5C5::i
-			IL_0140: br IL_002c
+			IL_011e: box [System.Runtime]System.Double
+			IL_0123: stloc.s 9
+			IL_0125: ldloc.2
+			IL_0126: castclass Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope_For_L5C5
+			IL_012b: ldloc.s 9
+			IL_012d: stfld object Modules.ControlFlow_ForLoop_LetClosureCapture_Continue/Scope_For_L5C5::i
+			IL_0132: br IL_002c
 		// end loop
 
-		IL_0145: ldstr "console"
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014f: stloc.s 5
-		IL_0151: ldloc.s 5
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0158: stloc.s 5
-		IL_015a: ldloc.1
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0160: stloc.s 10
-		IL_0162: ldc.i4.0
-		IL_0163: newarr [System.Runtime]System.Object
-		IL_0168: stloc.s 11
-		IL_016a: ldloc.s 10
-		IL_016c: ldc.r8 0.0
-		IL_0175: box [System.Runtime]System.Double
-		IL_017a: ldloc.s 11
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
-		IL_0181: stloc.s 10
-		IL_0183: ldloc.s 5
-		IL_0185: ldstr "log"
-		IL_018a: ldloc.s 10
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0191: pop
-		IL_0192: ldstr "console"
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_019c: stloc.s 10
-		IL_019e: ldloc.s 10
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a5: stloc.s 10
-		IL_01a7: ldloc.1
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ad: stloc.s 5
-		IL_01af: ldc.i4.0
-		IL_01b0: newarr [System.Runtime]System.Object
-		IL_01b5: stloc.s 11
-		IL_01b7: ldloc.s 5
-		IL_01b9: ldc.r8 1
-		IL_01c2: box [System.Runtime]System.Double
-		IL_01c7: ldloc.s 11
-		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
-		IL_01ce: stloc.s 5
-		IL_01d0: ldloc.s 10
-		IL_01d2: ldstr "log"
-		IL_01d7: ldloc.s 5
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01de: pop
-		IL_01df: ldstr "console"
-		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e9: stloc.s 5
-		IL_01eb: ldloc.s 5
-		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f2: stloc.s 5
-		IL_01f4: ldloc.1
-		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01fa: stloc.s 10
-		IL_01fc: ldc.i4.0
-		IL_01fd: newarr [System.Runtime]System.Object
-		IL_0202: stloc.s 11
-		IL_0204: ldloc.s 10
-		IL_0206: ldc.r8 2
-		IL_020f: box [System.Runtime]System.Double
-		IL_0214: ldloc.s 11
-		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
-		IL_021b: stloc.s 10
-		IL_021d: ldloc.s 5
-		IL_021f: ldstr "log"
-		IL_0224: ldloc.s 10
-		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_022b: pop
-		IL_022c: ret
+		IL_0137: ldstr "console"
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0141: stloc.s 5
+		IL_0143: ldloc.s 5
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014a: stloc.s 5
+		IL_014c: ldloc.1
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0152: stloc.s 10
+		IL_0154: ldc.i4.0
+		IL_0155: newarr [System.Runtime]System.Object
+		IL_015a: stloc.s 11
+		IL_015c: ldloc.s 10
+		IL_015e: ldc.r8 0.0
+		IL_0167: box [System.Runtime]System.Double
+		IL_016c: ldloc.s 11
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
+		IL_0173: stloc.s 10
+		IL_0175: ldloc.s 5
+		IL_0177: ldstr "log"
+		IL_017c: ldloc.s 10
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0183: pop
+		IL_0184: ldstr "console"
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_018e: stloc.s 10
+		IL_0190: ldloc.s 10
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0197: stloc.s 10
+		IL_0199: ldloc.1
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019f: stloc.s 5
+		IL_01a1: ldc.i4.0
+		IL_01a2: newarr [System.Runtime]System.Object
+		IL_01a7: stloc.s 11
+		IL_01a9: ldloc.s 5
+		IL_01ab: ldc.r8 1
+		IL_01b4: box [System.Runtime]System.Double
+		IL_01b9: ldloc.s 11
+		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
+		IL_01c0: stloc.s 5
+		IL_01c2: ldloc.s 10
+		IL_01c4: ldstr "log"
+		IL_01c9: ldloc.s 5
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01d0: pop
+		IL_01d1: ldstr "console"
+		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01db: stloc.s 5
+		IL_01dd: ldloc.s 5
+		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e4: stloc.s 5
+		IL_01e6: ldloc.1
+		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ec: stloc.s 10
+		IL_01ee: ldc.i4.0
+		IL_01ef: newarr [System.Runtime]System.Object
+		IL_01f4: stloc.s 11
+		IL_01f6: ldloc.s 10
+		IL_01f8: ldc.r8 2
+		IL_0201: box [System.Runtime]System.Double
+		IL_0206: ldloc.s 11
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallComputedMember(object, object, object[])
+		IL_020d: stloc.s 10
+		IL_020f: ldloc.s 5
+		IL_0211: ldstr "log"
+		IL_0216: ldloc.s 10
+		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_021d: pop
+		IL_021e: ret
 	} // end of method ControlFlow_ForLoop_LetClosureCapture_Continue::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_LetClosureCapture_Continue
@@ -375,7 +362,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e1
+		// Method begins at RVA 0x22b7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_VarClosureCapture.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_VarClosureCapture.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x221f
+				// Method begins at RVA 0x2205
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,23 +44,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x21ec
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x21eb
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.ControlFlow_ForLoop_VarClosureCapture/Scope::i
-			IL_0006: stloc.0
-			IL_0007: ldstr "i"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method ArrowFunction_L6C12::__js_call__
 
 	} // end of class ArrowFunction_L6C12
@@ -79,7 +70,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2216
+				// Method begins at RVA 0x21fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -100,7 +91,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x220d
+			// Method begins at RVA 0x21f3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -279,7 +270,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2228
+		// Method begins at RVA 0x220e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_ClosureCallback.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_ClosureCallback.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2262
+					// Method begins at RVA 0x224e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -53,7 +53,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2274
+						// Method begins at RVA 0x2260
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -71,7 +71,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x226b
+					// Method begins at RVA 0x2257
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -97,7 +97,7 @@
 				)
 				// Method begins at RVA 0x2148
 				// Header size: 12
-				// Code size: 233 (0xe9)
+				// Code size: 215 (0xd7)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -144,7 +144,7 @@
 						IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 						IL_0065: stloc.s 7
 						IL_0067: ldloc.s 7
-						IL_0069: brtrue IL_00cd
+						IL_0069: brtrue IL_00bb
 
 						IL_006e: ldloc.s 6
 						IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -158,57 +158,51 @@
 						IL_0084: ldelem.ref
 						IL_0085: castclass Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope
 						IL_008a: ldfld object Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope::callback
-						IL_008f: stloc.s 6
-						IL_0091: ldstr "callback"
-						IL_0096: ldloc.s 6
-						IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-						IL_009d: stloc.s 6
-						IL_009f: ldloc.s 6
-						IL_00a1: ldc.i4.2
-						IL_00a2: newarr [System.Runtime]System.Object
-						IL_00a7: dup
-						IL_00a8: ldc.i4.0
-						IL_00a9: ldarg.0
-						IL_00aa: ldc.i4.0
-						IL_00ab: ldelem.ref
-						IL_00ac: stelem.ref
-						IL_00ad: dup
-						IL_00ae: ldc.i4.1
-						IL_00af: ldarg.0
-						IL_00b0: ldc.i4.1
-						IL_00b1: ldelem.ref
-						IL_00b2: stelem.ref
-						IL_00b3: ldloc.s 4
-						IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-						IL_00ba: pop
-						IL_00bb: br IL_0056
+						IL_008f: ldc.i4.2
+						IL_0090: newarr [System.Runtime]System.Object
+						IL_0095: dup
+						IL_0096: ldc.i4.0
+						IL_0097: ldarg.0
+						IL_0098: ldc.i4.0
+						IL_0099: ldelem.ref
+						IL_009a: stelem.ref
+						IL_009b: dup
+						IL_009c: ldc.i4.1
+						IL_009d: ldarg.0
+						IL_009e: ldc.i4.1
+						IL_009f: ldelem.ref
+						IL_00a0: stelem.ref
+						IL_00a1: ldloc.s 4
+						IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+						IL_00a8: pop
+						IL_00a9: br IL_0056
 					// end loop
-					IL_00c0: ldloc.1
-					IL_00c1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-					IL_00c6: ldc.i4.1
-					IL_00c7: stloc.3
-					IL_00c8: leave IL_00e7
+					IL_00ae: ldloc.1
+					IL_00af: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+					IL_00b4: ldc.i4.1
+					IL_00b5: stloc.3
+					IL_00b6: leave IL_00d5
 
-					IL_00cd: ldc.i4.1
-					IL_00ce: stloc.2
-					IL_00cf: leave IL_00e7
+					IL_00bb: ldc.i4.1
+					IL_00bc: stloc.2
+					IL_00bd: leave IL_00d5
 				} // end .try
 				finally
 				{
-					IL_00d4: ldloc.2
-					IL_00d5: brtrue IL_00e6
+					IL_00c2: ldloc.2
+					IL_00c3: brtrue IL_00d4
 
-					IL_00da: ldloc.3
-					IL_00db: brtrue IL_00e6
+					IL_00c8: ldloc.3
+					IL_00c9: brtrue IL_00d4
 
-					IL_00e0: ldloc.1
-					IL_00e1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+					IL_00ce: ldloc.1
+					IL_00cf: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-					IL_00e6: endfinally
+					IL_00d4: endfinally
 				} // end handler
 
-				IL_00e7: ldnull
-				IL_00e8: ret
+				IL_00d5: ldnull
+				IL_00d6: ret
 			} // end of method inner::__js_call__
 
 		} // end of class inner
@@ -227,7 +221,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2259
+				// Method begins at RVA 0x2245
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -318,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x227d
+				// Method begins at RVA 0x2269
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -381,7 +375,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2250
+			// Method begins at RVA 0x223c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -467,7 +461,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2286
+		// Method begins at RVA 0x2272
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_CustomIterable_IteratorProtocol.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_CustomIterable_IteratorProtocol.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29e2
+					// Method begins at RVA 0x296e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,109 +48,87 @@
 				)
 				// Method begins at RVA 0x2708
 				// Header size: 12
-				// Code size: 270 (0x10e)
+				// Code size: 226 (0xe2)
 				.maxstack 8
 				.locals init (
 					[0] object,
-					[1] float64,
-					[2] object,
-					[3] bool
+					[1] bool
 				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope
-				IL_0008: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope::i
-				IL_000d: stloc.0
-				IL_000e: ldstr "i"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldc.r8 1
-				IL_002b: add
-				IL_002c: stloc.1
-				IL_002d: ldloc.1
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: stloc.2
-				IL_0034: ldarg.0
-				IL_0035: ldc.i4.1
-				IL_0036: ldelem.ref
-				IL_0037: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope
-				IL_003c: ldloc.2
-				IL_003d: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope::i
-				IL_0042: ldarg.0
-				IL_0043: ldc.i4.1
-				IL_0044: ldelem.ref
-				IL_0045: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope
-				IL_004a: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope::i
-				IL_004f: stloc.0
-				IL_0050: ldstr "i"
-				IL_0055: ldloc.0
-				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005b: stloc.0
-				IL_005c: ldloc.0
-				IL_005d: ldc.r8 1
-				IL_0066: box [System.Runtime]System.Double
-				IL_006b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0070: stloc.3
-				IL_0071: ldloc.3
-				IL_0072: brfalse IL_0099
+				IL_0008: ldarg.0
+				IL_0009: ldc.i4.1
+				IL_000a: ldelem.ref
+				IL_000b: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope
+				IL_0010: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope::i
+				IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001a: ldc.r8 1
+				IL_0023: add
+				IL_0024: box [System.Runtime]System.Double
+				IL_0029: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope::i
+				IL_002e: ldarg.0
+				IL_002f: ldc.i4.1
+				IL_0030: ldelem.ref
+				IL_0031: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope
+				IL_0036: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope::i
+				IL_003b: stloc.0
+				IL_003c: ldloc.0
+				IL_003d: ldc.r8 1
+				IL_0046: box [System.Runtime]System.Double
+				IL_004b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0050: stloc.1
+				IL_0051: ldloc.1
+				IL_0052: brfalse IL_0079
 
-				IL_0077: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_007c: dup
-				IL_007d: ldstr "value"
-				IL_0082: ldstr "a"
-				IL_0087: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_008c: dup
-				IL_008d: ldstr "done"
-				IL_0092: ldc.i4.0
-				IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0098: ret
+				IL_0057: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_005c: dup
+				IL_005d: ldstr "value"
+				IL_0062: ldstr "a"
+				IL_0067: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_006c: dup
+				IL_006d: ldstr "done"
+				IL_0072: ldc.i4.0
+				IL_0073: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0078: ret
 
-				IL_0099: ldarg.0
-				IL_009a: ldc.i4.1
-				IL_009b: ldelem.ref
-				IL_009c: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope
-				IL_00a1: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope::i
-				IL_00a6: stloc.0
-				IL_00a7: ldstr "i"
-				IL_00ac: ldloc.0
-				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00b2: stloc.0
-				IL_00b3: ldloc.0
-				IL_00b4: ldc.r8 2
-				IL_00bd: box [System.Runtime]System.Double
-				IL_00c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00c7: stloc.3
-				IL_00c8: ldloc.3
-				IL_00c9: brfalse IL_00f0
+				IL_0079: ldarg.0
+				IL_007a: ldc.i4.1
+				IL_007b: ldelem.ref
+				IL_007c: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope
+				IL_0081: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope::i
+				IL_0086: stloc.0
+				IL_0087: ldloc.0
+				IL_0088: ldc.r8 2
+				IL_0091: box [System.Runtime]System.Double
+				IL_0096: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_009b: stloc.1
+				IL_009c: ldloc.1
+				IL_009d: brfalse IL_00c4
 
-				IL_00ce: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00d3: dup
-				IL_00d4: ldstr "value"
-				IL_00d9: ldstr "b"
-				IL_00de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_00e3: dup
-				IL_00e4: ldstr "done"
-				IL_00e9: ldc.i4.0
-				IL_00ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_00ef: ret
+				IL_00a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_00a7: dup
+				IL_00a8: ldstr "value"
+				IL_00ad: ldstr "b"
+				IL_00b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_00b7: dup
+				IL_00b8: ldstr "done"
+				IL_00bd: ldc.i4.0
+				IL_00be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_00c3: ret
 
-				IL_00f0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00f5: dup
-				IL_00f6: ldstr "value"
-				IL_00fb: ldnull
-				IL_00fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0101: dup
-				IL_0102: ldstr "done"
-				IL_0107: ldc.i4.1
-				IL_0108: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_010d: ret
+				IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_00c9: dup
+				IL_00ca: ldstr "value"
+				IL_00cf: ldnull
+				IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_00d5: dup
+				IL_00d6: ldstr "done"
+				IL_00db: ldc.i4.1
+				IL_00dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_00e1: ret
 			} // end of method FunctionExpression_iterable::__js_call__
 
 		} // end of class FunctionExpression_iterable
@@ -166,7 +144,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29eb
+					// Method begins at RVA 0x2977
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -190,52 +168,35 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2824
+				// Method begins at RVA 0x27f8
 				// Header size: 12
-				// Code size: 100 (0x64)
+				// Code size: 80 (0x50)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] float64,
-					[2] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.0
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
-				IL_0008: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed
-				IL_000d: stloc.0
-				IL_000e: ldstr "closed"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldc.r8 1
-				IL_002b: add
-				IL_002c: stloc.1
-				IL_002d: ldloc.1
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: stloc.2
-				IL_0034: ldarg.0
-				IL_0035: ldc.i4.0
-				IL_0036: ldelem.ref
-				IL_0037: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
-				IL_003c: ldloc.2
-				IL_003d: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed
-				IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0047: dup
-				IL_0048: ldstr "value"
-				IL_004d: ldstr "ret"
-				IL_0052: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0057: dup
-				IL_0058: ldstr "done"
-				IL_005d: ldc.i4.1
-				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0063: ret
+				IL_0008: ldarg.0
+				IL_0009: ldc.i4.0
+				IL_000a: ldelem.ref
+				IL_000b: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
+				IL_0010: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed
+				IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001a: ldc.r8 1
+				IL_0023: add
+				IL_0024: box [System.Runtime]System.Double
+				IL_0029: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed
+				IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0033: dup
+				IL_0034: ldstr "value"
+				IL_0039: ldstr "ret"
+				IL_003e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0043: dup
+				IL_0044: ldstr "done"
+				IL_0049: ldc.i4.1
+				IL_004a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_004f: ret
 			} // end of method FunctionExpression_iterable_L15C14::__js_call__
 
 		} // end of class FunctionExpression_iterable_L15C14
@@ -253,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29d9
+				// Method begins at RVA 0x2965
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -365,7 +326,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a45
+					// Method begins at RVA 0x29d1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -389,93 +350,75 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2894
+				// Method begins at RVA 0x2854
 				// Header size: 12
-				// Code size: 196 (0xc4)
+				// Code size: 162 (0xa2)
 				.maxstack 8
 				.locals init (
 					[0] object,
 					[1] object,
-					[2] float64,
-					[3] object,
-					[4] bool
+					[2] bool
 				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope
-				IL_0008: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope::i
-				IL_000d: stloc.1
-				IL_000e: ldstr "i"
-				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldloc.1
-				IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0020: stloc.2
-				IL_0021: ldloc.2
-				IL_0022: ldc.r8 1
-				IL_002b: add
-				IL_002c: stloc.2
-				IL_002d: ldloc.2
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: stloc.3
-				IL_0034: ldarg.0
-				IL_0035: ldc.i4.1
-				IL_0036: ldelem.ref
-				IL_0037: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope
-				IL_003c: ldloc.3
-				IL_003d: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope::i
-				IL_0042: ldarg.0
-				IL_0043: ldc.i4.1
-				IL_0044: ldelem.ref
-				IL_0045: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope
-				IL_004a: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope::i
-				IL_004f: stloc.1
-				IL_0050: ldstr "i"
-				IL_0055: ldloc.1
-				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005b: stloc.1
-				IL_005c: ldloc.1
-				IL_005d: ldc.r8 1
-				IL_0066: box [System.Runtime]System.Double
-				IL_006b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0070: stloc.s 4
-				IL_0072: ldloc.s 4
-				IL_0074: brfalse IL_009b
+				IL_0008: ldarg.0
+				IL_0009: ldc.i4.1
+				IL_000a: ldelem.ref
+				IL_000b: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope
+				IL_0010: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope::i
+				IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001a: ldc.r8 1
+				IL_0023: add
+				IL_0024: box [System.Runtime]System.Double
+				IL_0029: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope::i
+				IL_002e: ldarg.0
+				IL_002f: ldc.i4.1
+				IL_0030: ldelem.ref
+				IL_0031: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope
+				IL_0036: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope::i
+				IL_003b: stloc.1
+				IL_003c: ldloc.1
+				IL_003d: ldc.r8 1
+				IL_0046: box [System.Runtime]System.Double
+				IL_004b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0050: stloc.2
+				IL_0051: ldloc.2
+				IL_0052: brfalse IL_0079
 
-				IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_007e: dup
-				IL_007f: ldstr "value"
-				IL_0084: ldstr "x"
-				IL_0089: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_008e: dup
-				IL_008f: ldstr "done"
-				IL_0094: ldc.i4.0
-				IL_0095: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_009a: ret
+				IL_0057: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_005c: dup
+				IL_005d: ldstr "value"
+				IL_0062: ldstr "x"
+				IL_0067: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_006c: dup
+				IL_006d: ldstr "done"
+				IL_0072: ldc.i4.0
+				IL_0073: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0078: ret
 
-				IL_009b: ldstr "nextboom"
-				IL_00a0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_00a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_00aa: stloc.1
-				IL_00ab: ldloc.1
-				IL_00ac: stloc.0
-				IL_00ad: ldloc.0
-				IL_00ae: isinst [System.Runtime]System.Exception
-				IL_00b3: dup
-				IL_00b4: brtrue IL_00c1
+				IL_0079: ldstr "nextboom"
+				IL_007e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0083: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0088: stloc.1
+				IL_0089: ldloc.1
+				IL_008a: stloc.0
+				IL_008b: ldloc.0
+				IL_008c: isinst [System.Runtime]System.Exception
+				IL_0091: dup
+				IL_0092: brtrue IL_009f
 
-				IL_00b9: pop
-				IL_00ba: ldloc.0
-				IL_00bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_00c0: throw
+				IL_0097: pop
+				IL_0098: ldloc.0
+				IL_0099: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_009e: throw
 
-				IL_00c1: throw
+				IL_009f: throw
 
-				IL_00c2: ldnull
-				IL_00c3: ret
+				IL_00a0: ldnull
+				IL_00a1: ret
 			} // end of method FunctionExpression_iterableThrow::__js_call__
 
 		} // end of class FunctionExpression_iterableThrow
@@ -491,7 +434,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a4e
+					// Method begins at RVA 0x29da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -515,52 +458,35 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2964
+				// Method begins at RVA 0x2904
 				// Header size: 12
-				// Code size: 96 (0x60)
+				// Code size: 76 (0x4c)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] float64,
-					[2] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.0
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
-				IL_0008: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed2
-				IL_000d: stloc.0
-				IL_000e: ldstr "closed2"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldc.r8 1
-				IL_002b: add
-				IL_002c: stloc.1
-				IL_002d: ldloc.1
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: stloc.2
-				IL_0034: ldarg.0
-				IL_0035: ldc.i4.0
-				IL_0036: ldelem.ref
-				IL_0037: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
-				IL_003c: ldloc.2
-				IL_003d: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed2
-				IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0047: dup
-				IL_0048: ldstr "value"
-				IL_004d: ldnull
-				IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0053: dup
-				IL_0054: ldstr "done"
-				IL_0059: ldc.i4.1
-				IL_005a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_005f: ret
+				IL_0008: ldarg.0
+				IL_0009: ldc.i4.0
+				IL_000a: ldelem.ref
+				IL_000b: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
+				IL_0010: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed2
+				IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001a: ldc.r8 1
+				IL_0023: add
+				IL_0024: box [System.Runtime]System.Double
+				IL_0029: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed2
+				IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0033: dup
+				IL_0034: ldstr "value"
+				IL_0039: ldnull
+				IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_003f: dup
+				IL_0040: ldstr "done"
+				IL_0045: ldc.i4.1
+				IL_0046: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_004b: ret
 			} // end of method FunctionExpression_iterableThrow_L56C14::__js_call__
 
 		} // end of class FunctionExpression_iterableThrow_L56C14
@@ -578,7 +504,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a3c
+				// Method begins at RVA 0x29c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -691,7 +617,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a18
+				// Method begins at RVA 0x29a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -715,7 +641,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a2a
+					// Method begins at RVA 0x29b6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -733,7 +659,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a21
+				// Method begins at RVA 0x29ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -753,7 +679,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a33
+				// Method begins at RVA 0x29bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -773,7 +699,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a57
+				// Method begins at RVA 0x29e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -797,7 +723,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a69
+					// Method begins at RVA 0x29f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -815,7 +741,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a60
+				// Method begins at RVA 0x29ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -835,7 +761,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a72
+				// Method begins at RVA 0x29fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -857,7 +783,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29d0
+			// Method begins at RVA 0x295c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -881,7 +807,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29fd
+				// Method begins at RVA 0x2989
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -899,7 +825,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29f4
+			// Method begins at RVA 0x2980
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -923,7 +849,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a0f
+				// Method begins at RVA 0x299b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -941,7 +867,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a06
+			// Method begins at RVA 0x2992
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1536,7 +1462,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a7b
+		// Method begins at RVA 0x2a07
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d3
+				// Method begins at RVA 0x22ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,25 +43,16 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Method begins at RVA 0x2290
-			// Header size: 12
-			// Code size: 28 (0x1c)
+			// Header size: 1
+			// Code size: 14 (0xe)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldc.i4.1
 			IL_0002: ldelem.ref
 			IL_0003: castclass Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5
 			IL_0008: ldfld object Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5::x
-			IL_000d: stloc.0
-			IL_000e: ldstr "x"
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ret
+			IL_000d: ret
 		} // end of method FunctionExpression_L6C13::__js_call__
 
 	} // end of class FunctionExpression_L6C13
@@ -73,7 +64,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22b8
+			// Method begins at RVA 0x229f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -101,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ca
+				// Method begins at RVA 0x22b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -122,7 +113,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22c1
+			// Method begins at RVA 0x22a8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -146,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e5
+				// Method begins at RVA 0x22cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -164,7 +155,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22dc
+			// Method begins at RVA 0x22c3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -430,7 +421,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22ee
+		// Method begins at RVA 0x22d5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Let_PerIterationBinding.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Let_PerIterationBinding.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x227b
+				// Method begins at RVA 0x2262
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,25 +43,16 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Method begins at RVA 0x2238
-			// Header size: 12
-			// Code size: 28 (0x1c)
+			// Header size: 1
+			// Code size: 14 (0xe)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldc.i4.1
 			IL_0002: ldelem.ref
 			IL_0003: castclass Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5
 			IL_0008: ldfld object Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5::x
-			IL_000d: stloc.0
-			IL_000e: ldstr "x"
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ret
+			IL_000d: ret
 		} // end of method FunctionExpression_L6C13::__js_call__
 
 	} // end of class FunctionExpression_L6C13
@@ -73,7 +64,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2260
+			// Method begins at RVA 0x2247
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -101,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2272
+				// Method begins at RVA 0x2259
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -122,7 +113,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2269
+			// Method begins at RVA 0x2250
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -146,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228d
+				// Method begins at RVA 0x2274
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -164,7 +155,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2284
+			// Method begins at RVA 0x226b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -399,7 +390,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2296
+		// Method begins at RVA 0x227d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_LabeledStatement_CapturesParentVar.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_LabeledStatement_CapturesParentVar.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21dc
+					// Method begins at RVA 0x21ce
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -83,7 +83,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21ee
+						// Method begins at RVA 0x21e0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -104,7 +104,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21e5
+					// Method begins at RVA 0x21d7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -130,7 +130,7 @@
 				)
 				// Method begins at RVA 0x2140
 				// Header size: 12
-				// Code size: 126 (0x7e)
+				// Code size: 112 (0x70)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -148,7 +148,7 @@
 				IL_0016: stloc.1
 				// loop start (head: IL_0017)
 					IL_0017: ldc.i4.1
-					IL_0018: brfalse IL_007c
+					IL_0018: brfalse IL_006e
 
 					IL_001d: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/Scope/Block_L14C17::.ctor()
 					IL_0022: stloc.2
@@ -157,39 +157,33 @@
 					IL_0025: ldelem.ref
 					IL_0026: castclass Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope
 					IL_002b: ldfld object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope::NodeTraversal
-					IL_0030: stloc.3
-					IL_0031: ldstr "NodeTraversal"
+					IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0035: stloc.3
 					IL_0036: ldloc.3
-					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_003c: stloc.3
-					IL_003d: ldloc.3
-					IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0043: stloc.3
-					IL_0044: ldloc.3
-					IL_0045: ldstr "nextSkippingChildren"
-					IL_004a: ldloc.1
-					IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0050: stloc.3
-					IL_0051: ldloc.3
-					IL_0052: stloc.1
-					IL_0053: ldstr "console"
-					IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_005d: stloc.3
-					IL_005e: ldloc.3
-					IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0064: stloc.3
-					IL_0065: ldloc.3
-					IL_0066: ldstr "log"
-					IL_006b: ldloc.1
-					IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0071: pop
-					IL_0072: br IL_007c
+					IL_0037: ldstr "nextSkippingChildren"
+					IL_003c: ldloc.1
+					IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0042: stloc.3
+					IL_0043: ldloc.3
+					IL_0044: stloc.1
+					IL_0045: ldstr "console"
+					IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+					IL_004f: stloc.3
+					IL_0050: ldloc.3
+					IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0056: stloc.3
+					IL_0057: ldloc.3
+					IL_0058: ldstr "log"
+					IL_005d: ldloc.1
+					IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0063: pop
+					IL_0064: br IL_006e
 
-					IL_0077: br IL_0017
+					IL_0069: br IL_0017
 				// end loop
 
-				IL_007c: ldnull
-				IL_007d: ret
+				IL_006e: ldnull
+				IL_006f: ret
 			} // end of method nextNode::__js_call__
 
 		} // end of class nextNode
@@ -209,7 +203,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d3
+				// Method begins at RVA 0x21c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -305,7 +299,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ca
+			// Method begins at RVA 0x21bc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -386,7 +380,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f7
+		// Method begins at RVA 0x21e9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ec
+				// Method begins at RVA 0x2489
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,35 +54,26 @@
 			)
 			// Method begins at RVA 0x2374
 			// Header size: 12
-			// Code size: 53 (0x35)
+			// Code size: 29 (0x1d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object,
-				[2] object
+				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Cleanup_Order/Scope::order
 			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
+			IL_0007: ldstr "cleanup:"
+			IL_000c: ldarg.2
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldstr "cleanup:"
-			IL_001f: ldarg.2
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0025: stloc.2
-			IL_0026: ldloc.1
-			IL_0027: ldstr "push"
-			IL_002c: ldloc.2
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0032: pop
-			IL_0033: ldnull
-			IL_0034: ret
+			IL_0013: ldloc.0
+			IL_0014: ldloc.1
+			IL_0015: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_001a: pop
+			IL_001b: ldnull
+			IL_001c: ret
 		} // end of method ArrowFunction_L4C43::__js_call__
 
 	} // end of class ArrowFunction_L4C43
@@ -98,7 +89,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2507
+				// Method begins at RVA 0x24a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -124,9 +115,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23b8
+			// Method begins at RVA 0x23a0
 			// Header size: 12
-			// Code size: 68 (0x44)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -141,22 +132,16 @@
 			IL_0015: stloc.0
 			IL_0016: ldarg.0
 			IL_0017: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
-			IL_001c: stloc.1
-			IL_001d: ldstr "registry"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0021: stloc.1
 			IL_0022: ldloc.1
-			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0028: stloc.1
-			IL_0029: ldloc.1
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002f: stloc.1
-			IL_0030: ldloc.1
-			IL_0031: ldstr "register"
-			IL_0036: ldloc.0
-			IL_0037: ldstr "held"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0041: pop
-			IL_0042: ldnull
-			IL_0043: ret
+			IL_0023: ldstr "register"
+			IL_0028: ldloc.0
+			IL_0029: ldstr "held"
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0033: pop
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L19C1::__js_call__
 
 	} // end of class FunctionExpression_L19C1
@@ -179,7 +164,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2510
+				// Method begins at RVA 0x24ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -203,7 +188,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2408
+			// Method begins at RVA 0x23e4
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -232,7 +217,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2519
+				// Method begins at RVA 0x24b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -258,32 +243,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2424
+			// Method begins at RVA 0x2400
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] float64,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Cleanup_Order/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "promise"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
+			IL_0006: ldstr "promise"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L24C42::__js_call__
 
 	} // end of class ArrowFunction_L24C42
@@ -299,7 +277,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2522
+				// Method begins at RVA 0x24bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -325,59 +303,43 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2460
+			// Method begins at RVA 0x2428
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 76 (0x4c)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object,
-				[2] object
+				[0] object,
+				[1] string
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Cleanup_Order/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "immediate"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldstr "console"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0035: stloc.1
-			IL_0036: ldloc.1
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0006: ldstr "immediate"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldstr "console"
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_001b: stloc.0
+			IL_001c: ldloc.0
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0022: stloc.0
+			IL_0023: ldarg.0
+			IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Cleanup_Order/Scope::order
+			IL_0029: ldc.i4.1
+			IL_002a: newarr [System.Runtime]System.Object
+			IL_002f: dup
+			IL_0030: ldc.i4.0
+			IL_0031: ldstr ","
+			IL_0036: stelem.ref
+			IL_0037: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
 			IL_003c: stloc.1
-			IL_003d: ldarg.0
-			IL_003e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Cleanup_Order/Scope::order
-			IL_0043: stloc.0
-			IL_0044: ldstr "order"
-			IL_0049: ldloc.0
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_004f: stloc.2
-			IL_0050: ldloc.2
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.2
-			IL_0057: ldloc.2
-			IL_0058: ldstr "join"
-			IL_005d: ldstr ","
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: stloc.2
-			IL_0068: ldloc.1
-			IL_0069: ldstr "log"
-			IL_006e: ldloc.2
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0074: pop
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_003d: ldloc.0
+			IL_003e: ldstr "log"
+			IL_0043: ldloc.1
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0049: pop
+			IL_004a: ldnull
+			IL_004b: ret
 		} // end of method ArrowFunction_L27C14::__js_call__
 
 	} // end of class ArrowFunction_L27C14
@@ -398,7 +360,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f5
+				// Method begins at RVA 0x2492
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -418,7 +380,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24fe
+				// Method begins at RVA 0x249b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -440,7 +402,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24e3
+			// Method begins at RVA 0x2480
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -775,7 +737,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x252b
+		// Method begins at RVA 0x24c8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b5
+				// Method begins at RVA 0x235e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -53,31 +53,17 @@
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
 			// Method begins at RVA 0x22c0
-			// Header size: 12
-			// Code size: 41 (0x29)
+			// Header size: 1
+			// Code size: 15 (0xf)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Unregister_Basic/Scope::hits
-			IL_0006: stloc.0
-			IL_0007: ldstr "hits"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0026: pop
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldnull
+			IL_000e: ret
 		} // end of method ArrowFunction_L4C43::__js_call__
 
 	} // end of class ArrowFunction_L4C43
@@ -93,7 +79,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23be
+				// Method begins at RVA 0x2367
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -119,14 +105,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x22f8
+			// Method begins at RVA 0x22d0
 			// Header size: 12
-			// Code size: 88 (0x58)
+			// Code size: 60 (0x3c)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[1] object,
-				[2] object
+				[1] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -137,30 +122,18 @@
 			IL_0015: stloc.0
 			IL_0016: ldarg.0
 			IL_0017: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
-			IL_001c: stloc.1
-			IL_001d: ldstr "registry"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0021: stloc.1
 			IL_0022: ldloc.1
-			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0028: stloc.1
-			IL_0029: ldloc.1
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002f: stloc.1
-			IL_0030: ldarg.0
-			IL_0031: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::token
-			IL_0036: stloc.2
-			IL_0037: ldstr "token"
-			IL_003c: ldloc.2
-			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0042: stloc.2
-			IL_0043: ldloc.1
-			IL_0044: ldstr "register"
-			IL_0049: ldloc.0
-			IL_004a: ldstr "held"
-			IL_004f: ldloc.2
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0055: pop
-			IL_0056: ldnull
-			IL_0057: ret
+			IL_0023: ldstr "register"
+			IL_0028: ldloc.0
+			IL_0029: ldstr "held"
+			IL_002e: ldarg.0
+			IL_002f: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::token
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0039: pop
+			IL_003a: ldnull
+			IL_003b: ret
 		} // end of method FunctionExpression_L9C1::__js_call__
 
 	} // end of class FunctionExpression_L9C1
@@ -176,7 +149,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d9
+				// Method begins at RVA 0x2382
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -202,16 +175,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x235c
+			// Method begins at RVA 0x2318
 			// Header size: 12
-			// Code size: 68 (0x44)
+			// Code size: 49 (0x31)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object,
-				[3] float64,
-				[4] object
+				[0] object
 			)
 
 			IL_0000: ldstr "console"
@@ -220,26 +189,17 @@
 			IL_000b: ldloc.0
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
-			IL_0012: ldarg.0
-			IL_0013: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Unregister_Basic/Scope::hits
-			IL_0018: stloc.1
-			IL_0019: ldstr "hits"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.2
-			IL_0025: ldloc.2
-			IL_0026: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_002b: stloc.3
-			IL_002c: ldloc.3
-			IL_002d: box [System.Runtime]System.Double
-			IL_0032: stloc.s 4
-			IL_0034: ldloc.0
-			IL_0035: ldstr "log"
-			IL_003a: ldloc.s 4
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0041: pop
-			IL_0042: ldnull
-			IL_0043: ret
+			IL_0012: ldloc.0
+			IL_0013: ldstr "log"
+			IL_0018: ldarg.0
+			IL_0019: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FinalizationRegistry_Unregister_Basic/Scope::hits
+			IL_001e: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0023: conv.r8
+			IL_0024: box [System.Runtime]System.Double
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_002e: pop
+			IL_002f: ldnull
+			IL_0030: ret
 		} // end of method ArrowFunction_L26C14::__js_call__
 
 	} // end of class ArrowFunction_L26C14
@@ -261,7 +221,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c7
+				// Method begins at RVA 0x2370
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -281,7 +241,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d0
+				// Method begins at RVA 0x2379
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -304,7 +264,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23ac
+			// Method begins at RVA 0x2355
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -571,7 +531,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23e2
+		// Method begins at RVA 0x238b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Arrow_Capture_HasScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Arrow_Capture_HasScopesParameter.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x213c
+				// Method begins at RVA 0x211b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,35 +51,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2100
-			// Header size: 12
-			// Code size: 39 (0x27)
+			// Method begins at RVA 0x20fe
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] float64,
-				[2] object
-			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Arrow_Capture_HasScopesParameter/Scope::factor
-			IL_0006: stloc.0
-			IL_0007: ldstr "factor"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.1
-			IL_001a: ldarg.2
-			IL_001b: ldloc.1
-			IL_001c: mul
-			IL_001d: stloc.1
-			IL_001e: ldloc.1
-			IL_001f: box [System.Runtime]System.Double
-			IL_0024: stloc.2
-			IL_0025: ldloc.2
-			IL_0026: ret
+			IL_0000: ldarg.2
+			IL_0001: ldarg.0
+			IL_0002: ldfld object Modules.Arrow_Capture_HasScopesParameter/Scope::factor
+			IL_0007: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000c: mul
+			IL_000d: box [System.Runtime]System.Double
+			IL_0012: ret
 		} // end of method ArrowFunction_L6C15::__js_call__
 
 	} // end of class ArrowFunction_L6C15
@@ -98,7 +81,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2133
+			// Method begins at RVA 0x2112
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -201,7 +184,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2145
+		// Method begins at RVA 0x2124
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Basics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Basics.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2462
+				// Method begins at RVA 0x2442
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2474
+					// Method begins at RVA 0x2454
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -171,11 +171,10 @@
 				)
 				// Method begins at RVA 0x236c
 				// Header size: 12
-				// Code size: 144 (0x90)
+				// Code size: 112 (0x70)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldstr "console"
@@ -184,52 +183,36 @@
 				IL_000b: ldloc.0
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0011: stloc.0
-				IL_0012: ldarg.0
-				IL_0013: ldc.i4.1
-				IL_0014: ldelem.ref
-				IL_0015: castclass Modules.Function_Arguments_Basics/outer/Scope
-				IL_001a: ldfld object Modules.Function_Arguments_Basics/outer/Scope::arguments
-				IL_001f: stloc.1
-				IL_0020: ldstr "arguments"
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002b: stloc.1
-				IL_002c: ldloc.1
-				IL_002d: ldstr "length"
-				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0037: stloc.1
-				IL_0038: ldloc.0
-				IL_0039: ldstr "log"
-				IL_003e: ldloc.1
-				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0044: pop
-				IL_0045: ldstr "console"
-				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_004f: stloc.1
-				IL_0050: ldloc.1
-				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0056: stloc.1
-				IL_0057: ldarg.0
-				IL_0058: ldc.i4.1
-				IL_0059: ldelem.ref
-				IL_005a: castclass Modules.Function_Arguments_Basics/outer/Scope
-				IL_005f: ldfld object Modules.Function_Arguments_Basics/outer/Scope::arguments
-				IL_0064: stloc.0
-				IL_0065: ldstr "arguments"
-				IL_006a: ldloc.0
-				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0070: stloc.0
-				IL_0071: ldloc.0
-				IL_0072: ldc.r8 0.0
-				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0080: stloc.0
-				IL_0081: ldloc.1
-				IL_0082: ldstr "log"
-				IL_0087: ldloc.0
-				IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_008d: pop
-				IL_008e: ldnull
-				IL_008f: ret
+				IL_0012: ldloc.0
+				IL_0013: ldstr "log"
+				IL_0018: ldarg.0
+				IL_0019: ldc.i4.1
+				IL_001a: ldelem.ref
+				IL_001b: castclass Modules.Function_Arguments_Basics/outer/Scope
+				IL_0020: ldfld object Modules.Function_Arguments_Basics/outer/Scope::arguments
+				IL_0025: ldstr "length"
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0034: pop
+				IL_0035: ldstr "console"
+				IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_003f: stloc.0
+				IL_0040: ldloc.0
+				IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0046: stloc.0
+				IL_0047: ldloc.0
+				IL_0048: ldstr "log"
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.1
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Function_Arguments_Basics/outer/Scope
+				IL_0055: ldfld object Modules.Function_Arguments_Basics/outer/Scope::arguments
+				IL_005a: ldc.r8 0.0
+				IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_006d: pop
+				IL_006e: ldnull
+				IL_006f: ret
 			} // end of method ArrowFunction_L14C19::__js_call__
 
 		} // end of class ArrowFunction_L14C19
@@ -248,7 +231,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x246b
+				// Method begins at RVA 0x244b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -365,7 +348,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2486
+					// Method begins at RVA 0x2466
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -388,7 +371,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2408
+				// Method begins at RVA 0x23e8
 				// Header size: 12
 				// Code size: 69 (0x45)
 				.maxstack 8
@@ -440,7 +423,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x247d
+				// Method begins at RVA 0x245d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -521,7 +504,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2459
+			// Method begins at RVA 0x2439
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -660,7 +643,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x248f
+		// Method begins at RVA 0x246f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ArrowFunctionExpression_ConciseBody_ForEachCapturesOuter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ArrowFunctionExpression_ConciseBody_ForEachCapturesOuter.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2176
+				// Method begins at RVA 0x2168
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -53,26 +53,19 @@
 			)
 			// Method begins at RVA 0x2144
 			// Header size: 12
-			// Code size: 29 (0x1d)
+			// Code size: 15 (0xf)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Function_ArrowFunctionExpression_ConciseBody_ForEachCapturesOuter/Scope::'add'
-			IL_0006: stloc.0
-			IL_0007: ldstr "add"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldarg.2
-			IL_0014: ldloc.0
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001a: stloc.1
-			IL_001b: ldloc.1
-			IL_001c: ret
+			IL_0000: ldarg.2
+			IL_0001: ldarg.0
+			IL_0002: ldfld object Modules.Function_ArrowFunctionExpression_ConciseBody_ForEachCapturesOuter/Scope::'add'
+			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_000c: stloc.0
+			IL_000d: ldloc.0
+			IL_000e: ret
 		} // end of method ArrowFunction_L5C27::__js_call__
 
 	} // end of class ArrowFunction_L5C27
@@ -91,7 +84,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x216d
+			// Method begins at RVA 0x215f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -214,7 +207,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x217f
+		// Method begins at RVA 0x2171
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Construct_NewTargetAndPrototype.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Construct_NewTargetAndPrototype.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2367
+				// Method begins at RVA 0x2347
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,15 +48,14 @@
 			)
 			// Method begins at RVA 0x22a8
 			// Header size: 12
-			// Code size: 170 (0xaa)
+			// Code size: 138 (0x8a)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
-				[2] object,
-				[3] bool,
-				[4] object,
-				[5] object
+				[2] bool,
+				[3] object,
+				[4] object
 			)
 
 			IL_0000: ldstr "console"
@@ -67,62 +66,50 @@
 			IL_0011: stloc.0
 			IL_0012: ldarg.1
 			IL_0013: stloc.1
-			IL_0014: ldarg.0
-			IL_0015: ldfld object Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope::C
-			IL_001a: stloc.2
-			IL_001b: ldstr "C"
-			IL_0020: ldloc.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0026: stloc.2
-			IL_0027: ldloc.1
-			IL_0028: ldloc.2
-			IL_0029: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_002e: stloc.3
-			IL_002f: ldloc.3
-			IL_0030: box [System.Runtime]System.Boolean
-			IL_0035: stloc.s 4
-			IL_0037: ldloc.0
-			IL_0038: ldstr "log"
-			IL_003d: ldloc.s 4
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0044: pop
-			IL_0045: ldstr "console"
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_004f: stloc.0
-			IL_0050: ldloc.0
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.0
-			IL_0057: ldarg.0
-			IL_0058: ldfld object Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope::boundThis
-			IL_005d: stloc.2
-			IL_005e: ldstr "boundThis"
-			IL_0063: ldloc.2
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0069: stloc.2
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_006f: ldloc.2
-			IL_0070: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0075: stloc.3
-			IL_0076: ldloc.3
-			IL_0077: box [System.Runtime]System.Boolean
-			IL_007c: stloc.s 4
-			IL_007e: ldloc.0
-			IL_007f: ldstr "log"
-			IL_0084: ldloc.s 4
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_008b: pop
-			IL_008c: ldarg.2
-			IL_008d: ldarg.3
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0093: stloc.s 5
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_009a: ldstr "sum"
-			IL_009f: ldloc.s 5
-			IL_00a1: ldc.i4.1
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_00a7: pop
-			IL_00a8: ldnull
-			IL_00a9: ret
+			IL_0014: ldloc.1
+			IL_0015: ldarg.0
+			IL_0016: ldfld object Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope::C
+			IL_001b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0020: stloc.2
+			IL_0021: ldloc.2
+			IL_0022: box [System.Runtime]System.Boolean
+			IL_0027: stloc.3
+			IL_0028: ldloc.0
+			IL_0029: ldstr "log"
+			IL_002e: ldloc.3
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0034: pop
+			IL_0035: ldstr "console"
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_003f: stloc.0
+			IL_0040: ldloc.0
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0046: stloc.0
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_004c: ldarg.0
+			IL_004d: ldfld object Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope::boundThis
+			IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0057: stloc.2
+			IL_0058: ldloc.2
+			IL_0059: box [System.Runtime]System.Boolean
+			IL_005e: stloc.3
+			IL_005f: ldloc.0
+			IL_0060: ldstr "log"
+			IL_0065: ldloc.3
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_006b: pop
+			IL_006c: ldarg.2
+			IL_006d: ldarg.3
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0073: stloc.s 4
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_007a: ldstr "sum"
+			IL_007f: ldloc.s 4
+			IL_0081: ldc.i4.1
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0087: pop
+			IL_0088: ldnull
+			IL_0089: ret
 		} // end of method C::__js_call__
 
 	} // end of class C
@@ -143,7 +130,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x235e
+			// Method begins at RVA 0x233e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -375,7 +362,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2370
+		// Method begins at RVA 0x2350
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Capture_HasScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Capture_HasScopesParameter.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20fa
+				// Method begins at RVA 0x20e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,23 +44,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20d0
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x20cf
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Function_Capture_HasScopesParameter/Scope::outerValue
-			IL_0006: stloc.0
-			IL_0007: ldstr "outerValue"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method captureOuter::__js_call__
 
 	} // end of class captureOuter
@@ -82,7 +73,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f1
+			// Method begins at RVA 0x20d7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -170,7 +161,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2103
+		// Method begins at RVA 0x20e9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x221b
+					// Method begins at RVA 0x2209
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -49,13 +49,11 @@
 				)
 				// Method begins at RVA 0x21c8
 				// Header size: 12
-				// Code size: 53 (0x35)
+				// Code size: 35 (0x23)
 				.maxstack 8
 				.locals init (
 					[0] object,
-					[1] float64,
-					[2] float64,
-					[3] object
+					[1] float64
 				)
 
 				IL_0000: ldarg.0
@@ -64,25 +62,15 @@
 				IL_0003: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope
 				IL_0008: ldfld object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope::factor
 				IL_000d: stloc.0
-				IL_000e: ldstr "factor"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldarg.2
-				IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.0
-				IL_0022: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0027: stloc.2
-				IL_0028: ldloc.1
-				IL_0029: ldloc.2
-				IL_002a: mul
-				IL_002b: stloc.2
-				IL_002c: ldloc.2
-				IL_002d: box [System.Runtime]System.Double
-				IL_0032: stloc.3
-				IL_0033: ldloc.3
-				IL_0034: ret
+				IL_000e: ldarg.2
+				IL_000f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0014: stloc.1
+				IL_0015: ldloc.1
+				IL_0016: ldloc.0
+				IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001c: mul
+				IL_001d: box [System.Runtime]System.Double
+				IL_0022: ret
 			} // end of method multiply::__js_call__
 
 		} // end of class multiply
@@ -103,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2212
+				// Method begins at RVA 0x2200
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -194,7 +182,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2209
+			// Method begins at RVA 0x21f7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -328,7 +316,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2224
+		// Method begins at RVA 0x2212
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureMutatesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureMutatesOuterVariable.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2206
+					// Method begins at RVA 0x21ea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,11 +48,10 @@
 				)
 				// Method begins at RVA 0x2194
 				// Header size: 12
-				// Code size: 84 (0x54)
+				// Code size: 56 (0x38)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldarg.0
@@ -60,33 +59,21 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope
 				IL_0008: ldfld object Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope::count
-				IL_000d: stloc.0
-				IL_000e: ldstr "count"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ldc.r8 1
-				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0029: stloc.1
+				IL_000d: ldc.r8 1
+				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_001b: stloc.0
+				IL_001c: ldarg.0
+				IL_001d: ldc.i4.1
+				IL_001e: ldelem.ref
+				IL_001f: castclass Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope
+				IL_0024: ldloc.0
+				IL_0025: stfld object Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope::count
 				IL_002a: ldarg.0
 				IL_002b: ldc.i4.1
 				IL_002c: ldelem.ref
 				IL_002d: castclass Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope
-				IL_0032: ldloc.1
-				IL_0033: stfld object Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope::count
-				IL_0038: ldarg.0
-				IL_0039: ldc.i4.1
-				IL_003a: ldelem.ref
-				IL_003b: castclass Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope
-				IL_0040: ldfld object Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope::count
-				IL_0045: stloc.0
-				IL_0046: ldstr "count"
-				IL_004b: ldloc.0
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0051: stloc.0
-				IL_0052: ldloc.0
-				IL_0053: ret
+				IL_0032: ldfld object Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope::count
+				IL_0037: ret
 			} // end of method increment::__js_call__
 
 		} // end of class increment
@@ -107,7 +94,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fd
+				// Method begins at RVA 0x21e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -192,7 +179,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21f4
+			// Method begins at RVA 0x21d8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -321,7 +308,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220f
+		// Method begins at RVA 0x21f3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_NonLiteral_RuntimeError.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_NonLiteral_RuntimeError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2245
+				// Method begins at RVA 0x2251
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x224e
+				// Method begins at RVA 0x225a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2257
+				// Method begins at RVA 0x2263
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2260
+				// Method begins at RVA 0x226c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x223c
+			// Method begins at RVA 0x2248
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 452 (0x1c4)
+		// Code size: 462 (0x1ce)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_NonLiteral_RuntimeError/Scope,
@@ -141,7 +141,8 @@
 			[13] object,
 			[14] string,
 			[15] object,
-			[16] object[]
+			[16] bool,
+			[17] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_Constructor_NonLiteral_RuntimeError/Scope::.ctor()
@@ -171,7 +172,7 @@
 			IL_0048: ldstr "call-no-error"
 			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0052: pop
-			IL_0053: leave IL_00e0
+			IL_0053: leave IL_00e5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -215,105 +216,107 @@
 			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00b7: stloc.s 15
 			IL_00b9: ldloc.s 15
-			IL_00bb: ldstr "includes"
+			IL_00bb: castclass [System.Runtime]System.String
 			IL_00c0: ldstr "string literal arguments"
-			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ca: stloc.s 15
+			IL_00c5: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_00ca: stloc.s 16
 			IL_00cc: ldloc.s 13
 			IL_00ce: ldstr "log"
-			IL_00d3: ldloc.s 15
-			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00da: pop
-			IL_00db: leave IL_00e0
+			IL_00d3: ldloc.s 16
+			IL_00d5: box [System.Runtime]System.Boolean
+			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00df: pop
+			IL_00e0: leave IL_00e5
 		} // end handler
 		.try
 		{
-			IL_00e0: newobj instance void Modules.Function_Constructor_NonLiteral_RuntimeError/Scope/Block_L12C4::.ctor()
-			IL_00e5: stloc.s 7
-			IL_00e7: ldstr "Function"
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00f1: stloc.s 15
-			IL_00f3: ldc.i4.1
-			IL_00f4: newarr [System.Runtime]System.Object
-			IL_00f9: dup
-			IL_00fa: ldc.i4.0
-			IL_00fb: ldloc.1
-			IL_00fc: stelem.ref
-			IL_00fd: stloc.s 16
-			IL_00ff: ldloc.s 15
-			IL_0101: ldloc.s 16
-			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0108: pop
-			IL_0109: ldstr "console"
-			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0113: stloc.s 15
-			IL_0115: ldloc.s 15
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011c: stloc.s 15
-			IL_011e: ldloc.s 15
-			IL_0120: ldstr "log"
-			IL_0125: ldstr "new-no-error"
-			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_012f: pop
-			IL_0130: leave IL_01c0
+			IL_00e5: newobj instance void Modules.Function_Constructor_NonLiteral_RuntimeError/Scope/Block_L12C4::.ctor()
+			IL_00ea: stloc.s 7
+			IL_00ec: ldstr "Function"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00f6: stloc.s 13
+			IL_00f8: ldc.i4.1
+			IL_00f9: newarr [System.Runtime]System.Object
+			IL_00fe: dup
+			IL_00ff: ldc.i4.0
+			IL_0100: ldloc.1
+			IL_0101: stelem.ref
+			IL_0102: stloc.s 17
+			IL_0104: ldloc.s 13
+			IL_0106: ldloc.s 17
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_010d: pop
+			IL_010e: ldstr "console"
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0118: stloc.s 13
+			IL_011a: ldloc.s 13
+			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0121: stloc.s 13
+			IL_0123: ldloc.s 13
+			IL_0125: ldstr "log"
+			IL_012a: ldstr "new-no-error"
+			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0134: pop
+			IL_0135: leave IL_01ca
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0135: stloc.s 8
-			IL_0137: ldloc.s 8
-			IL_0139: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_013e: dup
-			IL_013f: brtrue IL_0155
+			IL_013a: stloc.s 8
+			IL_013c: ldloc.s 8
+			IL_013e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0143: dup
+			IL_0144: brtrue IL_015a
 
-			IL_0144: pop
-			IL_0145: ldloc.s 8
-			IL_0147: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_014c: dup
-			IL_014d: brtrue IL_0161
+			IL_0149: pop
+			IL_014a: ldloc.s 8
+			IL_014c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0151: dup
+			IL_0152: brtrue IL_0166
 
-			IL_0152: pop
-			IL_0153: rethrow
+			IL_0157: pop
+			IL_0158: rethrow
 
-			IL_0155: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_015a: stloc.s 9
-			IL_015c: br IL_0163
+			IL_015a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_015f: stloc.s 9
+			IL_0161: br IL_0168
 
-			IL_0161: stloc.s 9
+			IL_0166: stloc.s 9
 
-			IL_0163: ldloc.s 9
-			IL_0165: stloc.s 15
-			IL_0167: ldloc.s 15
-			IL_0169: stloc.s 10
-			IL_016b: newobj instance void Modules.Function_Constructor_NonLiteral_RuntimeError/Scope/Block_L15C12::.ctor()
-			IL_0170: stloc.s 11
-			IL_0172: ldstr "console"
-			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_017c: stloc.s 15
-			IL_017e: ldloc.s 15
-			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0185: stloc.s 15
-			IL_0187: ldloc.s 10
-			IL_0189: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_018e: stloc.s 14
-			IL_0190: ldloc.s 14
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0197: stloc.s 13
-			IL_0199: ldloc.s 13
-			IL_019b: ldstr "includes"
-			IL_01a0: ldstr "string literal arguments"
-			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01aa: stloc.s 13
-			IL_01ac: ldloc.s 15
-			IL_01ae: ldstr "log"
-			IL_01b3: ldloc.s 13
-			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01ba: pop
-			IL_01bb: leave IL_01c0
+			IL_0168: ldloc.s 9
+			IL_016a: stloc.s 13
+			IL_016c: ldloc.s 13
+			IL_016e: stloc.s 10
+			IL_0170: newobj instance void Modules.Function_Constructor_NonLiteral_RuntimeError/Scope/Block_L15C12::.ctor()
+			IL_0175: stloc.s 11
+			IL_0177: ldstr "console"
+			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0181: stloc.s 13
+			IL_0183: ldloc.s 13
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_018a: stloc.s 13
+			IL_018c: ldloc.s 10
+			IL_018e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0193: stloc.s 14
+			IL_0195: ldloc.s 14
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_019c: stloc.s 15
+			IL_019e: ldloc.s 15
+			IL_01a0: castclass [System.Runtime]System.String
+			IL_01a5: ldstr "string literal arguments"
+			IL_01aa: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_01af: stloc.s 16
+			IL_01b1: ldloc.s 13
+			IL_01b3: ldstr "log"
+			IL_01b8: ldloc.s 16
+			IL_01ba: box [System.Runtime]System.Boolean
+			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01c4: pop
+			IL_01c5: leave IL_01ca
 		} // end handler
 
-		IL_01c0: ldnull
-		IL_01c1: stloc.s 12
-		IL_01c3: ret
+		IL_01ca: ldnull
+		IL_01cb: stloc.s 12
+		IL_01cd: ret
 	} // end of method Function_Constructor_NonLiteral_RuntimeError::__js_module_init__
 
 } // end of class Modules.Function_Constructor_NonLiteral_RuntimeError
@@ -325,7 +328,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2269
+		// Method begins at RVA 0x2275
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_SyntaxError.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_SyntaxError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a5
+				// Method begins at RVA 0x21ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ae
+				// Method begins at RVA 0x21b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x219c
+			// Method begins at RVA 0x21a4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 304 (0x130)
+		// Code size: 309 (0x135)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_SyntaxError/Scope,
@@ -95,7 +95,8 @@
 			[7] object,
 			[8] object,
 			[9] string,
-			[10] object
+			[10] object,
+			[11] bool
 		)
 
 		IL_0000: newobj instance void Modules.Function_Constructor_SyntaxError/Scope::.ctor()
@@ -131,7 +132,7 @@
 			IL_0059: ldstr "no-error"
 			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0063: pop
-			IL_0064: leave IL_012c
+			IL_0064: leave IL_0131
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -177,37 +178,38 @@
 			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00c9: stloc.s 10
 			IL_00cb: ldloc.s 10
-			IL_00cd: ldstr "includes"
+			IL_00cd: castclass [System.Runtime]System.String
 			IL_00d2: ldstr "SyntaxError"
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00dc: stloc.s 10
+			IL_00d7: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_00dc: stloc.s 11
 			IL_00de: ldloc.s 8
 			IL_00e0: ldstr "log"
-			IL_00e5: ldloc.s 10
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ec: pop
-			IL_00ed: ldstr "console"
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00f7: stloc.s 10
-			IL_00f9: ldloc.s 10
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0100: stloc.s 10
-			IL_0102: ldloc.s 10
-			IL_0104: ldstr "log"
-			IL_0109: ldloc.s 6
-			IL_010b: callvirt instance int32 [System.Runtime]System.String::get_Length()
-			IL_0110: conv.r8
-			IL_0111: ldc.r8 0.0
-			IL_011a: cgt
-			IL_011c: box [System.Runtime]System.Boolean
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0126: pop
-			IL_0127: leave IL_012c
+			IL_00e5: ldloc.s 11
+			IL_00e7: box [System.Runtime]System.Boolean
+			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f1: pop
+			IL_00f2: ldstr "console"
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00fc: stloc.s 8
+			IL_00fe: ldloc.s 8
+			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0105: stloc.s 8
+			IL_0107: ldloc.s 8
+			IL_0109: ldstr "log"
+			IL_010e: ldloc.s 6
+			IL_0110: callvirt instance int32 [System.Runtime]System.String::get_Length()
+			IL_0115: conv.r8
+			IL_0116: ldc.r8 0.0
+			IL_011f: cgt
+			IL_0121: box [System.Runtime]System.Boolean
+			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_012b: pop
+			IL_012c: leave IL_0131
 		} // end handler
 
-		IL_012c: ldnull
-		IL_012d: stloc.s 7
-		IL_012f: ret
+		IL_0131: ldnull
+		IL_0132: stloc.s 7
+		IL_0134: ret
 	} // end of method Function_Constructor_SyntaxError::__js_module_init__
 
 } // end of class Modules.Function_Constructor_SyntaxError
@@ -219,7 +221,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b7
+		// Method begins at RVA 0x21bf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21be
+					// Method begins at RVA 0x21b0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -49,29 +49,22 @@
 				)
 				// Method begins at RVA 0x217c
 				// Header size: 12
-				// Code size: 36 (0x24)
+				// Code size: 22 (0x16)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
-				IL_0000: ldarg.0
-				IL_0001: ldc.i4.1
-				IL_0002: ldelem.ref
-				IL_0003: castclass Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope
-				IL_0008: ldfld object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope::offset
-				IL_000d: stloc.0
-				IL_000e: ldstr "offset"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldarg.2
-				IL_001b: ldloc.0
-				IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0021: stloc.1
-				IL_0022: ldloc.1
-				IL_0023: ret
+				IL_0000: ldarg.2
+				IL_0001: ldarg.0
+				IL_0002: ldc.i4.1
+				IL_0003: ldelem.ref
+				IL_0004: castclass Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope
+				IL_0009: ldfld object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope::offset
+				IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0013: stloc.0
+				IL_0014: ldloc.0
+				IL_0015: ret
 			} // end of method FunctionExpression_L9C25::__js_call__
 
 		} // end of class FunctionExpression_L9C25
@@ -90,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b5
+				// Method begins at RVA 0x21a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -204,7 +197,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x219e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -293,7 +286,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c7
+		// Method begins at RVA 0x21b9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x219c
+				// Method begins at RVA 0x2190
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 			)
 			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 87 (0x57)
+			// Code size: 73 (0x49)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -67,22 +67,16 @@
 			IL_0030: pop
 			IL_0031: ldarg.0
 			IL_0032: ldfld object Modules.Function_GlobalFunctionCallsGlobalFunction/Scope::helloWorld
-			IL_0037: stloc.0
-			IL_0038: ldstr "helloWorld"
-			IL_003d: ldloc.0
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0043: stloc.0
-			IL_0044: ldloc.0
-			IL_0045: ldc.i4.1
-			IL_0046: newarr [System.Runtime]System.Object
-			IL_004b: dup
-			IL_004c: ldc.i4.0
-			IL_004d: ldarg.0
-			IL_004e: stelem.ref
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0054: pop
-			IL_0055: ldnull
-			IL_0056: ret
+			IL_0037: ldc.i4.1
+			IL_0038: newarr [System.Runtime]System.Object
+			IL_003d: dup
+			IL_003e: ldc.i4.0
+			IL_003f: ldarg.0
+			IL_0040: stelem.ref
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0046: pop
+			IL_0047: ldnull
+			IL_0048: ret
 		} // end of method helloWorldProxy::__js_call__
 
 	} // end of class helloWorldProxy
@@ -98,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a5
+				// Method begins at RVA 0x2199
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -121,7 +115,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2154
+			// Method begins at RVA 0x2148
 			// Header size: 12
 			// Code size: 51 (0x33)
 			.maxstack 8
@@ -166,7 +160,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2193
+			// Method begins at RVA 0x2187
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -264,7 +258,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ae
+		// Method begins at RVA 0x21a2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2262
+				// Method begins at RVA 0x221a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,14 +46,12 @@
 			)
 			// Method begins at RVA 0x214c
 			// Header size: 12
-			// Code size: 257 (0x101)
+			// Code size: 185 (0xb9)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
-				[2] object,
-				[3] object[],
-				[4] object
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -65,104 +63,74 @@
 			IL_0012: ldarg.0
 			IL_0013: ldfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
 			IL_0018: stloc.1
-			IL_0019: ldstr "counter"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: ldarg.0
-			IL_0026: ldfld string Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::message
-			IL_002b: stloc.2
-			IL_002c: ldstr "message"
-			IL_0031: ldloc.2
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0037: stloc.2
-			IL_0038: ldc.i4.4
-			IL_0039: newarr [System.Runtime]System.Object
-			IL_003e: dup
-			IL_003f: ldc.i4.0
-			IL_0040: ldstr "Before change - counter:"
-			IL_0045: stelem.ref
-			IL_0046: dup
-			IL_0047: ldc.i4.1
-			IL_0048: ldloc.1
-			IL_0049: stelem.ref
-			IL_004a: dup
-			IL_004b: ldc.i4.2
-			IL_004c: ldstr "message:"
-			IL_0051: stelem.ref
-			IL_0052: dup
-			IL_0053: ldc.i4.3
-			IL_0054: ldloc.2
-			IL_0055: stelem.ref
-			IL_0056: stloc.3
-			IL_0057: ldloc.0
-			IL_0058: ldstr "log"
-			IL_005d: ldloc.3
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0063: pop
+			IL_0019: ldloc.0
+			IL_001a: ldstr "log"
+			IL_001f: ldc.i4.4
+			IL_0020: newarr [System.Runtime]System.Object
+			IL_0025: dup
+			IL_0026: ldc.i4.0
+			IL_0027: ldstr "Before change - counter:"
+			IL_002c: stelem.ref
+			IL_002d: dup
+			IL_002e: ldc.i4.1
+			IL_002f: ldloc.1
+			IL_0030: stelem.ref
+			IL_0031: dup
+			IL_0032: ldc.i4.2
+			IL_0033: ldstr "message:"
+			IL_0038: stelem.ref
+			IL_0039: dup
+			IL_003a: ldc.i4.3
+			IL_003b: ldarg.0
+			IL_003c: ldfld string Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::message
+			IL_0041: stelem.ref
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0047: pop
+			IL_0048: ldarg.0
+			IL_0049: ldfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
+			IL_004e: ldc.r8 10
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_005c: stloc.2
+			IL_005d: ldarg.0
+			IL_005e: ldloc.2
+			IL_005f: stfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
 			IL_0064: ldarg.0
-			IL_0065: ldfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
-			IL_006a: stloc.0
-			IL_006b: ldstr "counter"
-			IL_0070: ldloc.0
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0076: stloc.0
-			IL_0077: ldloc.0
-			IL_0078: ldc.r8 10
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0086: stloc.s 4
-			IL_0088: ldarg.0
-			IL_0089: ldloc.s 4
-			IL_008b: stfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
-			IL_0090: ldarg.0
-			IL_0091: ldstr "Modified message"
-			IL_0096: stfld string Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::message
-			IL_009b: ldstr "console"
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00a5: stloc.0
-			IL_00a6: ldloc.0
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ac: stloc.0
-			IL_00ad: ldarg.0
-			IL_00ae: ldfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
-			IL_00b3: stloc.2
-			IL_00b4: ldstr "counter"
-			IL_00b9: ldloc.2
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00bf: stloc.2
-			IL_00c0: ldarg.0
-			IL_00c1: ldfld string Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::message
-			IL_00c6: stloc.1
-			IL_00c7: ldstr "message"
-			IL_00cc: ldloc.1
-			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00d2: stloc.1
-			IL_00d3: ldc.i4.4
-			IL_00d4: newarr [System.Runtime]System.Object
-			IL_00d9: dup
-			IL_00da: ldc.i4.0
-			IL_00db: ldstr "After change - counter:"
-			IL_00e0: stelem.ref
-			IL_00e1: dup
-			IL_00e2: ldc.i4.1
-			IL_00e3: ldloc.2
-			IL_00e4: stelem.ref
-			IL_00e5: dup
-			IL_00e6: ldc.i4.2
-			IL_00e7: ldstr "message:"
-			IL_00ec: stelem.ref
-			IL_00ed: dup
-			IL_00ee: ldc.i4.3
-			IL_00ef: ldloc.1
-			IL_00f0: stelem.ref
-			IL_00f1: stloc.3
-			IL_00f2: ldloc.0
-			IL_00f3: ldstr "log"
-			IL_00f8: ldloc.3
-			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_00fe: pop
-			IL_00ff: ldnull
-			IL_0100: ret
+			IL_0065: ldstr "Modified message"
+			IL_006a: stfld string Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::message
+			IL_006f: ldstr "console"
+			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0079: stloc.0
+			IL_007a: ldloc.0
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0080: stloc.0
+			IL_0081: ldarg.0
+			IL_0082: ldfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
+			IL_0087: stloc.1
+			IL_0088: ldloc.0
+			IL_0089: ldstr "log"
+			IL_008e: ldc.i4.4
+			IL_008f: newarr [System.Runtime]System.Object
+			IL_0094: dup
+			IL_0095: ldc.i4.0
+			IL_0096: ldstr "After change - counter:"
+			IL_009b: stelem.ref
+			IL_009c: dup
+			IL_009d: ldc.i4.1
+			IL_009e: ldloc.1
+			IL_009f: stelem.ref
+			IL_00a0: dup
+			IL_00a1: ldc.i4.2
+			IL_00a2: ldstr "message:"
+			IL_00a7: stelem.ref
+			IL_00a8: dup
+			IL_00a9: ldc.i4.3
+			IL_00aa: ldarg.0
+			IL_00ab: ldfld string Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::message
+			IL_00b0: stelem.ref
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_00b6: pop
+			IL_00b7: ldnull
+			IL_00b8: ret
 		} // end of method changeGlobalValues::__js_call__
 
 	} // end of class changeGlobalValues
@@ -187,7 +155,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2259
+			// Method begins at RVA 0x2211
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -331,7 +299,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x226b
+		// Method begins at RVA 0x2223
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2141
+				// Method begins at RVA 0x2125
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,11 +46,10 @@
 			)
 			// Method begins at RVA 0x20bc
 			// Header size: 12
-			// Code size: 112 (0x70)
+			// Code size: 84 (0x54)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldstr "console"
@@ -59,40 +58,28 @@
 			IL_000b: ldloc.0
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
-			IL_0012: ldarg.0
-			IL_0013: ldfld string Modules.Function_GlobalFunctionLogsGlobalVariable/Scope::globalMessage
-			IL_0018: stloc.1
-			IL_0019: ldstr "globalMessage"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: ldloc.0
-			IL_0026: ldstr "log"
-			IL_002b: ldstr "Global message:"
-			IL_0030: ldloc.1
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0036: pop
-			IL_0037: ldstr "console"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0041: stloc.1
-			IL_0042: ldloc.1
-			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0048: stloc.1
-			IL_0049: ldarg.0
-			IL_004a: ldfld object Modules.Function_GlobalFunctionLogsGlobalVariable/Scope::globalNumber
-			IL_004f: stloc.0
-			IL_0050: ldstr "globalNumber"
-			IL_0055: ldloc.0
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_005b: stloc.0
-			IL_005c: ldloc.1
-			IL_005d: ldstr "log"
-			IL_0062: ldstr "Global number:"
-			IL_0067: ldloc.0
-			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_006d: pop
-			IL_006e: ldnull
-			IL_006f: ret
+			IL_0012: ldloc.0
+			IL_0013: ldstr "log"
+			IL_0018: ldstr "Global message:"
+			IL_001d: ldarg.0
+			IL_001e: ldfld string Modules.Function_GlobalFunctionLogsGlobalVariable/Scope::globalMessage
+			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0028: pop
+			IL_0029: ldstr "console"
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0033: stloc.0
+			IL_0034: ldloc.0
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003a: stloc.0
+			IL_003b: ldloc.0
+			IL_003c: ldstr "log"
+			IL_0041: ldstr "Global number:"
+			IL_0046: ldarg.0
+			IL_0047: ldfld object Modules.Function_GlobalFunctionLogsGlobalVariable/Scope::globalNumber
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0051: pop
+			IL_0052: ldnull
+			IL_0053: ret
 		} // end of method logGlobalValues::__js_call__
 
 	} // end of class logGlobalValues
@@ -118,7 +105,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2138
+			// Method begins at RVA 0x211c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -197,7 +184,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x214a
+		// Method begins at RVA 0x212e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2239
+					// Method begins at RVA 0x220f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,13 +48,12 @@
 				)
 				// Method begins at RVA 0x2148
 				// Header size: 12
-				// Code size: 211 (0xd3)
+				// Code size: 169 (0xa9)
 				.maxstack 8
 				.locals init (
 					[0] object,
 					[1] object,
-					[2] object,
-					[3] object
+					[2] object
 				)
 
 				IL_0000: ldc.r8 5
@@ -66,72 +65,54 @@
 				IL_001a: ldloc.1
 				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0020: stloc.1
-				IL_0021: ldarg.0
-				IL_0022: ldc.i4.0
-				IL_0023: ldelem.ref
-				IL_0024: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
-				IL_0029: ldfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope::outerVar
-				IL_002e: stloc.2
-				IL_002f: ldstr "outerVar"
-				IL_0034: ldloc.2
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003a: stloc.2
-				IL_003b: ldloc.1
-				IL_003c: ldstr "log"
-				IL_0041: ldstr "Outer variable:"
-				IL_0046: ldloc.2
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_004c: pop
-				IL_004d: ldstr "console"
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0057: stloc.2
-				IL_0058: ldloc.2
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_005e: stloc.2
-				IL_005f: ldarg.0
-				IL_0060: ldc.i4.1
-				IL_0061: ldelem.ref
-				IL_0062: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope
-				IL_0067: ldfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope::param
-				IL_006c: stloc.1
-				IL_006d: ldstr "param"
-				IL_0072: ldloc.1
-				IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0078: stloc.1
-				IL_0079: ldloc.2
-				IL_007a: ldstr "log"
-				IL_007f: ldstr "Parameter:"
-				IL_0084: ldloc.1
-				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_008a: pop
-				IL_008b: ldstr "console"
-				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0095: stloc.1
-				IL_0096: ldloc.1
-				IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_009c: stloc.1
-				IL_009d: ldloc.1
-				IL_009e: ldstr "log"
-				IL_00a3: ldstr "Inner variable:"
-				IL_00a8: ldloc.0
-				IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00ae: pop
-				IL_00af: ldarg.0
-				IL_00b0: ldc.i4.1
-				IL_00b1: ldelem.ref
-				IL_00b2: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope
-				IL_00b7: ldfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope::param
-				IL_00bc: stloc.1
-				IL_00bd: ldstr "param"
-				IL_00c2: ldloc.1
-				IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00c8: stloc.1
-				IL_00c9: ldloc.1
-				IL_00ca: ldloc.0
-				IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00d0: stloc.3
-				IL_00d1: ldloc.3
-				IL_00d2: ret
+				IL_0021: ldloc.1
+				IL_0022: ldstr "log"
+				IL_0027: ldstr "Outer variable:"
+				IL_002c: ldarg.0
+				IL_002d: ldc.i4.0
+				IL_002e: ldelem.ref
+				IL_002f: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
+				IL_0034: ldfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope::outerVar
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_003e: pop
+				IL_003f: ldstr "console"
+				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0049: stloc.1
+				IL_004a: ldloc.1
+				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0050: stloc.1
+				IL_0051: ldloc.1
+				IL_0052: ldstr "log"
+				IL_0057: ldstr "Parameter:"
+				IL_005c: ldarg.0
+				IL_005d: ldc.i4.1
+				IL_005e: ldelem.ref
+				IL_005f: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope
+				IL_0064: ldfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope::param
+				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_006e: pop
+				IL_006f: ldstr "console"
+				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0079: stloc.1
+				IL_007a: ldloc.1
+				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0080: stloc.1
+				IL_0081: ldloc.1
+				IL_0082: ldstr "log"
+				IL_0087: ldstr "Inner variable:"
+				IL_008c: ldloc.0
+				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0092: pop
+				IL_0093: ldarg.0
+				IL_0094: ldc.i4.1
+				IL_0095: ldelem.ref
+				IL_0096: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope
+				IL_009b: ldfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope::param
+				IL_00a0: ldloc.0
+				IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00a6: stloc.2
+				IL_00a7: ldloc.2
+				IL_00a8: ret
 			} // end of method nestedFunction::__js_call__
 
 		} // end of class nestedFunction
@@ -153,7 +134,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2230
+				// Method begins at RVA 0x2206
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -239,7 +220,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2227
+			// Method begins at RVA 0x21fd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -342,7 +323,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2242
+		// Method begins at RVA 0x2218
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ca
+					// Method begins at RVA 0x21ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,12 +48,11 @@
 				)
 				// Method begins at RVA 0x2104
 				// Header size: 12
-				// Code size: 168 (0xa8)
+				// Code size: 140 (0x8c)
 				.maxstack 8
 				.locals init (
 					[0] string,
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: ldstr "I am inner"
@@ -64,58 +63,46 @@
 				IL_0011: ldloc.1
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0017: stloc.1
-				IL_0018: ldarg.0
-				IL_0019: ldc.i4.0
-				IL_001a: ldelem.ref
-				IL_001b: castclass Modules.Function_NestedFunctionAccessesMultipleScopes/Scope
-				IL_0020: ldfld string Modules.Function_NestedFunctionAccessesMultipleScopes/Scope::globalVar
-				IL_0025: stloc.2
-				IL_0026: ldstr "globalVar"
-				IL_002b: ldloc.2
-				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0031: stloc.2
-				IL_0032: ldloc.1
-				IL_0033: ldstr "log"
-				IL_0038: ldstr "Global:"
-				IL_003d: ldloc.2
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0043: pop
-				IL_0044: ldstr "console"
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_004e: stloc.2
-				IL_004f: ldloc.2
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0055: stloc.2
-				IL_0056: ldarg.0
-				IL_0057: ldc.i4.1
-				IL_0058: ldelem.ref
-				IL_0059: castclass Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope
-				IL_005e: ldfld string Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope::outerVar
-				IL_0063: stloc.1
-				IL_0064: ldstr "outerVar"
-				IL_0069: ldloc.1
-				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006f: stloc.1
-				IL_0070: ldloc.2
-				IL_0071: ldstr "log"
-				IL_0076: ldstr "Outer:"
-				IL_007b: ldloc.1
-				IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0081: pop
-				IL_0082: ldstr "console"
-				IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_008c: stloc.1
-				IL_008d: ldloc.1
-				IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0093: stloc.1
-				IL_0094: ldloc.1
-				IL_0095: ldstr "log"
-				IL_009a: ldstr "Inner:"
-				IL_009f: ldloc.0
-				IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00a5: pop
-				IL_00a6: ldnull
-				IL_00a7: ret
+				IL_0018: ldloc.1
+				IL_0019: ldstr "log"
+				IL_001e: ldstr "Global:"
+				IL_0023: ldarg.0
+				IL_0024: ldc.i4.0
+				IL_0025: ldelem.ref
+				IL_0026: castclass Modules.Function_NestedFunctionAccessesMultipleScopes/Scope
+				IL_002b: ldfld string Modules.Function_NestedFunctionAccessesMultipleScopes/Scope::globalVar
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0035: pop
+				IL_0036: ldstr "console"
+				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0040: stloc.1
+				IL_0041: ldloc.1
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0047: stloc.1
+				IL_0048: ldloc.1
+				IL_0049: ldstr "log"
+				IL_004e: ldstr "Outer:"
+				IL_0053: ldarg.0
+				IL_0054: ldc.i4.1
+				IL_0055: ldelem.ref
+				IL_0056: castclass Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope
+				IL_005b: ldfld string Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope::outerVar
+				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0065: pop
+				IL_0066: ldstr "console"
+				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0070: stloc.1
+				IL_0071: ldloc.1
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0077: stloc.1
+				IL_0078: ldloc.1
+				IL_0079: ldstr "log"
+				IL_007e: ldstr "Inner:"
+				IL_0083: ldloc.0
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0089: pop
+				IL_008a: ldnull
+				IL_008b: ret
 			} // end of method innerFunction::__js_call__
 
 		} // end of class innerFunction
@@ -137,7 +124,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c1
+				// Method begins at RVA 0x21a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -231,7 +218,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b8
+			// Method begins at RVA 0x219c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -306,7 +293,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d3
+		// Method begins at RVA 0x21b7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2186
+					// Method begins at RVA 0x2178
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -49,11 +49,10 @@
 				)
 				// Method begins at RVA 0x2104
 				// Header size: 12
-				// Code size: 100 (0x64)
+				// Code size: 86 (0x56)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldstr "console"
@@ -62,36 +61,30 @@
 				IL_000b: ldloc.0
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0011: stloc.0
-				IL_0012: ldarg.0
-				IL_0013: ldc.i4.1
-				IL_0014: ldelem.ref
-				IL_0015: castclass Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope
-				IL_001a: ldfld object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope::outerParam
-				IL_001f: stloc.1
-				IL_0020: ldstr "outerParam"
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002b: stloc.1
-				IL_002c: ldloc.0
-				IL_002d: ldstr "log"
-				IL_0032: ldstr "Outer Param:"
-				IL_0037: ldloc.1
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_003d: pop
-				IL_003e: ldstr "console"
-				IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0048: stloc.1
-				IL_0049: ldloc.1
-				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004f: stloc.1
-				IL_0050: ldloc.1
-				IL_0051: ldstr "log"
-				IL_0056: ldstr "Inner Param:"
-				IL_005b: ldarg.2
-				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0061: pop
-				IL_0062: ldnull
-				IL_0063: ret
+				IL_0012: ldloc.0
+				IL_0013: ldstr "log"
+				IL_0018: ldstr "Outer Param:"
+				IL_001d: ldarg.0
+				IL_001e: ldc.i4.1
+				IL_001f: ldelem.ref
+				IL_0020: castclass Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope
+				IL_0025: ldfld object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope::outerParam
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_002f: pop
+				IL_0030: ldstr "console"
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_003a: stloc.0
+				IL_003b: ldloc.0
+				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0041: stloc.0
+				IL_0042: ldloc.0
+				IL_0043: ldstr "log"
+				IL_0048: ldstr "Inner Param:"
+				IL_004d: ldarg.2
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0053: pop
+				IL_0054: ldnull
+				IL_0055: ret
 			} // end of method innerFunction::__js_call__
 
 		} // end of class innerFunction
@@ -113,7 +106,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x217d
+				// Method begins at RVA 0x216f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -197,7 +190,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2174
+			// Method begins at RVA 0x2166
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -283,7 +276,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218f
+		// Method begins at RVA 0x2181
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21af
+					// Method begins at RVA 0x21a1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b8
+					// Method begins at RVA 0x21aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -99,7 +99,7 @@
 				)
 				// Method begins at RVA 0x215c
 				// Header size: 12
-				// Code size: 53 (0x35)
+				// Code size: 39 (0x27)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -111,22 +111,16 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope
 				IL_0008: ldfld object Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope::Ctor
-				IL_000d: stloc.1
-				IL_000e: ldstr "Ctor"
-				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldloc.1
-				IL_001b: ldc.i4.0
-				IL_001c: newarr [System.Runtime]System.Object
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-				IL_0026: stloc.1
-				IL_0027: ldloc.1
-				IL_0028: stloc.0
-				IL_0029: ldloc.0
-				IL_002a: ldstr "value"
-				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0034: ret
+				IL_000d: ldc.i4.0
+				IL_000e: newarr [System.Runtime]System.Object
+				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+				IL_0018: stloc.1
+				IL_0019: ldloc.1
+				IL_001a: stloc.0
+				IL_001b: ldloc.0
+				IL_001c: ldstr "value"
+				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0026: ret
 			} // end of method inner::__js_call__
 
 		} // end of class inner
@@ -147,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a6
+				// Method begins at RVA 0x2198
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -258,7 +252,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x219d
+			// Method begins at RVA 0x218f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -342,7 +336,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c1
+		// Method begins at RVA 0x21b3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_MemberCallee_Compiles.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_MemberCallee_Compiles.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2177
+				// Method begins at RVA 0x2169
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2180
+				// Method begins at RVA 0x2172
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -97,7 +97,7 @@
 			)
 			// Method begins at RVA 0x2124
 			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Code size: 48 (0x30)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -106,30 +106,24 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Function_NewExpression_MemberCallee_Compiles/Scope::impl
-			IL_0006: stloc.1
-			IL_0007: ldstr "impl"
-			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: ldstr "Window"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.1
-			IL_001f: ldloc.1
-			IL_0020: ldc.i4.1
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldarg.2
-			IL_0029: stelem.ref
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_002f: stloc.1
-			IL_0030: ldloc.1
-			IL_0031: stloc.0
-			IL_0032: ldloc.0
-			IL_0033: ldstr "d"
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003d: ret
+			IL_0006: ldstr "Window"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: stloc.1
+			IL_0011: ldloc.1
+			IL_0012: ldc.i4.1
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldarg.2
+			IL_001b: stelem.ref
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0021: stloc.1
+			IL_0022: ldloc.1
+			IL_0023: stloc.0
+			IL_0024: ldloc.0
+			IL_0025: ldstr "d"
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002f: ret
 		} // end of method FunctionExpression_createWindow::__js_call__
 
 	} // end of class FunctionExpression_createWindow
@@ -148,7 +142,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x216e
+			// Method begins at RVA 0x2160
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -261,7 +255,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2189
+		// Method begins at RVA 0x217b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_Arrow_Inherits.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_Arrow_Inherits.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2190
+					// Method begins at RVA 0x2180
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,14 +48,13 @@
 				)
 				// Method begins at RVA 0x2124
 				// Header size: 12
-				// Code size: 78 (0x4e)
+				// Code size: 62 (0x3e)
 				.maxstack 8
 				.locals init (
 					[0] object,
 					[1] object,
-					[2] object,
-					[3] bool,
-					[4] object
+					[2] bool,
+					[3] object
 				)
 
 				IL_0000: ldstr "console"
@@ -66,30 +65,24 @@
 				IL_0011: stloc.0
 				IL_0012: ldarg.1
 				IL_0013: stloc.1
-				IL_0014: ldarg.0
-				IL_0015: ldc.i4.0
-				IL_0016: ldelem.ref
-				IL_0017: castclass Modules.Function_NewTarget_Arrow_Inherits/Scope
-				IL_001c: ldfld object Modules.Function_NewTarget_Arrow_Inherits/Scope::Outer
-				IL_0021: stloc.2
-				IL_0022: ldstr "Outer"
-				IL_0027: ldloc.2
-				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002d: stloc.2
-				IL_002e: ldloc.1
-				IL_002f: ldloc.2
-				IL_0030: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0035: stloc.3
-				IL_0036: ldloc.3
-				IL_0037: box [System.Runtime]System.Boolean
-				IL_003c: stloc.s 4
-				IL_003e: ldloc.0
-				IL_003f: ldstr "log"
-				IL_0044: ldloc.s 4
-				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004b: pop
-				IL_004c: ldnull
-				IL_004d: ret
+				IL_0014: ldloc.1
+				IL_0015: ldarg.0
+				IL_0016: ldc.i4.0
+				IL_0017: ldelem.ref
+				IL_0018: castclass Modules.Function_NewTarget_Arrow_Inherits/Scope
+				IL_001d: ldfld object Modules.Function_NewTarget_Arrow_Inherits/Scope::Outer
+				IL_0022: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0027: stloc.2
+				IL_0028: ldloc.2
+				IL_0029: box [System.Runtime]System.Boolean
+				IL_002e: stloc.3
+				IL_002f: ldloc.0
+				IL_0030: ldstr "log"
+				IL_0035: ldloc.3
+				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_003b: pop
+				IL_003c: ldnull
+				IL_003d: ret
 			} // end of method ArrowFunction_L4C19::__js_call__
 
 		} // end of class ArrowFunction_L4C19
@@ -101,7 +94,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2187
+				// Method begins at RVA 0x2177
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -197,7 +190,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217e
+			// Method begins at RVA 0x216e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -276,7 +269,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2199
+		// Method begins at RVA 0x2189
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_NewVsCall.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_NewVsCall.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x215d
+				// Method begins at RVA 0x214b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,15 +46,14 @@
 			)
 			// Method begins at RVA 0x20b8
 			// Header size: 12
-			// Code size: 144 (0x90)
+			// Code size: 126 (0x7e)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object,
-				[4] bool,
-				[5] object
+				[3] bool,
+				[4] object
 			)
 
 			IL_0000: ldstr "console"
@@ -65,55 +64,49 @@
 			IL_0011: stloc.1
 			IL_0012: ldarg.1
 			IL_0013: stloc.2
-			IL_0014: ldarg.0
-			IL_0015: ldfld object Modules.Function_NewTarget_NewVsCall/Scope::C
-			IL_001a: stloc.3
-			IL_001b: ldstr "C"
-			IL_0020: ldloc.3
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0026: stloc.3
-			IL_0027: ldloc.2
-			IL_0028: ldloc.3
-			IL_0029: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_002e: stloc.s 4
-			IL_0030: ldloc.s 4
-			IL_0032: box [System.Runtime]System.Boolean
-			IL_0037: stloc.s 5
-			IL_0039: ldloc.1
-			IL_003a: ldstr "log"
-			IL_003f: ldloc.s 5
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0046: pop
-			IL_0047: ldstr "console"
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0051: stloc.1
-			IL_0052: ldloc.1
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0058: stloc.1
-			IL_0059: ldarg.1
-			IL_005a: stloc.3
-			IL_005b: ldloc.3
-			IL_005c: ldc.i4.0
-			IL_005d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0062: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_0067: stloc.s 4
-			IL_0069: ldloc.s 4
-			IL_006b: brfalse IL_007b
+			IL_0014: ldloc.2
+			IL_0015: ldarg.0
+			IL_0016: ldfld object Modules.Function_NewTarget_NewVsCall/Scope::C
+			IL_001b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0020: stloc.3
+			IL_0021: ldloc.3
+			IL_0022: box [System.Runtime]System.Boolean
+			IL_0027: stloc.s 4
+			IL_0029: ldloc.1
+			IL_002a: ldstr "log"
+			IL_002f: ldloc.s 4
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0036: pop
+			IL_0037: ldstr "console"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0041: stloc.1
+			IL_0042: ldloc.1
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0048: stloc.1
+			IL_0049: ldarg.1
+			IL_004a: stloc.2
+			IL_004b: ldloc.2
+			IL_004c: ldc.i4.0
+			IL_004d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+			IL_0057: stloc.3
+			IL_0058: ldloc.3
+			IL_0059: brfalse IL_0069
 
-			IL_0070: ldstr "undefined"
-			IL_0075: stloc.0
-			IL_0076: br IL_0081
+			IL_005e: ldstr "undefined"
+			IL_0063: stloc.0
+			IL_0064: br IL_006f
 
-			IL_007b: ldstr "defined"
-			IL_0080: stloc.0
+			IL_0069: ldstr "defined"
+			IL_006e: stloc.0
 
-			IL_0081: ldloc.1
-			IL_0082: ldstr "log"
-			IL_0087: ldloc.0
-			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_008d: pop
-			IL_008e: ldnull
-			IL_008f: ret
+			IL_006f: ldloc.1
+			IL_0070: ldstr "log"
+			IL_0075: ldloc.0
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_007b: pop
+			IL_007c: ldnull
+			IL_007d: ret
 		} // end of method C::__js_call__
 
 	} // end of class C
@@ -131,7 +124,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2154
+			// Method begins at RVA 0x2142
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -210,7 +203,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2166
+		// Method begins at RVA 0x2154
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralValueFunction_ForEachCapturesOuter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralValueFunction_ForEachCapturesOuter.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x225b
+					// Method begins at RVA 0x224d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -49,33 +49,26 @@
 				)
 				// Method begins at RVA 0x2204
 				// Header size: 12
-				// Code size: 48 (0x30)
+				// Code size: 34 (0x22)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldarg.2
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0006: stloc.0
-				IL_0007: ldarg.0
-				IL_0008: ldc.i4.1
-				IL_0009: ldelem.ref
-				IL_000a: castclass Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope
-				IL_000f: ldfld object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope::toBeRemoved
-				IL_0014: stloc.1
-				IL_0015: ldstr "toBeRemoved"
-				IL_001a: ldloc.1
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.0
-				IL_0022: ldstr "_preremove"
-				IL_0027: ldloc.1
-				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_002d: pop
-				IL_002e: ldnull
-				IL_002f: ret
+				IL_0007: ldloc.0
+				IL_0008: ldstr "_preremove"
+				IL_000d: ldarg.0
+				IL_000e: ldc.i4.1
+				IL_000f: ldelem.ref
+				IL_0010: castclass Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope
+				IL_0015: ldfld object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope::toBeRemoved
+				IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_001f: pop
+				IL_0020: ldnull
+				IL_0021: ret
 			} // end of method FunctionExpression_DocumentLike::__js_call__
 
 		} // end of class FunctionExpression_DocumentLike
@@ -96,7 +89,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2252
+					// Method begins at RVA 0x2244
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -117,7 +110,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2249
+				// Method begins at RVA 0x223b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -218,7 +211,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2264
+				// Method begins at RVA 0x2256
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +267,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2240
+			// Method begins at RVA 0x2232
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -404,7 +397,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x226d
+		// Method begins at RVA 0x225f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x225f
+					// Method begins at RVA 0x224d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -49,13 +49,11 @@
 				)
 				// Method begins at RVA 0x220c
 				// Header size: 12
-				// Code size: 53 (0x35)
+				// Code size: 35 (0x23)
 				.maxstack 8
 				.locals init (
 					[0] object,
-					[1] float64,
-					[2] float64,
-					[3] object
+					[1] float64
 				)
 
 				IL_0000: ldarg.0
@@ -64,25 +62,15 @@
 				IL_0003: castclass Modules.Function_ReturnObjectWithClosure/createCalculator/Scope
 				IL_0008: ldfld object Modules.Function_ReturnObjectWithClosure/createCalculator/Scope::factor
 				IL_000d: stloc.0
-				IL_000e: ldstr "factor"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldarg.2
-				IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.0
-				IL_0022: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0027: stloc.2
-				IL_0028: ldloc.1
-				IL_0029: ldloc.2
-				IL_002a: mul
-				IL_002b: stloc.2
-				IL_002c: ldloc.2
-				IL_002d: box [System.Runtime]System.Double
-				IL_0032: stloc.3
-				IL_0033: ldloc.3
-				IL_0034: ret
+				IL_000e: ldarg.2
+				IL_000f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0014: stloc.1
+				IL_0015: ldloc.1
+				IL_0016: ldloc.0
+				IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001c: mul
+				IL_001d: box [System.Runtime]System.Double
+				IL_0022: ret
 			} // end of method multiply::__js_call__
 
 		} // end of class multiply
@@ -103,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2256
+				// Method begins at RVA 0x2244
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -199,7 +187,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x224d
+			// Method begins at RVA 0x223b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -347,7 +335,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2268
+		// Method begins at RVA 0x2256
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_NestedGenerator.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_NestedGenerator.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2747
+				// Method begins at RVA 0x2735
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -200,7 +200,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2750
+				// Method begins at RVA 0x273e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -226,7 +226,7 @@
 			)
 			// Method begins at RVA 0x2404
 			// Header size: 12
-			// Code size: 814 (0x32e)
+			// Code size: 796 (0x31c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Generator_YieldStar_NestedGenerator/outer/Scope,
@@ -293,269 +293,263 @@
 
 			IL_0068: ldloc.0
 			IL_0069: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_006e: switch (IL_007f, IL_0155, IL_0290)
+			IL_006e: switch (IL_007f, IL_0143, IL_027e)
 
 			IL_007f: ldarg.0
 			IL_0080: ldc.i4.1
 			IL_0081: ldelem.ref
 			IL_0082: castclass Modules.Generator_YieldStar_NestedGenerator/Scope
 			IL_0087: ldfld object Modules.Generator_YieldStar_NestedGenerator/Scope::inner
-			IL_008c: stloc.s 4
-			IL_008e: ldstr "inner"
-			IL_0093: ldloc.s 4
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_009a: stloc.s 4
-			IL_009c: ldloc.s 4
-			IL_009e: ldc.i4.1
-			IL_009f: newarr [System.Runtime]System.Object
-			IL_00a4: dup
-			IL_00a5: ldc.i4.0
-			IL_00a6: ldarg.0
-			IL_00a7: ldc.i4.1
-			IL_00a8: ldelem.ref
-			IL_00a9: stelem.ref
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00af: stloc.s 4
-			IL_00b1: ldloc.s 4
-			IL_00b3: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_00b8: stloc.s 5
-			IL_00ba: ldloc.s 5
-			IL_00bc: brtrue IL_01ba
+			IL_008c: ldc.i4.1
+			IL_008d: newarr [System.Runtime]System.Object
+			IL_0092: dup
+			IL_0093: ldc.i4.0
+			IL_0094: ldarg.0
+			IL_0095: ldc.i4.1
+			IL_0096: ldelem.ref
+			IL_0097: stelem.ref
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_009d: stloc.s 4
+			IL_009f: ldloc.s 4
+			IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_00a6: stloc.s 5
+			IL_00a8: ldloc.s 5
+			IL_00aa: brtrue IL_01a8
 
-			IL_00c1: ldloc.s 4
-			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::NormalizeForOfIterable(object)
-			IL_00c8: stloc.s 4
-			IL_00ca: ldloc.0
-			IL_00cb: ldc.r8 1
-			IL_00d4: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_00d9: ldloc.0
-			IL_00da: ldloc.s 4
-			IL_00dc: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_00e1: ldloc.0
-			IL_00e2: ldc.r8 0.0
-			IL_00eb: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_00f0: ldloc.s 4
-			IL_00f2: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_00f7: stloc.s 6
-			IL_00f9: ldloc.0
-			IL_00fa: ldloc.s 6
-			IL_00fc: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
+			IL_00af: ldloc.s 4
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::NormalizeForOfIterable(object)
+			IL_00b6: stloc.s 4
+			IL_00b8: ldloc.0
+			IL_00b9: ldc.r8 1
+			IL_00c2: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_00c7: ldloc.0
+			IL_00c8: ldloc.s 4
+			IL_00ca: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_00cf: ldloc.0
+			IL_00d0: ldc.r8 0.0
+			IL_00d9: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_00de: ldloc.s 4
+			IL_00e0: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+			IL_00e5: stloc.s 6
+			IL_00e7: ldloc.0
+			IL_00e8: ldloc.s 6
+			IL_00ea: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
 
-			IL_0101: ldloc.0
-			IL_0102: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_0107: stloc.s 6
-			IL_0109: ldloc.0
-			IL_010a: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
-			IL_010f: stloc.s 7
-			IL_0111: ldloc.s 6
-			IL_0113: ldloc.s 7
-			IL_0115: clt
-			IL_0117: brfalse IL_0197
+			IL_00ef: ldloc.0
+			IL_00f0: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_00f5: stloc.s 6
+			IL_00f7: ldloc.0
+			IL_00f8: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
+			IL_00fd: stloc.s 7
+			IL_00ff: ldloc.s 6
+			IL_0101: ldloc.s 7
+			IL_0103: clt
+			IL_0105: brfalse IL_0185
 
-			IL_011c: ldloc.0
-			IL_011d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_0122: stloc.s 4
-			IL_0124: ldloc.s 4
-			IL_0126: ldloc.s 6
-			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_012d: stloc.s 4
-			IL_012f: ldloc.s 6
-			IL_0131: ldc.r8 1
-			IL_013a: add
-			IL_013b: stloc.s 6
-			IL_013d: ldloc.0
-			IL_013e: ldloc.s 6
-			IL_0140: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_0145: ldloc.0
-			IL_0146: ldc.i4.1
-			IL_0147: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_014c: ldloc.s 4
-			IL_014e: ldc.i4.0
-			IL_014f: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0154: ret
+			IL_010a: ldloc.0
+			IL_010b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_0110: stloc.s 4
+			IL_0112: ldloc.s 4
+			IL_0114: ldloc.s 6
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_011b: stloc.s 4
+			IL_011d: ldloc.s 6
+			IL_011f: ldc.r8 1
+			IL_0128: add
+			IL_0129: stloc.s 6
+			IL_012b: ldloc.0
+			IL_012c: ldloc.s 6
+			IL_012e: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_0133: ldloc.0
+			IL_0134: ldc.i4.1
+			IL_0135: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_013a: ldloc.s 4
+			IL_013c: ldc.i4.0
+			IL_013d: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0142: ret
 
+			IL_0143: ldloc.0
+			IL_0144: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_0149: brfalse IL_0162
+
+			IL_014e: ldloc.0
+			IL_014f: ldc.i4.1
+			IL_0150: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
 			IL_0155: ldloc.0
-			IL_0156: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_015b: brfalse IL_0174
+			IL_0156: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_015b: ldc.i4.1
+			IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0161: ret
 
-			IL_0160: ldloc.0
-			IL_0161: ldc.i4.1
-			IL_0162: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0167: ldloc.0
-			IL_0168: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_016d: ldc.i4.1
-			IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0173: ret
+			IL_0162: ldloc.0
+			IL_0163: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0168: brfalse IL_0180
 
+			IL_016d: ldloc.0
+			IL_016e: ldc.i4.0
+			IL_016f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
 			IL_0174: ldloc.0
-			IL_0175: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_017a: brfalse IL_0192
+			IL_0175: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_017a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_017f: throw
 
-			IL_017f: ldloc.0
-			IL_0180: ldc.i4.0
-			IL_0181: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0186: ldloc.0
-			IL_0187: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_018c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0191: throw
+			IL_0180: br IL_00ef
 
-			IL_0192: br IL_0101
+			IL_0185: ldloc.0
+			IL_0186: ldc.r8 0.0
+			IL_018f: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_0194: ldloc.0
+			IL_0195: ldc.i4.0
+			IL_0196: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_019b: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01a0: ldnull
+			IL_01a1: stloc.s 4
+			IL_01a3: br IL_02c2
 
-			IL_0197: ldloc.0
-			IL_0198: ldc.r8 0.0
-			IL_01a1: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_01a6: ldloc.0
-			IL_01a7: ldc.i4.0
-			IL_01a8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01ad: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01b2: ldnull
-			IL_01b3: stloc.s 4
-			IL_01b5: br IL_02d4
+			IL_01a8: ldloc.0
+			IL_01a9: ldc.r8 2
+			IL_01b2: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_01b7: ldloc.0
+			IL_01b8: ldloc.s 5
+			IL_01ba: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01bf: ldc.i4.0
+			IL_01c0: stloc.2
 
-			IL_01ba: ldloc.0
-			IL_01bb: ldc.r8 2
-			IL_01c4: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_01c1: ldloc.0
+			IL_01c2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01c7: stloc.s 4
 			IL_01c9: ldloc.0
-			IL_01ca: ldloc.s 5
-			IL_01cc: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01d1: ldc.i4.0
-			IL_01d2: stloc.2
+			IL_01ca: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01cf: stloc.3
+			IL_01d0: ldloc.3
+			IL_01d1: brtrue IL_01e8
 
-			IL_01d3: ldloc.0
-			IL_01d4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01d9: stloc.s 4
-			IL_01db: ldloc.0
-			IL_01dc: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_01e1: stloc.3
-			IL_01e2: ldloc.3
-			IL_01e3: brtrue IL_01fa
+			IL_01d6: ldloc.0
+			IL_01d7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_01dc: stloc.3
+			IL_01dd: ldloc.3
+			IL_01de: brtrue IL_021b
 
-			IL_01e8: ldloc.0
-			IL_01e9: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_01ee: stloc.3
-			IL_01ef: ldloc.3
-			IL_01f0: brtrue IL_022d
+			IL_01e3: br IL_024e
 
-			IL_01f5: br IL_0260
+			IL_01e8: ldc.i4.1
+			IL_01e9: stloc.2
+			IL_01ea: ldloc.0
+			IL_01eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_01f0: stloc.s 8
+			IL_01f2: ldloc.0
+			IL_01f3: ldc.i4.0
+			IL_01f4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01f9: ldc.i4.1
+			IL_01fa: newarr [System.Runtime]System.Object
+			IL_01ff: dup
+			IL_0200: ldc.i4.0
+			IL_0201: ldloc.s 8
+			IL_0203: stelem.ref
+			IL_0204: stloc.s 9
+			IL_0206: ldloc.s 4
+			IL_0208: ldstr "return"
+			IL_020d: ldloc.s 9
+			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0214: stloc.s 4
+			IL_0216: br IL_0266
 
-			IL_01fa: ldc.i4.1
-			IL_01fb: stloc.2
-			IL_01fc: ldloc.0
-			IL_01fd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_0202: stloc.s 8
-			IL_0204: ldloc.0
-			IL_0205: ldc.i4.0
-			IL_0206: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_020b: ldc.i4.1
-			IL_020c: newarr [System.Runtime]System.Object
-			IL_0211: dup
-			IL_0212: ldc.i4.0
-			IL_0213: ldloc.s 8
-			IL_0215: stelem.ref
-			IL_0216: stloc.s 9
-			IL_0218: ldloc.s 4
-			IL_021a: ldstr "return"
-			IL_021f: ldloc.s 9
-			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0226: stloc.s 4
-			IL_0228: br IL_0278
+			IL_021b: ldc.i4.0
+			IL_021c: stloc.2
+			IL_021d: ldloc.0
+			IL_021e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0223: stloc.s 10
+			IL_0225: ldloc.0
+			IL_0226: ldc.i4.0
+			IL_0227: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_022c: ldc.i4.1
+			IL_022d: newarr [System.Runtime]System.Object
+			IL_0232: dup
+			IL_0233: ldc.i4.0
+			IL_0234: ldloc.s 10
+			IL_0236: stelem.ref
+			IL_0237: stloc.s 9
+			IL_0239: ldloc.s 4
+			IL_023b: ldstr "throw"
+			IL_0240: ldloc.s 9
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0247: stloc.s 4
+			IL_0249: br IL_0266
 
-			IL_022d: ldc.i4.0
-			IL_022e: stloc.2
-			IL_022f: ldloc.0
-			IL_0230: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0235: stloc.s 10
-			IL_0237: ldloc.0
-			IL_0238: ldc.i4.0
-			IL_0239: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_023e: ldc.i4.1
-			IL_023f: newarr [System.Runtime]System.Object
-			IL_0244: dup
-			IL_0245: ldc.i4.0
-			IL_0246: ldloc.s 10
-			IL_0248: stelem.ref
-			IL_0249: stloc.s 9
-			IL_024b: ldloc.s 4
-			IL_024d: ldstr "throw"
-			IL_0252: ldloc.s 9
-			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0259: stloc.s 4
-			IL_025b: br IL_0278
+			IL_024e: ldc.i4.0
+			IL_024f: stloc.2
+			IL_0250: ldloc.0
+			IL_0251: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeValue
+			IL_0256: stloc.s 11
+			IL_0258: ldloc.s 4
+			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNextForYieldStar(object)
+			IL_025f: stloc.s 4
+			IL_0261: br IL_0266
 
-			IL_0260: ldc.i4.0
-			IL_0261: stloc.2
-			IL_0262: ldloc.0
-			IL_0263: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeValue
-			IL_0268: stloc.s 11
-			IL_026a: ldloc.s 4
-			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNextForYieldStar(object)
-			IL_0271: stloc.s 4
-			IL_0273: br IL_0278
+			IL_0266: ldloc.s 4
+			IL_0268: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_026d: stloc.3
+			IL_026e: ldloc.3
+			IL_026f: brtrue IL_0283
 
-			IL_0278: ldloc.s 4
-			IL_027a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_027f: stloc.3
-			IL_0280: ldloc.3
-			IL_0281: brtrue IL_0295
+			IL_0274: ldloc.0
+			IL_0275: ldc.i4.2
+			IL_0276: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_027b: ldloc.s 4
+			IL_027d: ret
 
-			IL_0286: ldloc.0
-			IL_0287: ldc.i4.2
-			IL_0288: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_028d: ldloc.s 4
-			IL_028f: ret
+			IL_027e: br IL_01c1
 
-			IL_0290: br IL_01d3
+			IL_0283: ldloc.s 4
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_028a: stloc.s 4
+			IL_028c: ldloc.0
+			IL_028d: ldc.r8 0.0
+			IL_0296: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_029b: ldloc.0
+			IL_029c: ldc.i4.0
+			IL_029d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02a2: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_02a7: ldloc.2
+			IL_02a8: brtrue IL_02b2
 
-			IL_0295: ldloc.s 4
-			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_029c: stloc.s 4
-			IL_029e: ldloc.0
-			IL_029f: ldc.r8 0.0
-			IL_02a8: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_02ad: ldloc.0
-			IL_02ae: ldc.i4.0
-			IL_02af: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02b4: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_02b9: ldloc.2
-			IL_02ba: brtrue IL_02c4
+			IL_02ad: br IL_02c2
 
-			IL_02bf: br IL_02d4
+			IL_02b2: ldloc.0
+			IL_02b3: ldc.i4.1
+			IL_02b4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_02b9: ldloc.s 4
+			IL_02bb: ldc.i4.1
+			IL_02bc: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_02c1: ret
 
-			IL_02c4: ldloc.0
-			IL_02c5: ldc.i4.1
-			IL_02c6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_02cb: ldloc.s 4
-			IL_02cd: ldc.i4.1
-			IL_02ce: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_02d3: ret
-
-			IL_02d4: ldloc.0
-			IL_02d5: ldloc.s 4
-			IL_02d7: stfld object Modules.Generator_YieldStar_NestedGenerator/outer/Scope::r
-			IL_02dc: ldstr "console"
-			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02e6: stloc.s 4
-			IL_02e8: ldloc.s 4
-			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ef: stloc.s 4
-			IL_02f1: ldstr "r="
-			IL_02f6: ldloc.0
-			IL_02f7: ldfld object Modules.Generator_YieldStar_NestedGenerator/outer/Scope::r
-			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0301: stloc.s 12
-			IL_0303: ldloc.s 4
-			IL_0305: ldstr "log"
-			IL_030a: ldloc.s 12
-			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0311: pop
-			IL_0312: ldloc.0
-			IL_0313: ldc.i4.1
-			IL_0314: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0319: ldc.r8 4
-			IL_0322: box [System.Runtime]System.Double
-			IL_0327: ldc.i4.1
-			IL_0328: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_032d: ret
+			IL_02c2: ldloc.0
+			IL_02c3: ldloc.s 4
+			IL_02c5: stfld object Modules.Generator_YieldStar_NestedGenerator/outer/Scope::r
+			IL_02ca: ldstr "console"
+			IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02d4: stloc.s 4
+			IL_02d6: ldloc.s 4
+			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02dd: stloc.s 4
+			IL_02df: ldstr "r="
+			IL_02e4: ldloc.0
+			IL_02e5: ldfld object Modules.Generator_YieldStar_NestedGenerator/outer/Scope::r
+			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ef: stloc.s 12
+			IL_02f1: ldloc.s 4
+			IL_02f3: ldstr "log"
+			IL_02f8: ldloc.s 12
+			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02ff: pop
+			IL_0300: ldloc.0
+			IL_0301: ldc.i4.1
+			IL_0302: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_0307: ldc.r8 4
+			IL_0310: box [System.Runtime]System.Double
+			IL_0315: ldc.i4.1
+			IL_0316: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_031b: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -576,7 +570,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x273e
+			// Method begins at RVA 0x272c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -812,7 +806,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2759
+		// Method begins at RVA 0x2747
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_PassNextValue.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_PassNextValue.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26da
+				// Method begins at RVA 0x26c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -213,7 +213,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26e3
+				// Method begins at RVA 0x26d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -239,7 +239,7 @@
 			)
 			// Method begins at RVA 0x23a0
 			// Header size: 12
-			// Code size: 805 (0x325)
+			// Code size: 787 (0x313)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Generator_YieldStar_PassNextValue/outer/Scope,
@@ -306,268 +306,262 @@
 
 			IL_0068: ldloc.0
 			IL_0069: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_006e: switch (IL_007f, IL_0155, IL_0290)
+			IL_006e: switch (IL_007f, IL_0143, IL_027e)
 
 			IL_007f: ldarg.0
 			IL_0080: ldc.i4.1
 			IL_0081: ldelem.ref
 			IL_0082: castclass Modules.Generator_YieldStar_PassNextValue/Scope
 			IL_0087: ldfld object Modules.Generator_YieldStar_PassNextValue/Scope::inner
-			IL_008c: stloc.s 4
-			IL_008e: ldstr "inner"
-			IL_0093: ldloc.s 4
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_009a: stloc.s 4
-			IL_009c: ldloc.s 4
-			IL_009e: ldc.i4.1
-			IL_009f: newarr [System.Runtime]System.Object
-			IL_00a4: dup
-			IL_00a5: ldc.i4.0
-			IL_00a6: ldarg.0
-			IL_00a7: ldc.i4.1
-			IL_00a8: ldelem.ref
-			IL_00a9: stelem.ref
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00af: stloc.s 4
-			IL_00b1: ldloc.s 4
-			IL_00b3: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_00b8: stloc.s 5
-			IL_00ba: ldloc.s 5
-			IL_00bc: brtrue IL_01ba
+			IL_008c: ldc.i4.1
+			IL_008d: newarr [System.Runtime]System.Object
+			IL_0092: dup
+			IL_0093: ldc.i4.0
+			IL_0094: ldarg.0
+			IL_0095: ldc.i4.1
+			IL_0096: ldelem.ref
+			IL_0097: stelem.ref
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_009d: stloc.s 4
+			IL_009f: ldloc.s 4
+			IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_00a6: stloc.s 5
+			IL_00a8: ldloc.s 5
+			IL_00aa: brtrue IL_01a8
 
-			IL_00c1: ldloc.s 4
-			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::NormalizeForOfIterable(object)
-			IL_00c8: stloc.s 4
-			IL_00ca: ldloc.0
-			IL_00cb: ldc.r8 1
-			IL_00d4: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_00d9: ldloc.0
-			IL_00da: ldloc.s 4
-			IL_00dc: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_00e1: ldloc.0
-			IL_00e2: ldc.r8 0.0
-			IL_00eb: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_00f0: ldloc.s 4
-			IL_00f2: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_00f7: stloc.s 6
-			IL_00f9: ldloc.0
-			IL_00fa: ldloc.s 6
-			IL_00fc: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
+			IL_00af: ldloc.s 4
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::NormalizeForOfIterable(object)
+			IL_00b6: stloc.s 4
+			IL_00b8: ldloc.0
+			IL_00b9: ldc.r8 1
+			IL_00c2: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_00c7: ldloc.0
+			IL_00c8: ldloc.s 4
+			IL_00ca: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_00cf: ldloc.0
+			IL_00d0: ldc.r8 0.0
+			IL_00d9: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_00de: ldloc.s 4
+			IL_00e0: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+			IL_00e5: stloc.s 6
+			IL_00e7: ldloc.0
+			IL_00e8: ldloc.s 6
+			IL_00ea: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
 
-			IL_0101: ldloc.0
-			IL_0102: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_0107: stloc.s 6
-			IL_0109: ldloc.0
-			IL_010a: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
-			IL_010f: stloc.s 7
-			IL_0111: ldloc.s 6
-			IL_0113: ldloc.s 7
-			IL_0115: clt
-			IL_0117: brfalse IL_0197
+			IL_00ef: ldloc.0
+			IL_00f0: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_00f5: stloc.s 6
+			IL_00f7: ldloc.0
+			IL_00f8: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
+			IL_00fd: stloc.s 7
+			IL_00ff: ldloc.s 6
+			IL_0101: ldloc.s 7
+			IL_0103: clt
+			IL_0105: brfalse IL_0185
 
-			IL_011c: ldloc.0
-			IL_011d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_0122: stloc.s 4
-			IL_0124: ldloc.s 4
-			IL_0126: ldloc.s 6
-			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_012d: stloc.s 4
-			IL_012f: ldloc.s 6
-			IL_0131: ldc.r8 1
-			IL_013a: add
-			IL_013b: stloc.s 6
-			IL_013d: ldloc.0
-			IL_013e: ldloc.s 6
-			IL_0140: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_0145: ldloc.0
-			IL_0146: ldc.i4.1
-			IL_0147: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_014c: ldloc.s 4
-			IL_014e: ldc.i4.0
-			IL_014f: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0154: ret
+			IL_010a: ldloc.0
+			IL_010b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_0110: stloc.s 4
+			IL_0112: ldloc.s 4
+			IL_0114: ldloc.s 6
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_011b: stloc.s 4
+			IL_011d: ldloc.s 6
+			IL_011f: ldc.r8 1
+			IL_0128: add
+			IL_0129: stloc.s 6
+			IL_012b: ldloc.0
+			IL_012c: ldloc.s 6
+			IL_012e: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_0133: ldloc.0
+			IL_0134: ldc.i4.1
+			IL_0135: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_013a: ldloc.s 4
+			IL_013c: ldc.i4.0
+			IL_013d: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0142: ret
 
+			IL_0143: ldloc.0
+			IL_0144: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_0149: brfalse IL_0162
+
+			IL_014e: ldloc.0
+			IL_014f: ldc.i4.1
+			IL_0150: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
 			IL_0155: ldloc.0
-			IL_0156: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_015b: brfalse IL_0174
+			IL_0156: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_015b: ldc.i4.1
+			IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0161: ret
 
-			IL_0160: ldloc.0
-			IL_0161: ldc.i4.1
-			IL_0162: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0167: ldloc.0
-			IL_0168: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_016d: ldc.i4.1
-			IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0173: ret
+			IL_0162: ldloc.0
+			IL_0163: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0168: brfalse IL_0180
 
+			IL_016d: ldloc.0
+			IL_016e: ldc.i4.0
+			IL_016f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
 			IL_0174: ldloc.0
-			IL_0175: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_017a: brfalse IL_0192
+			IL_0175: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_017a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_017f: throw
 
-			IL_017f: ldloc.0
-			IL_0180: ldc.i4.0
-			IL_0181: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0186: ldloc.0
-			IL_0187: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_018c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0191: throw
+			IL_0180: br IL_00ef
 
-			IL_0192: br IL_0101
+			IL_0185: ldloc.0
+			IL_0186: ldc.r8 0.0
+			IL_018f: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_0194: ldloc.0
+			IL_0195: ldc.i4.0
+			IL_0196: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_019b: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01a0: ldnull
+			IL_01a1: stloc.s 4
+			IL_01a3: br IL_02c2
 
-			IL_0197: ldloc.0
-			IL_0198: ldc.r8 0.0
-			IL_01a1: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_01a6: ldloc.0
-			IL_01a7: ldc.i4.0
-			IL_01a8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01ad: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01b2: ldnull
-			IL_01b3: stloc.s 4
-			IL_01b5: br IL_02d4
+			IL_01a8: ldloc.0
+			IL_01a9: ldc.r8 2
+			IL_01b2: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_01b7: ldloc.0
+			IL_01b8: ldloc.s 5
+			IL_01ba: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01bf: ldc.i4.0
+			IL_01c0: stloc.2
 
-			IL_01ba: ldloc.0
-			IL_01bb: ldc.r8 2
-			IL_01c4: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_01c1: ldloc.0
+			IL_01c2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01c7: stloc.s 4
 			IL_01c9: ldloc.0
-			IL_01ca: ldloc.s 5
-			IL_01cc: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01d1: ldc.i4.0
-			IL_01d2: stloc.2
+			IL_01ca: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01cf: stloc.3
+			IL_01d0: ldloc.3
+			IL_01d1: brtrue IL_01e8
 
-			IL_01d3: ldloc.0
-			IL_01d4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01d9: stloc.s 4
-			IL_01db: ldloc.0
-			IL_01dc: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_01e1: stloc.3
-			IL_01e2: ldloc.3
-			IL_01e3: brtrue IL_01fa
+			IL_01d6: ldloc.0
+			IL_01d7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_01dc: stloc.3
+			IL_01dd: ldloc.3
+			IL_01de: brtrue IL_021b
 
-			IL_01e8: ldloc.0
-			IL_01e9: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_01ee: stloc.3
-			IL_01ef: ldloc.3
-			IL_01f0: brtrue IL_022d
+			IL_01e3: br IL_024e
 
-			IL_01f5: br IL_0260
+			IL_01e8: ldc.i4.1
+			IL_01e9: stloc.2
+			IL_01ea: ldloc.0
+			IL_01eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_01f0: stloc.s 8
+			IL_01f2: ldloc.0
+			IL_01f3: ldc.i4.0
+			IL_01f4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01f9: ldc.i4.1
+			IL_01fa: newarr [System.Runtime]System.Object
+			IL_01ff: dup
+			IL_0200: ldc.i4.0
+			IL_0201: ldloc.s 8
+			IL_0203: stelem.ref
+			IL_0204: stloc.s 9
+			IL_0206: ldloc.s 4
+			IL_0208: ldstr "return"
+			IL_020d: ldloc.s 9
+			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0214: stloc.s 4
+			IL_0216: br IL_0266
 
-			IL_01fa: ldc.i4.1
-			IL_01fb: stloc.2
-			IL_01fc: ldloc.0
-			IL_01fd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_0202: stloc.s 8
-			IL_0204: ldloc.0
-			IL_0205: ldc.i4.0
-			IL_0206: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_020b: ldc.i4.1
-			IL_020c: newarr [System.Runtime]System.Object
-			IL_0211: dup
-			IL_0212: ldc.i4.0
-			IL_0213: ldloc.s 8
-			IL_0215: stelem.ref
-			IL_0216: stloc.s 9
-			IL_0218: ldloc.s 4
-			IL_021a: ldstr "return"
-			IL_021f: ldloc.s 9
-			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0226: stloc.s 4
-			IL_0228: br IL_0278
+			IL_021b: ldc.i4.0
+			IL_021c: stloc.2
+			IL_021d: ldloc.0
+			IL_021e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0223: stloc.s 10
+			IL_0225: ldloc.0
+			IL_0226: ldc.i4.0
+			IL_0227: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_022c: ldc.i4.1
+			IL_022d: newarr [System.Runtime]System.Object
+			IL_0232: dup
+			IL_0233: ldc.i4.0
+			IL_0234: ldloc.s 10
+			IL_0236: stelem.ref
+			IL_0237: stloc.s 9
+			IL_0239: ldloc.s 4
+			IL_023b: ldstr "throw"
+			IL_0240: ldloc.s 9
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0247: stloc.s 4
+			IL_0249: br IL_0266
 
-			IL_022d: ldc.i4.0
-			IL_022e: stloc.2
-			IL_022f: ldloc.0
-			IL_0230: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0235: stloc.s 10
-			IL_0237: ldloc.0
-			IL_0238: ldc.i4.0
-			IL_0239: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_023e: ldc.i4.1
-			IL_023f: newarr [System.Runtime]System.Object
-			IL_0244: dup
-			IL_0245: ldc.i4.0
-			IL_0246: ldloc.s 10
-			IL_0248: stelem.ref
-			IL_0249: stloc.s 9
-			IL_024b: ldloc.s 4
-			IL_024d: ldstr "throw"
-			IL_0252: ldloc.s 9
-			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0259: stloc.s 4
-			IL_025b: br IL_0278
+			IL_024e: ldc.i4.0
+			IL_024f: stloc.2
+			IL_0250: ldloc.0
+			IL_0251: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeValue
+			IL_0256: stloc.s 11
+			IL_0258: ldloc.s 4
+			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNextForYieldStar(object)
+			IL_025f: stloc.s 4
+			IL_0261: br IL_0266
 
-			IL_0260: ldc.i4.0
-			IL_0261: stloc.2
-			IL_0262: ldloc.0
-			IL_0263: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeValue
-			IL_0268: stloc.s 11
-			IL_026a: ldloc.s 4
-			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNextForYieldStar(object)
-			IL_0271: stloc.s 4
-			IL_0273: br IL_0278
+			IL_0266: ldloc.s 4
+			IL_0268: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_026d: stloc.3
+			IL_026e: ldloc.3
+			IL_026f: brtrue IL_0283
 
-			IL_0278: ldloc.s 4
-			IL_027a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_027f: stloc.3
-			IL_0280: ldloc.3
-			IL_0281: brtrue IL_0295
+			IL_0274: ldloc.0
+			IL_0275: ldc.i4.2
+			IL_0276: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_027b: ldloc.s 4
+			IL_027d: ret
 
-			IL_0286: ldloc.0
-			IL_0287: ldc.i4.2
-			IL_0288: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_028d: ldloc.s 4
-			IL_028f: ret
+			IL_027e: br IL_01c1
 
-			IL_0290: br IL_01d3
+			IL_0283: ldloc.s 4
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_028a: stloc.s 4
+			IL_028c: ldloc.0
+			IL_028d: ldc.r8 0.0
+			IL_0296: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_029b: ldloc.0
+			IL_029c: ldc.i4.0
+			IL_029d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02a2: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_02a7: ldloc.2
+			IL_02a8: brtrue IL_02b2
 
-			IL_0295: ldloc.s 4
-			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_029c: stloc.s 4
-			IL_029e: ldloc.0
-			IL_029f: ldc.r8 0.0
-			IL_02a8: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_02ad: ldloc.0
-			IL_02ae: ldc.i4.0
-			IL_02af: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02b4: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_02b9: ldloc.2
-			IL_02ba: brtrue IL_02c4
+			IL_02ad: br IL_02c2
 
-			IL_02bf: br IL_02d4
+			IL_02b2: ldloc.0
+			IL_02b3: ldc.i4.1
+			IL_02b4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_02b9: ldloc.s 4
+			IL_02bb: ldc.i4.1
+			IL_02bc: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_02c1: ret
 
-			IL_02c4: ldloc.0
-			IL_02c5: ldc.i4.1
-			IL_02c6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_02cb: ldloc.s 4
-			IL_02cd: ldc.i4.1
-			IL_02ce: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_02d3: ret
-
-			IL_02d4: ldloc.0
-			IL_02d5: ldloc.s 4
-			IL_02d7: stfld object Modules.Generator_YieldStar_PassNextValue/outer/Scope::r
-			IL_02dc: ldstr "console"
-			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02e6: stloc.s 4
-			IL_02e8: ldloc.s 4
-			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ef: stloc.s 4
-			IL_02f1: ldstr "r="
-			IL_02f6: ldloc.0
-			IL_02f7: ldfld object Modules.Generator_YieldStar_PassNextValue/outer/Scope::r
-			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0301: stloc.s 12
-			IL_0303: ldloc.s 4
-			IL_0305: ldstr "log"
-			IL_030a: ldloc.s 12
-			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0311: pop
-			IL_0312: ldloc.0
-			IL_0313: ldc.i4.1
-			IL_0314: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0319: ldstr "done"
-			IL_031e: ldc.i4.1
-			IL_031f: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0324: ret
+			IL_02c2: ldloc.0
+			IL_02c3: ldloc.s 4
+			IL_02c5: stfld object Modules.Generator_YieldStar_PassNextValue/outer/Scope::r
+			IL_02ca: ldstr "console"
+			IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02d4: stloc.s 4
+			IL_02d6: ldloc.s 4
+			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02dd: stloc.s 4
+			IL_02df: ldstr "r="
+			IL_02e4: ldloc.0
+			IL_02e5: ldfld object Modules.Generator_YieldStar_PassNextValue/outer/Scope::r
+			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ef: stloc.s 12
+			IL_02f1: ldloc.s 4
+			IL_02f3: ldstr "log"
+			IL_02f8: ldloc.s 12
+			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02ff: pop
+			IL_0300: ldloc.0
+			IL_0301: ldc.i4.1
+			IL_0302: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_0307: ldstr "done"
+			IL_030c: ldc.i4.1
+			IL_030d: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0312: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -588,7 +582,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26d1
+			// Method begins at RVA 0x26bf
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -790,7 +784,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26ec
+		// Method begins at RVA 0x26da
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ReturnForwards.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ReturnForwards.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26bb
+				// Method begins at RVA 0x26a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -200,7 +200,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26c4
+				// Method begins at RVA 0x26b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -226,7 +226,7 @@
 			)
 			// Method begins at RVA 0x2328
 			// Header size: 12
-			// Code size: 894 (0x37e)
+			// Code size: 876 (0x36c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Generator_YieldStar_ReturnForwards/outer/Scope,
@@ -293,302 +293,296 @@
 
 			IL_0068: ldloc.0
 			IL_0069: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_006e: switch (IL_0083, IL_0159, IL_0294, IL_0332)
+			IL_006e: switch (IL_0083, IL_0147, IL_0282, IL_0320)
 
 			IL_0083: ldarg.0
 			IL_0084: ldc.i4.1
 			IL_0085: ldelem.ref
 			IL_0086: castclass Modules.Generator_YieldStar_ReturnForwards/Scope
 			IL_008b: ldfld object Modules.Generator_YieldStar_ReturnForwards/Scope::inner
-			IL_0090: stloc.s 4
-			IL_0092: ldstr "inner"
-			IL_0097: ldloc.s 4
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_009e: stloc.s 4
-			IL_00a0: ldloc.s 4
-			IL_00a2: ldc.i4.1
-			IL_00a3: newarr [System.Runtime]System.Object
-			IL_00a8: dup
-			IL_00a9: ldc.i4.0
-			IL_00aa: ldarg.0
-			IL_00ab: ldc.i4.1
-			IL_00ac: ldelem.ref
-			IL_00ad: stelem.ref
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00b3: stloc.s 4
-			IL_00b5: ldloc.s 4
-			IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_00bc: stloc.s 5
-			IL_00be: ldloc.s 5
-			IL_00c0: brtrue IL_01be
+			IL_0090: ldc.i4.1
+			IL_0091: newarr [System.Runtime]System.Object
+			IL_0096: dup
+			IL_0097: ldc.i4.0
+			IL_0098: ldarg.0
+			IL_0099: ldc.i4.1
+			IL_009a: ldelem.ref
+			IL_009b: stelem.ref
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00a1: stloc.s 4
+			IL_00a3: ldloc.s 4
+			IL_00a5: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_00aa: stloc.s 5
+			IL_00ac: ldloc.s 5
+			IL_00ae: brtrue IL_01ac
 
-			IL_00c5: ldloc.s 4
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::NormalizeForOfIterable(object)
-			IL_00cc: stloc.s 4
-			IL_00ce: ldloc.0
-			IL_00cf: ldc.r8 1
-			IL_00d8: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_00dd: ldloc.0
-			IL_00de: ldloc.s 4
-			IL_00e0: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_00e5: ldloc.0
-			IL_00e6: ldc.r8 0.0
-			IL_00ef: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_00f4: ldloc.s 4
-			IL_00f6: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_00fb: stloc.s 6
-			IL_00fd: ldloc.0
-			IL_00fe: ldloc.s 6
-			IL_0100: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
+			IL_00b3: ldloc.s 4
+			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::NormalizeForOfIterable(object)
+			IL_00ba: stloc.s 4
+			IL_00bc: ldloc.0
+			IL_00bd: ldc.r8 1
+			IL_00c6: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_00cb: ldloc.0
+			IL_00cc: ldloc.s 4
+			IL_00ce: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_00d3: ldloc.0
+			IL_00d4: ldc.r8 0.0
+			IL_00dd: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_00e2: ldloc.s 4
+			IL_00e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+			IL_00e9: stloc.s 6
+			IL_00eb: ldloc.0
+			IL_00ec: ldloc.s 6
+			IL_00ee: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
 
-			IL_0105: ldloc.0
-			IL_0106: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_010b: stloc.s 6
-			IL_010d: ldloc.0
-			IL_010e: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
-			IL_0113: stloc.s 7
-			IL_0115: ldloc.s 6
-			IL_0117: ldloc.s 7
-			IL_0119: clt
-			IL_011b: brfalse IL_019b
+			IL_00f3: ldloc.0
+			IL_00f4: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_00f9: stloc.s 6
+			IL_00fb: ldloc.0
+			IL_00fc: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
+			IL_0101: stloc.s 7
+			IL_0103: ldloc.s 6
+			IL_0105: ldloc.s 7
+			IL_0107: clt
+			IL_0109: brfalse IL_0189
 
-			IL_0120: ldloc.0
-			IL_0121: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_0126: stloc.s 4
-			IL_0128: ldloc.s 4
-			IL_012a: ldloc.s 6
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0131: stloc.s 4
-			IL_0133: ldloc.s 6
-			IL_0135: ldc.r8 1
-			IL_013e: add
-			IL_013f: stloc.s 6
-			IL_0141: ldloc.0
-			IL_0142: ldloc.s 6
-			IL_0144: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_0149: ldloc.0
-			IL_014a: ldc.i4.1
-			IL_014b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_0150: ldloc.s 4
-			IL_0152: ldc.i4.0
-			IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0158: ret
+			IL_010e: ldloc.0
+			IL_010f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_0114: stloc.s 4
+			IL_0116: ldloc.s 4
+			IL_0118: ldloc.s 6
+			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_011f: stloc.s 4
+			IL_0121: ldloc.s 6
+			IL_0123: ldc.r8 1
+			IL_012c: add
+			IL_012d: stloc.s 6
+			IL_012f: ldloc.0
+			IL_0130: ldloc.s 6
+			IL_0132: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_0137: ldloc.0
+			IL_0138: ldc.i4.1
+			IL_0139: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_013e: ldloc.s 4
+			IL_0140: ldc.i4.0
+			IL_0141: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0146: ret
 
+			IL_0147: ldloc.0
+			IL_0148: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_014d: brfalse IL_0166
+
+			IL_0152: ldloc.0
+			IL_0153: ldc.i4.1
+			IL_0154: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
 			IL_0159: ldloc.0
-			IL_015a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_015f: brfalse IL_0178
+			IL_015a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_015f: ldc.i4.1
+			IL_0160: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0165: ret
 
-			IL_0164: ldloc.0
-			IL_0165: ldc.i4.1
-			IL_0166: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_016b: ldloc.0
-			IL_016c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_0171: ldc.i4.1
-			IL_0172: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0177: ret
+			IL_0166: ldloc.0
+			IL_0167: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_016c: brfalse IL_0184
 
+			IL_0171: ldloc.0
+			IL_0172: ldc.i4.0
+			IL_0173: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
 			IL_0178: ldloc.0
-			IL_0179: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_017e: brfalse IL_0196
+			IL_0179: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_017e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0183: throw
 
-			IL_0183: ldloc.0
-			IL_0184: ldc.i4.0
-			IL_0185: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_018a: ldloc.0
-			IL_018b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0190: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0195: throw
+			IL_0184: br IL_00f3
 
-			IL_0196: br IL_0105
+			IL_0189: ldloc.0
+			IL_018a: ldc.r8 0.0
+			IL_0193: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_0198: ldloc.0
+			IL_0199: ldc.i4.0
+			IL_019a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_019f: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01a4: ldnull
+			IL_01a5: stloc.s 4
+			IL_01a7: br IL_02c6
 
-			IL_019b: ldloc.0
-			IL_019c: ldc.r8 0.0
-			IL_01a5: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_01aa: ldloc.0
-			IL_01ab: ldc.i4.0
-			IL_01ac: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01b1: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01b6: ldnull
-			IL_01b7: stloc.s 4
-			IL_01b9: br IL_02d8
+			IL_01ac: ldloc.0
+			IL_01ad: ldc.r8 2
+			IL_01b6: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_01bb: ldloc.0
+			IL_01bc: ldloc.s 5
+			IL_01be: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01c3: ldc.i4.0
+			IL_01c4: stloc.2
 
-			IL_01be: ldloc.0
-			IL_01bf: ldc.r8 2
-			IL_01c8: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_01c5: ldloc.0
+			IL_01c6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01cb: stloc.s 4
 			IL_01cd: ldloc.0
-			IL_01ce: ldloc.s 5
-			IL_01d0: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01d5: ldc.i4.0
-			IL_01d6: stloc.2
+			IL_01ce: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01d3: stloc.3
+			IL_01d4: ldloc.3
+			IL_01d5: brtrue IL_01ec
 
-			IL_01d7: ldloc.0
-			IL_01d8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01dd: stloc.s 4
-			IL_01df: ldloc.0
-			IL_01e0: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_01e5: stloc.3
-			IL_01e6: ldloc.3
-			IL_01e7: brtrue IL_01fe
+			IL_01da: ldloc.0
+			IL_01db: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_01e0: stloc.3
+			IL_01e1: ldloc.3
+			IL_01e2: brtrue IL_021f
 
-			IL_01ec: ldloc.0
-			IL_01ed: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_01f2: stloc.3
-			IL_01f3: ldloc.3
-			IL_01f4: brtrue IL_0231
+			IL_01e7: br IL_0252
 
-			IL_01f9: br IL_0264
+			IL_01ec: ldc.i4.1
+			IL_01ed: stloc.2
+			IL_01ee: ldloc.0
+			IL_01ef: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_01f4: stloc.s 8
+			IL_01f6: ldloc.0
+			IL_01f7: ldc.i4.0
+			IL_01f8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01fd: ldc.i4.1
+			IL_01fe: newarr [System.Runtime]System.Object
+			IL_0203: dup
+			IL_0204: ldc.i4.0
+			IL_0205: ldloc.s 8
+			IL_0207: stelem.ref
+			IL_0208: stloc.s 9
+			IL_020a: ldloc.s 4
+			IL_020c: ldstr "return"
+			IL_0211: ldloc.s 9
+			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0218: stloc.s 4
+			IL_021a: br IL_026a
 
-			IL_01fe: ldc.i4.1
-			IL_01ff: stloc.2
-			IL_0200: ldloc.0
-			IL_0201: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_0206: stloc.s 8
-			IL_0208: ldloc.0
-			IL_0209: ldc.i4.0
-			IL_020a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_020f: ldc.i4.1
-			IL_0210: newarr [System.Runtime]System.Object
-			IL_0215: dup
-			IL_0216: ldc.i4.0
-			IL_0217: ldloc.s 8
-			IL_0219: stelem.ref
-			IL_021a: stloc.s 9
-			IL_021c: ldloc.s 4
-			IL_021e: ldstr "return"
-			IL_0223: ldloc.s 9
-			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_022a: stloc.s 4
-			IL_022c: br IL_027c
+			IL_021f: ldc.i4.0
+			IL_0220: stloc.2
+			IL_0221: ldloc.0
+			IL_0222: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0227: stloc.s 10
+			IL_0229: ldloc.0
+			IL_022a: ldc.i4.0
+			IL_022b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0230: ldc.i4.1
+			IL_0231: newarr [System.Runtime]System.Object
+			IL_0236: dup
+			IL_0237: ldc.i4.0
+			IL_0238: ldloc.s 10
+			IL_023a: stelem.ref
+			IL_023b: stloc.s 9
+			IL_023d: ldloc.s 4
+			IL_023f: ldstr "throw"
+			IL_0244: ldloc.s 9
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_024b: stloc.s 4
+			IL_024d: br IL_026a
 
-			IL_0231: ldc.i4.0
-			IL_0232: stloc.2
-			IL_0233: ldloc.0
-			IL_0234: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0239: stloc.s 10
-			IL_023b: ldloc.0
-			IL_023c: ldc.i4.0
-			IL_023d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0242: ldc.i4.1
-			IL_0243: newarr [System.Runtime]System.Object
-			IL_0248: dup
-			IL_0249: ldc.i4.0
-			IL_024a: ldloc.s 10
-			IL_024c: stelem.ref
-			IL_024d: stloc.s 9
-			IL_024f: ldloc.s 4
-			IL_0251: ldstr "throw"
-			IL_0256: ldloc.s 9
-			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_025d: stloc.s 4
-			IL_025f: br IL_027c
+			IL_0252: ldc.i4.0
+			IL_0253: stloc.2
+			IL_0254: ldloc.0
+			IL_0255: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeValue
+			IL_025a: stloc.s 11
+			IL_025c: ldloc.s 4
+			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNextForYieldStar(object)
+			IL_0263: stloc.s 4
+			IL_0265: br IL_026a
 
-			IL_0264: ldc.i4.0
-			IL_0265: stloc.2
-			IL_0266: ldloc.0
-			IL_0267: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeValue
-			IL_026c: stloc.s 11
-			IL_026e: ldloc.s 4
-			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNextForYieldStar(object)
-			IL_0275: stloc.s 4
-			IL_0277: br IL_027c
+			IL_026a: ldloc.s 4
+			IL_026c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_0271: stloc.3
+			IL_0272: ldloc.3
+			IL_0273: brtrue IL_0287
 
-			IL_027c: ldloc.s 4
-			IL_027e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_0283: stloc.3
-			IL_0284: ldloc.3
-			IL_0285: brtrue IL_0299
+			IL_0278: ldloc.0
+			IL_0279: ldc.i4.2
+			IL_027a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_027f: ldloc.s 4
+			IL_0281: ret
 
-			IL_028a: ldloc.0
-			IL_028b: ldc.i4.2
-			IL_028c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_0291: ldloc.s 4
-			IL_0293: ret
+			IL_0282: br IL_01c5
 
-			IL_0294: br IL_01d7
+			IL_0287: ldloc.s 4
+			IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_028e: stloc.s 4
+			IL_0290: ldloc.0
+			IL_0291: ldc.r8 0.0
+			IL_029a: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_029f: ldloc.0
+			IL_02a0: ldc.i4.0
+			IL_02a1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02a6: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_02ab: ldloc.2
+			IL_02ac: brtrue IL_02b6
 
-			IL_0299: ldloc.s 4
-			IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_02a0: stloc.s 4
-			IL_02a2: ldloc.0
-			IL_02a3: ldc.r8 0.0
-			IL_02ac: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_02b1: ldloc.0
-			IL_02b2: ldc.i4.0
-			IL_02b3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02b8: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_02bd: ldloc.2
-			IL_02be: brtrue IL_02c8
+			IL_02b1: br IL_02c6
 
-			IL_02c3: br IL_02d8
+			IL_02b6: ldloc.0
+			IL_02b7: ldc.i4.1
+			IL_02b8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_02bd: ldloc.s 4
+			IL_02bf: ldc.i4.1
+			IL_02c0: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_02c5: ret
 
-			IL_02c8: ldloc.0
-			IL_02c9: ldc.i4.1
-			IL_02ca: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_02cf: ldloc.s 4
-			IL_02d1: ldc.i4.1
-			IL_02d2: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_02d7: ret
+			IL_02c6: ldloc.0
+			IL_02c7: ldloc.s 4
+			IL_02c9: stfld object Modules.Generator_YieldStar_ReturnForwards/outer/Scope::r
+			IL_02ce: ldstr "console"
+			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02d8: stloc.s 4
+			IL_02da: ldloc.s 4
+			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02e1: stloc.s 4
+			IL_02e3: ldstr "r="
+			IL_02e8: ldloc.0
+			IL_02e9: ldfld object Modules.Generator_YieldStar_ReturnForwards/outer/Scope::r
+			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02f3: stloc.s 12
+			IL_02f5: ldloc.s 4
+			IL_02f7: ldstr "log"
+			IL_02fc: ldloc.s 12
+			IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0303: pop
+			IL_0304: ldloc.0
+			IL_0305: ldc.i4.3
+			IL_0306: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_030b: ldc.r8 2
+			IL_0314: box [System.Runtime]System.Double
+			IL_0319: ldc.i4.0
+			IL_031a: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_031f: ret
 
-			IL_02d8: ldloc.0
-			IL_02d9: ldloc.s 4
-			IL_02db: stfld object Modules.Generator_YieldStar_ReturnForwards/outer/Scope::r
-			IL_02e0: ldstr "console"
-			IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02ea: stloc.s 4
-			IL_02ec: ldloc.s 4
-			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02f3: stloc.s 4
-			IL_02f5: ldstr "r="
-			IL_02fa: ldloc.0
-			IL_02fb: ldfld object Modules.Generator_YieldStar_ReturnForwards/outer/Scope::r
-			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0305: stloc.s 12
-			IL_0307: ldloc.s 4
-			IL_0309: ldstr "log"
-			IL_030e: ldloc.s 12
-			IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0315: pop
-			IL_0316: ldloc.0
-			IL_0317: ldc.i4.3
-			IL_0318: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_031d: ldc.r8 2
-			IL_0326: box [System.Runtime]System.Double
-			IL_032b: ldc.i4.0
-			IL_032c: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0331: ret
+			IL_0320: ldloc.0
+			IL_0321: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_0326: brfalse IL_033f
 
+			IL_032b: ldloc.0
+			IL_032c: ldc.i4.1
+			IL_032d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
 			IL_0332: ldloc.0
-			IL_0333: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_0338: brfalse IL_0351
+			IL_0333: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_0338: ldc.i4.1
+			IL_0339: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_033e: ret
 
-			IL_033d: ldloc.0
-			IL_033e: ldc.i4.1
-			IL_033f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0344: ldloc.0
-			IL_0345: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_034a: ldc.i4.1
-			IL_034b: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0350: ret
+			IL_033f: ldloc.0
+			IL_0340: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0345: brfalse IL_035d
 
+			IL_034a: ldloc.0
+			IL_034b: ldc.i4.0
+			IL_034c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
 			IL_0351: ldloc.0
-			IL_0352: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0357: brfalse IL_036f
+			IL_0352: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0357: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_035c: throw
 
-			IL_035c: ldloc.0
-			IL_035d: ldc.i4.0
-			IL_035e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0363: ldloc.0
-			IL_0364: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0369: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_036e: throw
-
-			IL_036f: ldloc.0
-			IL_0370: ldc.i4.1
-			IL_0371: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0376: ldnull
-			IL_0377: ldc.i4.1
-			IL_0378: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_037d: ret
+			IL_035d: ldloc.0
+			IL_035e: ldc.i4.1
+			IL_035f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_0364: ldnull
+			IL_0365: ldc.i4.1
+			IL_0366: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_036b: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -609,7 +603,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26b2
+			// Method begins at RVA 0x26a0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -775,7 +769,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26cd
+		// Method begins at RVA 0x26bb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2593
+					// Method begins at RVA 0x24e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -56,14 +56,13 @@
 				)
 				// Method begins at RVA 0x22c8
 				// Header size: 12
-				// Code size: 595 (0x253)
+				// Code size: 463 (0x1cf)
 				.maxstack 8
 				.locals init (
 					[0] object,
-					[1] object,
-					[2] bool,
-					[3] object,
-					[4] object
+					[1] bool,
+					[2] object,
+					[3] object
 				)
 
 				IL_0000: ldstr "console"
@@ -77,200 +76,150 @@
 				IL_0014: ldelem.ref
 				IL_0015: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
 				IL_001a: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_001f: stloc.1
-				IL_0020: ldstr "nsA"
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002b: stloc.1
-				IL_002c: ldloc.1
-				IL_002d: ldarg.2
-				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0033: stloc.2
-				IL_0034: ldloc.2
-				IL_0035: box [System.Runtime]System.Boolean
-				IL_003a: stloc.3
-				IL_003b: ldloc.0
-				IL_003c: ldstr "log"
-				IL_0041: ldstr "same:"
-				IL_0046: ldloc.3
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_004c: pop
-				IL_004d: ldstr "console"
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0057: stloc.0
-				IL_0058: ldloc.0
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_005e: stloc.0
-				IL_005f: ldarg.0
-				IL_0060: ldc.i4.1
-				IL_0061: ldelem.ref
-				IL_0062: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
-				IL_0067: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_006c: stloc.1
-				IL_006d: ldstr "nsA"
-				IL_0072: ldloc.1
-				IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0078: stloc.1
-				IL_0079: ldloc.1
-				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-				IL_007f: stloc.1
-				IL_0080: ldloc.1
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0086: stloc.1
-				IL_0087: ldloc.1
-				IL_0088: ldstr "sort"
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0092: stloc.1
-				IL_0093: ldloc.1
-				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0099: stloc.1
-				IL_009a: ldloc.1
-				IL_009b: ldstr "join"
-				IL_00a0: ldstr ","
-				IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00aa: stloc.1
-				IL_00ab: ldloc.0
-				IL_00ac: ldstr "log"
-				IL_00b1: ldstr "keys:"
-				IL_00b6: ldloc.1
-				IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00bc: pop
-				IL_00bd: ldstr "console"
-				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00c7: stloc.1
-				IL_00c8: ldloc.1
-				IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ce: stloc.1
-				IL_00cf: ldarg.0
-				IL_00d0: ldc.i4.1
-				IL_00d1: ldelem.ref
-				IL_00d2: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
-				IL_00d7: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_00dc: stloc.0
-				IL_00dd: ldstr "nsA"
-				IL_00e2: ldloc.0
-				IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00e8: stloc.0
-				IL_00e9: ldloc.0
-				IL_00ea: ldstr "default"
-				IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00f4: stloc.0
-				IL_00f5: ldarg.0
-				IL_00f6: ldc.i4.1
-				IL_00f7: ldelem.ref
-				IL_00f8: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
-				IL_00fd: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_0102: stloc.s 4
-				IL_0104: ldstr "nsA"
-				IL_0109: ldloc.s 4
-				IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0110: stloc.s 4
-				IL_0112: ldloc.s 4
-				IL_0114: ldstr "module.exports"
-				IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_011e: stloc.s 4
-				IL_0120: ldloc.0
-				IL_0121: ldloc.s 4
-				IL_0123: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0128: stloc.2
-				IL_0129: ldloc.2
-				IL_012a: box [System.Runtime]System.Boolean
-				IL_012f: stloc.3
-				IL_0130: ldloc.1
-				IL_0131: ldstr "log"
-				IL_0136: ldstr "defaultSame:"
-				IL_013b: ldloc.3
-				IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0141: pop
-				IL_0142: ldstr "console"
-				IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_014c: stloc.1
-				IL_014d: ldloc.1
-				IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0153: stloc.1
-				IL_0154: ldarg.0
-				IL_0155: ldc.i4.1
-				IL_0156: ldelem.ref
-				IL_0157: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
-				IL_015c: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_0161: stloc.s 4
-				IL_0163: ldstr "nsA"
-				IL_0168: ldloc.s 4
-				IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_016f: stloc.s 4
-				IL_0171: ldloc.s 4
-				IL_0173: ldstr "value"
-				IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_017d: stloc.s 4
-				IL_017f: ldloc.1
-				IL_0180: ldstr "log"
-				IL_0185: ldstr "value0:"
-				IL_018a: ldloc.s 4
-				IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0191: pop
-				IL_0192: ldarg.0
-				IL_0193: ldc.i4.1
-				IL_0194: ldelem.ref
-				IL_0195: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
-				IL_019a: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_019f: stloc.s 4
-				IL_01a1: ldstr "nsA"
-				IL_01a6: ldloc.s 4
-				IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_01ad: stloc.s 4
-				IL_01af: ldloc.s 4
-				IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01b6: stloc.s 4
-				IL_01b8: ldloc.s 4
-				IL_01ba: ldstr "inc"
-				IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_01c4: pop
-				IL_01c5: ldstr "console"
-				IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_01cf: stloc.s 4
-				IL_01d1: ldloc.s 4
-				IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01d8: stloc.s 4
-				IL_01da: ldloc.s 4
-				IL_01dc: ldstr "log"
-				IL_01e1: ldstr "value1:"
-				IL_01e6: ldarg.2
-				IL_01e7: ldstr "value"
-				IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_01f6: pop
-				IL_01f7: ldstr "console"
-				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0201: stloc.s 4
-				IL_0203: ldloc.s 4
-				IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_020a: stloc.s 4
-				IL_020c: ldarg.0
-				IL_020d: ldc.i4.1
-				IL_020e: ldelem.ref
-				IL_020f: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
-				IL_0214: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_0219: stloc.1
-				IL_021a: ldstr "nsA"
-				IL_021f: ldloc.1
-				IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0225: stloc.1
-				IL_0226: ldloc.1
-				IL_0227: ldstr "default"
-				IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0231: stloc.1
-				IL_0232: ldloc.1
-				IL_0233: ldstr "value"
-				IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_023d: stloc.1
-				IL_023e: ldloc.s 4
-				IL_0240: ldstr "log"
-				IL_0245: ldstr "default1:"
-				IL_024a: ldloc.1
-				IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0250: pop
-				IL_0251: ldnull
-				IL_0252: ret
+				IL_001f: ldarg.2
+				IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0025: stloc.1
+				IL_0026: ldloc.1
+				IL_0027: box [System.Runtime]System.Boolean
+				IL_002c: stloc.2
+				IL_002d: ldloc.0
+				IL_002e: ldstr "log"
+				IL_0033: ldstr "same:"
+				IL_0038: ldloc.2
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_003e: pop
+				IL_003f: ldstr "console"
+				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0049: stloc.0
+				IL_004a: ldloc.0
+				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0050: stloc.0
+				IL_0051: ldarg.0
+				IL_0052: ldc.i4.1
+				IL_0053: ldelem.ref
+				IL_0054: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
+				IL_0059: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+				IL_0063: stloc.3
+				IL_0064: ldloc.3
+				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_006a: stloc.3
+				IL_006b: ldloc.3
+				IL_006c: ldstr "sort"
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0076: stloc.3
+				IL_0077: ldloc.3
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_007d: stloc.3
+				IL_007e: ldloc.3
+				IL_007f: ldstr "join"
+				IL_0084: ldstr ","
+				IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_008e: stloc.3
+				IL_008f: ldloc.0
+				IL_0090: ldstr "log"
+				IL_0095: ldstr "keys:"
+				IL_009a: ldloc.3
+				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00a0: pop
+				IL_00a1: ldstr "console"
+				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00ab: stloc.3
+				IL_00ac: ldloc.3
+				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00b2: stloc.3
+				IL_00b3: ldarg.0
+				IL_00b4: ldc.i4.1
+				IL_00b5: ldelem.ref
+				IL_00b6: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
+				IL_00bb: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_00c0: ldstr "default"
+				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00ca: stloc.0
+				IL_00cb: ldloc.0
+				IL_00cc: ldarg.0
+				IL_00cd: ldc.i4.1
+				IL_00ce: ldelem.ref
+				IL_00cf: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
+				IL_00d4: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_00d9: ldstr "module.exports"
+				IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00e3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00e8: stloc.1
+				IL_00e9: ldloc.1
+				IL_00ea: box [System.Runtime]System.Boolean
+				IL_00ef: stloc.2
+				IL_00f0: ldloc.3
+				IL_00f1: ldstr "log"
+				IL_00f6: ldstr "defaultSame:"
+				IL_00fb: ldloc.2
+				IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0101: pop
+				IL_0102: ldstr "console"
+				IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_010c: stloc.3
+				IL_010d: ldloc.3
+				IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0113: stloc.3
+				IL_0114: ldloc.3
+				IL_0115: ldstr "log"
+				IL_011a: ldstr "value0:"
+				IL_011f: ldarg.0
+				IL_0120: ldc.i4.1
+				IL_0121: ldelem.ref
+				IL_0122: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
+				IL_0127: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_012c: ldstr "value"
+				IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_013b: pop
+				IL_013c: ldarg.0
+				IL_013d: ldc.i4.1
+				IL_013e: ldelem.ref
+				IL_013f: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
+				IL_0144: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_014e: stloc.3
+				IL_014f: ldloc.3
+				IL_0150: ldstr "inc"
+				IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_015a: pop
+				IL_015b: ldstr "console"
+				IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0165: stloc.3
+				IL_0166: ldloc.3
+				IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_016c: stloc.3
+				IL_016d: ldloc.3
+				IL_016e: ldstr "log"
+				IL_0173: ldstr "value1:"
+				IL_0178: ldarg.2
+				IL_0179: ldstr "value"
+				IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0188: pop
+				IL_0189: ldstr "console"
+				IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0193: stloc.3
+				IL_0194: ldloc.3
+				IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_019a: stloc.3
+				IL_019b: ldloc.3
+				IL_019c: ldstr "log"
+				IL_01a1: ldstr "default1:"
+				IL_01a6: ldarg.0
+				IL_01a7: ldc.i4.1
+				IL_01a8: ldelem.ref
+				IL_01a9: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
+				IL_01ae: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_01b3: ldstr "default"
+				IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01bd: ldstr "value"
+				IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_01cc: pop
+				IL_01cd: ldnull
+				IL_01ce: ret
 			} // end of method ArrowFunction_L4C72::__js_call__
 
 		} // end of class ArrowFunction_L4C72
@@ -289,7 +238,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x258a
+				// Method begins at RVA 0x24df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -390,7 +339,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x259c
+				// Method begins at RVA 0x24f1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -485,7 +434,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2581
+			// Method begins at RVA 0x24d6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -607,7 +556,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25ae
+				// Method begins at RVA 0x2503
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -633,31 +582,24 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2528
+			// Method begins at RVA 0x24a4
 			// Header size: 12
-			// Code size: 44 (0x2c)
+			// Code size: 30 (0x1e)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope::'value'
-			IL_0006: stloc.0
-			IL_0007: ldstr "value"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.r8 1
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0022: stloc.1
-			IL_0023: ldarg.0
-			IL_0024: ldloc.1
-			IL_0025: stfld object Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope::'value'
-			IL_002a: ldnull
-			IL_002b: ret
+			IL_0006: ldc.r8 1
+			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0014: stloc.0
+			IL_0015: ldarg.0
+			IL_0016: ldloc.0
+			IL_0017: stfld object Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope::'value'
+			IL_001c: ldnull
+			IL_001d: ret
 		} // end of method FunctionExpression_L6C7::__js_call__
 
 	} // end of class FunctionExpression_L6C7
@@ -673,7 +615,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25b7
+				// Method begins at RVA 0x250c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -699,23 +641,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2560
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x24ce
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope::'value'
-			IL_0006: stloc.0
-			IL_0007: ldstr "value"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L9C13::__js_call__
 
 	} // end of class FunctionExpression_L9C13
@@ -734,7 +667,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25a5
+			// Method begins at RVA 0x24fa
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -847,7 +780,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25c0
+		// Method begins at RVA 0x2515
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2f68
+					// Method begins at RVA 0x2e28
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -56,12 +56,12 @@
 				)
 				// Method begins at RVA 0x2450
 				// Header size: 12
-				// Code size: 437 (0x1b5)
+				// Code size: 365 (0x16d)
 				.maxstack 8
 				.locals init (
 					[0] object,
-					[1] object,
-					[2] bool,
+					[1] bool,
+					[2] object,
 					[3] object
 				)
 
@@ -76,152 +76,120 @@
 				IL_0014: ldelem.ref
 				IL_0015: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
 				IL_001a: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_001f: stloc.1
-				IL_0020: ldstr "nsA"
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002b: stloc.1
-				IL_002c: ldloc.1
-				IL_002d: ldarg.2
-				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0033: stloc.2
-				IL_0034: ldloc.2
-				IL_0035: box [System.Runtime]System.Boolean
-				IL_003a: stloc.3
-				IL_003b: ldloc.0
-				IL_003c: ldstr "log"
-				IL_0041: ldstr "same:"
-				IL_0046: ldloc.3
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_004c: pop
-				IL_004d: ldstr "console"
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0057: stloc.0
-				IL_0058: ldloc.0
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_005e: stloc.0
-				IL_005f: ldarg.0
-				IL_0060: ldc.i4.1
-				IL_0061: ldelem.ref
-				IL_0062: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
-				IL_0067: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_006c: stloc.1
-				IL_006d: ldstr "nsA"
-				IL_0072: ldloc.1
-				IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0078: stloc.1
-				IL_0079: ldloc.1
-				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-				IL_007f: stloc.1
-				IL_0080: ldloc.1
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0086: stloc.1
-				IL_0087: ldloc.1
-				IL_0088: ldstr "sort"
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0092: stloc.1
-				IL_0093: ldloc.1
-				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0099: stloc.1
-				IL_009a: ldloc.1
-				IL_009b: ldstr "join"
-				IL_00a0: ldstr ","
-				IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00aa: stloc.1
-				IL_00ab: ldloc.0
-				IL_00ac: ldstr "log"
-				IL_00b1: ldstr "keys:"
-				IL_00b6: ldloc.1
-				IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00bc: pop
-				IL_00bd: ldstr "console"
-				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00c7: stloc.1
-				IL_00c8: ldloc.1
-				IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ce: stloc.1
-				IL_00cf: ldarg.0
-				IL_00d0: ldc.i4.1
-				IL_00d1: ldelem.ref
-				IL_00d2: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
-				IL_00d7: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_00dc: stloc.0
-				IL_00dd: ldstr "nsA"
-				IL_00e2: ldloc.0
-				IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00e8: stloc.0
-				IL_00e9: ldloc.0
-				IL_00ea: ldstr "value"
-				IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00f4: stloc.0
-				IL_00f5: ldloc.1
-				IL_00f6: ldstr "log"
-				IL_00fb: ldstr "value0:"
-				IL_0100: ldloc.0
-				IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0106: pop
-				IL_0107: ldarg.0
-				IL_0108: ldc.i4.1
-				IL_0109: ldelem.ref
-				IL_010a: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
-				IL_010f: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_0114: stloc.0
-				IL_0115: ldstr "nsA"
-				IL_011a: ldloc.0
-				IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0120: stloc.0
-				IL_0121: ldloc.0
-				IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0127: stloc.0
-				IL_0128: ldloc.0
-				IL_0129: ldstr "inc"
-				IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0133: pop
-				IL_0134: ldstr "console"
-				IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_013e: stloc.0
-				IL_013f: ldloc.0
-				IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0145: stloc.0
-				IL_0146: ldloc.0
-				IL_0147: ldstr "log"
-				IL_014c: ldstr "value1:"
-				IL_0151: ldarg.2
-				IL_0152: ldstr "value"
-				IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0161: pop
-				IL_0162: ldstr "console"
-				IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_016c: stloc.0
-				IL_016d: ldloc.0
-				IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0173: stloc.0
-				IL_0174: ldarg.0
-				IL_0175: ldc.i4.1
-				IL_0176: ldelem.ref
-				IL_0177: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
-				IL_017c: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_0181: stloc.1
-				IL_0182: ldstr "nsA"
-				IL_0187: ldloc.1
-				IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_018d: stloc.1
-				IL_018e: ldloc.1
-				IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0194: stloc.1
-				IL_0195: ldloc.1
-				IL_0196: ldstr "default"
-				IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_01a0: stloc.1
-				IL_01a1: ldloc.0
-				IL_01a2: ldstr "log"
-				IL_01a7: ldstr "default1:"
-				IL_01ac: ldloc.1
-				IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_01b2: pop
-				IL_01b3: ldnull
-				IL_01b4: ret
+				IL_001f: ldarg.2
+				IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0025: stloc.1
+				IL_0026: ldloc.1
+				IL_0027: box [System.Runtime]System.Boolean
+				IL_002c: stloc.2
+				IL_002d: ldloc.0
+				IL_002e: ldstr "log"
+				IL_0033: ldstr "same:"
+				IL_0038: ldloc.2
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_003e: pop
+				IL_003f: ldstr "console"
+				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0049: stloc.0
+				IL_004a: ldloc.0
+				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0050: stloc.0
+				IL_0051: ldarg.0
+				IL_0052: ldc.i4.1
+				IL_0053: ldelem.ref
+				IL_0054: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
+				IL_0059: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+				IL_0063: stloc.3
+				IL_0064: ldloc.3
+				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_006a: stloc.3
+				IL_006b: ldloc.3
+				IL_006c: ldstr "sort"
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0076: stloc.3
+				IL_0077: ldloc.3
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_007d: stloc.3
+				IL_007e: ldloc.3
+				IL_007f: ldstr "join"
+				IL_0084: ldstr ","
+				IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_008e: stloc.3
+				IL_008f: ldloc.0
+				IL_0090: ldstr "log"
+				IL_0095: ldstr "keys:"
+				IL_009a: ldloc.3
+				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00a0: pop
+				IL_00a1: ldstr "console"
+				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00ab: stloc.3
+				IL_00ac: ldloc.3
+				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00b2: stloc.3
+				IL_00b3: ldloc.3
+				IL_00b4: ldstr "log"
+				IL_00b9: ldstr "value0:"
+				IL_00be: ldarg.0
+				IL_00bf: ldc.i4.1
+				IL_00c0: ldelem.ref
+				IL_00c1: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
+				IL_00c6: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_00cb: ldstr "value"
+				IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00da: pop
+				IL_00db: ldarg.0
+				IL_00dc: ldc.i4.1
+				IL_00dd: ldelem.ref
+				IL_00de: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
+				IL_00e3: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00ed: stloc.3
+				IL_00ee: ldloc.3
+				IL_00ef: ldstr "inc"
+				IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_00f9: pop
+				IL_00fa: ldstr "console"
+				IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0104: stloc.3
+				IL_0105: ldloc.3
+				IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_010b: stloc.3
+				IL_010c: ldloc.3
+				IL_010d: ldstr "log"
+				IL_0112: ldstr "value1:"
+				IL_0117: ldarg.2
+				IL_0118: ldstr "value"
+				IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0127: pop
+				IL_0128: ldstr "console"
+				IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0132: stloc.3
+				IL_0133: ldloc.3
+				IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0139: stloc.3
+				IL_013a: ldarg.0
+				IL_013b: ldc.i4.1
+				IL_013c: ldelem.ref
+				IL_013d: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
+				IL_0142: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_014c: stloc.0
+				IL_014d: ldloc.0
+				IL_014e: ldstr "default"
+				IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0158: stloc.0
+				IL_0159: ldloc.3
+				IL_015a: ldstr "log"
+				IL_015f: ldstr "default1:"
+				IL_0164: ldloc.0
+				IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_016a: pop
+				IL_016b: ldnull
+				IL_016c: ret
 			} // end of method ArrowFunction_L4C72::__js_call__
 
 		} // end of class ArrowFunction_L4C72
@@ -240,7 +208,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f5f
+				// Method begins at RVA 0x2e1f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -341,7 +309,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f71
+				// Method begins at RVA 0x2e31
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -436,7 +404,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2f56
+			// Method begins at RVA 0x2e16
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -558,7 +526,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f8e
+				// Method begins at RVA 0x2e4e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -584,9 +552,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2614
+			// Method begins at RVA 0x25cc
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -597,12 +565,8 @@
 			IL_0006: ldstr "Cannot access 'value' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "value"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L3C27::__js_call__
 
 	} // end of class FunctionExpression_L3C27
@@ -618,7 +582,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f97
+				// Method begins at RVA 0x2e57
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -644,23 +608,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2640
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x25eb
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::inc
-			IL_0006: stloc.0
-			IL_0007: ldstr "inc"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L4C25::__js_call__
 
 	} // end of class FunctionExpression_L4C25
@@ -676,7 +631,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fa0
+				// Method begins at RVA 0x2e60
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -702,23 +657,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2664
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x25f3
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::readValue
-			IL_0006: stloc.0
-			IL_0007: ldstr "readValue"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L5C29::__js_call__
 
 	} // end of class FunctionExpression_L5C29
@@ -734,7 +680,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fa9
+				// Method begins at RVA 0x2e69
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -760,9 +706,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2688
+			// Method begins at RVA 0x25fc
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -774,19 +720,15 @@
 			IL_0006: ldstr "Cannot access 'value' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "value"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ldc.r8 1
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::'value'
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0011: ldloc.0
+			IL_0012: ldc.r8 1
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0020: stloc.1
+			IL_0021: ldarg.0
+			IL_0022: ldloc.1
+			IL_0023: stfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::'value'
+			IL_0028: ldnull
+			IL_0029: ret
 		} // end of method inc::__js_call__
 
 	} // end of class inc
@@ -802,7 +744,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fb2
+				// Method begins at RVA 0x2e72
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -828,9 +770,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x26cc
+			// Method begins at RVA 0x2634
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -841,12 +783,8 @@
 			IL_0006: ldstr "Cannot access 'value' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "value"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method readValue::__js_call__
 
 	} // end of class readValue
@@ -866,7 +804,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fc4
+					// Method begins at RVA 0x2e84
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -884,7 +822,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fbb
+				// Method begins at RVA 0x2e7b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -910,9 +848,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x26f8
+			// Method begins at RVA 0x2654
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/Scope/Block_L20C70,
@@ -938,53 +876,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/Scope/Block_L20C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/Scope/Block_L20C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -1000,7 +930,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fcd
+				// Method begins at RVA 0x2e8d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1024,7 +954,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27b4
+			// Method begins at RVA 0x26f8
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -1105,7 +1035,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fd6
+				// Method begins at RVA 0x2e96
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1130,7 +1060,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2844
+			// Method begins at RVA 0x2788
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1158,7 +1088,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3003
+					// Method begins at RVA 0x2ec3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1182,26 +1112,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e18
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2d40
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L44C86::__js_call__
 
 		} // end of class FunctionExpression_L44C86
@@ -1217,7 +1138,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x300c
+					// Method begins at RVA 0x2ecc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1241,26 +1162,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e40
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2d4f
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L45C93::__js_call__
 
 		} // end of class FunctionExpression_L45C93
@@ -1280,7 +1192,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3039
+						// Method begins at RVA 0x2ef9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1304,41 +1216,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2f0c
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x2df5
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope
-					IL_0022: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope
+					IL_0015: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L55C86::__js_call__
 
 			} // end of class FunctionExpression_L55C86
@@ -1356,7 +1250,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3030
+					// Method begins at RVA 0x2ef0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1381,9 +1275,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e68
+				// Method begins at RVA 0x2d60
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope,
@@ -1404,61 +1298,57 @@
 				IL_0010: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L54C9::__js_call__
 
 		} // end of class FunctionExpression_L54C9
@@ -1478,7 +1368,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fe8
+					// Method begins at RVA 0x2ea8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1498,7 +1388,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ff1
+					// Method begins at RVA 0x2eb1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1518,7 +1408,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ffa
+					// Method begins at RVA 0x2eba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1542,7 +1432,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x301e
+						// Method begins at RVA 0x2ede
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1562,7 +1452,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3027
+						// Method begins at RVA 0x2ee7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1580,7 +1470,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3015
+					// Method begins at RVA 0x2ed5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1600,7 +1490,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3042
+					// Method begins at RVA 0x2f02
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1620,7 +1510,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x304b
+					// Method begins at RVA 0x2f0b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1642,7 +1532,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fdf
+				// Method begins at RVA 0x2e9f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1669,7 +1559,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2850
+			// Method begins at RVA 0x2794
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -2216,7 +2106,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3054
+				// Method begins at RVA 0x2f14
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2244,9 +2134,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2da0
+			// Method begins at RVA 0x2ce4
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -2254,46 +2144,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -2323,7 +2203,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2f7a
+			// Method begins at RVA 0x2e3a
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2595,7 +2475,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x305d
+		// Method begins at RVA 0x2f1d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3557
+					// Method begins at RVA 0x33e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x354e
+				// Method begins at RVA 0x33da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			)
 			// Method begins at RVA 0x2410
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportNamedFrom/__jroc_esm_mark/Scope/Block_L13C70,
@@ -94,53 +94,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_ExportNamedFrom/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_mark/Scope/Block_L13C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_ExportNamedFrom/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_mark/Scope/Block_L13C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_ExportNamedFrom/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -156,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3560
+				// Method begins at RVA 0x33ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +172,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24cc
+			// Method begins at RVA 0x24b4
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -261,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3569
+				// Method begins at RVA 0x33f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +278,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x255c
+			// Method begins at RVA 0x2544
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,7 +306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3596
+					// Method begins at RVA 0x3422
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -338,26 +330,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b30
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2afc
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L37C86::__js_call__
 
 		} // end of class FunctionExpression_L37C86
@@ -373,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x359f
+					// Method begins at RVA 0x342b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -397,26 +380,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b58
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2b0b
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L38C93::__js_call__
 
 		} // end of class FunctionExpression_L38C93
@@ -436,7 +410,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35cc
+						// Method begins at RVA 0x3458
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -460,41 +434,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2c24
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x2bb1
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope
-					IL_0022: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope
+					IL_0015: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L48C86::__js_call__
 
 			} // end of class FunctionExpression_L48C86
@@ -512,7 +468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35c3
+					// Method begins at RVA 0x344f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,9 +493,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b80
+				// Method begins at RVA 0x2b1c
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope,
@@ -560,61 +516,57 @@
 				IL_0010: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L47C9::__js_call__
 
 		} // end of class FunctionExpression_L47C9
@@ -634,7 +586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x357b
+					// Method begins at RVA 0x3407
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -654,7 +606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3584
+					// Method begins at RVA 0x3410
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -674,7 +626,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x358d
+					// Method begins at RVA 0x3419
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -698,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35b1
+						// Method begins at RVA 0x343d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -718,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35ba
+						// Method begins at RVA 0x3446
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -736,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35a8
+					// Method begins at RVA 0x3434
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -756,7 +708,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35d5
+					// Method begins at RVA 0x3461
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35de
+					// Method begins at RVA 0x346a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -798,7 +750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3572
+				// Method begins at RVA 0x33fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -825,7 +777,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2568
+			// Method begins at RVA 0x2550
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -1372,7 +1324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35e7
+				// Method begins at RVA 0x3473
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1400,9 +1352,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2ab8
+			// Method begins at RVA 0x2aa0
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1410,46 +1362,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_ExportNamedFrom/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_ExportNamedFrom/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportNamedFrom/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1473,7 +1415,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3545
+			// Method begins at RVA 0x33d1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1687,7 +1629,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35f9
+				// Method begins at RVA 0x3485
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1713,27 +1655,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2c70
-			// Header size: 12
-			// Code size: 33 (0x21)
+			// Method begins at RVA 0x2bd2
+			// Header size: 1
+			// Code size: 17 (0x11)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::__jroc_esm_mod_0
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mod_0"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "value"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: ret
+			IL_0006: ldstr "value"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: ret
 		} // end of method FunctionExpression_L7C27::__js_call__
 
 	} // end of class FunctionExpression_L7C27
@@ -1749,7 +1680,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3602
+				// Method begins at RVA 0x348e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1775,27 +1706,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2ca0
-			// Header size: 12
-			// Code size: 33 (0x21)
+			// Method begins at RVA 0x2be4
+			// Header size: 1
+			// Code size: 17 (0x11)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::__jroc_esm_mod_0
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mod_0"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "doubled"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: ret
+			IL_0006: ldstr "doubled"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: ret
 		} // end of method FunctionExpression_L8C29::__js_call__
 
 	} // end of class FunctionExpression_L8C29
@@ -1815,7 +1735,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3614
+					// Method begins at RVA 0x34a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1833,7 +1753,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x360b
+				// Method begins at RVA 0x3497
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1859,9 +1779,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2cd0
+			// Method begins at RVA 0x2bf8
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/Scope/Block_L12C70,
@@ -1887,53 +1807,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/Scope/Block_L12C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/Scope/Block_L12C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -1949,7 +1861,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x361d
+				// Method begins at RVA 0x34a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1973,7 +1885,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d8c
+			// Method begins at RVA 0x2c9c
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2054,7 +1966,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3626
+				// Method begins at RVA 0x34b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2079,7 +1991,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e1c
+			// Method begins at RVA 0x2d2c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2107,7 +2019,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3653
+					// Method begins at RVA 0x34df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2131,26 +2043,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33f0
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x32e4
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L36C86::__js_call__
 
 		} // end of class FunctionExpression_L36C86
@@ -2166,7 +2069,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x365c
+					// Method begins at RVA 0x34e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2190,26 +2093,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3418
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x32f3
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L37C93::__js_call__
 
 		} // end of class FunctionExpression_L37C93
@@ -2229,7 +2123,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3689
+						// Method begins at RVA 0x3515
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2253,41 +2147,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x34e4
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x3399
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope
-					IL_0022: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope
+					IL_0015: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L47C86::__js_call__
 
 			} // end of class FunctionExpression_L47C86
@@ -2305,7 +2181,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3680
+					// Method begins at RVA 0x350c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2330,9 +2206,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3440
+				// Method begins at RVA 0x3304
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope,
@@ -2353,61 +2229,57 @@
 				IL_0010: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L46C9::__js_call__
 
 		} // end of class FunctionExpression_L46C9
@@ -2427,7 +2299,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3638
+					// Method begins at RVA 0x34c4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2447,7 +2319,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3641
+					// Method begins at RVA 0x34cd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2467,7 +2339,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x364a
+					// Method begins at RVA 0x34d6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2491,7 +2363,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x366e
+						// Method begins at RVA 0x34fa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2511,7 +2383,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3677
+						// Method begins at RVA 0x3503
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2529,7 +2401,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3665
+					// Method begins at RVA 0x34f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2549,7 +2421,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3692
+					// Method begins at RVA 0x351e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2569,7 +2441,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x369b
+					// Method begins at RVA 0x3527
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2591,7 +2463,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x362f
+				// Method begins at RVA 0x34bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2618,7 +2490,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2e28
+			// Method begins at RVA 0x2d38
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -3165,7 +3037,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36a4
+				// Method begins at RVA 0x3530
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3193,9 +3065,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3378
+			// Method begins at RVA 0x3288
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -3203,46 +3075,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3267,7 +3129,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x35f0
+			// Method begins at RVA 0x347c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3479,7 +3341,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36b6
+				// Method begins at RVA 0x3542
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3503,7 +3365,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x352e
+			// Method begins at RVA 0x33ba
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -3525,7 +3387,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x36ad
+			// Method begins at RVA 0x3539
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3602,7 +3464,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x36bf
+		// Method begins at RVA 0x354b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3753
+					// Method begins at RVA 0x35df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x374a
+				// Method begins at RVA 0x35d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			)
 			// Method begins at RVA 0x25c0
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFrom/__jroc_esm_mark/Scope/Block_L15C70,
@@ -94,53 +94,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_ExportStarFrom/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_mark/Scope/Block_L15C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_ExportStarFrom/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_mark/Scope/Block_L15C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_ExportStarFrom/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -156,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x375c
+				// Method begins at RVA 0x35e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +172,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x267c
+			// Method begins at RVA 0x2664
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -261,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3765
+				// Method begins at RVA 0x35f1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +278,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x270c
+			// Method begins at RVA 0x26f4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,7 +306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3792
+					// Method begins at RVA 0x361e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -338,26 +330,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ce0
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2cac
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L39C86::__js_call__
 
 		} // end of class FunctionExpression_L39C86
@@ -373,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x379b
+					// Method begins at RVA 0x3627
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -397,26 +380,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d08
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2cbb
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L40C93::__js_call__
 
 		} // end of class FunctionExpression_L40C93
@@ -436,7 +410,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37c8
+						// Method begins at RVA 0x3654
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -460,41 +434,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2dd4
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x2d61
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope
-					IL_0022: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope
+					IL_0015: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L50C86::__js_call__
 
 			} // end of class FunctionExpression_L50C86
@@ -512,7 +468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37bf
+					// Method begins at RVA 0x364b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,9 +493,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d30
+				// Method begins at RVA 0x2ccc
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope,
@@ -560,61 +516,57 @@
 				IL_0010: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L49C9::__js_call__
 
 		} // end of class FunctionExpression_L49C9
@@ -634,7 +586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3777
+					// Method begins at RVA 0x3603
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -654,7 +606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3780
+					// Method begins at RVA 0x360c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -674,7 +626,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3789
+					// Method begins at RVA 0x3615
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -698,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37ad
+						// Method begins at RVA 0x3639
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -718,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37b6
+						// Method begins at RVA 0x3642
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -736,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37a4
+					// Method begins at RVA 0x3630
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -756,7 +708,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37d1
+					// Method begins at RVA 0x365d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37da
+					// Method begins at RVA 0x3666
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -798,7 +750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x376e
+				// Method begins at RVA 0x35fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -825,7 +777,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2718
+			// Method begins at RVA 0x2700
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -1372,7 +1324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37e3
+				// Method begins at RVA 0x366f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1400,9 +1352,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2c68
+			// Method begins at RVA 0x2c50
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1410,46 +1362,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_ExportStarFrom/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_ExportStarFrom/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportStarFrom/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1473,7 +1415,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3741
+			// Method begins at RVA 0x35cd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1723,7 +1665,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x382b
+					// Method begins at RVA 0x36b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1741,7 +1683,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3822
+				// Method begins at RVA 0x36ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1767,9 +1709,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2e20
+			// Method begins at RVA 0x2d84
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/Scope/Block_L15C70,
@@ -1795,53 +1737,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/Scope/Block_L15C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/Scope/Block_L15C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -1857,7 +1791,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3834
+				// Method begins at RVA 0x36c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1881,7 +1815,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2edc
+			// Method begins at RVA 0x2e28
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -1962,7 +1896,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x383d
+				// Method begins at RVA 0x36c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1987,7 +1921,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f6c
+			// Method begins at RVA 0x2eb8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2015,7 +1949,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x386a
+					// Method begins at RVA 0x36f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2039,26 +1973,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x35b4
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x34d4
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L39C86::__js_call__
 
 		} // end of class FunctionExpression_L39C86
@@ -2074,7 +1999,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3873
+					// Method begins at RVA 0x36ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2098,26 +2023,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x35dc
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x34e3
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L40C93::__js_call__
 
 		} // end of class FunctionExpression_L40C93
@@ -2137,7 +2053,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x38a0
+						// Method begins at RVA 0x372c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2161,41 +2077,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x36f4
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x35a9
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope
-					IL_0022: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope
+					IL_0015: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L50C86::__js_call__
 
 			} // end of class FunctionExpression_L50C86
@@ -2213,7 +2111,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3897
+					// Method begins at RVA 0x3723
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2238,9 +2136,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3650
+				// Method begins at RVA 0x3514
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope,
@@ -2261,61 +2159,57 @@
 				IL_0010: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L49C9::__js_call__
 
 		} // end of class FunctionExpression_L49C9
@@ -2335,7 +2229,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x384f
+					// Method begins at RVA 0x36db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2355,7 +2249,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3858
+					// Method begins at RVA 0x36e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2375,7 +2269,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3861
+					// Method begins at RVA 0x36ed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2399,7 +2293,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3885
+						// Method begins at RVA 0x3711
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2419,7 +2313,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x388e
+						// Method begins at RVA 0x371a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2437,7 +2331,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x387c
+					// Method begins at RVA 0x3708
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2457,7 +2351,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38a9
+					// Method begins at RVA 0x3735
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2477,7 +2371,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38b2
+					// Method begins at RVA 0x373e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2499,7 +2393,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3846
+				// Method begins at RVA 0x36d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2526,7 +2420,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2f78
+			// Method begins at RVA 0x2ec4
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -3073,7 +2967,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38bb
+				// Method begins at RVA 0x3747
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3101,9 +2995,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x34c8
+			// Method begins at RVA 0x3414
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -3111,46 +3005,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3170,7 +3054,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3819
+					// Method begins at RVA 0x36a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3194,41 +3078,23 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3604
-				// Header size: 12
-				// Code size: 62 (0x3e)
+				// Method begins at RVA 0x34f2
+				// Header size: 1
+				// Code size: 32 (0x20)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.0
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFrom_LibB/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
-				IL_000d: stloc.0
-				IL_000e: ldstr "__jroc_esm_mod_0"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldarg.0
-				IL_001b: ldc.i4.1
-				IL_001c: ldelem.ref
-				IL_001d: castclass Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope
-				IL_0022: ldfld object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope::__k
-				IL_0027: stloc.1
-				IL_0028: ldstr "__k"
-				IL_002d: ldloc.1
-				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0033: stloc.1
-				IL_0034: ldloc.0
-				IL_0035: ldloc.1
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_003b: stloc.1
-				IL_003c: ldloc.1
-				IL_003d: ret
+				IL_000d: ldarg.0
+				IL_000e: ldc.i4.1
+				IL_000f: ldelem.ref
+				IL_0010: castclass Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope
+				IL_0015: ldfld object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope::__k
+				IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_001f: ret
 			} // end of method FunctionExpression_L10C42::__js_call__
 
 		} // end of class FunctionExpression_L10C42
@@ -3247,7 +3113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3810
+				// Method begins at RVA 0x369c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3274,16 +3140,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3540
+			// Method begins at RVA 0x3470
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope,
-				[1] object,
-				[2] object[],
-				[3] object,
-				[4] object
+				[1] object[],
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope::.ctor()
@@ -3291,50 +3156,44 @@
 			IL_0006: ldloc.0
 			IL_0007: ldarg.2
 			IL_0008: stfld object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope::__k
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_export
-			IL_0013: stloc.1
-			IL_0014: ldstr "__jroc_esm_export"
-			IL_0019: ldloc.1
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001f: stloc.1
-			IL_0020: ldc.i4.1
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldarg.0
-			IL_0029: stelem.ref
-			IL_002a: stloc.2
+			IL_000d: ldc.i4.1
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldarg.0
+			IL_0016: stelem.ref
+			IL_0017: stloc.1
+			IL_0018: ldloc.0
+			IL_0019: ldfld object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope::__k
+			IL_001e: stloc.2
+			IL_001f: ldc.i4.2
+			IL_0020: newarr [System.Runtime]System.Object
+			IL_0025: dup
+			IL_0026: ldc.i4.0
+			IL_0027: ldarg.0
+			IL_0028: stelem.ref
+			IL_0029: dup
+			IL_002a: ldc.i4.1
 			IL_002b: ldloc.0
-			IL_002c: ldfld object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope::__k
-			IL_0031: stloc.3
-			IL_0032: ldc.i4.2
-			IL_0033: newarr [System.Runtime]System.Object
-			IL_0038: dup
-			IL_0039: ldc.i4.0
-			IL_003a: ldarg.0
-			IL_003b: stelem.ref
-			IL_003c: dup
-			IL_003d: ldc.i4.1
-			IL_003e: ldloc.0
-			IL_003f: stelem.ref
-			IL_0040: ldftn object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
-			IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_004b: ldc.i4.0
-			IL_004c: conv.r8
-			IL_004d: ldstr ""
-			IL_0052: ldc.i4.0
-			IL_0053: ldc.i4.1
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0059: stloc.s 4
-			IL_005b: ldloc.1
-			IL_005c: ldloc.2
-			IL_005d: ldloc.3
-			IL_005e: ldloc.s 4
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0065: pop
-			IL_0066: ldnull
-			IL_0067: ret
+			IL_002c: stelem.ref
+			IL_002d: ldftn object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
+			IL_0033: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0038: ldc.i4.0
+			IL_0039: conv.r8
+			IL_003a: ldstr ""
+			IL_003f: ldc.i4.0
+			IL_0040: ldc.i4.1
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0046: stloc.3
+			IL_0047: ldarg.0
+			IL_0048: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_export
+			IL_004d: ldloc.1
+			IL_004e: ldloc.2
+			IL_004f: ldloc.3
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0055: pop
+			IL_0056: ldnull
+			IL_0057: ret
 		} // end of method FunctionExpression_L10C3::__js_call__
 
 	} // end of class FunctionExpression_L10C3
@@ -3358,7 +3217,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37fe
+					// Method begins at RVA 0x368a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3378,7 +3237,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3807
+					// Method begins at RVA 0x3693
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3396,7 +3255,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37f5
+				// Method begins at RVA 0x3681
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3423,7 +3282,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x37ec
+			// Method begins at RVA 0x3678
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3742,7 +3601,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38cd
+				// Method begins at RVA 0x3759
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3765,7 +3624,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x373e
+			// Method begins at RVA 0x35ca
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -3790,7 +3649,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x38c4
+			// Method begins at RVA 0x3750
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3884,7 +3743,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x38d6
+		// Method begins at RVA 0x3762
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4cf0
+					// Method begins at RVA 0x49e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ce7
+				// Method begins at RVA 0x49db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			)
 			// Method begins at RVA 0x295c
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/Scope/Block_L14C70,
@@ -94,53 +94,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_ExportStarFromMultiHop/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/Scope/Block_L14C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_ExportStarFromMultiHop/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/Scope/Block_L14C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_ExportStarFromMultiHop/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -156,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cf9
+				// Method begins at RVA 0x49ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +172,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a18
+			// Method begins at RVA 0x2a00
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -261,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d02
+				// Method begins at RVA 0x49f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +278,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2aa8
+			// Method begins at RVA 0x2a90
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,7 +306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d2f
+					// Method begins at RVA 0x4a23
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -338,26 +330,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x307c
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x3048
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L38C86::__js_call__
 
 		} // end of class FunctionExpression_L38C86
@@ -373,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d38
+					// Method begins at RVA 0x4a2c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -397,26 +380,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x30a4
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x3057
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L39C93::__js_call__
 
 		} // end of class FunctionExpression_L39C93
@@ -436,7 +410,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4d65
+						// Method begins at RVA 0x4a59
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -460,41 +434,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3170
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x30fd
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
-					IL_0022: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
+					IL_0015: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L49C86::__js_call__
 
 			} // end of class FunctionExpression_L49C86
@@ -512,7 +468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d5c
+					// Method begins at RVA 0x4a50
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,9 +493,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x30cc
+				// Method begins at RVA 0x3068
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope,
@@ -560,61 +516,57 @@
 				IL_0010: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L48C9::__js_call__
 
 		} // end of class FunctionExpression_L48C9
@@ -634,7 +586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d14
+					// Method begins at RVA 0x4a08
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -654,7 +606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d1d
+					// Method begins at RVA 0x4a11
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -674,7 +626,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d26
+					// Method begins at RVA 0x4a1a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -698,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4d4a
+						// Method begins at RVA 0x4a3e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -718,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4d53
+						// Method begins at RVA 0x4a47
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -736,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d41
+					// Method begins at RVA 0x4a35
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -756,7 +708,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d6e
+					// Method begins at RVA 0x4a62
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d77
+					// Method begins at RVA 0x4a6b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -798,7 +750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d0b
+				// Method begins at RVA 0x49ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -825,7 +777,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 31 00 00 02
 			)
-			// Method begins at RVA 0x2ab4
+			// Method begins at RVA 0x2a9c
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -1372,7 +1324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d80
+				// Method begins at RVA 0x4a74
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1400,9 +1352,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 31 00 00 02
 			)
-			// Method begins at RVA 0x3004
+			// Method begins at RVA 0x2fec
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1410,46 +1362,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_ExportStarFromMultiHop/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_ExportStarFromMultiHop/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportStarFromMultiHop/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1473,7 +1415,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4cde
+			// Method begins at RVA 0x49d2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1698,7 +1640,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4dc8
+					// Method begins at RVA 0x4abc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1716,7 +1658,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4dbf
+				// Method begins at RVA 0x4ab3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1742,9 +1684,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x31bc
+			// Method begins at RVA 0x3120
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/Scope/Block_L15C70,
@@ -1770,53 +1712,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/Scope/Block_L15C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/Scope/Block_L15C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -1832,7 +1766,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4dd1
+				// Method begins at RVA 0x4ac5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1856,7 +1790,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3278
+			// Method begins at RVA 0x31c4
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -1937,7 +1871,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4dda
+				// Method begins at RVA 0x4ace
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1962,7 +1896,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3308
+			// Method begins at RVA 0x3254
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1990,7 +1924,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e07
+					// Method begins at RVA 0x4afb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2014,26 +1948,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3950
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x3870
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L39C86::__js_call__
 
 		} // end of class FunctionExpression_L39C86
@@ -2049,7 +1974,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e10
+					// Method begins at RVA 0x4b04
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2073,26 +1998,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3978
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x387f
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L40C93::__js_call__
 
 		} // end of class FunctionExpression_L40C93
@@ -2112,7 +2028,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4e3d
+						// Method begins at RVA 0x4b31
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2136,41 +2052,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3a90
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x3945
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope
-					IL_0022: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope
+					IL_0015: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L50C86::__js_call__
 
 			} // end of class FunctionExpression_L50C86
@@ -2188,7 +2086,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e34
+					// Method begins at RVA 0x4b28
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2213,9 +2111,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x39ec
+				// Method begins at RVA 0x38b0
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope,
@@ -2236,61 +2134,57 @@
 				IL_0010: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L49C9::__js_call__
 
 		} // end of class FunctionExpression_L49C9
@@ -2310,7 +2204,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4dec
+					// Method begins at RVA 0x4ae0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2330,7 +2224,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4df5
+					// Method begins at RVA 0x4ae9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2350,7 +2244,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4dfe
+					// Method begins at RVA 0x4af2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2374,7 +2268,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4e22
+						// Method begins at RVA 0x4b16
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2394,7 +2288,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4e2b
+						// Method begins at RVA 0x4b1f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2412,7 +2306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e19
+					// Method begins at RVA 0x4b0d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2432,7 +2326,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e46
+					// Method begins at RVA 0x4b3a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2452,7 +2346,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e4f
+					// Method begins at RVA 0x4b43
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2474,7 +2368,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4de3
+				// Method begins at RVA 0x4ad7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2501,7 +2395,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x3314
+			// Method begins at RVA 0x3260
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -3048,7 +2942,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e58
+				// Method begins at RVA 0x4b4c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3076,9 +2970,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x3864
+			// Method begins at RVA 0x37b0
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -3086,46 +2980,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3145,7 +3029,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4db6
+					// Method begins at RVA 0x4aaa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3169,41 +3053,23 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x39a0
-				// Header size: 12
-				// Code size: 62 (0x3e)
+				// Method begins at RVA 0x388e
+				// Header size: 1
+				// Code size: 32 (0x20)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.0
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
-				IL_000d: stloc.0
-				IL_000e: ldstr "__jroc_esm_mod_0"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldarg.0
-				IL_001b: ldc.i4.1
-				IL_001c: ldelem.ref
-				IL_001d: castclass Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope
-				IL_0022: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope::__k
-				IL_0027: stloc.1
-				IL_0028: ldstr "__k"
-				IL_002d: ldloc.1
-				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0033: stloc.1
-				IL_0034: ldloc.0
-				IL_0035: ldloc.1
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_003b: stloc.1
-				IL_003c: ldloc.1
-				IL_003d: ret
+				IL_000d: ldarg.0
+				IL_000e: ldc.i4.1
+				IL_000f: ldelem.ref
+				IL_0010: castclass Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope
+				IL_0015: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope::__k
+				IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_001f: ret
 			} // end of method FunctionExpression_L10C42::__js_call__
 
 		} // end of class FunctionExpression_L10C42
@@ -3222,7 +3088,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4dad
+				// Method begins at RVA 0x4aa1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3249,16 +3115,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x38dc
+			// Method begins at RVA 0x380c
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope,
-				[1] object,
-				[2] object[],
-				[3] object,
-				[4] object
+				[1] object[],
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope::.ctor()
@@ -3266,50 +3131,44 @@
 			IL_0006: ldloc.0
 			IL_0007: ldarg.2
 			IL_0008: stfld object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope::__k
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_export
-			IL_0013: stloc.1
-			IL_0014: ldstr "__jroc_esm_export"
-			IL_0019: ldloc.1
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001f: stloc.1
-			IL_0020: ldc.i4.1
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldarg.0
-			IL_0029: stelem.ref
-			IL_002a: stloc.2
+			IL_000d: ldc.i4.1
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldarg.0
+			IL_0016: stelem.ref
+			IL_0017: stloc.1
+			IL_0018: ldloc.0
+			IL_0019: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope::__k
+			IL_001e: stloc.2
+			IL_001f: ldc.i4.2
+			IL_0020: newarr [System.Runtime]System.Object
+			IL_0025: dup
+			IL_0026: ldc.i4.0
+			IL_0027: ldarg.0
+			IL_0028: stelem.ref
+			IL_0029: dup
+			IL_002a: ldc.i4.1
 			IL_002b: ldloc.0
-			IL_002c: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope::__k
-			IL_0031: stloc.3
-			IL_0032: ldc.i4.2
-			IL_0033: newarr [System.Runtime]System.Object
-			IL_0038: dup
-			IL_0039: ldc.i4.0
-			IL_003a: ldarg.0
-			IL_003b: stelem.ref
-			IL_003c: dup
-			IL_003d: ldc.i4.1
-			IL_003e: ldloc.0
-			IL_003f: stelem.ref
-			IL_0040: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
-			IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_004b: ldc.i4.0
-			IL_004c: conv.r8
-			IL_004d: ldstr ""
-			IL_0052: ldc.i4.0
-			IL_0053: ldc.i4.1
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0059: stloc.s 4
-			IL_005b: ldloc.1
-			IL_005c: ldloc.2
-			IL_005d: ldloc.3
-			IL_005e: ldloc.s 4
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0065: pop
-			IL_0066: ldnull
-			IL_0067: ret
+			IL_002c: stelem.ref
+			IL_002d: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
+			IL_0033: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0038: ldc.i4.0
+			IL_0039: conv.r8
+			IL_003a: ldstr ""
+			IL_003f: ldc.i4.0
+			IL_0040: ldc.i4.1
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0046: stloc.3
+			IL_0047: ldarg.0
+			IL_0048: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_export
+			IL_004d: ldloc.1
+			IL_004e: ldloc.2
+			IL_004f: ldloc.3
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0055: pop
+			IL_0056: ldnull
+			IL_0057: ret
 		} // end of method FunctionExpression_L10C3::__js_call__
 
 	} // end of class FunctionExpression_L10C3
@@ -3333,7 +3192,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d9b
+					// Method begins at RVA 0x4a8f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3353,7 +3212,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4da4
+					// Method begins at RVA 0x4a98
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3371,7 +3230,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d92
+				// Method begins at RVA 0x4a86
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3398,7 +3257,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4d89
+			// Method begins at RVA 0x4a7d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3717,7 +3576,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e75
+				// Method begins at RVA 0x4b69
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3743,9 +3602,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3adc
+			// Method begins at RVA 0x3968
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -3756,12 +3615,8 @@
 			IL_0006: ldstr "Cannot access 'gamma' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "gamma"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L3C27::__js_call__
 
 	} // end of class FunctionExpression_L3C27
@@ -3781,7 +3636,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4eb4
+					// Method begins at RVA 0x4ba8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3799,7 +3654,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4eab
+				// Method begins at RVA 0x4b9f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3825,9 +3680,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3b08
+			// Method begins at RVA 0x3988
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/Scope/Block_L17C70,
@@ -3853,53 +3708,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/Scope/Block_L17C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/Scope/Block_L17C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -3915,7 +3762,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ebd
+				// Method begins at RVA 0x4bb1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3939,7 +3786,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3bc4
+			// Method begins at RVA 0x3a2c
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -4020,7 +3867,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ec6
+				// Method begins at RVA 0x4bba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4045,7 +3892,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3c54
+			// Method begins at RVA 0x3abc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4073,7 +3920,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ef3
+					// Method begins at RVA 0x4be7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4097,26 +3944,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x429c
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x40d8
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L41C86::__js_call__
 
 		} // end of class FunctionExpression_L41C86
@@ -4132,7 +3970,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4efc
+					// Method begins at RVA 0x4bf0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4156,26 +3994,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x42c4
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x40e7
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L42C93::__js_call__
 
 		} // end of class FunctionExpression_L42C93
@@ -4195,7 +4024,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f29
+						// Method begins at RVA 0x4c1d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4219,41 +4048,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x43dc
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x41ad
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope
-					IL_0022: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope
+					IL_0015: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L52C86::__js_call__
 
 			} // end of class FunctionExpression_L52C86
@@ -4271,7 +4082,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f20
+					// Method begins at RVA 0x4c14
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4296,9 +4107,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4338
+				// Method begins at RVA 0x4118
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope,
@@ -4319,61 +4130,57 @@
 				IL_0010: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L51C9::__js_call__
 
 		} // end of class FunctionExpression_L51C9
@@ -4393,7 +4200,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ed8
+					// Method begins at RVA 0x4bcc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4413,7 +4220,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ee1
+					// Method begins at RVA 0x4bd5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4433,7 +4240,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4eea
+					// Method begins at RVA 0x4bde
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4457,7 +4264,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f0e
+						// Method begins at RVA 0x4c02
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4477,7 +4284,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f17
+						// Method begins at RVA 0x4c0b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4495,7 +4302,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f05
+					// Method begins at RVA 0x4bf9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4515,7 +4322,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f32
+					// Method begins at RVA 0x4c26
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4535,7 +4342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f3b
+					// Method begins at RVA 0x4c2f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4557,7 +4364,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ecf
+				// Method begins at RVA 0x4bc3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4584,7 +4391,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3c60
+			// Method begins at RVA 0x3ac8
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -5131,7 +4938,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f44
+				// Method begins at RVA 0x4c38
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5159,9 +4966,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x41b0
+			// Method begins at RVA 0x4018
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -5169,46 +4976,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -5228,7 +5025,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ea2
+					// Method begins at RVA 0x4b96
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5252,41 +5049,23 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x42ec
-				// Header size: 12
-				// Code size: 62 (0x3e)
+				// Method begins at RVA 0x40f6
+				// Header size: 1
+				// Code size: 32 (0x20)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.0
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
-				IL_000d: stloc.0
-				IL_000e: ldstr "__jroc_esm_mod_0"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldarg.0
-				IL_001b: ldc.i4.1
-				IL_001c: ldelem.ref
-				IL_001d: castclass Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope
-				IL_0022: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope::__k
-				IL_0027: stloc.1
-				IL_0028: ldstr "__k"
-				IL_002d: ldloc.1
-				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0033: stloc.1
-				IL_0034: ldloc.0
-				IL_0035: ldloc.1
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_003b: stloc.1
-				IL_003c: ldloc.1
-				IL_003d: ret
+				IL_000d: ldarg.0
+				IL_000e: ldc.i4.1
+				IL_000f: ldelem.ref
+				IL_0010: castclass Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope
+				IL_0015: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope::__k
+				IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_001f: ret
 			} // end of method FunctionExpression_L11C42::__js_call__
 
 		} // end of class FunctionExpression_L11C42
@@ -5305,7 +5084,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e99
+				// Method begins at RVA 0x4b8d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5332,16 +5111,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x4228
+			// Method begins at RVA 0x4074
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope,
-				[1] object,
-				[2] object[],
-				[3] object,
-				[4] object
+				[1] object[],
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope::.ctor()
@@ -5349,50 +5127,44 @@
 			IL_0006: ldloc.0
 			IL_0007: ldarg.2
 			IL_0008: stfld object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope::__k
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_export
-			IL_0013: stloc.1
-			IL_0014: ldstr "__jroc_esm_export"
-			IL_0019: ldloc.1
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001f: stloc.1
-			IL_0020: ldc.i4.1
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldarg.0
-			IL_0029: stelem.ref
-			IL_002a: stloc.2
+			IL_000d: ldc.i4.1
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldarg.0
+			IL_0016: stelem.ref
+			IL_0017: stloc.1
+			IL_0018: ldloc.0
+			IL_0019: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope::__k
+			IL_001e: stloc.2
+			IL_001f: ldc.i4.2
+			IL_0020: newarr [System.Runtime]System.Object
+			IL_0025: dup
+			IL_0026: ldc.i4.0
+			IL_0027: ldarg.0
+			IL_0028: stelem.ref
+			IL_0029: dup
+			IL_002a: ldc.i4.1
 			IL_002b: ldloc.0
-			IL_002c: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope::__k
-			IL_0031: stloc.3
-			IL_0032: ldc.i4.2
-			IL_0033: newarr [System.Runtime]System.Object
-			IL_0038: dup
-			IL_0039: ldc.i4.0
-			IL_003a: ldarg.0
-			IL_003b: stelem.ref
-			IL_003c: dup
-			IL_003d: ldc.i4.1
-			IL_003e: ldloc.0
-			IL_003f: stelem.ref
-			IL_0040: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42::__js_call__(object[], object)
-			IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_004b: ldc.i4.0
-			IL_004c: conv.r8
-			IL_004d: ldstr ""
-			IL_0052: ldc.i4.0
-			IL_0053: ldc.i4.1
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0059: stloc.s 4
-			IL_005b: ldloc.1
-			IL_005c: ldloc.2
-			IL_005d: ldloc.3
-			IL_005e: ldloc.s 4
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0065: pop
-			IL_0066: ldnull
-			IL_0067: ret
+			IL_002c: stelem.ref
+			IL_002d: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42::__js_call__(object[], object)
+			IL_0033: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0038: ldc.i4.0
+			IL_0039: conv.r8
+			IL_003a: ldstr ""
+			IL_003f: ldc.i4.0
+			IL_0040: ldc.i4.1
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0046: stloc.3
+			IL_0047: ldarg.0
+			IL_0048: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_export
+			IL_004d: ldloc.1
+			IL_004e: ldloc.2
+			IL_004f: ldloc.3
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0055: pop
+			IL_0056: ldnull
+			IL_0057: ret
 		} // end of method FunctionExpression_L11C3::__js_call__
 
 	} // end of class FunctionExpression_L11C3
@@ -5417,7 +5189,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e87
+					// Method begins at RVA 0x4b7b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5437,7 +5209,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e90
+					// Method begins at RVA 0x4b84
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5455,7 +5227,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e7e
+				// Method begins at RVA 0x4b72
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5483,7 +5255,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4e61
+			// Method begins at RVA 0x4b55
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5835,7 +5607,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f6c
+				// Method begins at RVA 0x4c60
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5861,9 +5633,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4428
+			// Method begins at RVA 0x41d0
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -5874,12 +5646,8 @@
 			IL_0006: ldstr "Cannot access 'alpha' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "alpha"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L3C27::__js_call__
 
 	} // end of class FunctionExpression_L3C27
@@ -5895,7 +5663,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f75
+				// Method begins at RVA 0x4c69
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5921,9 +5689,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4454
+			// Method begins at RVA 0x41f0
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -5934,12 +5702,8 @@
 			IL_0006: ldstr "Cannot access 'beta' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "beta"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L4C26::__js_call__
 
 	} // end of class FunctionExpression_L4C26
@@ -5959,7 +5723,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f87
+					// Method begins at RVA 0x4c7b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5977,7 +5741,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f7e
+				// Method begins at RVA 0x4c72
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6003,9 +5767,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4480
+			// Method begins at RVA 0x4210
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/Scope/Block_L12C70,
@@ -6031,53 +5795,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/Scope/Block_L12C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/Scope/Block_L12C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -6093,7 +5849,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f90
+				// Method begins at RVA 0x4c84
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6117,7 +5873,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x453c
+			// Method begins at RVA 0x42b4
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -6198,7 +5954,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f99
+				// Method begins at RVA 0x4c8d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6223,7 +5979,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x45cc
+			// Method begins at RVA 0x4344
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -6251,7 +6007,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fc6
+					// Method begins at RVA 0x4cba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6275,26 +6031,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4ba0
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x48fc
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L36C86::__js_call__
 
 		} // end of class FunctionExpression_L36C86
@@ -6310,7 +6057,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fcf
+					// Method begins at RVA 0x4cc3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6334,26 +6081,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4bc8
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x490b
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L37C93::__js_call__
 
 		} // end of class FunctionExpression_L37C93
@@ -6373,7 +6111,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4ffc
+						// Method begins at RVA 0x4cf0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6397,41 +6135,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x4c94
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x49b1
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope
-					IL_0022: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope
+					IL_0015: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L47C86::__js_call__
 
 			} // end of class FunctionExpression_L47C86
@@ -6449,7 +6169,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ff3
+					// Method begins at RVA 0x4ce7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6474,9 +6194,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4bf0
+				// Method begins at RVA 0x491c
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope,
@@ -6497,61 +6217,57 @@
 				IL_0010: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L46C9::__js_call__
 
 		} // end of class FunctionExpression_L46C9
@@ -6571,7 +6287,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fab
+					// Method begins at RVA 0x4c9f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6591,7 +6307,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fb4
+					// Method begins at RVA 0x4ca8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6611,7 +6327,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fbd
+					// Method begins at RVA 0x4cb1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6635,7 +6351,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4fe1
+						// Method begins at RVA 0x4cd5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6655,7 +6371,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4fea
+						// Method begins at RVA 0x4cde
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6673,7 +6389,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fd8
+					// Method begins at RVA 0x4ccc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6693,7 +6409,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5005
+					// Method begins at RVA 0x4cf9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6713,7 +6429,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x500e
+					// Method begins at RVA 0x4d02
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6735,7 +6451,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fa2
+				// Method begins at RVA 0x4c96
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6762,7 +6478,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x45d8
+			// Method begins at RVA 0x4350
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -7309,7 +7025,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5017
+				// Method begins at RVA 0x4d0b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7337,9 +7053,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4b28
+			// Method begins at RVA 0x48a0
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -7347,46 +7063,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -7414,7 +7120,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4f4d
+			// Method begins at RVA 0x4c41
 			// Header size: 1
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -7623,7 +7329,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x5020
+		// Method begins at RVA 0x4d14
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3a7c
+					// Method begins at RVA 0x3914
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3a73
+				// Method begins at RVA 0x390b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			)
 			// Method begins at RVA 0x28fc
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ImportMeta_Url/__jroc_esm_mark/Scope/Block_L25C70,
@@ -94,53 +94,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_ImportMeta_Url/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_mark/Scope/Block_L25C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_ImportMeta_Url/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_mark/Scope/Block_L25C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_ImportMeta_Url/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -156,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3a85
+				// Method begins at RVA 0x391d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +172,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29b8
+			// Method begins at RVA 0x29a0
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -261,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3a8e
+				// Method begins at RVA 0x3926
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +278,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a48
+			// Method begins at RVA 0x2a30
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,7 +306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3abb
+					// Method begins at RVA 0x3953
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -338,26 +330,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x301c
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2fe8
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L49C86::__js_call__
 
 		} // end of class FunctionExpression_L49C86
@@ -373,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ac4
+					// Method begins at RVA 0x395c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -397,26 +380,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3044
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2ff7
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L50C93::__js_call__
 
 		} // end of class FunctionExpression_L50C93
@@ -436,7 +410,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3af1
+						// Method begins at RVA 0x3989
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -460,41 +434,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3110
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x309d
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope
-					IL_0022: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope
+					IL_0015: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L60C86::__js_call__
 
 			} // end of class FunctionExpression_L60C86
@@ -512,7 +468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ae8
+					// Method begins at RVA 0x3980
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,9 +493,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x306c
+				// Method begins at RVA 0x3008
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope,
@@ -560,61 +516,57 @@
 				IL_0010: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L59C9::__js_call__
 
 		} // end of class FunctionExpression_L59C9
@@ -634,7 +586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3aa0
+					// Method begins at RVA 0x3938
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -654,7 +606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3aa9
+					// Method begins at RVA 0x3941
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -674,7 +626,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ab2
+					// Method begins at RVA 0x394a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -698,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3ad6
+						// Method begins at RVA 0x396e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -718,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3adf
+						// Method begins at RVA 0x3977
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -736,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3acd
+					// Method begins at RVA 0x3965
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -756,7 +708,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3afa
+					// Method begins at RVA 0x3992
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3b03
+					// Method begins at RVA 0x399b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -798,7 +750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3a97
+				// Method begins at RVA 0x392f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -825,7 +777,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2a54
+			// Method begins at RVA 0x2a3c
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -1372,7 +1324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3b0c
+				// Method begins at RVA 0x39a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1400,9 +1352,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2fa4
+			// Method begins at RVA 0x2f8c
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1410,46 +1362,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_ImportMeta_Url/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_ImportMeta_Url/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ImportMeta_Url/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1473,7 +1415,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3a6a
+			// Method begins at RVA 0x3902
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2004,7 +1946,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3b4a
+				// Method begins at RVA 0x39e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2030,9 +1972,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x315c
+			// Method begins at RVA 0x30c0
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -2043,12 +1985,8 @@
 			IL_0006: ldstr "Cannot access 'importedUrl' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "importedUrl"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L3C33::__js_call__
 
 	} // end of class FunctionExpression_L3C33
@@ -2064,7 +2002,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3b53
+				// Method begins at RVA 0x39eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2090,9 +2028,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3188
+			// Method begins at RVA 0x30e0
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -2103,12 +2041,8 @@
 			IL_0006: ldstr "Cannot access 'importedUrlHasFileScheme' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "importedUrlHasFileScheme"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L4C46::__js_call__
 
 	} // end of class FunctionExpression_L4C46
@@ -2124,7 +2058,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3b5c
+				// Method begins at RVA 0x39f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2150,9 +2084,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x31b4
+			// Method begins at RVA 0x3100
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -2163,12 +2097,8 @@
 			IL_0006: ldstr "Cannot access 'importedModuleFilenameMatches' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "importedModuleFilenameMatches"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L5C51::__js_call__
 
 	} // end of class FunctionExpression_L5C51
@@ -2184,7 +2114,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3b65
+				// Method begins at RVA 0x39fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2210,9 +2140,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x31e0
+			// Method begins at RVA 0x3120
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -2223,12 +2153,8 @@
 			IL_0006: ldstr "Cannot access 'importedModulePathMatches' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "importedModulePathMatches"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L6C47::__js_call__
 
 	} // end of class FunctionExpression_L6C47
@@ -2248,7 +2174,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3b77
+					// Method begins at RVA 0x3a0f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2266,7 +2192,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3b6e
+				// Method begins at RVA 0x3a06
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2292,9 +2218,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x320c
+			// Method begins at RVA 0x3140
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/Scope/Block_L16C70,
@@ -2320,53 +2246,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/Scope/Block_L16C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/Scope/Block_L16C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -2382,7 +2300,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3b80
+				// Method begins at RVA 0x3a18
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2406,7 +2324,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x32c8
+			// Method begins at RVA 0x31e4
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2487,7 +2405,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3b89
+				// Method begins at RVA 0x3a21
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2512,7 +2430,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3358
+			// Method begins at RVA 0x3274
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2540,7 +2458,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3bb6
+					// Method begins at RVA 0x3a4e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2564,26 +2482,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x392c
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x382c
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L40C86::__js_call__
 
 		} // end of class FunctionExpression_L40C86
@@ -2599,7 +2508,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3bbf
+					// Method begins at RVA 0x3a57
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2623,26 +2532,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3954
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x383b
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L41C93::__js_call__
 
 		} // end of class FunctionExpression_L41C93
@@ -2662,7 +2562,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3bec
+						// Method begins at RVA 0x3a84
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2686,41 +2586,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3a20
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x38e1
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope
-					IL_0022: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope
+					IL_0015: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L51C86::__js_call__
 
 			} // end of class FunctionExpression_L51C86
@@ -2738,7 +2620,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3be3
+					// Method begins at RVA 0x3a7b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2763,9 +2645,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x397c
+				// Method begins at RVA 0x384c
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope,
@@ -2786,61 +2668,57 @@
 				IL_0010: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L50C9::__js_call__
 
 		} // end of class FunctionExpression_L50C9
@@ -2860,7 +2738,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3b9b
+					// Method begins at RVA 0x3a33
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2880,7 +2758,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ba4
+					// Method begins at RVA 0x3a3c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2900,7 +2778,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3bad
+					// Method begins at RVA 0x3a45
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2924,7 +2802,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3bd1
+						// Method begins at RVA 0x3a69
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2944,7 +2822,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3bda
+						// Method begins at RVA 0x3a72
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2962,7 +2840,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3bc8
+					// Method begins at RVA 0x3a60
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2982,7 +2860,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3bf5
+					// Method begins at RVA 0x3a8d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3002,7 +2880,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3bfe
+					// Method begins at RVA 0x3a96
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3024,7 +2902,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3b92
+				// Method begins at RVA 0x3a2a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3051,7 +2929,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3364
+			// Method begins at RVA 0x3280
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -3598,7 +3476,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c07
+				// Method begins at RVA 0x3a9f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3626,9 +3504,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x38b4
+			// Method begins at RVA 0x37d0
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -3636,46 +3514,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3716,7 +3584,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3b15
+			// Method begins at RVA 0x39ad
 			// Header size: 1
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -4062,7 +3930,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3c10
+		// Method begins at RVA 0x3aa8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4404
+					// Method begins at RVA 0x4178
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x43fb
+				// Method begins at RVA 0x416f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			)
 			// Method begins at RVA 0x28ec
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/Scope/Block_L25C70,
@@ -94,53 +94,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_LiveBindings_Cycle/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/Scope/Block_L25C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_LiveBindings_Cycle/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/Scope/Block_L25C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_LiveBindings_Cycle/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -156,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x440d
+				// Method begins at RVA 0x4181
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +172,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29a8
+			// Method begins at RVA 0x2990
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -261,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4416
+				// Method begins at RVA 0x418a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +278,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a38
+			// Method begins at RVA 0x2a20
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,7 +306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4443
+					// Method begins at RVA 0x41b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -338,26 +330,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x300c
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2fd8
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L49C86::__js_call__
 
 		} // end of class FunctionExpression_L49C86
@@ -373,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x444c
+					// Method begins at RVA 0x41c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -397,26 +380,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3034
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2fe7
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L50C93::__js_call__
 
 		} // end of class FunctionExpression_L50C93
@@ -436,7 +410,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4479
+						// Method begins at RVA 0x41ed
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -460,41 +434,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3100
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x308d
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope
-					IL_0022: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope
+					IL_0015: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L60C86::__js_call__
 
 			} // end of class FunctionExpression_L60C86
@@ -512,7 +468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4470
+					// Method begins at RVA 0x41e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,9 +493,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x305c
+				// Method begins at RVA 0x2ff8
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope,
@@ -560,61 +516,57 @@
 				IL_0010: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L59C9::__js_call__
 
 		} // end of class FunctionExpression_L59C9
@@ -634,7 +586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4428
+					// Method begins at RVA 0x419c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -654,7 +606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4431
+					// Method begins at RVA 0x41a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -674,7 +626,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x443a
+					// Method begins at RVA 0x41ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -698,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x445e
+						// Method begins at RVA 0x41d2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -718,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4467
+						// Method begins at RVA 0x41db
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -736,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4455
+					// Method begins at RVA 0x41c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -756,7 +708,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4482
+					// Method begins at RVA 0x41f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x448b
+					// Method begins at RVA 0x41ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -798,7 +750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x441f
+				// Method begins at RVA 0x4193
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -825,7 +777,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x2a44
+			// Method begins at RVA 0x2a2c
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -1372,7 +1324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4494
+				// Method begins at RVA 0x4208
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1400,9 +1352,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x2f94
+			// Method begins at RVA 0x2f7c
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1410,46 +1362,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_LiveBindings_Cycle/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_LiveBindings_Cycle/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1473,7 +1415,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x43f2
+			// Method begins at RVA 0x4166
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1865,7 +1807,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44b1
+				// Method begins at RVA 0x4225
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1891,9 +1833,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x314c
+			// Method begins at RVA 0x30b0
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1904,12 +1846,8 @@
 			IL_0006: ldstr "Cannot access 'a' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "a"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L3C23::__js_call__
 
 	} // end of class FunctionExpression_L3C23
@@ -1925,7 +1863,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44ba
+				// Method begins at RVA 0x422e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1951,23 +1889,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x3178
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x30cf
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::incA
-			IL_0006: stloc.0
-			IL_0007: ldstr "incA"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L4C26::__js_call__
 
 	} // end of class FunctionExpression_L4C26
@@ -1983,7 +1912,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44c3
+				// Method begins at RVA 0x4237
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2009,23 +1938,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x319c
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x30d7
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::getBFromA
-			IL_0006: stloc.0
-			IL_0007: ldstr "getBFromA"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L5C31::__js_call__
 
 	} // end of class FunctionExpression_L5C31
@@ -2041,7 +1961,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44cc
+				// Method begins at RVA 0x4240
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2067,9 +1987,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x31c0
+			// Method begins at RVA 0x30e0
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2081,19 +2001,15 @@
 			IL_0006: ldstr "Cannot access 'a' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "a"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ldc.r8 1
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld object Modules.Import_LiveBindings_Cycle_A/Scope::a
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0011: ldloc.0
+			IL_0012: ldc.r8 1
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0020: stloc.1
+			IL_0021: ldarg.0
+			IL_0022: ldloc.1
+			IL_0023: stfld object Modules.Import_LiveBindings_Cycle_A/Scope::a
+			IL_0028: ldnull
+			IL_0029: ret
 		} // end of method incA::__js_call__
 
 	} // end of class incA
@@ -2109,7 +2025,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44d5
+				// Method begins at RVA 0x4249
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2135,9 +2051,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x3204
+			// Method begins at RVA 0x3118
 			// Header size: 12
-			// Code size: 47 (0x2f)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2147,26 +2063,22 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::__jroc_esm_mod_0
 			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mod_0"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldnull
-			IL_001f: ldloc.0
-			IL_0020: ldstr "b"
-			IL_0025: tail.
-			IL_0027: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get::__js_call__(object, object, object)
-			IL_002c: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldnull
+			IL_0013: ldloc.0
+			IL_0014: ldstr "b"
+			IL_0019: tail.
+			IL_001b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get::__js_call__(object, object, object)
+			IL_0020: ret
 
-			IL_002d: ldnull
-			IL_002e: ret
+			IL_0021: ldnull
+			IL_0022: ret
 		} // end of method getBFromA::__js_call__
 
 	} // end of class getBFromA
@@ -2186,7 +2098,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x44e7
+					// Method begins at RVA 0x425b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2204,7 +2116,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44de
+				// Method begins at RVA 0x4252
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2230,9 +2142,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x3240
+			// Method begins at RVA 0x3148
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/Scope/Block_L23C70,
@@ -2258,53 +2170,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/Scope/Block_L23C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/Scope/Block_L23C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -2320,7 +2224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44f0
+				// Method begins at RVA 0x4264
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2344,7 +2248,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x32fc
+			// Method begins at RVA 0x31ec
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2425,7 +2329,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44f9
+				// Method begins at RVA 0x426d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2450,7 +2354,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x338c
+			// Method begins at RVA 0x327c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2478,7 +2382,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4526
+					// Method begins at RVA 0x429a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2502,26 +2406,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3960
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x3834
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L47C86::__js_call__
 
 		} // end of class FunctionExpression_L47C86
@@ -2537,7 +2432,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x452f
+					// Method begins at RVA 0x42a3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2561,26 +2456,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3988
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x3843
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L48C93::__js_call__
 
 		} // end of class FunctionExpression_L48C93
@@ -2600,7 +2486,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x455c
+						// Method begins at RVA 0x42d0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2624,41 +2510,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3a54
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x38e9
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope
-					IL_0022: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope
+					IL_0015: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L58C86::__js_call__
 
 			} // end of class FunctionExpression_L58C86
@@ -2676,7 +2544,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4553
+					// Method begins at RVA 0x42c7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2701,9 +2569,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x39b0
+				// Method begins at RVA 0x3854
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope,
@@ -2724,61 +2592,57 @@
 				IL_0010: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L57C9::__js_call__
 
 		} // end of class FunctionExpression_L57C9
@@ -2798,7 +2662,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x450b
+					// Method begins at RVA 0x427f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2818,7 +2682,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4514
+					// Method begins at RVA 0x4288
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2838,7 +2702,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x451d
+					// Method begins at RVA 0x4291
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2862,7 +2726,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4541
+						// Method begins at RVA 0x42b5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2882,7 +2746,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x454a
+						// Method begins at RVA 0x42be
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2900,7 +2764,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4538
+					// Method begins at RVA 0x42ac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2920,7 +2784,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4565
+					// Method begins at RVA 0x42d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2940,7 +2804,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x456e
+					// Method begins at RVA 0x42e2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2962,7 +2826,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4502
+				// Method begins at RVA 0x4276
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2989,7 +2853,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x3398
+			// Method begins at RVA 0x3288
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -3536,7 +3400,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4577
+				// Method begins at RVA 0x42eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3564,9 +3428,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x38e8
+			// Method begins at RVA 0x37d8
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -3574,46 +3438,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3644,7 +3498,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x449d
+			// Method begins at RVA 0x4211
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3931,7 +3785,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4594
+				// Method begins at RVA 0x4308
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3957,9 +3811,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3aa0
+			// Method begins at RVA 0x390c
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -3970,12 +3824,8 @@
 			IL_0006: ldstr "Cannot access 'b' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "b"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L3C23::__js_call__
 
 	} // end of class FunctionExpression_L3C23
@@ -3991,7 +3841,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x459d
+				// Method begins at RVA 0x4311
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4017,23 +3867,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3acc
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x392b
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::incB
-			IL_0006: stloc.0
-			IL_0007: ldstr "incB"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L4C26::__js_call__
 
 	} // end of class FunctionExpression_L4C26
@@ -4049,7 +3890,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45a6
+				// Method begins at RVA 0x431a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4075,23 +3916,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3af0
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x3933
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::getAFromB
-			IL_0006: stloc.0
-			IL_0007: ldstr "getAFromB"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L5C31::__js_call__
 
 	} // end of class FunctionExpression_L5C31
@@ -4107,7 +3939,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45af
+				// Method begins at RVA 0x4323
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4133,9 +3965,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3b14
+			// Method begins at RVA 0x393c
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4147,19 +3979,15 @@
 			IL_0006: ldstr "Cannot access 'b' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "b"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ldc.r8 1
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld object Modules.Import_LiveBindings_Cycle_B/Scope::b
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0011: ldloc.0
+			IL_0012: ldc.r8 1
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0020: stloc.1
+			IL_0021: ldarg.0
+			IL_0022: ldloc.1
+			IL_0023: stfld object Modules.Import_LiveBindings_Cycle_B/Scope::b
+			IL_0028: ldnull
+			IL_0029: ret
 		} // end of method incB::__js_call__
 
 	} // end of class incB
@@ -4175,7 +4003,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45b8
+				// Method begins at RVA 0x432c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4201,9 +4029,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3b58
+			// Method begins at RVA 0x3974
 			// Header size: 12
-			// Code size: 47 (0x2f)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4213,26 +4041,22 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::__jroc_esm_mod_0
 			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mod_0"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldnull
-			IL_001f: ldloc.0
-			IL_0020: ldstr "a"
-			IL_0025: tail.
-			IL_0027: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get::__js_call__(object, object, object)
-			IL_002c: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldnull
+			IL_0013: ldloc.0
+			IL_0014: ldstr "a"
+			IL_0019: tail.
+			IL_001b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get::__js_call__(object, object, object)
+			IL_0020: ret
 
-			IL_002d: ldnull
-			IL_002e: ret
+			IL_0021: ldnull
+			IL_0022: ret
 		} // end of method getAFromB::__js_call__
 
 	} // end of class getAFromB
@@ -4252,7 +4076,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45ca
+					// Method begins at RVA 0x433e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4270,7 +4094,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45c1
+				// Method begins at RVA 0x4335
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4296,9 +4120,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3b94
+			// Method begins at RVA 0x39a4
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/Scope/Block_L23C70,
@@ -4324,53 +4148,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/Scope/Block_L23C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/Scope/Block_L23C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -4386,7 +4202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45d3
+				// Method begins at RVA 0x4347
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4410,7 +4226,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3c50
+			// Method begins at RVA 0x3a48
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -4491,7 +4307,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45dc
+				// Method begins at RVA 0x4350
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4516,7 +4332,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3ce0
+			// Method begins at RVA 0x3ad8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4544,7 +4360,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4609
+					// Method begins at RVA 0x437d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4568,26 +4384,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x42b4
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x4090
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L47C86::__js_call__
 
 		} // end of class FunctionExpression_L47C86
@@ -4603,7 +4410,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4612
+					// Method begins at RVA 0x4386
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4627,26 +4434,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x42dc
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x409f
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L48C93::__js_call__
 
 		} // end of class FunctionExpression_L48C93
@@ -4666,7 +4464,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x463f
+						// Method begins at RVA 0x43b3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4690,41 +4488,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x43a8
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x4145
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope
-					IL_0022: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope
+					IL_0015: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L58C86::__js_call__
 
 			} // end of class FunctionExpression_L58C86
@@ -4742,7 +4522,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4636
+					// Method begins at RVA 0x43aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4767,9 +4547,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4304
+				// Method begins at RVA 0x40b0
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope,
@@ -4790,61 +4570,57 @@
 				IL_0010: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L57C9::__js_call__
 
 		} // end of class FunctionExpression_L57C9
@@ -4864,7 +4640,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45ee
+					// Method begins at RVA 0x4362
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4884,7 +4660,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45f7
+					// Method begins at RVA 0x436b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4904,7 +4680,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4600
+					// Method begins at RVA 0x4374
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4928,7 +4704,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4624
+						// Method begins at RVA 0x4398
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4948,7 +4724,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x462d
+						// Method begins at RVA 0x43a1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4966,7 +4742,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x461b
+					// Method begins at RVA 0x438f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4986,7 +4762,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4648
+					// Method begins at RVA 0x43bc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5006,7 +4782,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4651
+					// Method begins at RVA 0x43c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5028,7 +4804,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45e5
+				// Method begins at RVA 0x4359
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5055,7 +4831,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3cec
+			// Method begins at RVA 0x3ae4
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -5602,7 +5378,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x465a
+				// Method begins at RVA 0x43ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5630,9 +5406,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x423c
+			// Method begins at RVA 0x4034
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -5640,46 +5416,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -5710,7 +5476,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4580
+			// Method begins at RVA 0x42f4
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5989,7 +5755,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4663
+		// Method begins at RVA 0x43d7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3540
+					// Method begins at RVA 0x33d4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3537
+				// Method begins at RVA 0x33cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			)
 			// Method begins at RVA 0x23dc
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_LiveBindings_Named/__jroc_esm_mark/Scope/Block_L14C70,
@@ -94,53 +94,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_LiveBindings_Named/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_mark/Scope/Block_L14C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_LiveBindings_Named/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_mark/Scope/Block_L14C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_LiveBindings_Named/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -156,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3549
+				// Method begins at RVA 0x33dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +172,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2498
+			// Method begins at RVA 0x2480
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -261,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3552
+				// Method begins at RVA 0x33e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +278,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2528
+			// Method begins at RVA 0x2510
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,7 +306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x357f
+					// Method begins at RVA 0x3413
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -338,26 +330,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2afc
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2ac8
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L38C86::__js_call__
 
 		} // end of class FunctionExpression_L38C86
@@ -373,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3588
+					// Method begins at RVA 0x341c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -397,26 +380,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b24
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2ad7
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L39C93::__js_call__
 
 		} // end of class FunctionExpression_L39C93
@@ -436,7 +410,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35b5
+						// Method begins at RVA 0x3449
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -460,41 +434,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2bf0
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x2b7d
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
-					IL_0022: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
+					IL_0015: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L49C86::__js_call__
 
 			} // end of class FunctionExpression_L49C86
@@ -512,7 +468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35ac
+					// Method begins at RVA 0x3440
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,9 +493,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b4c
+				// Method begins at RVA 0x2ae8
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope,
@@ -560,61 +516,57 @@
 				IL_0010: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L48C9::__js_call__
 
 		} // end of class FunctionExpression_L48C9
@@ -634,7 +586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3564
+					// Method begins at RVA 0x33f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -654,7 +606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x356d
+					// Method begins at RVA 0x3401
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -674,7 +626,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3576
+					// Method begins at RVA 0x340a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -698,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x359a
+						// Method begins at RVA 0x342e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -718,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35a3
+						// Method begins at RVA 0x3437
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -736,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3591
+					// Method begins at RVA 0x3425
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -756,7 +708,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35be
+					// Method begins at RVA 0x3452
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35c7
+					// Method begins at RVA 0x345b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -798,7 +750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x355b
+				// Method begins at RVA 0x33ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -825,7 +777,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2534
+			// Method begins at RVA 0x251c
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -1372,7 +1324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35d0
+				// Method begins at RVA 0x3464
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1400,9 +1352,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2a84
+			// Method begins at RVA 0x2a6c
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1410,46 +1362,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Named/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_LiveBindings_Named/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_LiveBindings_Named/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1473,7 +1415,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x352e
+			// Method begins at RVA 0x33c2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1690,7 +1632,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35ed
+				// Method begins at RVA 0x3481
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1716,9 +1658,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2c3c
+			// Method begins at RVA 0x2ba0
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1729,12 +1671,8 @@
 			IL_0006: ldstr "Cannot access 'x' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "x"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L3C23::__js_call__
 
 	} // end of class FunctionExpression_L3C23
@@ -1750,7 +1688,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35f6
+				// Method begins at RVA 0x348a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1776,23 +1714,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2c68
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x2bbf
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::inc
-			IL_0006: stloc.0
-			IL_0007: ldstr "inc"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L4C25::__js_call__
 
 	} // end of class FunctionExpression_L4C25
@@ -1808,7 +1737,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35ff
+				// Method begins at RVA 0x3493
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1834,9 +1763,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2c8c
+			// Method begins at RVA 0x2bc8
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1848,19 +1777,15 @@
 			IL_0006: ldstr "Cannot access 'x' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "x"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ldc.r8 1
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld object Modules.Import_LiveBindings_Named_Lib/Scope::x
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0011: ldloc.0
+			IL_0012: ldc.r8 1
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0020: stloc.1
+			IL_0021: ldarg.0
+			IL_0022: ldloc.1
+			IL_0023: stfld object Modules.Import_LiveBindings_Named_Lib/Scope::x
+			IL_0028: ldnull
+			IL_0029: ret
 		} // end of method inc::__js_call__
 
 	} // end of class inc
@@ -1880,7 +1805,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3611
+					// Method begins at RVA 0x34a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1898,7 +1823,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3608
+				// Method begins at RVA 0x349c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1924,9 +1849,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2cd0
+			// Method begins at RVA 0x2c00
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/Scope/Block_L14C70,
@@ -1952,53 +1877,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/Scope/Block_L14C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/Scope/Block_L14C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -2014,7 +1931,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x361a
+				// Method begins at RVA 0x34ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2038,7 +1955,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d8c
+			// Method begins at RVA 0x2ca4
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2119,7 +2036,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3623
+				// Method begins at RVA 0x34b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2144,7 +2061,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e1c
+			// Method begins at RVA 0x2d34
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2172,7 +2089,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3650
+					// Method begins at RVA 0x34e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2196,26 +2113,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33f0
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x32ec
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L38C86::__js_call__
 
 		} // end of class FunctionExpression_L38C86
@@ -2231,7 +2139,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3659
+					// Method begins at RVA 0x34ed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2255,26 +2163,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3418
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x32fb
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L39C93::__js_call__
 
 		} // end of class FunctionExpression_L39C93
@@ -2294,7 +2193,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3686
+						// Method begins at RVA 0x351a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2318,41 +2217,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x34e4
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x33a1
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
-					IL_0022: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
+					IL_0015: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L49C86::__js_call__
 
 			} // end of class FunctionExpression_L49C86
@@ -2370,7 +2251,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x367d
+					// Method begins at RVA 0x3511
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2395,9 +2276,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3440
+				// Method begins at RVA 0x330c
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope,
@@ -2418,61 +2299,57 @@
 				IL_0010: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L48C9::__js_call__
 
 		} // end of class FunctionExpression_L48C9
@@ -2492,7 +2369,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3635
+					// Method begins at RVA 0x34c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2512,7 +2389,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x363e
+					// Method begins at RVA 0x34d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2532,7 +2409,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3647
+					// Method begins at RVA 0x34db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2556,7 +2433,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x366b
+						// Method begins at RVA 0x34ff
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2576,7 +2453,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3674
+						// Method begins at RVA 0x3508
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2594,7 +2471,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3662
+					// Method begins at RVA 0x34f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2614,7 +2491,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x368f
+					// Method begins at RVA 0x3523
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2634,7 +2511,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3698
+					// Method begins at RVA 0x352c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2656,7 +2533,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x362c
+				// Method begins at RVA 0x34c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2683,7 +2560,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2e28
+			// Method begins at RVA 0x2d40
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -3230,7 +3107,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36a1
+				// Method begins at RVA 0x3535
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3258,9 +3135,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x3378
+			// Method begins at RVA 0x3290
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -3268,46 +3145,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3334,7 +3201,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x35d9
+			// Method begins at RVA 0x346d
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3559,7 +3426,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x36aa
+		// Method begins at RVA 0x353e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3818
+					// Method begins at RVA 0x3684
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x380f
+				// Method begins at RVA 0x367b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			)
 			// Method begins at RVA 0x2664
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/Scope/Block_L21C70,
@@ -94,53 +94,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_Namespace_Esm_Basic/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/Scope/Block_L21C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_Namespace_Esm_Basic/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/Scope/Block_L21C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_Namespace_Esm_Basic/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -156,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3821
+				// Method begins at RVA 0x368d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +172,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2720
+			// Method begins at RVA 0x2708
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -261,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x382a
+				// Method begins at RVA 0x3696
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +278,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27b0
+			// Method begins at RVA 0x2798
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,7 +306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3857
+					// Method begins at RVA 0x36c3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -338,26 +330,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d84
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2d50
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L45C86::__js_call__
 
 		} // end of class FunctionExpression_L45C86
@@ -373,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3860
+					// Method begins at RVA 0x36cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -397,26 +380,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2dac
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2d5f
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L46C93::__js_call__
 
 		} // end of class FunctionExpression_L46C93
@@ -436,7 +410,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x388d
+						// Method begins at RVA 0x36f9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -460,41 +434,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2e78
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x2e05
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope
-					IL_0022: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope
+					IL_0015: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L56C86::__js_call__
 
 			} // end of class FunctionExpression_L56C86
@@ -512,7 +468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3884
+					// Method begins at RVA 0x36f0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,9 +493,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2dd4
+				// Method begins at RVA 0x2d70
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope,
@@ -560,61 +516,57 @@
 				IL_0010: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L55C9::__js_call__
 
 		} // end of class FunctionExpression_L55C9
@@ -634,7 +586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x383c
+					// Method begins at RVA 0x36a8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -654,7 +606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3845
+					// Method begins at RVA 0x36b1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -674,7 +626,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x384e
+					// Method begins at RVA 0x36ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -698,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3872
+						// Method begins at RVA 0x36de
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -718,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x387b
+						// Method begins at RVA 0x36e7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -736,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3869
+					// Method begins at RVA 0x36d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -756,7 +708,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3896
+					// Method begins at RVA 0x3702
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x389f
+					// Method begins at RVA 0x370b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -798,7 +750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3833
+				// Method begins at RVA 0x369f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -825,7 +777,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x27bc
+			// Method begins at RVA 0x27a4
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -1372,7 +1324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38a8
+				// Method begins at RVA 0x3714
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1400,9 +1352,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2d0c
+			// Method begins at RVA 0x2cf4
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1410,46 +1362,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_Namespace_Esm_Basic/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_Namespace_Esm_Basic/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_Namespace_Esm_Basic/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1473,7 +1415,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3806
+			// Method begins at RVA 0x3672
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1840,7 +1782,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38c5
+				// Method begins at RVA 0x3731
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1866,9 +1808,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2ec4
+			// Method begins at RVA 0x2e28
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1879,12 +1821,8 @@
 			IL_0006: ldstr "Cannot access 'x' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "x"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L3C23::__js_call__
 
 	} // end of class FunctionExpression_L3C23
@@ -1900,7 +1838,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38ce
+				// Method begins at RVA 0x373a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1926,23 +1864,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2ef0
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x2e47
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::inc
-			IL_0006: stloc.0
-			IL_0007: ldstr "inc"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L4C25::__js_call__
 
 	} // end of class FunctionExpression_L4C25
@@ -1958,7 +1887,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38d7
+				// Method begins at RVA 0x3743
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1984,23 +1913,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2f14
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x2e4f
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::getX
-			IL_0006: stloc.0
-			IL_0007: ldstr "getX"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L5C29::__js_call__
 
 	} // end of class FunctionExpression_L5C29
@@ -2016,7 +1936,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38e0
+				// Method begins at RVA 0x374c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2042,9 +1962,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2f38
+			// Method begins at RVA 0x2e58
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2056,19 +1976,15 @@
 			IL_0006: ldstr "Cannot access 'x' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "x"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ldc.r8 1
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::x
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0011: ldloc.0
+			IL_0012: ldc.r8 1
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0020: stloc.1
+			IL_0021: ldarg.0
+			IL_0022: ldloc.1
+			IL_0023: stfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::x
+			IL_0028: ldnull
+			IL_0029: ret
 		} // end of method inc::__js_call__
 
 	} // end of class inc
@@ -2084,7 +2000,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38e9
+				// Method begins at RVA 0x3755
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2110,9 +2026,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2f7c
+			// Method begins at RVA 0x2e90
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -2123,12 +2039,8 @@
 			IL_0006: ldstr "Cannot access 'x' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "x"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method getX::__js_call__
 
 	} // end of class getX
@@ -2148,7 +2060,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38fb
+					// Method begins at RVA 0x3767
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2166,7 +2078,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38f2
+				// Method begins at RVA 0x375e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2192,9 +2104,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2fa8
+			// Method begins at RVA 0x2eb0
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/Scope/Block_L19C70,
@@ -2220,53 +2132,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/Scope/Block_L19C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/Scope/Block_L19C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -2282,7 +2186,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3904
+				// Method begins at RVA 0x3770
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2306,7 +2210,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3064
+			// Method begins at RVA 0x2f54
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2387,7 +2291,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x390d
+				// Method begins at RVA 0x3779
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2412,7 +2316,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30f4
+			// Method begins at RVA 0x2fe4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2440,7 +2344,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x393a
+					// Method begins at RVA 0x37a6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2464,26 +2368,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36c8
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x359c
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L43C86::__js_call__
 
 		} // end of class FunctionExpression_L43C86
@@ -2499,7 +2394,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3943
+					// Method begins at RVA 0x37af
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2523,26 +2418,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36f0
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x35ab
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L44C93::__js_call__
 
 		} // end of class FunctionExpression_L44C93
@@ -2562,7 +2448,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3970
+						// Method begins at RVA 0x37dc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2586,41 +2472,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x37bc
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x3651
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope
-					IL_0022: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope
+					IL_0015: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L54C86::__js_call__
 
 			} // end of class FunctionExpression_L54C86
@@ -2638,7 +2506,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3967
+					// Method begins at RVA 0x37d3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2663,9 +2531,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3718
+				// Method begins at RVA 0x35bc
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope,
@@ -2686,61 +2554,57 @@
 				IL_0010: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L53C9::__js_call__
 
 		} // end of class FunctionExpression_L53C9
@@ -2760,7 +2624,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x391f
+					// Method begins at RVA 0x378b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2780,7 +2644,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3928
+					// Method begins at RVA 0x3794
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2800,7 +2664,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3931
+					// Method begins at RVA 0x379d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2824,7 +2688,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3955
+						// Method begins at RVA 0x37c1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2844,7 +2708,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x395e
+						// Method begins at RVA 0x37ca
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2862,7 +2726,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x394c
+					// Method begins at RVA 0x37b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2882,7 +2746,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3979
+					// Method begins at RVA 0x37e5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2902,7 +2766,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3982
+					// Method begins at RVA 0x37ee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2924,7 +2788,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3916
+				// Method begins at RVA 0x3782
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2951,7 +2815,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x3100
+			// Method begins at RVA 0x2ff0
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -3498,7 +3362,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x398b
+				// Method begins at RVA 0x37f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3526,9 +3390,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x3650
+			// Method begins at RVA 0x3540
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -3536,46 +3400,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3604,7 +3458,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x38b1
+			// Method begins at RVA 0x371d
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3876,7 +3730,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3994
+		// Method begins at RVA 0x3800
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40cc
+					// Method begins at RVA 0x3ea4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40c3
+				// Method begins at RVA 0x3e9b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			)
 			// Method begins at RVA 0x26f4
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/Scope/Block_L19C70,
@@ -94,53 +94,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/Scope/Block_L19C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/Scope/Block_L19C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -156,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40d5
+				// Method begins at RVA 0x3ead
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +172,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27b0
+			// Method begins at RVA 0x2798
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -261,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40de
+				// Method begins at RVA 0x3eb6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +278,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2840
+			// Method begins at RVA 0x2828
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,7 +306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x410b
+					// Method begins at RVA 0x3ee3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -338,26 +330,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e14
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2de0
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L43C86::__js_call__
 
 		} // end of class FunctionExpression_L43C86
@@ -373,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4114
+					// Method begins at RVA 0x3eec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -397,26 +380,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e3c
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2def
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L44C93::__js_call__
 
 		} // end of class FunctionExpression_L44C93
@@ -436,7 +410,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4141
+						// Method begins at RVA 0x3f19
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -460,41 +434,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2f08
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x2e95
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope
-					IL_0022: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope
+					IL_0015: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L54C86::__js_call__
 
 			} // end of class FunctionExpression_L54C86
@@ -512,7 +468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4138
+					// Method begins at RVA 0x3f10
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,9 +493,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e64
+				// Method begins at RVA 0x2e00
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope,
@@ -560,61 +516,57 @@
 				IL_0010: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L53C9::__js_call__
 
 		} // end of class FunctionExpression_L53C9
@@ -634,7 +586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40f0
+					// Method begins at RVA 0x3ec8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -654,7 +606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40f9
+					// Method begins at RVA 0x3ed1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -674,7 +626,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4102
+					// Method begins at RVA 0x3eda
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -698,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4126
+						// Method begins at RVA 0x3efe
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -718,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x412f
+						// Method begins at RVA 0x3f07
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -736,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x411d
+					// Method begins at RVA 0x3ef5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -756,7 +708,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x414a
+					// Method begins at RVA 0x3f22
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4153
+					// Method begins at RVA 0x3f2b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -798,7 +750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40e7
+				// Method begins at RVA 0x3ebf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -825,7 +777,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x284c
+			// Method begins at RVA 0x2834
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -1372,7 +1324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x415c
+				// Method begins at RVA 0x3f34
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1400,9 +1352,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2d9c
+			// Method begins at RVA 0x2d84
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1410,46 +1362,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1473,7 +1415,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x40ba
+			// Method begins at RVA 0x3e92
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1823,7 +1765,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x416e
+				// Method begins at RVA 0x3f46
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1849,23 +1791,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x2f54
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x2eb6
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::ns
-			IL_0006: stloc.0
-			IL_0007: ldstr "ns"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L10C24::__js_call__
 
 	} // end of class FunctionExpression_L10C24
@@ -1885,7 +1818,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4180
+					// Method begins at RVA 0x3f58
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1903,7 +1836,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4177
+				// Method begins at RVA 0x3f4f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1929,9 +1862,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x2f78
+			// Method begins at RVA 0x2ec0
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/Scope/Block_L14C70,
@@ -1957,53 +1890,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/Scope/Block_L14C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/Scope/Block_L14C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -2019,7 +1944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4189
+				// Method begins at RVA 0x3f61
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2043,7 +1968,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3034
+			// Method begins at RVA 0x2f64
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2124,7 +2049,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4192
+				// Method begins at RVA 0x3f6a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2149,7 +2074,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30c4
+			// Method begins at RVA 0x2ff4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2177,7 +2102,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41bf
+					// Method begins at RVA 0x3f97
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2201,26 +2126,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3698
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x35ac
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L38C86::__js_call__
 
 		} // end of class FunctionExpression_L38C86
@@ -2236,7 +2152,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41c8
+					// Method begins at RVA 0x3fa0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2260,26 +2176,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36c0
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x35bb
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L39C93::__js_call__
 
 		} // end of class FunctionExpression_L39C93
@@ -2299,7 +2206,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x41f5
+						// Method begins at RVA 0x3fcd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2323,41 +2230,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x378c
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x3661
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
-					IL_0022: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
+					IL_0015: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L49C86::__js_call__
 
 			} // end of class FunctionExpression_L49C86
@@ -2375,7 +2264,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41ec
+					// Method begins at RVA 0x3fc4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2400,9 +2289,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36e8
+				// Method begins at RVA 0x35cc
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope,
@@ -2423,61 +2312,57 @@
 				IL_0010: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L48C9::__js_call__
 
 		} // end of class FunctionExpression_L48C9
@@ -2497,7 +2382,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41a4
+					// Method begins at RVA 0x3f7c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2517,7 +2402,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41ad
+					// Method begins at RVA 0x3f85
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2537,7 +2422,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41b6
+					// Method begins at RVA 0x3f8e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2561,7 +2446,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x41da
+						// Method begins at RVA 0x3fb2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2581,7 +2466,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x41e3
+						// Method begins at RVA 0x3fbb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2599,7 +2484,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41d1
+					// Method begins at RVA 0x3fa9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2619,7 +2504,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41fe
+					// Method begins at RVA 0x3fd6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2639,7 +2524,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4207
+					// Method begins at RVA 0x3fdf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2661,7 +2546,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x419b
+				// Method begins at RVA 0x3f73
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2688,7 +2573,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x30d0
+			// Method begins at RVA 0x3000
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -3235,7 +3120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4210
+				// Method begins at RVA 0x3fe8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3263,9 +3148,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x3620
+			// Method begins at RVA 0x3550
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -3273,46 +3158,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3338,7 +3213,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4165
+			// Method begins at RVA 0x3f3d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3532,7 +3407,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4222
+				// Method begins at RVA 0x3ffa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3558,46 +3433,33 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4b 00 00 02
 			)
-			// Method begins at RVA 0x37d8
+			// Method begins at RVA 0x3684
 			// Header size: 12
-			// Code size: 82 (0x52)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] object
+				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_Namespace_FromCjs_Stable_Lib/Scope::exports
 			IL_0006: stloc.0
-			IL_0007: ldstr "exports"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldarg.0
-			IL_0014: ldfld object Modules.Import_Namespace_FromCjs_Stable_Lib/Scope::exports
-			IL_0019: stloc.1
-			IL_001a: ldstr "exports"
-			IL_001f: ldloc.1
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.Import_Namespace_FromCjs_Stable_Lib/Scope::exports
+			IL_000d: ldstr "x"
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0017: ldc.r8 1
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
 			IL_0025: stloc.1
-			IL_0026: ldloc.1
+			IL_0026: ldloc.0
 			IL_0027: ldstr "x"
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0031: stloc.1
-			IL_0032: ldloc.1
-			IL_0033: ldc.r8 1
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0041: stloc.2
-			IL_0042: ldloc.0
-			IL_0043: ldstr "x"
-			IL_0048: ldloc.2
-			IL_0049: ldc.i4.1
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_004f: pop
-			IL_0050: ldnull
-			IL_0051: ret
+			IL_002c: ldloc.1
+			IL_002d: ldc.i4.1
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0033: pop
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L4C14::__js_call__
 
 	} // end of class FunctionExpression_L4C14
@@ -3616,7 +3478,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4219
+			// Method begins at RVA 0x3ff1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3706,7 +3568,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4234
+				// Method begins at RVA 0x400c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3732,23 +3594,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3838
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x36c6
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::ns
-			IL_0006: stloc.0
-			IL_0007: ldstr "ns"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L10C24::__js_call__
 
 	} // end of class FunctionExpression_L10C24
@@ -3768,7 +3621,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4246
+					// Method begins at RVA 0x401e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3786,7 +3639,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x423d
+				// Method begins at RVA 0x4015
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3812,9 +3665,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x385c
+			// Method begins at RVA 0x36d0
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/Scope/Block_L14C70,
@@ -3840,53 +3693,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/Scope/Block_L14C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/Scope/Block_L14C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -3902,7 +3747,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x424f
+				// Method begins at RVA 0x4027
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3926,7 +3771,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3918
+			// Method begins at RVA 0x3774
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -4007,7 +3852,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4258
+				// Method begins at RVA 0x4030
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4032,7 +3877,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x39a8
+			// Method begins at RVA 0x3804
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4060,7 +3905,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4285
+					// Method begins at RVA 0x405d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4084,26 +3929,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3f7c
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x3dbc
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L38C86::__js_call__
 
 		} // end of class FunctionExpression_L38C86
@@ -4119,7 +3955,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x428e
+					// Method begins at RVA 0x4066
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4143,26 +3979,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3fa4
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x3dcb
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L39C93::__js_call__
 
 		} // end of class FunctionExpression_L39C93
@@ -4182,7 +4009,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x42bb
+						// Method begins at RVA 0x4093
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4206,41 +4033,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x4070
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x3e71
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
-					IL_0022: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
+					IL_0015: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L49C86::__js_call__
 
 			} // end of class FunctionExpression_L49C86
@@ -4258,7 +4067,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42b2
+					// Method begins at RVA 0x408a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4283,9 +4092,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3fcc
+				// Method begins at RVA 0x3ddc
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope,
@@ -4306,61 +4115,57 @@
 				IL_0010: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L48C9::__js_call__
 
 		} // end of class FunctionExpression_L48C9
@@ -4380,7 +4185,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x426a
+					// Method begins at RVA 0x4042
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4400,7 +4205,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4273
+					// Method begins at RVA 0x404b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4420,7 +4225,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x427c
+					// Method begins at RVA 0x4054
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4444,7 +4249,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x42a0
+						// Method begins at RVA 0x4078
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4464,7 +4269,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x42a9
+						// Method begins at RVA 0x4081
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4482,7 +4287,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4297
+					// Method begins at RVA 0x406f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4502,7 +4307,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42c4
+					// Method begins at RVA 0x409c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4522,7 +4327,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42cd
+					// Method begins at RVA 0x40a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4544,7 +4349,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4261
+				// Method begins at RVA 0x4039
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4571,7 +4376,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x39b4
+			// Method begins at RVA 0x3810
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -5118,7 +4923,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x42d6
+				// Method begins at RVA 0x40ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5146,9 +4951,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3f04
+			// Method begins at RVA 0x3d60
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -5156,46 +4961,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -5221,7 +5016,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x422b
+			// Method begins at RVA 0x4003
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5407,7 +5202,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x42df
+		// Method begins at RVA 0x40b7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2c16
+			// Method begins at RVA 0x2b36
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -128,7 +128,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c33
+				// Method begins at RVA 0x2b53
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -156,7 +156,7 @@
 			)
 			// Method begins at RVA 0x232c
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -167,12 +167,8 @@
 			IL_0006: ldstr "Cannot access 'named' before initialization"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0010: stloc.0
-			IL_0011: ldstr "named"
-			IL_0016: ldloc.0
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001c: stloc.0
-			IL_001d: ldloc.0
-			IL_001e: ret
+			IL_0011: ldloc.0
+			IL_0012: ret
 		} // end of method FunctionExpression_L3C27::__js_call__
 
 	} // end of class FunctionExpression_L3C27
@@ -188,7 +184,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c3c
+				// Method begins at RVA 0x2b5c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -214,23 +210,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2358
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x234b
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::sum
-			IL_0006: stloc.0
-			IL_0007: ldstr "sum"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L4C25::__js_call__
 
 	} // end of class FunctionExpression_L4C25
@@ -246,7 +233,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c45
+				// Method begins at RVA 0x2b65
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -271,7 +258,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x237c
+			// Method begins at RVA 0x2354
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -300,7 +287,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c4e
+				// Method begins at RVA 0x2b6e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -326,23 +313,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2394
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x236a
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld string Modules.Import_RequireEsmModule_Lib/Scope::__jroc_esm_default_0
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_default_0"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_L15C29::__js_call__
 
 	} // end of class FunctionExpression_L15C29
@@ -362,7 +340,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c60
+					// Method begins at RVA 0x2b80
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -380,7 +358,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c57
+				// Method begins at RVA 0x2b77
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -406,9 +384,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x23b8
+			// Method begins at RVA 0x2374
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/Scope/Block_L19C70,
@@ -434,53 +412,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/Scope/Block_L19C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/Scope/Block_L19C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -496,7 +466,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c69
+				// Method begins at RVA 0x2b89
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -520,7 +490,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2474
+			// Method begins at RVA 0x2418
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -601,7 +571,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c72
+				// Method begins at RVA 0x2b92
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -626,7 +596,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2504
+			// Method begins at RVA 0x24a8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -654,7 +624,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c9f
+					// Method begins at RVA 0x2bbf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -678,26 +648,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ad8
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2a60
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L43C86::__js_call__
 
 		} // end of class FunctionExpression_L43C86
@@ -713,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ca8
+					// Method begins at RVA 0x2bc8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -737,26 +698,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b00
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2a6f
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L44C93::__js_call__
 
 		} // end of class FunctionExpression_L44C93
@@ -776,7 +728,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2cd5
+						// Method begins at RVA 0x2bf5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -800,41 +752,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2bcc
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x2b15
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope
-					IL_0022: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope
+					IL_0015: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L54C86::__js_call__
 
 			} // end of class FunctionExpression_L54C86
@@ -852,7 +786,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ccc
+					// Method begins at RVA 0x2bec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -877,9 +811,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b28
+				// Method begins at RVA 0x2a80
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope,
@@ -900,61 +834,57 @@
 				IL_0010: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L53C9::__js_call__
 
 		} // end of class FunctionExpression_L53C9
@@ -974,7 +904,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c84
+					// Method begins at RVA 0x2ba4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -994,7 +924,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c8d
+					// Method begins at RVA 0x2bad
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1014,7 +944,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c96
+					// Method begins at RVA 0x2bb6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1038,7 +968,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2cba
+						// Method begins at RVA 0x2bda
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1058,7 +988,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2cc3
+						// Method begins at RVA 0x2be3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1076,7 +1006,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2cb1
+					// Method begins at RVA 0x2bd1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1096,7 +1026,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2cde
+					// Method begins at RVA 0x2bfe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1116,7 +1046,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ce7
+					// Method begins at RVA 0x2c07
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1138,7 +1068,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c7b
+				// Method begins at RVA 0x2b9b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1165,7 +1095,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2510
+			// Method begins at RVA 0x24b4
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -1712,7 +1642,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2cf0
+				// Method begins at RVA 0x2c10
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1740,9 +1670,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2a60
+			// Method begins at RVA 0x2a04
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1750,46 +1680,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1818,7 +1738,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2c1f
+			// Method begins at RVA 0x2b3f
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2064,7 +1984,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2cf9
+		// Method begins at RVA 0x2c19
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b24
+					// Method begins at RVA 0x2a88
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b1b
+				// Method begins at RVA 0x2a7f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,7 +68,7 @@
 			)
 			// Method begins at RVA 0x22b4
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/Scope/Block_L18C70,
@@ -94,53 +94,45 @@
 			IL_002a: ldarg.0
 			IL_002b: ldfld object Modules.Import_StaticImport_FromCjs/Scope::exports
 			IL_0030: stloc.2
-			IL_0031: ldstr "exports"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.1
-			IL_003e: ldstr "call"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "call"
+			IL_0037: ldloc.2
+			IL_0038: ldstr "__esModule"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0042: stloc.2
 			IL_0043: ldloc.2
-			IL_0044: ldstr "__esModule"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0055: ldc.i4.0
-			IL_0056: ceq
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: brfalse IL_00ad
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: brfalse IL_0095
 
-			IL_005f: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/Scope/Block_L18C70::.ctor()
-			IL_0064: stloc.0
-			IL_0065: ldarg.0
-			IL_0066: ldfld object Modules.Import_StaticImport_FromCjs/Scope::exports
-			IL_006b: stloc.2
-			IL_006c: ldstr "exports"
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.2
-			IL_0078: ldloc.2
-			IL_0079: ldstr "__esModule"
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0053: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/Scope/Block_L18C70::.ctor()
+			IL_0058: stloc.0
+			IL_0059: ldarg.0
+			IL_005a: ldfld object Modules.Import_StaticImport_FromCjs/Scope::exports
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: ldstr "__esModule"
+			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006b: dup
+			IL_006c: ldstr "value"
+			IL_0071: ldc.i4.1
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0077: dup
+			IL_0078: ldstr "enumerable"
+			IL_007d: ldc.i4.0
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0083: dup
-			IL_0084: ldstr "value"
+			IL_0084: ldstr "configurable"
 			IL_0089: ldc.i4.1
 			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008f: dup
-			IL_0090: ldstr "enumerable"
-			IL_0095: ldc.i4.0
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: dup
-			IL_009c: ldstr "configurable"
-			IL_00a1: ldc.i4.1
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_00ac: pop
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0094: pop
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method __jroc_esm_mark::__js_call__
 
 	} // end of class __jroc_esm_mark
@@ -156,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b2d
+				// Method begins at RVA 0x2a91
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +172,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2370
+			// Method begins at RVA 0x2358
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -261,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b36
+				// Method begins at RVA 0x2a9a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +278,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2400
+			// Method begins at RVA 0x23e8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,7 +306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b63
+					// Method begins at RVA 0x2ac7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -338,26 +330,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x29d4
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x29a0
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L42C86::__js_call__
 
 		} // end of class FunctionExpression_L42C86
@@ -373,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b6c
+					// Method begins at RVA 0x2ad0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -397,26 +380,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x29fc
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x29af
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope
 				IL_0008: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::mod
-				IL_000d: stloc.0
-				IL_000e: ldstr "mod"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L43C93::__js_call__
 
 		} // end of class FunctionExpression_L43C93
@@ -436,7 +410,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b99
+						// Method begins at RVA 0x2afd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -460,41 +434,23 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2ac8
-					// Header size: 12
-					// Code size: 62 (0x3e)
+					// Method begins at RVA 0x2a55
+					// Header size: 1
+					// Code size: 32 (0x20)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope
 					IL_0008: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::mod
-					IL_000d: stloc.0
-					IL_000e: ldstr "mod"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldarg.0
-					IL_001b: ldc.i4.2
-					IL_001c: ldelem.ref
-					IL_001d: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope
-					IL_0022: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope::k
-					IL_0027: stloc.1
-					IL_0028: ldstr "k"
-					IL_002d: ldloc.1
-					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0033: stloc.1
-					IL_0034: ldloc.0
-					IL_0035: ldloc.1
-					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_003b: stloc.1
-					IL_003c: ldloc.1
-					IL_003d: ret
+					IL_000d: ldarg.0
+					IL_000e: ldc.i4.2
+					IL_000f: ldelem.ref
+					IL_0010: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope
+					IL_0015: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope::k
+					IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_001f: ret
 				} // end of method FunctionExpression_L53C86::__js_call__
 
 			} // end of class FunctionExpression_L53C86
@@ -512,7 +468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b90
+					// Method begins at RVA 0x2af4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,9 +493,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a24
+				// Method begins at RVA 0x29c0
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 137 (0x89)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope,
@@ -560,61 +516,57 @@
 				IL_0010: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope
 				IL_0015: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::ns
 				IL_001a: stloc.1
-				IL_001b: ldstr "ns"
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0026: stloc.1
-				IL_0027: ldloc.0
-				IL_0028: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope::k
-				IL_002d: stloc.2
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
+				IL_001b: ldloc.0
+				IL_001c: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope::k
+				IL_0021: stloc.2
+				IL_0022: ldc.i4.3
+				IL_0023: newarr [System.Runtime]System.Object
+				IL_0028: dup
+				IL_0029: ldc.i4.0
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: stelem.ref
+				IL_002e: dup
+				IL_002f: ldc.i4.1
+				IL_0030: ldarg.0
+				IL_0031: ldc.i4.1
+				IL_0032: ldelem.ref
+				IL_0033: stelem.ref
 				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: ldftn object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86::__js_call__(object[], object)
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_004f: ldc.i4.0
-				IL_0050: conv.r8
-				IL_0051: ldstr ""
-				IL_0056: ldc.i4.0
-				IL_0057: ldc.i4.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_005d: stloc.3
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0035: ldc.i4.2
+				IL_0036: ldloc.0
+				IL_0037: stelem.ref
+				IL_0038: ldftn object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86::__js_call__(object[], object)
+				IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0043: ldc.i4.0
+				IL_0044: conv.r8
+				IL_0045: ldstr ""
+				IL_004a: ldc.i4.0
+				IL_004b: ldc.i4.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0051: stloc.3
+				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0057: dup
+				IL_0058: ldstr "enumerable"
+				IL_005d: ldc.i4.1
+				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_0063: dup
-				IL_0064: ldstr "enumerable"
+				IL_0064: ldstr "configurable"
 				IL_0069: ldc.i4.1
 				IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_006f: dup
-				IL_0070: ldstr "configurable"
-				IL_0075: ldc.i4.1
-				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007b: dup
-				IL_007c: ldstr "get"
-				IL_0081: ldloc.3
-				IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0087: stloc.s 4
-				IL_0089: ldloc.1
-				IL_008a: ldloc.2
-				IL_008b: ldloc.s 4
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-				IL_0092: pop
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0070: ldstr "get"
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.1
+				IL_007e: ldloc.2
+				IL_007f: ldloc.s 4
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+				IL_0086: pop
+				IL_0087: ldnull
+				IL_0088: ret
 			} // end of method FunctionExpression_L52C9::__js_call__
 
 		} // end of class FunctionExpression_L52C9
@@ -634,7 +586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b48
+					// Method begins at RVA 0x2aac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -654,7 +606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b51
+					// Method begins at RVA 0x2ab5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -674,7 +626,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b5a
+					// Method begins at RVA 0x2abe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -698,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b7e
+						// Method begins at RVA 0x2ae2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -718,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b87
+						// Method begins at RVA 0x2aeb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -736,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b75
+					// Method begins at RVA 0x2ad9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -756,7 +708,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ba2
+					// Method begins at RVA 0x2b06
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bab
+					// Method begins at RVA 0x2b0f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -798,7 +750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b3f
+				// Method begins at RVA 0x2aa3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -825,7 +777,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x240c
+			// Method begins at RVA 0x23f4
 			// Header size: 12
 			// Code size: 1329 (0x531)
 			.maxstack 8
@@ -1372,7 +1324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bb4
+				// Method begins at RVA 0x2b18
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1400,9 +1352,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x295c
+			// Method begins at RVA 0x2944
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1410,46 +1362,36 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_StaticImport_FromCjs/Scope::__jroc_esm_mark
-			IL_0006: stloc.0
-			IL_0007: ldstr "__jroc_esm_mark"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: pop
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Import_StaticImport_FromCjs/Scope::exports
-			IL_002a: stloc.0
-			IL_002b: ldstr "exports"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: ldarg.2
-			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003e: dup
-			IL_003f: ldstr "enumerable"
-			IL_0044: ldc.i4.1
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004a: dup
-			IL_004b: ldstr "configurable"
-			IL_0050: ldc.i4.1
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0056: dup
-			IL_0057: ldstr "get"
-			IL_005c: ldarg.3
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_StaticImport_FromCjs/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1473,7 +1415,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b12
+			// Method begins at RVA 0x2a76
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1716,7 +1658,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2bbd
+			// Method begins at RVA 0x2b21
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1775,7 +1717,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2bc6
+		// Method begins at RVA 0x2b2a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x298e
+				// Method begins at RVA 0x27c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2997
+				// Method begins at RVA 0x27cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29a9
+					// Method begins at RVA 0x27dd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29a0
+				// Method begins at RVA 0x27d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29bb
+					// Method begins at RVA 0x27ef
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29b2
+				// Method begins at RVA 0x27e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -275,7 +275,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29c4
+				// Method begins at RVA 0x27f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -299,7 +299,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29d6
+					// Method begins at RVA 0x280a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -317,7 +317,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29cd
+				// Method begins at RVA 0x2801
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -345,16 +345,12 @@
 			)
 			// Method begins at RVA 0x247c
 			// Header size: 12
-			// Code size: 162 (0xa2)
+			// Code size: 92 (0x5c)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/Scope_For_L16C9/Block_L16C37,
-				[2] float64,
-				[3] object,
-				[4] float64,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[6] object
+				[2] float64
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -362,58 +358,36 @@
 			// loop start (head: IL_000a)
 				IL_000a: ldloc.0
 				IL_000b: stloc.2
-				IL_000c: ldstr "i"
-				IL_0011: ldarg.0
-				IL_0012: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0017: box [System.Runtime]System.Double
-				IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0021: stloc.3
-				IL_0022: ldloc.3
-				IL_0023: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0028: stloc.s 4
-				IL_002a: ldloc.s 4
-				IL_002c: ldc.r8 15
-				IL_0035: mul
-				IL_0036: stloc.s 4
-				IL_0038: ldloc.2
-				IL_0039: ldloc.s 4
-				IL_003b: clt
-				IL_003d: brfalse IL_00a0
+				IL_000c: ldloc.2
+				IL_000d: ldarg.0
+				IL_000e: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_0013: ldc.r8 15
+				IL_001c: mul
+				IL_001d: clt
+				IL_001f: brfalse IL_005a
 
-				IL_0042: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/Scope_For_L16C9/Block_L16C37::.ctor()
-				IL_0047: stloc.1
-				IL_0048: ldarg.0
-				IL_0049: ldc.i4.0
-				IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_004f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0054: ldarg.0
-				IL_0055: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_005a: stloc.s 5
-				IL_005c: ldstr "ret"
-				IL_0061: ldloc.s 5
-				IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0068: stloc.3
-				IL_0069: ldstr "i"
-				IL_006e: ldarg.0
-				IL_006f: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0074: box [System.Runtime]System.Double
-				IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_007e: stloc.s 6
-				IL_0080: ldloc.3
-				IL_0081: ldstr "length"
-				IL_0086: ldloc.s 6
-				IL_0088: ldc.i4.1
-				IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_008e: pop
-				IL_008f: ldloc.0
-				IL_0090: ldc.r8 1
-				IL_0099: add
-				IL_009a: stloc.0
-				IL_009b: br IL_000a
+				IL_0024: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/Scope_For_L16C9/Block_L16C37::.ctor()
+				IL_0029: stloc.1
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_0031: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_0036: ldarg.0
+				IL_0037: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_003c: stloc.2
+				IL_003d: ldarg.0
+				IL_003e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_0043: ldloc.2
+				IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::set_length(float64)
+				IL_0049: ldloc.0
+				IL_004a: ldc.r8 1
+				IL_0053: add
+				IL_0054: stloc.0
+				IL_0055: br IL_000a
 			// end loop
 
-			IL_00a0: ldnull
-			IL_00a1: ret
+			IL_005a: ldnull
+			IL_005b: ret
 		} // end of method ArrowFunction_L15C32::__js_call__
 
 	} // end of class ArrowFunction_L15C32
@@ -429,7 +403,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29df
+				// Method begins at RVA 0x2813
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -449,7 +423,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29e8
+				// Method begins at RVA 0x281c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -475,15 +449,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x252c
+			// Method begins at RVA 0x24e4
 			// Header size: 12
-			// Code size: 131 (0x83)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
-				[3] float64
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -491,51 +464,37 @@
 			// loop start (head: IL_000a)
 				IL_000a: ldloc.0
 				IL_000b: stloc.1
-				IL_000c: ldstr "i"
-				IL_0011: ldarg.0
-				IL_0012: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0017: box [System.Runtime]System.Double
-				IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0021: stloc.2
-				IL_0022: ldloc.2
-				IL_0023: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0028: stloc.3
-				IL_0029: ldloc.3
-				IL_002a: ldc.r8 10
-				IL_0033: mul
-				IL_0034: stloc.3
-				IL_0035: ldloc.1
-				IL_0036: ldloc.3
-				IL_0037: clt
-				IL_0039: brfalse IL_0081
+				IL_000c: ldloc.1
+				IL_000d: ldarg.0
+				IL_000e: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_0013: ldc.r8 10
+				IL_001c: mul
+				IL_001d: clt
+				IL_001f: brfalse IL_005b
 
-				IL_003e: ldstr "i"
-				IL_0043: ldarg.0
-				IL_0044: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0049: box [System.Runtime]System.Double
-				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0053: stloc.2
-				IL_0054: ldc.i4.1
-				IL_0055: newarr [System.Runtime]System.Object
-				IL_005a: dup
-				IL_005b: ldc.i4.0
-				IL_005c: ldloc.2
-				IL_005d: stelem.ref
-				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::Construct(object[])
-				IL_0063: stloc.2
-				IL_0064: ldarg.0
-				IL_0065: ldloc.2
-				IL_0066: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_006b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0070: ldloc.0
-				IL_0071: ldc.r8 1
-				IL_007a: add
-				IL_007b: stloc.0
-				IL_007c: br IL_000a
+				IL_0024: ldc.i4.1
+				IL_0025: newarr [System.Runtime]System.Object
+				IL_002a: dup
+				IL_002b: ldc.i4.0
+				IL_002c: ldarg.0
+				IL_002d: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_0032: box [System.Runtime]System.Double
+				IL_0037: stelem.ref
+				IL_0038: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::Construct(object[])
+				IL_003d: stloc.2
+				IL_003e: ldarg.0
+				IL_003f: ldloc.2
+				IL_0040: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0045: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_004a: ldloc.0
+				IL_004b: ldc.r8 1
+				IL_0054: add
+				IL_0055: stloc.0
+				IL_0056: br IL_000a
 			// end loop
 
-			IL_0081: ldnull
-			IL_0082: ret
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method ArrowFunction_L22C41::__js_call__
 
 	} // end of class ArrowFunction_L22C41
@@ -551,7 +510,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29f1
+				// Method begins at RVA 0x2825
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -571,7 +530,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29fa
+				// Method begins at RVA 0x282e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -597,17 +556,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x25bc
+			// Method begins at RVA 0x2550
 			// Header size: 12
-			// Code size: 131 (0x83)
+			// Code size: 79 (0x4f)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
-				[3] float64,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[5] object
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -619,47 +576,31 @@
 			// loop start (head: IL_0016)
 				IL_0016: ldloc.0
 				IL_0017: stloc.1
-				IL_0018: ldstr "i"
-				IL_001d: ldarg.0
-				IL_001e: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0023: box [System.Runtime]System.Double
-				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002d: stloc.2
-				IL_002e: ldloc.2
-				IL_002f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0034: stloc.3
-				IL_0035: ldloc.1
-				IL_0036: ldloc.3
-				IL_0037: clt
-				IL_0039: brfalse IL_0081
+				IL_0018: ldloc.1
+				IL_0019: ldarg.0
+				IL_001a: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_001f: clt
+				IL_0021: brfalse IL_004d
 
-				IL_003e: ldarg.0
-				IL_003f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0044: stloc.s 4
-				IL_0046: ldstr "ret"
-				IL_004b: ldloc.s 4
-				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0052: stloc.2
-				IL_0053: ldloc.2
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0059: stloc.2
-				IL_005a: ldloc.0
-				IL_005b: box [System.Runtime]System.Double
-				IL_0060: stloc.s 5
-				IL_0062: ldloc.2
-				IL_0063: ldstr "unshift"
-				IL_0068: ldloc.s 5
-				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_006f: pop
-				IL_0070: ldloc.0
-				IL_0071: ldc.r8 1
-				IL_007a: add
-				IL_007b: stloc.0
-				IL_007c: br IL_0016
+				IL_0026: ldarg.0
+				IL_0027: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_002c: stloc.2
+				IL_002d: ldloc.0
+				IL_002e: box [System.Runtime]System.Double
+				IL_0033: stloc.3
+				IL_0034: ldloc.2
+				IL_0035: ldloc.3
+				IL_0036: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::unshift(object)
+				IL_003b: pop
+				IL_003c: ldloc.0
+				IL_003d: ldc.r8 1
+				IL_0046: add
+				IL_0047: stloc.0
+				IL_0048: br IL_0016
 			// end loop
 
-			IL_0081: ldnull
-			IL_0082: ret
+			IL_004d: ldnull
+			IL_004e: ret
 		} // end of method ArrowFunction_L27C37::__js_call__
 
 	} // end of class ArrowFunction_L27C37
@@ -675,7 +616,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a03
+				// Method begins at RVA 0x2837
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -695,7 +636,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a0c
+				// Method begins at RVA 0x2840
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -721,17 +662,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x264c
+			// Method begins at RVA 0x25ac
 			// Header size: 12
-			// Code size: 159 (0x9f)
+			// Code size: 107 (0x6b)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
-				[3] float64,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[5] object
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -743,51 +682,35 @@
 			// loop start (head: IL_0016)
 				IL_0016: ldloc.0
 				IL_0017: stloc.1
-				IL_0018: ldstr "i"
-				IL_001d: ldarg.0
-				IL_001e: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0023: box [System.Runtime]System.Double
-				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002d: stloc.2
-				IL_002e: ldloc.2
-				IL_002f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0034: stloc.3
-				IL_0035: ldloc.1
-				IL_0036: ldloc.3
-				IL_0037: clt
-				IL_0039: brfalse IL_009d
+				IL_0018: ldloc.1
+				IL_0019: ldarg.0
+				IL_001a: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_001f: clt
+				IL_0021: brfalse IL_0069
 
-				IL_003e: ldarg.0
-				IL_003f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0044: stloc.s 4
-				IL_0046: ldstr "ret"
-				IL_004b: ldloc.s 4
-				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0052: stloc.2
-				IL_0053: ldloc.2
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0059: stloc.2
-				IL_005a: ldloc.0
-				IL_005b: box [System.Runtime]System.Double
-				IL_0060: stloc.s 5
-				IL_0062: ldloc.2
-				IL_0063: ldstr "splice"
-				IL_0068: ldc.r8 0.0
-				IL_0071: box [System.Runtime]System.Double
-				IL_0076: ldc.r8 0.0
-				IL_007f: box [System.Runtime]System.Double
-				IL_0084: ldloc.s 5
-				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_008b: pop
-				IL_008c: ldloc.0
-				IL_008d: ldc.r8 1
-				IL_0096: add
-				IL_0097: stloc.0
-				IL_0098: br IL_0016
+				IL_0026: ldarg.0
+				IL_0027: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_002c: stloc.2
+				IL_002d: ldloc.0
+				IL_002e: box [System.Runtime]System.Double
+				IL_0033: stloc.3
+				IL_0034: ldloc.2
+				IL_0035: ldc.r8 0.0
+				IL_003e: box [System.Runtime]System.Double
+				IL_0043: ldc.r8 0.0
+				IL_004c: box [System.Runtime]System.Double
+				IL_0051: ldloc.3
+				IL_0052: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object, object)
+				IL_0057: pop
+				IL_0058: ldloc.0
+				IL_0059: ldc.r8 1
+				IL_0062: add
+				IL_0063: stloc.0
+				IL_0064: br IL_0016
 			// end loop
 
-			IL_009d: ldnull
-			IL_009e: ret
+			IL_0069: ldnull
+			IL_006a: ret
 		} // end of method ArrowFunction_L33C36::__js_call__
 
 	} // end of class ArrowFunction_L33C36
@@ -803,7 +726,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a15
+				// Method begins at RVA 0x2849
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -823,7 +746,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a1e
+				// Method begins at RVA 0x2852
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -849,73 +772,50 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x26f8
+			// Method begins at RVA 0x2624
 			// Header size: 12
-			// Code size: 139 (0x8b)
+			// Code size: 75 (0x4b)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] float64,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[3] object,
-				[4] float64,
-				[5] float64
+				[3] float64,
+				[4] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-			IL_0006: stloc.2
-			IL_0007: ldstr "ret"
+			IL_0006: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_000b: stloc.2
 			IL_000c: ldloc.2
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.3
-			IL_0013: ldloc.3
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.3
-			IL_001a: ldloc.3
-			IL_001b: ldstr "slice"
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0025: stloc.3
-			IL_0026: ldloc.3
-			IL_0027: stloc.0
-			IL_0028: ldc.r8 0.0
-			IL_0031: stloc.1
-			// loop start (head: IL_0032)
-				IL_0032: ldloc.1
-				IL_0033: stloc.s 4
-				IL_0035: ldstr "i"
-				IL_003a: ldarg.0
-				IL_003b: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0040: box [System.Runtime]System.Double
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_004a: stloc.3
-				IL_004b: ldloc.3
-				IL_004c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0051: stloc.s 5
-				IL_0053: ldloc.s 4
-				IL_0055: ldloc.s 5
-				IL_0057: clt
-				IL_0059: brfalse IL_0089
+			IL_000d: stloc.0
+			IL_000e: ldc.r8 0.0
+			IL_0017: stloc.1
+			// loop start (head: IL_0018)
+				IL_0018: ldloc.1
+				IL_0019: stloc.3
+				IL_001a: ldloc.3
+				IL_001b: ldarg.0
+				IL_001c: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_0021: clt
+				IL_0023: brfalse IL_0049
 
-				IL_005e: ldloc.0
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0064: stloc.3
-				IL_0065: ldloc.3
-				IL_0066: ldstr "shift"
-				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0070: stloc.3
-				IL_0071: ldarg.0
-				IL_0072: ldloc.3
-				IL_0073: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
-				IL_0078: ldloc.1
-				IL_0079: ldc.r8 1
-				IL_0082: add
-				IL_0083: stloc.1
-				IL_0084: br IL_0032
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::shift()
+				IL_002e: stloc.s 4
+				IL_0030: ldarg.0
+				IL_0031: ldloc.s 4
+				IL_0033: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
+				IL_0038: ldloc.1
+				IL_0039: ldc.r8 1
+				IL_0042: add
+				IL_0043: stloc.1
+				IL_0044: br IL_0018
 			// end loop
 
-			IL_0089: ldnull
-			IL_008a: ret
+			IL_0049: ldnull
+			IL_004a: ret
 		} // end of method ArrowFunction_L39C37::__js_call__
 
 	} // end of class ArrowFunction_L39C37
@@ -931,7 +831,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a27
+				// Method begins at RVA 0x285b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -951,7 +851,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a30
+				// Method begins at RVA 0x2864
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -977,77 +877,53 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2790
+			// Method begins at RVA 0x267c
 			// Header size: 12
-			// Code size: 167 (0xa7)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] float64,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[3] object,
-				[4] float64,
-				[5] float64
+				[3] float64
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-			IL_0006: stloc.2
-			IL_0007: ldstr "ret"
+			IL_0006: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_000b: stloc.2
 			IL_000c: ldloc.2
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.3
-			IL_0013: ldloc.3
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.3
-			IL_001a: ldloc.3
-			IL_001b: ldstr "slice"
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0025: stloc.3
-			IL_0026: ldloc.3
-			IL_0027: stloc.0
-			IL_0028: ldc.r8 0.0
-			IL_0031: stloc.1
-			// loop start (head: IL_0032)
-				IL_0032: ldloc.1
-				IL_0033: stloc.s 4
-				IL_0035: ldstr "i"
-				IL_003a: ldarg.0
-				IL_003b: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0040: box [System.Runtime]System.Double
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_004a: stloc.3
-				IL_004b: ldloc.3
-				IL_004c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0051: stloc.s 5
-				IL_0053: ldloc.s 4
-				IL_0055: ldloc.s 5
-				IL_0057: clt
-				IL_0059: brfalse IL_00a5
+			IL_000d: stloc.0
+			IL_000e: ldc.r8 0.0
+			IL_0017: stloc.1
+			// loop start (head: IL_0018)
+				IL_0018: ldloc.1
+				IL_0019: stloc.3
+				IL_001a: ldloc.3
+				IL_001b: ldarg.0
+				IL_001c: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_0021: clt
+				IL_0023: brfalse IL_0063
 
-				IL_005e: ldloc.0
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0064: stloc.3
-				IL_0065: ldloc.3
-				IL_0066: ldstr "splice"
-				IL_006b: ldc.r8 0.0
-				IL_0074: box [System.Runtime]System.Double
-				IL_0079: ldc.r8 1
-				IL_0082: box [System.Runtime]System.Double
-				IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_008c: stloc.3
-				IL_008d: ldarg.0
-				IL_008e: ldloc.3
-				IL_008f: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
-				IL_0094: ldloc.1
-				IL_0095: ldc.r8 1
-				IL_009e: add
-				IL_009f: stloc.1
-				IL_00a0: br IL_0032
+				IL_0028: ldloc.0
+				IL_0029: ldc.r8 0.0
+				IL_0032: box [System.Runtime]System.Double
+				IL_0037: ldc.r8 1
+				IL_0040: box [System.Runtime]System.Double
+				IL_0045: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
+				IL_0052: ldloc.1
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.1
+				IL_005e: br IL_0018
 			// end loop
 
-			IL_00a5: ldnull
-			IL_00a6: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method ArrowFunction_L45C38::__js_call__
 
 	} // end of class ArrowFunction_L45C38
@@ -1063,7 +939,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a39
+				// Method begins at RVA 0x286d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1083,7 +959,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a42
+				// Method begins at RVA 0x2876
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1109,17 +985,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2844
+			// Method begins at RVA 0x26f0
 			// Header size: 12
-			// Code size: 143 (0x8f)
+			// Code size: 89 (0x59)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] object,
-				[3] float64,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[5] object
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -1131,51 +1005,33 @@
 			// loop start (head: IL_0016)
 				IL_0016: ldloc.0
 				IL_0017: stloc.1
-				IL_0018: ldstr "i"
-				IL_001d: ldarg.0
-				IL_001e: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0023: box [System.Runtime]System.Double
-				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002d: stloc.2
-				IL_002e: ldloc.2
-				IL_002f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0034: stloc.3
-				IL_0035: ldloc.3
-				IL_0036: ldc.r8 25
-				IL_003f: mul
-				IL_0040: stloc.3
-				IL_0041: ldloc.1
-				IL_0042: ldloc.3
-				IL_0043: clt
-				IL_0045: brfalse IL_008d
+				IL_0018: ldloc.1
+				IL_0019: ldarg.0
+				IL_001a: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_001f: ldc.r8 25
+				IL_0028: mul
+				IL_0029: clt
+				IL_002b: brfalse IL_0057
 
-				IL_004a: ldarg.0
-				IL_004b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0050: stloc.s 4
-				IL_0052: ldstr "ret"
-				IL_0057: ldloc.s 4
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005e: stloc.2
-				IL_005f: ldloc.2
-				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0065: stloc.2
-				IL_0066: ldloc.0
-				IL_0067: box [System.Runtime]System.Double
-				IL_006c: stloc.s 5
-				IL_006e: ldloc.2
-				IL_006f: ldstr "push"
-				IL_0074: ldloc.s 5
-				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_007b: pop
-				IL_007c: ldloc.0
-				IL_007d: ldc.r8 1
-				IL_0086: add
-				IL_0087: stloc.0
-				IL_0088: br IL_0016
+				IL_0030: ldarg.0
+				IL_0031: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_0036: stloc.2
+				IL_0037: ldloc.0
+				IL_0038: box [System.Runtime]System.Double
+				IL_003d: stloc.3
+				IL_003e: ldloc.2
+				IL_003f: ldloc.3
+				IL_0040: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0045: pop
+				IL_0046: ldloc.0
+				IL_0047: ldc.r8 1
+				IL_0050: add
+				IL_0051: stloc.0
+				IL_0052: br IL_0016
 			// end loop
 
-			IL_008d: ldnull
-			IL_008e: ret
+			IL_0057: ldnull
+			IL_0058: ret
 		} // end of method ArrowFunction_L51C34::__js_call__
 
 	} // end of class ArrowFunction_L51C34
@@ -1191,7 +1047,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a4b
+				// Method begins at RVA 0x287f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1211,7 +1067,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a54
+				// Method begins at RVA 0x2888
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1237,77 +1093,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x28e0
+			// Method begins at RVA 0x2758
 			// Header size: 12
-			// Code size: 153 (0x99)
+			// Code size: 85 (0x55)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] float64,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[3] object,
-				[4] float64,
-				[5] float64
+				[3] float64,
+				[4] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-			IL_0006: stloc.2
-			IL_0007: ldstr "ret"
+			IL_0006: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_000b: stloc.2
 			IL_000c: ldloc.2
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.3
-			IL_0013: ldloc.3
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.3
-			IL_001a: ldloc.3
-			IL_001b: ldstr "slice"
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0025: stloc.3
-			IL_0026: ldloc.3
-			IL_0027: stloc.0
-			IL_0028: ldc.r8 0.0
-			IL_0031: stloc.1
-			// loop start (head: IL_0032)
-				IL_0032: ldloc.1
-				IL_0033: stloc.s 4
-				IL_0035: ldstr "i"
-				IL_003a: ldarg.0
-				IL_003b: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0040: box [System.Runtime]System.Double
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_004a: stloc.3
-				IL_004b: ldloc.3
-				IL_004c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0051: stloc.s 5
-				IL_0053: ldloc.s 5
-				IL_0055: ldc.r8 25
-				IL_005e: mul
-				IL_005f: stloc.s 5
-				IL_0061: ldloc.s 4
-				IL_0063: ldloc.s 5
-				IL_0065: clt
-				IL_0067: brfalse IL_0097
+			IL_000d: stloc.0
+			IL_000e: ldc.r8 0.0
+			IL_0017: stloc.1
+			// loop start (head: IL_0018)
+				IL_0018: ldloc.1
+				IL_0019: stloc.3
+				IL_001a: ldloc.3
+				IL_001b: ldarg.0
+				IL_001c: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+				IL_0021: ldc.r8 25
+				IL_002a: mul
+				IL_002b: clt
+				IL_002d: brfalse IL_0053
 
-				IL_006c: ldloc.0
-				IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0072: stloc.3
-				IL_0073: ldloc.3
-				IL_0074: ldstr "pop"
-				IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_007e: stloc.3
-				IL_007f: ldarg.0
-				IL_0080: ldloc.3
-				IL_0081: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
-				IL_0086: ldloc.1
-				IL_0087: ldc.r8 1
-				IL_0090: add
-				IL_0091: stloc.1
-				IL_0092: br IL_0032
+				IL_0032: ldloc.0
+				IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
+				IL_0038: stloc.s 4
+				IL_003a: ldarg.0
+				IL_003b: ldloc.s 4
+				IL_003d: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
+				IL_0042: ldloc.1
+				IL_0043: ldc.r8 1
+				IL_004c: add
+				IL_004d: stloc.1
+				IL_004e: br IL_0018
 			// end loop
 
-			IL_0097: ldnull
-			IL_0098: ret
+			IL_0053: ldnull
+			IL_0054: ret
 		} // end of method ArrowFunction_L57C35::__js_call__
 
 	} // end of class ArrowFunction_L57C35
@@ -1337,7 +1168,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2985
+			// Method begins at RVA 0x27b9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1742,7 +1573,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a5d
+		// Method begins at RVA 0x2891
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5aa6
+				// Method begins at RVA 0x5466
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5aaf
+				// Method begins at RVA 0x546f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ac1
+					// Method begins at RVA 0x5481
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ab8
+				// Method begins at RVA 0x5478
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ad3
+					// Method begins at RVA 0x5493
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5aca
+				// Method begins at RVA 0x548a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -275,7 +275,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5adc
+				// Method begins at RVA 0x549c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -349,7 +349,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5af7
+						// Method begins at RVA 0x54b7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -369,7 +369,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5b00
+						// Method begins at RVA 0x54c0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -387,7 +387,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5aee
+					// Method begins at RVA 0x54ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -405,7 +405,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ae5
+				// Method begins at RVA 0x54a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -434,7 +434,7 @@
 			)
 			// Method begins at RVA 0x3468
 			// Header size: 12
-			// Code size: 843 (0x34b)
+			// Code size: 658 (0x292)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -445,9 +445,9 @@
 				[5] class Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L32C39,
 				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L37C48,
 				[7] object,
-				[8] float64,
+				[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[9] object,
-				[10] object,
+				[10] float64,
 				[11] object,
 				[12] float64,
 				[13] string
@@ -459,309 +459,246 @@
 			IL_0003: stloc.1
 			IL_0004: ldarg.0
 			IL_0005: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-			IL_000a: stloc.s 7
-			IL_000c: ldstr "testStrings"
-			IL_0011: ldloc.s 7
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.s 7
-			IL_001a: ldloc.s 7
-			IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_0021: stloc.s 8
-			IL_0023: ldloc.s 8
-			IL_0025: ldarg.2
-			IL_0026: clt
-			IL_0028: ldc.i4.0
-			IL_0029: ceq
-			IL_002b: brfalse IL_0079
+			IL_000a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_000f: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0014: conv.r8
+			IL_0015: ldarg.2
+			IL_0016: clt
+			IL_0018: ldc.i4.0
+			IL_0019: ceq
+			IL_001b: brfalse IL_0052
 
-			IL_0030: ldarg.0
-			IL_0031: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-			IL_0036: stloc.s 7
-			IL_0038: ldstr "testStrings"
-			IL_003d: ldloc.s 7
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0044: stloc.s 7
-			IL_0046: ldloc.s 7
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004d: stloc.s 7
-			IL_004f: ldloc.s 7
-			IL_0051: ldstr "slice"
-			IL_0056: ldc.r8 0.0
-			IL_005f: box [System.Runtime]System.Double
-			IL_0064: ldarg.2
-			IL_0065: box [System.Runtime]System.Double
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_006f: stloc.s 7
-			IL_0071: ldloc.s 7
-			IL_0073: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0078: ret
+			IL_0020: ldarg.0
+			IL_0021: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_002b: stloc.s 7
+			IL_002d: ldloc.s 7
+			IL_002f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0034: ldc.r8 0.0
+			IL_003d: box [System.Runtime]System.Double
+			IL_0042: ldarg.2
+			IL_0043: box [System.Runtime]System.Double
+			IL_0048: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice(object, object)
+			IL_004d: stloc.s 8
+			IL_004f: ldloc.s 8
+			IL_0051: ret
 
-			IL_0079: ldarg.0
-			IL_007a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-			IL_007f: stloc.s 7
-			IL_0081: ldstr "testStrings"
-			IL_0086: ldloc.s 7
-			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_008d: stloc.s 7
-			IL_008f: ldloc.s 7
-			IL_0091: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_0096: stloc.s 8
-			IL_0098: ldloc.s 8
-			IL_009a: box [System.Runtime]System.Double
-			IL_009f: stloc.s 9
-			IL_00a1: ldloc.s 9
-			IL_00a3: stloc.2
-			// loop start (head: IL_00a4)
-				IL_00a4: ldloc.2
-				IL_00a5: stloc.s 9
-				IL_00a7: ldloc.s 9
-				IL_00a9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ae: stloc.s 8
-				IL_00b0: ldloc.s 8
-				IL_00b2: ldarg.2
-				IL_00b3: clt
-				IL_00b5: brfalse IL_032d
+			IL_0052: ldarg.0
+			IL_0053: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_0058: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_005d: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0062: conv.r8
+			IL_0063: box [System.Runtime]System.Double
+			IL_0068: stloc.2
+			// loop start (head: IL_0069)
+				IL_0069: ldloc.2
+				IL_006a: stloc.s 9
+				IL_006c: ldloc.s 9
+				IL_006e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0073: stloc.s 10
+				IL_0075: ldloc.s 10
+				IL_0077: ldarg.2
+				IL_0078: clt
+				IL_007a: brfalse IL_0286
 
-				IL_00ba: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53::.ctor()
-				IL_00bf: stloc.3
-				IL_00c0: ldarg.0
-				IL_00c1: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-				IL_00c6: stloc.s 7
-				IL_00c8: ldstr "randomChar"
-				IL_00cd: ldloc.s 7
-				IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00d4: stloc.s 7
-				IL_00d6: ldloc.s 7
-				IL_00d8: ldc.i4.1
-				IL_00d9: newarr [System.Runtime]System.Object
-				IL_00de: dup
-				IL_00df: ldc.i4.0
-				IL_00e0: ldarg.0
-				IL_00e1: stelem.ref
-				IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_00e7: stloc.s 7
-				IL_00e9: ldarg.0
-				IL_00ea: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-				IL_00ef: stloc.s 10
-				IL_00f1: ldstr "str"
-				IL_00f6: ldloc.s 10
-				IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00fd: stloc.s 10
-				IL_00ff: ldloc.s 7
-				IL_0101: ldloc.s 10
-				IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0108: stloc.s 11
-				IL_010a: ldarg.0
-				IL_010b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-				IL_0110: stloc.s 10
-				IL_0112: ldstr "randomChar"
-				IL_0117: ldloc.s 10
-				IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_011e: stloc.s 10
-				IL_0120: ldloc.s 10
-				IL_0122: ldc.i4.1
-				IL_0123: newarr [System.Runtime]System.Object
-				IL_0128: dup
-				IL_0129: ldc.i4.0
-				IL_012a: ldarg.0
-				IL_012b: stelem.ref
-				IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0131: stloc.s 10
-				IL_0133: ldloc.s 11
-				IL_0135: ldloc.s 10
-				IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_013c: stloc.s 11
-				IL_013e: ldloc.s 11
-				IL_0140: stloc.0
-				IL_0141: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-				IL_0146: stloc.s 8
-				IL_0148: ldc.r8 4
-				IL_0151: ldloc.s 8
-				IL_0153: mul
-				IL_0154: stloc.s 8
-				IL_0156: ldloc.s 8
-				IL_0158: box [System.Runtime]System.Double
-				IL_015d: stloc.s 9
-				IL_015f: ldloc.s 9
-				IL_0161: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-				IL_0166: stloc.s 8
-				IL_0168: ldloc.s 8
-				IL_016a: box [System.Runtime]System.Double
-				IL_016f: stloc.s 9
-				IL_0171: ldloc.s 9
-				IL_0173: stloc.1
-				IL_0174: ldc.r8 0.0
-				IL_017d: box [System.Runtime]System.Double
-				IL_0182: stloc.s 4
-				// loop start (head: IL_0184)
-					IL_0184: ldloc.s 4
-					IL_0186: stloc.s 9
-					IL_0188: ldloc.s 9
-					IL_018a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_018f: stloc.s 8
-					IL_0191: ldloc.1
-					IL_0192: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0197: stloc.s 12
-					IL_0199: ldloc.s 8
-					IL_019b: ldloc.s 12
-					IL_019d: clt
-					IL_019f: brfalse IL_023e
+				IL_007f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53::.ctor()
+				IL_0084: stloc.3
+				IL_0085: ldarg.0
+				IL_0086: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+				IL_008b: ldc.i4.1
+				IL_008c: newarr [System.Runtime]System.Object
+				IL_0091: dup
+				IL_0092: ldc.i4.0
+				IL_0093: ldarg.0
+				IL_0094: stelem.ref
+				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_009a: stloc.s 7
+				IL_009c: ldloc.s 7
+				IL_009e: ldarg.0
+				IL_009f: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+				IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00a9: stloc.s 11
+				IL_00ab: ldarg.0
+				IL_00ac: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+				IL_00b1: ldc.i4.1
+				IL_00b2: newarr [System.Runtime]System.Object
+				IL_00b7: dup
+				IL_00b8: ldc.i4.0
+				IL_00b9: ldarg.0
+				IL_00ba: stelem.ref
+				IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_00c0: stloc.s 7
+				IL_00c2: ldloc.s 11
+				IL_00c4: ldloc.s 7
+				IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00cb: stloc.s 11
+				IL_00cd: ldloc.s 11
+				IL_00cf: stloc.0
+				IL_00d0: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+				IL_00d5: stloc.s 10
+				IL_00d7: ldc.r8 4
+				IL_00e0: ldloc.s 10
+				IL_00e2: mul
+				IL_00e3: stloc.s 10
+				IL_00e5: ldloc.s 10
+				IL_00e7: box [System.Runtime]System.Double
+				IL_00ec: stloc.s 9
+				IL_00ee: ldloc.s 9
+				IL_00f0: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+				IL_00f5: stloc.s 10
+				IL_00f7: ldloc.s 10
+				IL_00f9: box [System.Runtime]System.Double
+				IL_00fe: stloc.s 9
+				IL_0100: ldloc.s 9
+				IL_0102: stloc.1
+				IL_0103: ldc.r8 0.0
+				IL_010c: box [System.Runtime]System.Double
+				IL_0111: stloc.s 4
+				// loop start (head: IL_0113)
+					IL_0113: ldloc.s 4
+					IL_0115: stloc.s 9
+					IL_0117: ldloc.s 9
+					IL_0119: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_011e: stloc.s 10
+					IL_0120: ldloc.1
+					IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0126: stloc.s 12
+					IL_0128: ldloc.s 10
+					IL_012a: ldloc.s 12
+					IL_012c: clt
+					IL_012e: brfalse IL_01a9
 
-					IL_01a4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L32C39::.ctor()
-					IL_01a9: stloc.s 5
-					IL_01ab: ldarg.0
-					IL_01ac: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-					IL_01b1: stloc.s 10
-					IL_01b3: ldstr "randomChar"
-					IL_01b8: ldloc.s 10
-					IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_01bf: stloc.s 10
-					IL_01c1: ldloc.s 10
-					IL_01c3: ldc.i4.1
-					IL_01c4: newarr [System.Runtime]System.Object
-					IL_01c9: dup
-					IL_01ca: ldc.i4.0
-					IL_01cb: ldarg.0
-					IL_01cc: stelem.ref
-					IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+					IL_0133: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L32C39::.ctor()
+					IL_0138: stloc.s 5
+					IL_013a: ldarg.0
+					IL_013b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+					IL_0140: ldc.i4.1
+					IL_0141: newarr [System.Runtime]System.Object
+					IL_0146: dup
+					IL_0147: ldc.i4.0
+					IL_0148: ldarg.0
+					IL_0149: stelem.ref
+					IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+					IL_014f: stloc.s 7
+					IL_0151: ldloc.s 7
+					IL_0153: ldloc.0
+					IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0159: stloc.s 11
+					IL_015b: ldarg.0
+					IL_015c: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+					IL_0161: ldc.i4.1
+					IL_0162: newarr [System.Runtime]System.Object
+					IL_0167: dup
+					IL_0168: ldc.i4.0
+					IL_0169: ldarg.0
+					IL_016a: stelem.ref
+					IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+					IL_0170: stloc.s 7
+					IL_0172: ldloc.s 11
+					IL_0174: ldloc.s 7
+					IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_017b: stloc.s 11
+					IL_017d: ldloc.s 11
+					IL_017f: stloc.0
+					IL_0180: ldloc.s 4
+					IL_0182: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0187: stloc.s 12
+					IL_0189: ldloc.s 12
+					IL_018b: ldc.r8 1
+					IL_0194: add
+					IL_0195: stloc.s 12
+					IL_0197: ldloc.s 12
+					IL_0199: box [System.Runtime]System.Double
+					IL_019e: stloc.s 9
+					IL_01a0: ldloc.s 9
+					IL_01a2: stloc.s 4
+					IL_01a4: br IL_0113
+				// end loop
+
+				IL_01a9: ldc.r8 0.0
+				IL_01b2: box [System.Runtime]System.Double
+				IL_01b7: stloc.s 4
+				// loop start (head: IL_01b9)
+					IL_01b9: ldloc.s 4
+					IL_01bb: stloc.s 9
+					IL_01bd: ldloc.0
+					IL_01be: castclass [System.Runtime]System.String
+					IL_01c3: callvirt instance int32 [System.Runtime]System.String::get_Length()
+					IL_01c8: conv.r8
+					IL_01c9: stloc.s 12
+					IL_01cb: ldloc.s 9
+					IL_01cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 					IL_01d2: stloc.s 10
 					IL_01d4: ldloc.s 10
-					IL_01d6: ldloc.0
-					IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_01dc: stloc.s 11
-					IL_01de: ldarg.0
-					IL_01df: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-					IL_01e4: stloc.s 10
-					IL_01e6: ldstr "randomChar"
-					IL_01eb: ldloc.s 10
-					IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_01f2: stloc.s 10
-					IL_01f4: ldloc.s 10
-					IL_01f6: ldc.i4.1
-					IL_01f7: newarr [System.Runtime]System.Object
-					IL_01fc: dup
-					IL_01fd: ldc.i4.0
-					IL_01fe: ldarg.0
-					IL_01ff: stelem.ref
-					IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-					IL_0205: stloc.s 10
-					IL_0207: ldloc.s 11
-					IL_0209: ldloc.s 10
-					IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0210: stloc.s 11
-					IL_0212: ldloc.s 11
-					IL_0214: stloc.0
-					IL_0215: ldloc.s 4
-					IL_0217: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_021c: stloc.s 12
-					IL_021e: ldloc.s 12
-					IL_0220: ldc.r8 1
-					IL_0229: add
-					IL_022a: stloc.s 12
-					IL_022c: ldloc.s 12
-					IL_022e: box [System.Runtime]System.Double
-					IL_0233: stloc.s 9
-					IL_0235: ldloc.s 9
-					IL_0237: stloc.s 4
-					IL_0239: br IL_0184
+					IL_01d6: ldloc.s 12
+					IL_01d8: clt
+					IL_01da: brfalse IL_0250
+
+					IL_01df: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L37C48::.ctor()
+					IL_01e4: stloc.s 6
+					IL_01e6: ldarg.0
+					IL_01e7: ldloc.0
+					IL_01e8: ldloc.s 4
+					IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+					IL_01ef: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+					IL_01f4: ldloc.0
+					IL_01f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_01fa: stloc.s 13
+					IL_01fc: ldloc.s 4
+					IL_01fe: stloc.s 9
+					IL_0200: ldloc.s 9
+					IL_0202: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0207: stloc.s 12
+					IL_0209: ldloc.s 12
+					IL_020b: ldc.r8 100
+					IL_0214: add
+					IL_0215: stloc.s 12
+					IL_0217: ldloc.s 12
+					IL_0219: box [System.Runtime]System.Double
+					IL_021e: stloc.s 9
+					IL_0220: ldloc.s 13
+					IL_0222: ldloc.s 4
+					IL_0224: ldloc.s 9
+					IL_0226: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+					IL_022b: stloc.s 13
+					IL_022d: ldarg.0
+					IL_022e: ldloc.s 13
+					IL_0230: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+					IL_0235: ldloc.s 4
+					IL_0237: ldc.r8 100
+					IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+					IL_0245: stloc.s 11
+					IL_0247: ldloc.s 11
+					IL_0249: stloc.s 4
+					IL_024b: br IL_01b9
 				// end loop
 
-				IL_023e: ldc.r8 0.0
-				IL_0247: box [System.Runtime]System.Double
-				IL_024c: stloc.s 4
-				// loop start (head: IL_024e)
-					IL_024e: ldloc.s 4
-					IL_0250: stloc.s 9
-					IL_0252: ldloc.0
-					IL_0253: castclass [System.Runtime]System.String
-					IL_0258: callvirt instance int32 [System.Runtime]System.String::get_Length()
-					IL_025d: conv.r8
-					IL_025e: stloc.s 12
-					IL_0260: ldloc.s 9
-					IL_0262: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0267: stloc.s 8
-					IL_0269: ldloc.s 8
-					IL_026b: ldloc.s 12
-					IL_026d: clt
-					IL_026f: brfalse IL_02e5
-
-					IL_0274: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L37C48::.ctor()
-					IL_0279: stloc.s 6
-					IL_027b: ldarg.0
-					IL_027c: ldloc.0
-					IL_027d: ldloc.s 4
-					IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_0284: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-					IL_0289: ldloc.0
-					IL_028a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_028f: stloc.s 13
-					IL_0291: ldloc.s 4
-					IL_0293: stloc.s 9
-					IL_0295: ldloc.s 9
-					IL_0297: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_029c: stloc.s 12
-					IL_029e: ldloc.s 12
-					IL_02a0: ldc.r8 100
-					IL_02a9: add
-					IL_02aa: stloc.s 12
-					IL_02ac: ldloc.s 12
-					IL_02ae: box [System.Runtime]System.Double
-					IL_02b3: stloc.s 9
-					IL_02b5: ldloc.s 13
-					IL_02b7: ldloc.s 4
-					IL_02b9: ldloc.s 9
-					IL_02bb: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-					IL_02c0: stloc.s 13
-					IL_02c2: ldarg.0
-					IL_02c3: ldloc.s 13
-					IL_02c5: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-					IL_02ca: ldloc.s 4
-					IL_02cc: ldc.r8 100
-					IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-					IL_02da: stloc.s 11
-					IL_02dc: ldloc.s 11
-					IL_02de: stloc.s 4
-					IL_02e0: br IL_024e
-				// end loop
-
-				IL_02e5: ldarg.0
-				IL_02e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-				IL_02eb: stloc.s 10
-				IL_02ed: ldstr "testStrings"
-				IL_02f2: ldloc.s 10
-				IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_02f9: stloc.s 10
-				IL_02fb: ldloc.s 10
-				IL_02fd: ldloc.2
-				IL_02fe: ldloc.0
-				IL_02ff: ldc.i4.1
-				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_0305: pop
-				IL_0306: ldloc.2
-				IL_0307: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_030c: stloc.s 12
-				IL_030e: ldloc.s 12
-				IL_0310: ldc.r8 1
-				IL_0319: add
-				IL_031a: stloc.s 12
-				IL_031c: ldloc.s 12
-				IL_031e: box [System.Runtime]System.Double
-				IL_0323: stloc.s 9
-				IL_0325: ldloc.s 9
-				IL_0327: stloc.2
-				IL_0328: br IL_00a4
+				IL_0250: ldarg.0
+				IL_0251: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+				IL_0256: ldloc.2
+				IL_0257: ldloc.0
+				IL_0258: ldc.i4.1
+				IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_025e: pop
+				IL_025f: ldloc.2
+				IL_0260: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0265: stloc.s 12
+				IL_0267: ldloc.s 12
+				IL_0269: ldc.r8 1
+				IL_0272: add
+				IL_0273: stloc.s 12
+				IL_0275: ldloc.s 12
+				IL_0277: box [System.Runtime]System.Double
+				IL_027c: stloc.s 9
+				IL_027e: ldloc.s 9
+				IL_0280: stloc.2
+				IL_0281: br IL_0069
 			// end loop
 
-			IL_032d: ldarg.0
-			IL_032e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-			IL_0333: stloc.s 10
-			IL_0335: ldstr "testStrings"
-			IL_033a: ldloc.s 10
-			IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0341: stloc.s 10
-			IL_0343: ldloc.s 10
-			IL_0345: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_034a: ret
+			IL_0286: ldarg.0
+			IL_0287: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_028c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0291: ret
 		} // end of method generateTestStrings::__js_call__
 
 	} // end of class generateTestStrings
@@ -777,7 +714,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b09
+				// Method begins at RVA 0x54c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -803,9 +740,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x37c0
+			// Method begins at RVA 0x3708
 			// Header size: 12
-			// Code size: 89 (0x59)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -823,29 +760,25 @@
 			IL_0017: ldarg.0
 			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_001d: stloc.1
-			IL_001e: ldstr "generateTestStrings"
-			IL_0023: ldloc.1
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0029: stloc.1
-			IL_002a: ldc.i4.1
-			IL_002b: newarr [System.Runtime]System.Object
-			IL_0030: dup
-			IL_0031: ldc.i4.0
-			IL_0032: ldarg.0
-			IL_0033: stelem.ref
-			IL_0034: stloc.2
-			IL_0035: ldloc.1
-			IL_0036: ldloc.2
-			IL_0037: ldc.r8 30
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_004a: stloc.1
-			IL_004b: ldarg.0
-			IL_004c: ldloc.1
-			IL_004d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0052: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0057: ldnull
-			IL_0058: ret
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 30
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L48C5::__js_call__
 
 	} // end of class FunctionExpression_L48C5
@@ -861,7 +794,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b12
+				// Method begins at RVA 0x54d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -887,16 +820,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3828
+			// Method begins at RVA 0x3764
 			// Header size: 12
-			// Code size: 155 (0x9b)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] float64,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -911,54 +843,40 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 30
 				IL_0022: clt
-				IL_0024: brfalse IL_0099
+				IL_0024: brfalse IL_0075
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
-				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "split"
-				IL_0067: ldloc.s 4
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_006e: stloc.s 4
-				IL_0070: ldarg.0
-				IL_0071: ldloc.s 4
-				IL_0073: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0078: ldloc.0
-				IL_0079: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007e: stloc.2
-				IL_007f: ldloc.2
-				IL_0080: ldc.r8 1
-				IL_0089: add
-				IL_008a: stloc.2
-				IL_008b: ldloc.2
-				IL_008c: box [System.Runtime]System.Double
-				IL_0091: stloc.1
-				IL_0092: ldloc.1
-				IL_0093: stloc.0
-				IL_0094: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldloc.3
+				IL_003c: ldstr "split"
+				IL_0041: ldarg.0
+				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldloc.3
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.2
+				IL_0067: ldloc.2
+				IL_0068: box [System.Runtime]System.Double
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: stloc.0
+				IL_0070: br IL_000f
 			// end loop
 
-			IL_0099: ldnull
-			IL_009a: ret
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method FunctionExpression_L56C36::__js_call__
 
 	} // end of class FunctionExpression_L56C36
@@ -974,7 +892,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b1b
+				// Method begins at RVA 0x54db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1000,9 +918,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x38d0
+			// Method begins at RVA 0x37e8
 			// Header size: 12
-			// Code size: 89 (0x59)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -1020,29 +938,25 @@
 			IL_0017: ldarg.0
 			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_001d: stloc.1
-			IL_001e: ldstr "generateTestStrings"
-			IL_0023: ldloc.1
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0029: stloc.1
-			IL_002a: ldc.i4.1
-			IL_002b: newarr [System.Runtime]System.Object
-			IL_0030: dup
-			IL_0031: ldc.i4.0
-			IL_0032: ldarg.0
-			IL_0033: stelem.ref
-			IL_0034: stloc.2
-			IL_0035: ldloc.1
-			IL_0036: ldloc.2
-			IL_0037: ldc.r8 30
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_004a: stloc.1
-			IL_004b: ldarg.0
-			IL_004c: ldloc.1
-			IL_004d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0052: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0057: ldnull
-			IL_0058: ret
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 30
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L61C5::__js_call__
 
 	} // end of class FunctionExpression_L61C5
@@ -1058,7 +972,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b24
+				// Method begins at RVA 0x54e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1084,16 +998,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3938
+			// Method begins at RVA 0x3844
 			// Header size: 12
-			// Code size: 155 (0x9b)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] float64,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -1108,54 +1021,40 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 30
 				IL_0022: clt
-				IL_0024: brfalse IL_0099
+				IL_0024: brfalse IL_0075
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
-				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "split"
-				IL_0067: ldloc.s 4
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_006e: stloc.s 4
-				IL_0070: ldarg.0
-				IL_0071: ldloc.s 4
-				IL_0073: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0078: ldloc.0
-				IL_0079: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007e: stloc.2
-				IL_007f: ldloc.2
-				IL_0080: ldc.r8 1
-				IL_0089: add
-				IL_008a: stloc.2
-				IL_008b: ldloc.2
-				IL_008c: box [System.Runtime]System.Double
-				IL_0091: stloc.1
-				IL_0092: ldloc.1
-				IL_0093: stloc.0
-				IL_0094: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldloc.3
+				IL_003c: ldstr "split"
+				IL_0041: ldarg.0
+				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldloc.3
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.2
+				IL_0067: ldloc.2
+				IL_0068: box [System.Runtime]System.Double
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: stloc.0
+				IL_0070: br IL_000f
 			// end loop
 
-			IL_0099: ldnull
-			IL_009a: ret
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method FunctionExpression_L66C35::__js_call__
 
 	} // end of class FunctionExpression_L66C35
@@ -1171,7 +1070,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b2d
+				// Method begins at RVA 0x54ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1197,9 +1096,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x39e0
+			// Method begins at RVA 0x38c8
 			// Header size: 12
-			// Code size: 89 (0x59)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -1217,29 +1116,25 @@
 			IL_0017: ldarg.0
 			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_001d: stloc.1
-			IL_001e: ldstr "generateTestStrings"
-			IL_0023: ldloc.1
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0029: stloc.1
-			IL_002a: ldc.i4.1
-			IL_002b: newarr [System.Runtime]System.Object
-			IL_0030: dup
-			IL_0031: ldc.i4.0
-			IL_0032: ldarg.0
-			IL_0033: stelem.ref
-			IL_0034: stloc.2
-			IL_0035: ldloc.1
-			IL_0036: ldloc.2
-			IL_0037: ldc.r8 100
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_004a: stloc.1
-			IL_004b: ldarg.0
-			IL_004c: ldloc.1
-			IL_004d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0052: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0057: ldnull
-			IL_0058: ret
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 100
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L71C5::__js_call__
 
 	} // end of class FunctionExpression_L71C5
@@ -1255,7 +1150,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b36
+				// Method begins at RVA 0x54f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1281,16 +1176,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3a48
+			// Method begins at RVA 0x3924
 			// Header size: 12
-			// Code size: 155 (0x9b)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] float64,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -1305,54 +1199,40 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 100
 				IL_0022: clt
-				IL_0024: brfalse IL_0099
+				IL_0024: brfalse IL_0075
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
-				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "split"
-				IL_0067: ldloc.s 4
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_006e: stloc.s 4
-				IL_0070: ldarg.0
-				IL_0071: ldloc.s 4
-				IL_0073: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0078: ldloc.0
-				IL_0079: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007e: stloc.2
-				IL_007f: ldloc.2
-				IL_0080: ldc.r8 1
-				IL_0089: add
-				IL_008a: stloc.2
-				IL_008b: ldloc.2
-				IL_008c: box [System.Runtime]System.Double
-				IL_0091: stloc.1
-				IL_0092: ldloc.1
-				IL_0093: stloc.0
-				IL_0094: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldloc.3
+				IL_003c: ldstr "split"
+				IL_0041: ldarg.0
+				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldloc.3
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.2
+				IL_0067: ldloc.2
+				IL_0068: box [System.Runtime]System.Double
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: stloc.0
+				IL_0070: br IL_000f
 			// end loop
 
-			IL_0099: ldnull
-			IL_009a: ret
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method FunctionExpression_L76C39::__js_call__
 
 	} // end of class FunctionExpression_L76C39
@@ -1368,7 +1248,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b3f
+				// Method begins at RVA 0x54ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1394,9 +1274,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3af0
+			// Method begins at RVA 0x39a8
 			// Header size: 12
-			// Code size: 89 (0x59)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -1414,29 +1294,25 @@
 			IL_0017: ldarg.0
 			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_001d: stloc.1
-			IL_001e: ldstr "generateTestStrings"
-			IL_0023: ldloc.1
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0029: stloc.1
-			IL_002a: ldc.i4.1
-			IL_002b: newarr [System.Runtime]System.Object
-			IL_0030: dup
-			IL_0031: ldc.i4.0
-			IL_0032: ldarg.0
-			IL_0033: stelem.ref
-			IL_0034: stloc.2
-			IL_0035: ldloc.1
-			IL_0036: ldloc.2
-			IL_0037: ldc.r8 100
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_004a: stloc.1
-			IL_004b: ldarg.0
-			IL_004c: ldloc.1
-			IL_004d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0052: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0057: ldnull
-			IL_0058: ret
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 100
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L83C5::__js_call__
 
 	} // end of class FunctionExpression_L83C5
@@ -1452,7 +1328,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b48
+				// Method begins at RVA 0x5508
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1478,16 +1354,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3b58
+			// Method begins at RVA 0x3a04
 			// Header size: 12
-			// Code size: 155 (0x9b)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] float64,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -1502,54 +1377,40 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 100
 				IL_0022: clt
-				IL_0024: brfalse IL_0099
+				IL_0024: brfalse IL_0075
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
-				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "match"
-				IL_0067: ldloc.s 4
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_006e: stloc.s 4
-				IL_0070: ldarg.0
-				IL_0071: ldloc.s 4
-				IL_0073: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0078: ldloc.0
-				IL_0079: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007e: stloc.2
-				IL_007f: ldloc.2
-				IL_0080: ldc.r8 1
-				IL_0089: add
-				IL_008a: stloc.2
-				IL_008b: ldloc.2
-				IL_008c: box [System.Runtime]System.Double
-				IL_0091: stloc.1
-				IL_0092: ldloc.1
-				IL_0093: stloc.0
-				IL_0094: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldloc.3
+				IL_003c: ldstr "match"
+				IL_0041: ldarg.0
+				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldloc.3
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.2
+				IL_0067: ldloc.2
+				IL_0068: box [System.Runtime]System.Double
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: stloc.0
+				IL_0070: br IL_000f
 			// end loop
 
-			IL_0099: ldnull
-			IL_009a: ret
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method FunctionExpression_L88C23::__js_call__
 
 	} // end of class FunctionExpression_L88C23
@@ -1565,7 +1426,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b51
+				// Method begins at RVA 0x5511
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1591,9 +1452,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3c00
+			// Method begins at RVA 0x3a88
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1603,29 +1464,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 100
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L93C5::__js_call__
 
 	} // end of class FunctionExpression_L93C5
@@ -1641,7 +1498,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b5a
+				// Method begins at RVA 0x551a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1667,16 +1524,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3c50
+			// Method begins at RVA 0x3acc
 			// Header size: 12
-			// Code size: 157 (0x9d)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] float64,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -1691,54 +1547,40 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 100
 				IL_0022: clt
-				IL_0024: brfalse IL_009b
+				IL_0024: brfalse IL_0075
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_002f: stloc.3
-				IL_0030: ldstr "re"
+				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0034: stloc.3
 				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0042: stloc.3
-				IL_0043: ldarg.0
-				IL_0044: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0049: stloc.s 4
-				IL_004b: ldstr "tmp"
-				IL_0050: ldloc.s 4
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0057: stloc.s 4
-				IL_0059: ldloc.s 4
-				IL_005b: ldloc.0
-				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0061: stloc.s 4
-				IL_0063: ldloc.3
-				IL_0064: ldstr "test"
-				IL_0069: ldloc.s 4
-				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0070: stloc.s 4
-				IL_0072: ldarg.0
-				IL_0073: ldloc.s 4
-				IL_0075: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007a: ldloc.0
-				IL_007b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0080: stloc.2
-				IL_0081: ldloc.2
-				IL_0082: ldc.r8 1
-				IL_008b: add
-				IL_008c: stloc.2
-				IL_008d: ldloc.2
-				IL_008e: box [System.Runtime]System.Double
-				IL_0093: stloc.1
-				IL_0094: ldloc.1
-				IL_0095: stloc.0
-				IL_0096: br IL_000f
+				IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0041: ldloc.0
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldloc.3
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.2
+				IL_0067: ldloc.2
+				IL_0068: box [System.Runtime]System.Double
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: stloc.0
+				IL_0070: br IL_000f
 			// end loop
 
-			IL_009b: ldnull
-			IL_009c: ret
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method FunctionExpression_L97C22::__js_call__
 
 	} // end of class FunctionExpression_L97C22
@@ -1754,7 +1596,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b63
+				// Method begins at RVA 0x5523
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1780,9 +1622,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3cfc
+			// Method begins at RVA 0x3b50
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1792,29 +1634,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 100
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L102C5::__js_call__
 
 	} // end of class FunctionExpression_L102C5
@@ -1830,7 +1668,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b6c
+				// Method begins at RVA 0x552c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1856,9 +1694,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3d4c
+			// Method begins at RVA 0x3b94
 			// Header size: 12
-			// Code size: 160 (0xa0)
+			// Code size: 130 (0x82)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1880,55 +1718,43 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_009e
+				IL_0024: brfalse IL_0080
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.s 4
+				IL_0043: ldloc.3
+				IL_0044: ldstr "replace"
+				IL_0049: ldloc.s 4
+				IL_004b: ldstr ""
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0055: stloc.s 4
+				IL_0057: ldarg.0
 				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "replace"
-				IL_0067: ldloc.s 4
-				IL_0069: ldstr ""
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0073: stloc.s 4
-				IL_0075: ldarg.0
-				IL_0076: ldloc.s 4
-				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007d: ldloc.0
-				IL_007e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0083: stloc.2
-				IL_0084: ldloc.2
-				IL_0085: ldc.r8 1
-				IL_008e: add
-				IL_008f: stloc.2
-				IL_0090: ldloc.2
-				IL_0091: box [System.Runtime]System.Double
-				IL_0096: stloc.1
-				IL_0097: ldloc.1
-				IL_0098: stloc.0
-				IL_0099: br IL_000f
+				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005f: ldloc.0
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: stloc.2
+				IL_0066: ldloc.2
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.2
+				IL_0072: ldloc.2
+				IL_0073: box [System.Runtime]System.Double
+				IL_0078: stloc.1
+				IL_0079: ldloc.1
+				IL_007a: stloc.0
+				IL_007b: br IL_000f
 			// end loop
 
-			IL_009e: ldnull
-			IL_009f: ret
+			IL_0080: ldnull
+			IL_0081: ret
 		} // end of method FunctionExpression_L106C31::__js_call__
 
 	} // end of class FunctionExpression_L106C31
@@ -1944,7 +1770,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b75
+				// Method begins at RVA 0x5535
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1970,9 +1796,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3df8
+			// Method begins at RVA 0x3c24
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1982,29 +1808,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L111C5::__js_call__
 
 	} // end of class FunctionExpression_L111C5
@@ -2020,7 +1842,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b7e
+				// Method begins at RVA 0x553e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2046,9 +1868,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3e48
+			// Method begins at RVA 0x3c68
 			// Header size: 12
-			// Code size: 160 (0xa0)
+			// Code size: 130 (0x82)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2070,55 +1892,43 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_009e
+				IL_0024: brfalse IL_0080
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.s 4
+				IL_0043: ldloc.3
+				IL_0044: ldstr "replace"
+				IL_0049: ldloc.s 4
+				IL_004b: ldstr "asdfasdfasdf"
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0055: stloc.s 4
+				IL_0057: ldarg.0
 				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "replace"
-				IL_0067: ldloc.s 4
-				IL_0069: ldstr "asdfasdfasdf"
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0073: stloc.s 4
-				IL_0075: ldarg.0
-				IL_0076: ldloc.s 4
-				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007d: ldloc.0
-				IL_007e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0083: stloc.2
-				IL_0084: ldloc.2
-				IL_0085: ldc.r8 1
-				IL_008e: add
-				IL_008f: stloc.2
-				IL_0090: ldloc.2
-				IL_0091: box [System.Runtime]System.Double
-				IL_0096: stloc.1
-				IL_0097: ldloc.1
-				IL_0098: stloc.0
-				IL_0099: br IL_000f
+				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005f: ldloc.0
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: stloc.2
+				IL_0066: ldloc.2
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.2
+				IL_0072: ldloc.2
+				IL_0073: box [System.Runtime]System.Double
+				IL_0078: stloc.1
+				IL_0079: ldloc.1
+				IL_007a: stloc.0
+				IL_007b: br IL_000f
 			// end loop
 
-			IL_009e: ldnull
-			IL_009f: ret
+			IL_0080: ldnull
+			IL_0081: ret
 		} // end of method FunctionExpression_L115C33::__js_call__
 
 	} // end of class FunctionExpression_L115C33
@@ -2134,7 +1944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b87
+				// Method begins at RVA 0x5547
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2160,9 +1970,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3ef4
+			// Method begins at RVA 0x3cf8
 			// Header size: 12
-			// Code size: 89 (0x59)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -2180,29 +1990,25 @@
 			IL_0017: ldarg.0
 			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_001d: stloc.1
-			IL_001e: ldstr "generateTestStrings"
-			IL_0023: ldloc.1
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0029: stloc.1
-			IL_002a: ldc.i4.1
-			IL_002b: newarr [System.Runtime]System.Object
-			IL_0030: dup
-			IL_0031: ldc.i4.0
-			IL_0032: ldarg.0
-			IL_0033: stelem.ref
-			IL_0034: stloc.2
-			IL_0035: ldloc.1
-			IL_0036: ldloc.2
-			IL_0037: ldc.r8 100
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_004a: stloc.1
-			IL_004b: ldarg.0
-			IL_004c: ldloc.1
-			IL_004d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0052: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0057: ldnull
-			IL_0058: ret
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 100
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L120C5::__js_call__
 
 	} // end of class FunctionExpression_L120C5
@@ -2218,7 +2024,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b90
+				// Method begins at RVA 0x5550
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2244,16 +2050,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3f5c
+			// Method begins at RVA 0x3d54
 			// Header size: 12
-			// Code size: 155 (0x9b)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] float64,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -2268,54 +2073,40 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 100
 				IL_0022: clt
-				IL_0024: brfalse IL_0099
+				IL_0024: brfalse IL_0075
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
-				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "match"
-				IL_0067: ldloc.s 4
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_006e: stloc.s 4
-				IL_0070: ldarg.0
-				IL_0071: ldloc.s 4
-				IL_0073: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0078: ldloc.0
-				IL_0079: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007e: stloc.2
-				IL_007f: ldloc.2
-				IL_0080: ldc.r8 1
-				IL_0089: add
-				IL_008a: stloc.2
-				IL_008b: ldloc.2
-				IL_008c: box [System.Runtime]System.Double
-				IL_0091: stloc.1
-				IL_0092: ldloc.1
-				IL_0093: stloc.0
-				IL_0094: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldloc.3
+				IL_003c: ldstr "match"
+				IL_0041: ldarg.0
+				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldloc.3
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.2
+				IL_0067: ldloc.2
+				IL_0068: box [System.Runtime]System.Double
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: stloc.0
+				IL_0070: br IL_000f
 			// end loop
 
-			IL_0099: ldnull
-			IL_009a: ret
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method FunctionExpression_L125C30::__js_call__
 
 	} // end of class FunctionExpression_L125C30
@@ -2331,7 +2122,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5b99
+				// Method begins at RVA 0x5559
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2357,9 +2148,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4004
+			// Method begins at RVA 0x3dd8
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2369,29 +2160,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 100
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L130C5::__js_call__
 
 	} // end of class FunctionExpression_L130C5
@@ -2407,7 +2194,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ba2
+				// Method begins at RVA 0x5562
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2433,16 +2220,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4054
+			// Method begins at RVA 0x3e1c
 			// Header size: 12
-			// Code size: 157 (0x9d)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] float64,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -2457,54 +2243,40 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 100
 				IL_0022: clt
-				IL_0024: brfalse IL_009b
+				IL_0024: brfalse IL_0075
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_002f: stloc.3
-				IL_0030: ldstr "re"
+				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0034: stloc.3
 				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0042: stloc.3
-				IL_0043: ldarg.0
-				IL_0044: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0049: stloc.s 4
-				IL_004b: ldstr "tmp"
-				IL_0050: ldloc.s 4
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0057: stloc.s 4
-				IL_0059: ldloc.s 4
-				IL_005b: ldloc.0
-				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0061: stloc.s 4
-				IL_0063: ldloc.3
-				IL_0064: ldstr "test"
-				IL_0069: ldloc.s 4
-				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0070: stloc.s 4
-				IL_0072: ldarg.0
-				IL_0073: ldloc.s 4
-				IL_0075: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007a: ldloc.0
-				IL_007b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0080: stloc.2
-				IL_0081: ldloc.2
-				IL_0082: ldc.r8 1
-				IL_008b: add
-				IL_008c: stloc.2
-				IL_008d: ldloc.2
-				IL_008e: box [System.Runtime]System.Double
-				IL_0093: stloc.1
-				IL_0094: ldloc.1
-				IL_0095: stloc.0
-				IL_0096: br IL_000f
+				IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0041: ldloc.0
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldloc.3
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.2
+				IL_0067: ldloc.2
+				IL_0068: box [System.Runtime]System.Double
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: stloc.0
+				IL_0070: br IL_000f
 			// end loop
 
-			IL_009b: ldnull
-			IL_009c: ret
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method FunctionExpression_L134C29::__js_call__
 
 	} // end of class FunctionExpression_L134C29
@@ -2520,7 +2292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5bab
+				// Method begins at RVA 0x556b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2546,9 +2318,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4100
+			// Method begins at RVA 0x3ea0
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2558,29 +2330,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L139C5::__js_call__
 
 	} // end of class FunctionExpression_L139C5
@@ -2596,7 +2364,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5bb4
+				// Method begins at RVA 0x5574
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2622,9 +2390,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4150
+			// Method begins at RVA 0x3ee4
 			// Header size: 12
-			// Code size: 160 (0xa0)
+			// Code size: 130 (0x82)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2646,55 +2414,43 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_009e
+				IL_0024: brfalse IL_0080
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.s 4
+				IL_0043: ldloc.3
+				IL_0044: ldstr "replace"
+				IL_0049: ldloc.s 4
+				IL_004b: ldstr ""
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0055: stloc.s 4
+				IL_0057: ldarg.0
 				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "replace"
-				IL_0067: ldloc.s 4
-				IL_0069: ldstr ""
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0073: stloc.s 4
-				IL_0075: ldarg.0
-				IL_0076: ldloc.s 4
-				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007d: ldloc.0
-				IL_007e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0083: stloc.2
-				IL_0084: ldloc.2
-				IL_0085: ldc.r8 1
-				IL_008e: add
-				IL_008f: stloc.2
-				IL_0090: ldloc.2
-				IL_0091: box [System.Runtime]System.Double
-				IL_0096: stloc.1
-				IL_0097: ldloc.1
-				IL_0098: stloc.0
-				IL_0099: br IL_000f
+				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005f: ldloc.0
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: stloc.2
+				IL_0066: ldloc.2
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.2
+				IL_0072: ldloc.2
+				IL_0073: box [System.Runtime]System.Double
+				IL_0078: stloc.1
+				IL_0079: ldloc.1
+				IL_007a: stloc.0
+				IL_007b: br IL_000f
 			// end loop
 
-			IL_009e: ldnull
-			IL_009f: ret
+			IL_0080: ldnull
+			IL_0081: ret
 		} // end of method FunctionExpression_L143C38::__js_call__
 
 	} // end of class FunctionExpression_L143C38
@@ -2710,7 +2466,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5bbd
+				// Method begins at RVA 0x557d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2736,9 +2492,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x41fc
+			// Method begins at RVA 0x3f74
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2748,29 +2504,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L148C5::__js_call__
 
 	} // end of class FunctionExpression_L148C5
@@ -2786,7 +2538,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5bc6
+				// Method begins at RVA 0x5586
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2812,9 +2564,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x424c
+			// Method begins at RVA 0x3fb8
 			// Header size: 12
-			// Code size: 160 (0xa0)
+			// Code size: 130 (0x82)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2836,55 +2588,43 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_009e
+				IL_0024: brfalse IL_0080
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.s 4
+				IL_0043: ldloc.3
+				IL_0044: ldstr "replace"
+				IL_0049: ldloc.s 4
+				IL_004b: ldstr "asdfasdfasdf"
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0055: stloc.s 4
+				IL_0057: ldarg.0
 				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "replace"
-				IL_0067: ldloc.s 4
-				IL_0069: ldstr "asdfasdfasdf"
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0073: stloc.s 4
-				IL_0075: ldarg.0
-				IL_0076: ldloc.s 4
-				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007d: ldloc.0
-				IL_007e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0083: stloc.2
-				IL_0084: ldloc.2
-				IL_0085: ldc.r8 1
-				IL_008e: add
-				IL_008f: stloc.2
-				IL_0090: ldloc.2
-				IL_0091: box [System.Runtime]System.Double
-				IL_0096: stloc.1
-				IL_0097: ldloc.1
-				IL_0098: stloc.0
-				IL_0099: br IL_000f
+				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005f: ldloc.0
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: stloc.2
+				IL_0066: ldloc.2
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.2
+				IL_0072: ldloc.2
+				IL_0073: box [System.Runtime]System.Double
+				IL_0078: stloc.1
+				IL_0079: ldloc.1
+				IL_007a: stloc.0
+				IL_007b: br IL_000f
 			// end loop
 
-			IL_009e: ldnull
-			IL_009f: ret
+			IL_0080: ldnull
+			IL_0081: ret
 		} // end of method FunctionExpression_L152C40::__js_call__
 
 	} // end of class FunctionExpression_L152C40
@@ -2900,7 +2640,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5bcf
+				// Method begins at RVA 0x558f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2926,9 +2666,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x42f8
+			// Method begins at RVA 0x4048
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2938,29 +2678,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L157C5::__js_call__
 
 	} // end of class FunctionExpression_L157C5
@@ -2980,7 +2716,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5be1
+					// Method begins at RVA 0x55a1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3004,7 +2740,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x5a45
+				// Method begins at RVA 0x5405
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -3022,7 +2758,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5bd8
+				// Method begins at RVA 0x5598
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3048,9 +2784,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4348
+			// Method begins at RVA 0x408c
 			// Header size: 12
-			// Code size: 199 (0xc7)
+			// Code size: 163 (0xa3)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/Scope,
@@ -3076,65 +2812,53 @@
 				IL_001e: ldloc.3
 				IL_001f: ldc.r8 50
 				IL_0028: clt
-				IL_002a: brfalse IL_00c5
+				IL_002a: brfalse IL_00a1
 
 				IL_002f: ldarg.0
 				IL_0030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0035: stloc.s 4
-				IL_0037: ldstr "tmp"
-				IL_003c: ldloc.s 4
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0043: stloc.s 4
-				IL_0045: ldloc.s 4
-				IL_0047: ldloc.1
-				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_004d: stloc.s 4
-				IL_004f: ldloc.s 4
-				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0056: stloc.s 4
-				IL_0058: ldarg.0
-				IL_0059: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_005e: stloc.s 5
-				IL_0060: ldstr "re"
-				IL_0065: ldloc.s 5
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006c: stloc.s 5
-				IL_006e: ldnull
-				IL_006f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
-				IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-				IL_007a: ldc.i4.1
-				IL_007b: conv.r8
-				IL_007c: ldstr ""
-				IL_0081: ldc.i4.0
-				IL_0082: ldc.i4.1
-				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0088: stloc.s 6
-				IL_008a: ldloc.s 4
-				IL_008c: ldstr "replace"
-				IL_0091: ldloc.s 5
-				IL_0093: ldloc.s 6
-				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_009a: stloc.s 6
-				IL_009c: ldarg.0
-				IL_009d: ldloc.s 6
-				IL_009f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_00a4: ldloc.1
-				IL_00a5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00aa: stloc.3
-				IL_00ab: ldloc.3
-				IL_00ac: ldc.r8 1
-				IL_00b5: add
-				IL_00b6: stloc.3
-				IL_00b7: ldloc.3
-				IL_00b8: box [System.Runtime]System.Double
-				IL_00bd: stloc.2
-				IL_00be: ldloc.2
-				IL_00bf: stloc.1
-				IL_00c0: br IL_0015
+				IL_0035: ldloc.1
+				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0040: stloc.s 4
+				IL_0042: ldarg.0
+				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0048: stloc.s 5
+				IL_004a: ldnull
+				IL_004b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
+				IL_0051: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+				IL_0056: ldc.i4.1
+				IL_0057: conv.r8
+				IL_0058: ldstr ""
+				IL_005d: ldc.i4.0
+				IL_005e: ldc.i4.1
+				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0064: stloc.s 6
+				IL_0066: ldloc.s 4
+				IL_0068: ldstr "replace"
+				IL_006d: ldloc.s 5
+				IL_006f: ldloc.s 6
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0076: stloc.s 6
+				IL_0078: ldarg.0
+				IL_0079: ldloc.s 6
+				IL_007b: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0080: ldloc.1
+				IL_0081: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0086: stloc.3
+				IL_0087: ldloc.3
+				IL_0088: ldc.r8 1
+				IL_0091: add
+				IL_0092: stloc.3
+				IL_0093: ldloc.3
+				IL_0094: box [System.Runtime]System.Double
+				IL_0099: stloc.2
+				IL_009a: ldloc.2
+				IL_009b: stloc.1
+				IL_009c: br IL_0015
 			// end loop
 
-			IL_00c5: ldnull
-			IL_00c6: ret
+			IL_00a1: ldnull
+			IL_00a2: ret
 		} // end of method FunctionExpression_L161C49::__js_call__
 
 	} // end of class FunctionExpression_L161C49
@@ -3150,7 +2874,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5bea
+				// Method begins at RVA 0x55aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3176,9 +2900,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x441c
+			// Method begins at RVA 0x413c
 			// Header size: 12
-			// Code size: 89 (0x59)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -3196,29 +2920,25 @@
 			IL_0017: ldarg.0
 			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_001d: stloc.1
-			IL_001e: ldstr "generateTestStrings"
-			IL_0023: ldloc.1
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0029: stloc.1
-			IL_002a: ldc.i4.1
-			IL_002b: newarr [System.Runtime]System.Object
-			IL_0030: dup
-			IL_0031: ldc.i4.0
-			IL_0032: ldarg.0
-			IL_0033: stelem.ref
-			IL_0034: stloc.2
-			IL_0035: ldloc.1
-			IL_0036: ldloc.2
-			IL_0037: ldc.r8 100
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_004a: stloc.1
-			IL_004b: ldarg.0
-			IL_004c: ldloc.1
-			IL_004d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0052: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0057: ldnull
-			IL_0058: ret
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 100
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L170C5::__js_call__
 
 	} // end of class FunctionExpression_L170C5
@@ -3234,7 +2954,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5bf3
+				// Method begins at RVA 0x55b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3260,16 +2980,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4484
+			// Method begins at RVA 0x4198
 			// Header size: 12
-			// Code size: 155 (0x9b)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] float64,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -3284,54 +3003,40 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 100
 				IL_0022: clt
-				IL_0024: brfalse IL_0099
+				IL_0024: brfalse IL_0075
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
-				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "match"
-				IL_0067: ldloc.s 4
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_006e: stloc.s 4
-				IL_0070: ldarg.0
-				IL_0071: ldloc.s 4
-				IL_0073: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0078: ldloc.0
-				IL_0079: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007e: stloc.2
-				IL_007f: ldloc.2
-				IL_0080: ldc.r8 1
-				IL_0089: add
-				IL_008a: stloc.2
-				IL_008b: ldloc.2
-				IL_008c: box [System.Runtime]System.Double
-				IL_0091: stloc.1
-				IL_0092: ldloc.1
-				IL_0093: stloc.0
-				IL_0094: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldloc.3
+				IL_003c: ldstr "match"
+				IL_0041: ldarg.0
+				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldloc.3
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.2
+				IL_0067: ldloc.2
+				IL_0068: box [System.Runtime]System.Double
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: stloc.0
+				IL_0070: br IL_000f
 			// end loop
 
-			IL_0099: ldnull
-			IL_009a: ret
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method FunctionExpression_L175C32::__js_call__
 
 	} // end of class FunctionExpression_L175C32
@@ -3347,7 +3052,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5bfc
+				// Method begins at RVA 0x55bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3373,9 +3078,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x452c
+			// Method begins at RVA 0x421c
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3385,29 +3090,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 100
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L180C5::__js_call__
 
 	} // end of class FunctionExpression_L180C5
@@ -3423,7 +3124,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5c05
+				// Method begins at RVA 0x55c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3449,9 +3150,179 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x457c
+			// Method begins at RVA 0x4260
 			// Header size: 12
-			// Code size: 157 (0x9d)
+			// Code size: 119 (0x77)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] float64,
+				[3] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: box [System.Runtime]System.Double
+			IL_000e: stloc.0
+			// loop start (head: IL_000f)
+				IL_000f: ldloc.0
+				IL_0010: stloc.1
+				IL_0011: ldloc.1
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: stloc.2
+				IL_0018: ldloc.2
+				IL_0019: ldc.r8 100
+				IL_0022: clt
+				IL_0024: brfalse IL_0075
+
+				IL_0029: ldarg.0
+				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0034: stloc.3
+				IL_0035: ldloc.3
+				IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0041: ldloc.0
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldloc.3
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.2
+				IL_0067: ldloc.2
+				IL_0068: box [System.Runtime]System.Double
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: stloc.0
+				IL_0070: br IL_000f
+			// end loop
+
+			IL_0075: ldnull
+			IL_0076: ret
+		} // end of method FunctionExpression_L184C31::__js_call__
+
+	} // end of class FunctionExpression_L184C31
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L189C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x55ce
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 51 00 00 02
+			)
+			// Method begins at RVA 0x42e4
+			// Header size: 12
+			// Code size: 54 (0x36)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object[]
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
+		} // end of method FunctionExpression_L189C5::__js_call__
+
+	} // end of class FunctionExpression_L189C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L193C40
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x55d7
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 51 00 00 02
+			)
+			// Method begins at RVA 0x4328
+			// Header size: 12
+			// Code size: 130 (0x82)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3471,61 +3342,50 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: stloc.2
 				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
+				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_009b
+				IL_0024: brfalse IL_0080
 
 				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_002f: stloc.3
-				IL_0030: ldstr "re"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0042: stloc.3
-				IL_0043: ldarg.0
-				IL_0044: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0049: stloc.s 4
-				IL_004b: ldstr "tmp"
-				IL_0050: ldloc.s 4
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0057: stloc.s 4
-				IL_0059: ldloc.s 4
-				IL_005b: ldloc.0
-				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0061: stloc.s 4
-				IL_0063: ldloc.3
-				IL_0064: ldstr "test"
-				IL_0069: ldloc.s 4
-				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0070: stloc.s 4
-				IL_0072: ldarg.0
-				IL_0073: ldloc.s 4
-				IL_0075: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007a: ldloc.0
-				IL_007b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0080: stloc.2
-				IL_0081: ldloc.2
-				IL_0082: ldc.r8 1
-				IL_008b: add
-				IL_008c: stloc.2
-				IL_008d: ldloc.2
-				IL_008e: box [System.Runtime]System.Double
-				IL_0093: stloc.1
-				IL_0094: ldloc.1
-				IL_0095: stloc.0
-				IL_0096: br IL_000f
+				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.s 4
+				IL_0043: ldloc.3
+				IL_0044: ldstr "replace"
+				IL_0049: ldloc.s 4
+				IL_004b: ldstr ""
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0055: stloc.s 4
+				IL_0057: ldarg.0
+				IL_0058: ldloc.s 4
+				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005f: ldloc.0
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: stloc.2
+				IL_0066: ldloc.2
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.2
+				IL_0072: ldloc.2
+				IL_0073: box [System.Runtime]System.Double
+				IL_0078: stloc.1
+				IL_0079: ldloc.1
+				IL_007a: stloc.0
+				IL_007b: br IL_000f
 			// end loop
 
-			IL_009b: ldnull
-			IL_009c: ret
-		} // end of method FunctionExpression_L184C31::__js_call__
+			IL_0080: ldnull
+			IL_0081: ret
+		} // end of method FunctionExpression_L193C40::__js_call__
 
-	} // end of class FunctionExpression_L184C31
+	} // end of class FunctionExpression_L193C40
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L189C5
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L198C5
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -3536,7 +3396,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5c0e
+				// Method begins at RVA 0x55e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3562,9 +3422,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4628
+			// Method begins at RVA 0x43b8
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3574,34 +3434,30 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
-		} // end of method FunctionExpression_L189C5::__js_call__
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
+		} // end of method FunctionExpression_L198C5::__js_call__
 
-	} // end of class FunctionExpression_L189C5
+	} // end of class FunctionExpression_L198C5
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L193C40
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L202C42
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -3612,7 +3468,529 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5c17
+				// Method begins at RVA 0x55e9
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 51 00 00 02
+			)
+			// Method begins at RVA 0x43fc
+			// Header size: 12
+			// Code size: 130 (0x82)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] float64,
+				[3] object,
+				[4] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: box [System.Runtime]System.Double
+			IL_000e: stloc.0
+			// loop start (head: IL_000f)
+				IL_000f: ldloc.0
+				IL_0010: stloc.1
+				IL_0011: ldloc.1
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: stloc.2
+				IL_0018: ldloc.2
+				IL_0019: ldc.r8 50
+				IL_0022: clt
+				IL_0024: brfalse IL_0080
+
+				IL_0029: ldarg.0
+				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.s 4
+				IL_0043: ldloc.3
+				IL_0044: ldstr "replace"
+				IL_0049: ldloc.s 4
+				IL_004b: ldstr "asdfasdfasdf"
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0055: stloc.s 4
+				IL_0057: ldarg.0
+				IL_0058: ldloc.s 4
+				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005f: ldloc.0
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: stloc.2
+				IL_0066: ldloc.2
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.2
+				IL_0072: ldloc.2
+				IL_0073: box [System.Runtime]System.Double
+				IL_0078: stloc.1
+				IL_0079: ldloc.1
+				IL_007a: stloc.0
+				IL_007b: br IL_000f
+			// end loop
+
+			IL_0080: ldnull
+			IL_0081: ret
+		} // end of method FunctionExpression_L202C42::__js_call__
+
+	} // end of class FunctionExpression_L202C42
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L207C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x55f2
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 51 00 00 02
+			)
+			// Method begins at RVA 0x448c
+			// Header size: 12
+			// Code size: 77 (0x4d)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[1] object,
+				[2] object[]
+			)
+
+			IL_0000: ldstr "aaaaaaaaaa"
+			IL_0005: ldstr "g"
+			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_000f: stloc.0
+			IL_0010: ldarg.0
+			IL_0011: ldloc.0
+			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+			IL_0017: ldarg.0
+			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_001d: stloc.1
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 100
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
+		} // end of method FunctionExpression_L207C5::__js_call__
+
+	} // end of class FunctionExpression_L207C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L212C39
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x55fb
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 51 00 00 02
+			)
+			// Method begins at RVA 0x44e8
+			// Header size: 12
+			// Code size: 119 (0x77)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] float64,
+				[3] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: box [System.Runtime]System.Double
+			IL_000e: stloc.0
+			// loop start (head: IL_000f)
+				IL_000f: ldloc.0
+				IL_0010: stloc.1
+				IL_0011: ldloc.1
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: stloc.2
+				IL_0018: ldloc.2
+				IL_0019: ldc.r8 100
+				IL_0022: clt
+				IL_0024: brfalse IL_0075
+
+				IL_0029: ldarg.0
+				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldloc.3
+				IL_003c: ldstr "match"
+				IL_0041: ldarg.0
+				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldloc.3
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.2
+				IL_0067: ldloc.2
+				IL_0068: box [System.Runtime]System.Double
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: stloc.0
+				IL_0070: br IL_000f
+			// end loop
+
+			IL_0075: ldnull
+			IL_0076: ret
+		} // end of method FunctionExpression_L212C39::__js_call__
+
+	} // end of class FunctionExpression_L212C39
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L217C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5604
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 51 00 00 02
+			)
+			// Method begins at RVA 0x456c
+			// Header size: 12
+			// Code size: 54 (0x36)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object[]
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
+		} // end of method FunctionExpression_L217C5::__js_call__
+
+	} // end of class FunctionExpression_L217C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L221C38
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x560d
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 51 00 00 02
+			)
+			// Method begins at RVA 0x45b0
+			// Header size: 12
+			// Code size: 119 (0x77)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] float64,
+				[3] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: box [System.Runtime]System.Double
+			IL_000e: stloc.0
+			// loop start (head: IL_000f)
+				IL_000f: ldloc.0
+				IL_0010: stloc.1
+				IL_0011: ldloc.1
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: stloc.2
+				IL_0018: ldloc.2
+				IL_0019: ldc.r8 100
+				IL_0022: clt
+				IL_0024: brfalse IL_0075
+
+				IL_0029: ldarg.0
+				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0034: stloc.3
+				IL_0035: ldloc.3
+				IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0041: ldloc.0
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldloc.3
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.2
+				IL_0067: ldloc.2
+				IL_0068: box [System.Runtime]System.Double
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: stloc.0
+				IL_0070: br IL_000f
+			// end loop
+
+			IL_0075: ldnull
+			IL_0076: ret
+		} // end of method FunctionExpression_L221C38::__js_call__
+
+	} // end of class FunctionExpression_L221C38
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L226C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5616
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 51 00 00 02
+			)
+			// Method begins at RVA 0x4634
+			// Header size: 12
+			// Code size: 54 (0x36)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object[]
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
+		} // end of method FunctionExpression_L226C5::__js_call__
+
+	} // end of class FunctionExpression_L226C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L230C47
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x561f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3640,7 +4018,7 @@
 			)
 			// Method begins at RVA 0x4678
 			// Header size: 12
-			// Code size: 160 (0xa0)
+			// Code size: 130 (0x82)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3662,60 +4040,48 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_009e
+				IL_0024: brfalse IL_0080
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.s 4
+				IL_0043: ldloc.3
+				IL_0044: ldstr "replace"
+				IL_0049: ldloc.s 4
+				IL_004b: ldstr ""
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0055: stloc.s 4
+				IL_0057: ldarg.0
 				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "replace"
-				IL_0067: ldloc.s 4
-				IL_0069: ldstr ""
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0073: stloc.s 4
-				IL_0075: ldarg.0
-				IL_0076: ldloc.s 4
-				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007d: ldloc.0
-				IL_007e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0083: stloc.2
-				IL_0084: ldloc.2
-				IL_0085: ldc.r8 1
-				IL_008e: add
-				IL_008f: stloc.2
-				IL_0090: ldloc.2
-				IL_0091: box [System.Runtime]System.Double
-				IL_0096: stloc.1
-				IL_0097: ldloc.1
-				IL_0098: stloc.0
-				IL_0099: br IL_000f
+				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005f: ldloc.0
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: stloc.2
+				IL_0066: ldloc.2
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.2
+				IL_0072: ldloc.2
+				IL_0073: box [System.Runtime]System.Double
+				IL_0078: stloc.1
+				IL_0079: ldloc.1
+				IL_007a: stloc.0
+				IL_007b: br IL_000f
 			// end loop
 
-			IL_009e: ldnull
-			IL_009f: ret
-		} // end of method FunctionExpression_L193C40::__js_call__
+			IL_0080: ldnull
+			IL_0081: ret
+		} // end of method FunctionExpression_L230C47::__js_call__
 
-	} // end of class FunctionExpression_L193C40
+	} // end of class FunctionExpression_L230C47
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L198C5
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L235C5
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -3726,7 +4092,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5c20
+				// Method begins at RVA 0x5628
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3752,9 +4118,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4724
+			// Method begins at RVA 0x4708
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3764,34 +4130,30 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
-		} // end of method FunctionExpression_L198C5::__js_call__
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
+		} // end of method FunctionExpression_L235C5::__js_call__
 
-	} // end of class FunctionExpression_L198C5
+	} // end of class FunctionExpression_L235C5
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L202C42
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L239C49
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -3802,7 +4164,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5c29
+				// Method begins at RVA 0x5631
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3828,9 +4190,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4774
+			// Method begins at RVA 0x474c
 			// Header size: 12
-			// Code size: 160 (0xa0)
+			// Code size: 130 (0x82)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3852,60 +4214,48 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_009e
+				IL_0024: brfalse IL_0080
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.s 4
+				IL_0043: ldloc.3
+				IL_0044: ldstr "replace"
+				IL_0049: ldloc.s 4
+				IL_004b: ldstr "asdfasdfasdf"
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0055: stloc.s 4
+				IL_0057: ldarg.0
 				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "replace"
-				IL_0067: ldloc.s 4
-				IL_0069: ldstr "asdfasdfasdf"
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0073: stloc.s 4
-				IL_0075: ldarg.0
-				IL_0076: ldloc.s 4
-				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007d: ldloc.0
-				IL_007e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0083: stloc.2
-				IL_0084: ldloc.2
-				IL_0085: ldc.r8 1
-				IL_008e: add
-				IL_008f: stloc.2
-				IL_0090: ldloc.2
-				IL_0091: box [System.Runtime]System.Double
-				IL_0096: stloc.1
-				IL_0097: ldloc.1
-				IL_0098: stloc.0
-				IL_0099: br IL_000f
+				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005f: ldloc.0
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: stloc.2
+				IL_0066: ldloc.2
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.2
+				IL_0072: ldloc.2
+				IL_0073: box [System.Runtime]System.Double
+				IL_0078: stloc.1
+				IL_0079: ldloc.1
+				IL_007a: stloc.0
+				IL_007b: br IL_000f
 			// end loop
 
-			IL_009e: ldnull
-			IL_009f: ret
-		} // end of method FunctionExpression_L202C42::__js_call__
+			IL_0080: ldnull
+			IL_0081: ret
+		} // end of method FunctionExpression_L239C49::__js_call__
 
-	} // end of class FunctionExpression_L202C42
+	} // end of class FunctionExpression_L239C49
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L207C5
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L244C5
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -3916,7 +4266,125 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5c32
+				// Method begins at RVA 0x563a
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 51 00 00 02
+			)
+			// Method begins at RVA 0x47dc
+			// Header size: 12
+			// Code size: 54 (0x36)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object[]
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
+		} // end of method FunctionExpression_L244C5::__js_call__
+
+	} // end of class FunctionExpression_L244C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L248C58
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L250C33
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x564c
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object newTarget,
+					object all
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 00 00 00 00 00 00
+				)
+				// Method begins at RVA 0x540c
+				// Header size: 1
+				// Code size: 6 (0x6)
+				.maxstack 8
+
+				IL_0000: ldstr "asdfasdfasdf"
+				IL_0005: ret
+			} // end of method FunctionExpression_L250C33::__js_call__
+
+		} // end of class FunctionExpression_L250C33
+
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5643
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3944,895 +4412,7 @@
 			)
 			// Method begins at RVA 0x4820
 			// Header size: 12
-			// Code size: 89 (0x59)
-			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object,
-				[2] object[]
-			)
-
-			IL_0000: ldstr "aaaaaaaaaa"
-			IL_0005: ldstr "g"
-			IL_000a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_000f: stloc.0
-			IL_0010: ldarg.0
-			IL_0011: ldloc.0
-			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-			IL_0017: ldarg.0
-			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_001d: stloc.1
-			IL_001e: ldstr "generateTestStrings"
-			IL_0023: ldloc.1
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0029: stloc.1
-			IL_002a: ldc.i4.1
-			IL_002b: newarr [System.Runtime]System.Object
-			IL_0030: dup
-			IL_0031: ldc.i4.0
-			IL_0032: ldarg.0
-			IL_0033: stelem.ref
-			IL_0034: stloc.2
-			IL_0035: ldloc.1
-			IL_0036: ldloc.2
-			IL_0037: ldc.r8 100
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_004a: stloc.1
-			IL_004b: ldarg.0
-			IL_004c: ldloc.1
-			IL_004d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0052: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0057: ldnull
-			IL_0058: ret
-		} // end of method FunctionExpression_L207C5::__js_call__
-
-	} // end of class FunctionExpression_L207C5
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L212C39
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c3b
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 51 00 00 02
-			)
-			// Method begins at RVA 0x4888
-			// Header size: 12
-			// Code size: 155 (0x9b)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
-			)
-
-			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0099
-
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
-				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "match"
-				IL_0067: ldloc.s 4
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_006e: stloc.s 4
-				IL_0070: ldarg.0
-				IL_0071: ldloc.s 4
-				IL_0073: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0078: ldloc.0
-				IL_0079: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007e: stloc.2
-				IL_007f: ldloc.2
-				IL_0080: ldc.r8 1
-				IL_0089: add
-				IL_008a: stloc.2
-				IL_008b: ldloc.2
-				IL_008c: box [System.Runtime]System.Double
-				IL_0091: stloc.1
-				IL_0092: ldloc.1
-				IL_0093: stloc.0
-				IL_0094: br IL_000f
-			// end loop
-
-			IL_0099: ldnull
-			IL_009a: ret
-		} // end of method FunctionExpression_L212C39::__js_call__
-
-	} // end of class FunctionExpression_L212C39
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L217C5
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c44
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 51 00 00 02
-			)
-			// Method begins at RVA 0x4930
-			// Header size: 12
-			// Code size: 66 (0x42)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object[]
-			)
-
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 100
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
-		} // end of method FunctionExpression_L217C5::__js_call__
-
-	} // end of class FunctionExpression_L217C5
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L221C38
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c4d
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 51 00 00 02
-			)
-			// Method begins at RVA 0x4980
-			// Header size: 12
-			// Code size: 157 (0x9d)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
-			)
-
-			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_009b
-
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_002f: stloc.3
-				IL_0030: ldstr "re"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0042: stloc.3
-				IL_0043: ldarg.0
-				IL_0044: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0049: stloc.s 4
-				IL_004b: ldstr "tmp"
-				IL_0050: ldloc.s 4
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0057: stloc.s 4
-				IL_0059: ldloc.s 4
-				IL_005b: ldloc.0
-				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0061: stloc.s 4
-				IL_0063: ldloc.3
-				IL_0064: ldstr "test"
-				IL_0069: ldloc.s 4
-				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0070: stloc.s 4
-				IL_0072: ldarg.0
-				IL_0073: ldloc.s 4
-				IL_0075: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007a: ldloc.0
-				IL_007b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0080: stloc.2
-				IL_0081: ldloc.2
-				IL_0082: ldc.r8 1
-				IL_008b: add
-				IL_008c: stloc.2
-				IL_008d: ldloc.2
-				IL_008e: box [System.Runtime]System.Double
-				IL_0093: stloc.1
-				IL_0094: ldloc.1
-				IL_0095: stloc.0
-				IL_0096: br IL_000f
-			// end loop
-
-			IL_009b: ldnull
-			IL_009c: ret
-		} // end of method FunctionExpression_L221C38::__js_call__
-
-	} // end of class FunctionExpression_L221C38
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L226C5
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c56
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 51 00 00 02
-			)
-			// Method begins at RVA 0x4a2c
-			// Header size: 12
-			// Code size: 66 (0x42)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object[]
-			)
-
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
-		} // end of method FunctionExpression_L226C5::__js_call__
-
-	} // end of class FunctionExpression_L226C5
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L230C47
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c5f
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 51 00 00 02
-			)
-			// Method begins at RVA 0x4a7c
-			// Header size: 12
-			// Code size: 160 (0xa0)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
-			)
-
-			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_009e
-
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
-				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "replace"
-				IL_0067: ldloc.s 4
-				IL_0069: ldstr ""
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0073: stloc.s 4
-				IL_0075: ldarg.0
-				IL_0076: ldloc.s 4
-				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007d: ldloc.0
-				IL_007e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0083: stloc.2
-				IL_0084: ldloc.2
-				IL_0085: ldc.r8 1
-				IL_008e: add
-				IL_008f: stloc.2
-				IL_0090: ldloc.2
-				IL_0091: box [System.Runtime]System.Double
-				IL_0096: stloc.1
-				IL_0097: ldloc.1
-				IL_0098: stloc.0
-				IL_0099: br IL_000f
-			// end loop
-
-			IL_009e: ldnull
-			IL_009f: ret
-		} // end of method FunctionExpression_L230C47::__js_call__
-
-	} // end of class FunctionExpression_L230C47
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L235C5
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c68
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 51 00 00 02
-			)
-			// Method begins at RVA 0x4b28
-			// Header size: 12
-			// Code size: 66 (0x42)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object[]
-			)
-
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
-		} // end of method FunctionExpression_L235C5::__js_call__
-
-	} // end of class FunctionExpression_L235C5
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L239C49
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c71
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 51 00 00 02
-			)
-			// Method begins at RVA 0x4b78
-			// Header size: 12
-			// Code size: 160 (0xa0)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
-			)
-
-			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_009e
-
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
-				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "replace"
-				IL_0067: ldloc.s 4
-				IL_0069: ldstr "asdfasdfasdf"
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0073: stloc.s 4
-				IL_0075: ldarg.0
-				IL_0076: ldloc.s 4
-				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007d: ldloc.0
-				IL_007e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0083: stloc.2
-				IL_0084: ldloc.2
-				IL_0085: ldc.r8 1
-				IL_008e: add
-				IL_008f: stloc.2
-				IL_0090: ldloc.2
-				IL_0091: box [System.Runtime]System.Double
-				IL_0096: stloc.1
-				IL_0097: ldloc.1
-				IL_0098: stloc.0
-				IL_0099: br IL_000f
-			// end loop
-
-			IL_009e: ldnull
-			IL_009f: ret
-		} // end of method FunctionExpression_L239C49::__js_call__
-
-	} // end of class FunctionExpression_L239C49
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L244C5
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c7a
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 51 00 00 02
-			)
-			// Method begins at RVA 0x4c24
-			// Header size: 12
-			// Code size: 66 (0x42)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object[]
-			)
-
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
-		} // end of method FunctionExpression_L244C5::__js_call__
-
-	} // end of class FunctionExpression_L244C5
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L248C58
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L250C33
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested public auto ansi beforefieldinit Scope
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x5c8c
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Scope::.ctor
-
-			} // end of class Scope
-
-
-			// Methods
-			.method public hidebysig static 
-				object __js_call__ (
-					object newTarget,
-					object all
-				) cil managed 
-			{
-				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-					01 00 00 00 00 00 00 00
-				)
-				// Method begins at RVA 0x5a4c
-				// Header size: 1
-				// Code size: 6 (0x6)
-				.maxstack 8
-
-				IL_0000: ldstr "asdfasdfasdf"
-				IL_0005: ret
-			} // end of method FunctionExpression_L250C33::__js_call__
-
-		} // end of class FunctionExpression_L250C33
-
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x5c83
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 51 00 00 02
-			)
-			// Method begins at RVA 0x4c74
-			// Header size: 12
-			// Code size: 199 (0xc7)
+			// Code size: 163 (0xa3)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/Scope,
@@ -4858,65 +4438,53 @@
 				IL_001e: ldloc.3
 				IL_001f: ldc.r8 50
 				IL_0028: clt
-				IL_002a: brfalse IL_00c5
+				IL_002a: brfalse IL_00a1
 
 				IL_002f: ldarg.0
 				IL_0030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0035: stloc.s 4
-				IL_0037: ldstr "tmp"
-				IL_003c: ldloc.s 4
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0043: stloc.s 4
-				IL_0045: ldloc.s 4
-				IL_0047: ldloc.1
-				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_004d: stloc.s 4
-				IL_004f: ldloc.s 4
-				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0056: stloc.s 4
-				IL_0058: ldarg.0
-				IL_0059: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_005e: stloc.s 5
-				IL_0060: ldstr "re"
-				IL_0065: ldloc.s 5
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006c: stloc.s 5
-				IL_006e: ldnull
-				IL_006f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
-				IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-				IL_007a: ldc.i4.1
-				IL_007b: conv.r8
-				IL_007c: ldstr ""
-				IL_0081: ldc.i4.0
-				IL_0082: ldc.i4.1
-				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0088: stloc.s 6
-				IL_008a: ldloc.s 4
-				IL_008c: ldstr "replace"
-				IL_0091: ldloc.s 5
-				IL_0093: ldloc.s 6
-				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_009a: stloc.s 6
-				IL_009c: ldarg.0
-				IL_009d: ldloc.s 6
-				IL_009f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_00a4: ldloc.1
-				IL_00a5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00aa: stloc.3
-				IL_00ab: ldloc.3
-				IL_00ac: ldc.r8 1
-				IL_00b5: add
-				IL_00b6: stloc.3
-				IL_00b7: ldloc.3
-				IL_00b8: box [System.Runtime]System.Double
-				IL_00bd: stloc.2
-				IL_00be: ldloc.2
-				IL_00bf: stloc.1
-				IL_00c0: br IL_0015
+				IL_0035: ldloc.1
+				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0040: stloc.s 4
+				IL_0042: ldarg.0
+				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0048: stloc.s 5
+				IL_004a: ldnull
+				IL_004b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
+				IL_0051: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+				IL_0056: ldc.i4.1
+				IL_0057: conv.r8
+				IL_0058: ldstr ""
+				IL_005d: ldc.i4.0
+				IL_005e: ldc.i4.1
+				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0064: stloc.s 6
+				IL_0066: ldloc.s 4
+				IL_0068: ldstr "replace"
+				IL_006d: ldloc.s 5
+				IL_006f: ldloc.s 6
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0076: stloc.s 6
+				IL_0078: ldarg.0
+				IL_0079: ldloc.s 6
+				IL_007b: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0080: ldloc.1
+				IL_0081: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0086: stloc.3
+				IL_0087: ldloc.3
+				IL_0088: ldc.r8 1
+				IL_0091: add
+				IL_0092: stloc.3
+				IL_0093: ldloc.3
+				IL_0094: box [System.Runtime]System.Double
+				IL_0099: stloc.2
+				IL_009a: ldloc.2
+				IL_009b: stloc.1
+				IL_009c: br IL_0015
 			// end loop
 
-			IL_00c5: ldnull
-			IL_00c6: ret
+			IL_00a1: ldnull
+			IL_00a2: ret
 		} // end of method FunctionExpression_L248C58::__js_call__
 
 	} // end of class FunctionExpression_L248C58
@@ -4932,7 +4500,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5c95
+				// Method begins at RVA 0x5655
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4958,9 +4526,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4d48
+			// Method begins at RVA 0x48d0
 			// Header size: 12
-			// Code size: 89 (0x59)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -4978,29 +4546,25 @@
 			IL_0017: ldarg.0
 			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_001d: stloc.1
-			IL_001e: ldstr "generateTestStrings"
-			IL_0023: ldloc.1
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0029: stloc.1
-			IL_002a: ldc.i4.1
-			IL_002b: newarr [System.Runtime]System.Object
-			IL_0030: dup
-			IL_0031: ldc.i4.0
-			IL_0032: ldarg.0
-			IL_0033: stelem.ref
-			IL_0034: stloc.2
-			IL_0035: ldloc.1
-			IL_0036: ldloc.2
-			IL_0037: ldc.r8 100
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_004a: stloc.1
-			IL_004b: ldarg.0
-			IL_004c: ldloc.1
-			IL_004d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0052: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0057: ldnull
-			IL_0058: ret
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 100
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L257C5::__js_call__
 
 	} // end of class FunctionExpression_L257C5
@@ -5016,7 +4580,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5c9e
+				// Method begins at RVA 0x565e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5042,16 +4606,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4db0
+			// Method begins at RVA 0x492c
 			// Header size: 12
-			// Code size: 155 (0x9b)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] float64,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -5066,54 +4629,40 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 100
 				IL_0022: clt
-				IL_0024: brfalse IL_0099
+				IL_0024: brfalse IL_0075
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
-				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "match"
-				IL_0067: ldloc.s 4
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_006e: stloc.s 4
-				IL_0070: ldarg.0
-				IL_0071: ldloc.s 4
-				IL_0073: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0078: ldloc.0
-				IL_0079: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007e: stloc.2
-				IL_007f: ldloc.2
-				IL_0080: ldc.r8 1
-				IL_0089: add
-				IL_008a: stloc.2
-				IL_008b: ldloc.2
-				IL_008c: box [System.Runtime]System.Double
-				IL_0091: stloc.1
-				IL_0092: ldloc.1
-				IL_0093: stloc.0
-				IL_0094: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldloc.3
+				IL_003c: ldstr "match"
+				IL_0041: ldarg.0
+				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004c: stloc.3
+				IL_004d: ldarg.0
+				IL_004e: ldloc.3
+				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: ldc.r8 1
+				IL_0065: add
+				IL_0066: stloc.2
+				IL_0067: ldloc.2
+				IL_0068: box [System.Runtime]System.Double
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: stloc.0
+				IL_0070: br IL_000f
 			// end loop
 
-			IL_0099: ldnull
-			IL_009a: ret
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method FunctionExpression_L262C31::__js_call__
 
 	} // end of class FunctionExpression_L262C31
@@ -5129,7 +4678,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ca7
+				// Method begins at RVA 0x5667
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5155,9 +4704,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4e58
+			// Method begins at RVA 0x49b0
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5167,29 +4716,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L267C5::__js_call__
 
 	} // end of class FunctionExpression_L267C5
@@ -5205,7 +4750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5cb0
+				// Method begins at RVA 0x5670
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5231,9 +4776,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4ea8
+			// Method begins at RVA 0x49f4
 			// Header size: 12
-			// Code size: 160 (0xa0)
+			// Code size: 130 (0x82)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5255,55 +4800,43 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_009e
+				IL_0024: brfalse IL_0080
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.s 4
+				IL_0043: ldloc.3
+				IL_0044: ldstr "replace"
+				IL_0049: ldloc.s 4
+				IL_004b: ldstr "asdfasdfasdf"
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0055: stloc.s 4
+				IL_0057: ldarg.0
 				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "replace"
-				IL_0067: ldloc.s 4
-				IL_0069: ldstr "asdfasdfasdf"
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0073: stloc.s 4
-				IL_0075: ldarg.0
-				IL_0076: ldloc.s 4
-				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007d: ldloc.0
-				IL_007e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0083: stloc.2
-				IL_0084: ldloc.2
-				IL_0085: ldc.r8 1
-				IL_008e: add
-				IL_008f: stloc.2
-				IL_0090: ldloc.2
-				IL_0091: box [System.Runtime]System.Double
-				IL_0096: stloc.1
-				IL_0097: ldloc.1
-				IL_0098: stloc.0
-				IL_0099: br IL_000f
+				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005f: ldloc.0
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: stloc.2
+				IL_0066: ldloc.2
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.2
+				IL_0072: ldloc.2
+				IL_0073: box [System.Runtime]System.Double
+				IL_0078: stloc.1
+				IL_0079: ldloc.1
+				IL_007a: stloc.0
+				IL_007b: br IL_000f
 			// end loop
 
-			IL_009e: ldnull
-			IL_009f: ret
+			IL_0080: ldnull
+			IL_0081: ret
 		} // end of method FunctionExpression_L271C33::__js_call__
 
 	} // end of class FunctionExpression_L271C33
@@ -5319,7 +4852,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5cb9
+				// Method begins at RVA 0x5679
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5345,9 +4878,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4f54
+			// Method begins at RVA 0x4a84
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5357,29 +4890,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L276C5::__js_call__
 
 	} // end of class FunctionExpression_L276C5
@@ -5395,7 +4924,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5cc2
+				// Method begins at RVA 0x5682
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5421,9 +4950,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4fa4
+			// Method begins at RVA 0x4ac8
 			// Header size: 12
-			// Code size: 160 (0xa0)
+			// Code size: 130 (0x82)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5445,55 +4974,43 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_009e
+				IL_0024: brfalse IL_0080
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldarg.0
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0051: stloc.s 4
-				IL_0053: ldstr "re"
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldarg.0
+				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0041: stloc.s 4
+				IL_0043: ldloc.3
+				IL_0044: ldstr "replace"
+				IL_0049: ldloc.s 4
+				IL_004b: ldstr "asdf\\1asdfasdf"
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0055: stloc.s 4
+				IL_0057: ldarg.0
 				IL_0058: ldloc.s 4
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.3
-				IL_0062: ldstr "replace"
-				IL_0067: ldloc.s 4
-				IL_0069: ldstr "asdf\\1asdfasdf"
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0073: stloc.s 4
-				IL_0075: ldarg.0
-				IL_0076: ldloc.s 4
-				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_007d: ldloc.0
-				IL_007e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0083: stloc.2
-				IL_0084: ldloc.2
-				IL_0085: ldc.r8 1
-				IL_008e: add
-				IL_008f: stloc.2
-				IL_0090: ldloc.2
-				IL_0091: box [System.Runtime]System.Double
-				IL_0096: stloc.1
-				IL_0097: ldloc.1
-				IL_0098: stloc.0
-				IL_0099: br IL_000f
+				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005f: ldloc.0
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: stloc.2
+				IL_0066: ldloc.2
+				IL_0067: ldc.r8 1
+				IL_0070: add
+				IL_0071: stloc.2
+				IL_0072: ldloc.2
+				IL_0073: box [System.Runtime]System.Double
+				IL_0078: stloc.1
+				IL_0079: ldloc.1
+				IL_007a: stloc.0
+				IL_007b: br IL_000f
 			// end loop
 
-			IL_009e: ldnull
-			IL_009f: ret
+			IL_0080: ldnull
+			IL_0081: ret
 		} // end of method FunctionExpression_L280C46::__js_call__
 
 	} // end of class FunctionExpression_L280C46
@@ -5509,7 +5026,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ccb
+				// Method begins at RVA 0x568b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5535,9 +5052,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5050
+			// Method begins at RVA 0x4b58
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5547,29 +5064,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L285C5::__js_call__
 
 	} // end of class FunctionExpression_L285C5
@@ -5589,7 +5102,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5cdd
+					// Method begins at RVA 0x569d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5614,7 +5127,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x5a54
+				// Method begins at RVA 0x5414
 				// Header size: 12
 				// Code size: 26 (0x1a)
 				.maxstack 8
@@ -5643,7 +5156,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5cd4
+				// Method begins at RVA 0x5694
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5669,9 +5182,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x50a0
+			// Method begins at RVA 0x4b9c
 			// Header size: 12
-			// Code size: 199 (0xc7)
+			// Code size: 163 (0xa3)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/Scope,
@@ -5697,65 +5210,53 @@
 				IL_001e: ldloc.3
 				IL_001f: ldc.r8 50
 				IL_0028: clt
-				IL_002a: brfalse IL_00c5
+				IL_002a: brfalse IL_00a1
 
 				IL_002f: ldarg.0
 				IL_0030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0035: stloc.s 4
-				IL_0037: ldstr "tmp"
-				IL_003c: ldloc.s 4
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0043: stloc.s 4
-				IL_0045: ldloc.s 4
-				IL_0047: ldloc.1
-				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_004d: stloc.s 4
-				IL_004f: ldloc.s 4
-				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0056: stloc.s 4
-				IL_0058: ldarg.0
-				IL_0059: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_005e: stloc.s 5
-				IL_0060: ldstr "re"
-				IL_0065: ldloc.s 5
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006c: stloc.s 5
-				IL_006e: ldnull
-				IL_006f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
-				IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-				IL_007a: ldc.i4.2
-				IL_007b: conv.r8
-				IL_007c: ldstr ""
-				IL_0081: ldc.i4.0
-				IL_0082: ldc.i4.1
-				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0088: stloc.s 6
-				IL_008a: ldloc.s 4
-				IL_008c: ldstr "replace"
-				IL_0091: ldloc.s 5
-				IL_0093: ldloc.s 6
-				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_009a: stloc.s 6
-				IL_009c: ldarg.0
-				IL_009d: ldloc.s 6
-				IL_009f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_00a4: ldloc.1
-				IL_00a5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00aa: stloc.3
-				IL_00ab: ldloc.3
-				IL_00ac: ldc.r8 1
-				IL_00b5: add
-				IL_00b6: stloc.3
-				IL_00b7: ldloc.3
-				IL_00b8: box [System.Runtime]System.Double
-				IL_00bd: stloc.2
-				IL_00be: ldloc.2
-				IL_00bf: stloc.1
-				IL_00c0: br IL_0015
+				IL_0035: ldloc.1
+				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0040: stloc.s 4
+				IL_0042: ldarg.0
+				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0048: stloc.s 5
+				IL_004a: ldnull
+				IL_004b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
+				IL_0051: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+				IL_0056: ldc.i4.2
+				IL_0057: conv.r8
+				IL_0058: ldstr ""
+				IL_005d: ldc.i4.0
+				IL_005e: ldc.i4.1
+				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0064: stloc.s 6
+				IL_0066: ldloc.s 4
+				IL_0068: ldstr "replace"
+				IL_006d: ldloc.s 5
+				IL_006f: ldloc.s 6
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0076: stloc.s 6
+				IL_0078: ldarg.0
+				IL_0079: ldloc.s 6
+				IL_007b: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0080: ldloc.1
+				IL_0081: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0086: stloc.3
+				IL_0087: ldloc.3
+				IL_0088: ldc.r8 1
+				IL_0091: add
+				IL_0092: stloc.3
+				IL_0093: ldloc.3
+				IL_0094: box [System.Runtime]System.Double
+				IL_0099: stloc.2
+				IL_009a: ldloc.2
+				IL_009b: stloc.1
+				IL_009c: br IL_0015
 			// end loop
 
-			IL_00c5: ldnull
-			IL_00c6: ret
+			IL_00a1: ldnull
+			IL_00a2: ret
 		} // end of method FunctionExpression_L289C55::__js_call__
 
 	} // end of class FunctionExpression_L289C55
@@ -5771,7 +5272,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ce6
+				// Method begins at RVA 0x56a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5797,9 +5298,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5174
+			// Method begins at RVA 0x4c4c
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5809,29 +5310,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L296C5::__js_call__
 
 	} // end of class FunctionExpression_L296C5
@@ -5851,7 +5348,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5cf8
+					// Method begins at RVA 0x56b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5876,7 +5373,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x5a7c
+				// Method begins at RVA 0x543c
 				// Header size: 12
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -5904,7 +5401,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5cef
+				// Method begins at RVA 0x56af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5930,9 +5427,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x51c4
+			// Method begins at RVA 0x4c90
 			// Header size: 12
-			// Code size: 199 (0xc7)
+			// Code size: 163 (0xa3)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/Scope,
@@ -5958,65 +5455,53 @@
 				IL_001e: ldloc.3
 				IL_001f: ldc.r8 50
 				IL_0028: clt
-				IL_002a: brfalse IL_00c5
+				IL_002a: brfalse IL_00a1
 
 				IL_002f: ldarg.0
 				IL_0030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0035: stloc.s 4
-				IL_0037: ldstr "tmp"
-				IL_003c: ldloc.s 4
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0043: stloc.s 4
-				IL_0045: ldloc.s 4
-				IL_0047: ldloc.1
-				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_004d: stloc.s 4
-				IL_004f: ldloc.s 4
-				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0056: stloc.s 4
-				IL_0058: ldarg.0
-				IL_0059: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_005e: stloc.s 5
-				IL_0060: ldstr "re"
-				IL_0065: ldloc.s 5
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006c: stloc.s 5
-				IL_006e: ldnull
-				IL_006f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
-				IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-				IL_007a: ldc.i4.2
-				IL_007b: conv.r8
-				IL_007c: ldstr ""
-				IL_0081: ldc.i4.0
-				IL_0082: ldc.i4.1
-				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0088: stloc.s 6
-				IL_008a: ldloc.s 4
-				IL_008c: ldstr "replace"
-				IL_0091: ldloc.s 5
-				IL_0093: ldloc.s 6
-				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_009a: stloc.s 6
-				IL_009c: ldarg.0
-				IL_009d: ldloc.s 6
-				IL_009f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_00a4: ldloc.1
-				IL_00a5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00aa: stloc.3
-				IL_00ab: ldloc.3
-				IL_00ac: ldc.r8 1
-				IL_00b5: add
-				IL_00b6: stloc.3
-				IL_00b7: ldloc.3
-				IL_00b8: box [System.Runtime]System.Double
-				IL_00bd: stloc.2
-				IL_00be: ldloc.2
-				IL_00bf: stloc.1
-				IL_00c0: br IL_0015
+				IL_0035: ldloc.1
+				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0040: stloc.s 4
+				IL_0042: ldarg.0
+				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0048: stloc.s 5
+				IL_004a: ldnull
+				IL_004b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
+				IL_0051: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+				IL_0056: ldc.i4.2
+				IL_0057: conv.r8
+				IL_0058: ldstr ""
+				IL_005d: ldc.i4.0
+				IL_005e: ldc.i4.1
+				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0064: stloc.s 6
+				IL_0066: ldloc.s 4
+				IL_0068: ldstr "replace"
+				IL_006d: ldloc.s 5
+				IL_006f: ldloc.s 6
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0076: stloc.s 6
+				IL_0078: ldarg.0
+				IL_0079: ldloc.s 6
+				IL_007b: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0080: ldloc.1
+				IL_0081: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0086: stloc.3
+				IL_0087: ldloc.3
+				IL_0088: ldc.r8 1
+				IL_0091: add
+				IL_0092: stloc.3
+				IL_0093: ldloc.3
+				IL_0094: box [System.Runtime]System.Double
+				IL_0099: stloc.2
+				IL_009a: ldloc.2
+				IL_009b: stloc.1
+				IL_009c: br IL_0015
 			// end loop
 
-			IL_00c5: ldnull
-			IL_00c6: ret
+			IL_00a1: ldnull
+			IL_00a2: ret
 		} // end of method FunctionExpression_L300C64::__js_call__
 
 	} // end of class FunctionExpression_L300C64
@@ -6032,7 +5517,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d01
+				// Method begins at RVA 0x56c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6058,9 +5543,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5298
+			// Method begins at RVA 0x4d40
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6070,29 +5555,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 100
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L309C5::__js_call__
 
 	} // end of class FunctionExpression_L309C5
@@ -6108,7 +5589,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d0a
+				// Method begins at RVA 0x56ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6134,9 +5615,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x52e8
+			// Method begins at RVA 0x4d84
 			// Header size: 12
-			// Code size: 148 (0x94)
+			// Code size: 132 (0x84)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6158,51 +5639,43 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 100
 				IL_0022: clt
-				IL_0024: brfalse IL_0092
+				IL_0024: brfalse IL_0082
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldstr "aaaaaaaaaa"
-				IL_0050: ldstr "g"
-				IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_005a: stloc.s 4
-				IL_005c: ldloc.3
-				IL_005d: ldstr "match"
-				IL_0062: ldloc.s 4
-				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0069: stloc.3
-				IL_006a: ldarg.0
-				IL_006b: ldloc.3
-				IL_006c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0071: ldloc.0
-				IL_0072: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0077: stloc.2
-				IL_0078: ldloc.2
-				IL_0079: ldc.r8 1
-				IL_0082: add
-				IL_0083: stloc.2
-				IL_0084: ldloc.2
-				IL_0085: box [System.Runtime]System.Double
-				IL_008a: stloc.1
-				IL_008b: ldloc.1
-				IL_008c: stloc.0
-				IL_008d: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldstr "aaaaaaaaaa"
+				IL_0040: ldstr "g"
+				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_004a: stloc.s 4
+				IL_004c: ldloc.3
+				IL_004d: ldstr "match"
+				IL_0052: ldloc.s 4
+				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0059: stloc.3
+				IL_005a: ldarg.0
+				IL_005b: ldloc.3
+				IL_005c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0061: ldloc.0
+				IL_0062: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0067: stloc.2
+				IL_0068: ldloc.2
+				IL_0069: ldc.r8 1
+				IL_0072: add
+				IL_0073: stloc.2
+				IL_0074: ldloc.2
+				IL_0075: box [System.Runtime]System.Double
+				IL_007a: stloc.1
+				IL_007b: ldloc.1
+				IL_007c: stloc.0
+				IL_007d: br IL_000f
 			// end loop
 
-			IL_0092: ldnull
-			IL_0093: ret
+			IL_0082: ldnull
+			IL_0083: ret
 		} // end of method FunctionExpression_L313C25::__js_call__
 
 	} // end of class FunctionExpression_L313C25
@@ -6218,7 +5691,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d13
+				// Method begins at RVA 0x56d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6244,9 +5717,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5388
+			// Method begins at RVA 0x4e14
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6256,29 +5729,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 100
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L318C5::__js_call__
 
 	} // end of class FunctionExpression_L318C5
@@ -6294,7 +5763,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d1c
+				// Method begins at RVA 0x56dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6320,17 +5789,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x53d8
+			// Method begins at RVA 0x4e58
 			// Header size: 12
-			// Code size: 156 (0x9c)
+			// Code size: 134 (0x86)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] float64,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[4] object,
-				[5] object
+				[4] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -6345,7 +5813,7 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 100
 				IL_0022: clt
-				IL_0024: brfalse IL_009a
+				IL_0024: brfalse IL_0084
 
 				IL_0029: ldstr "aaaaaaaaaa"
 				IL_002e: ldstr "g"
@@ -6354,42 +5822,34 @@
 				IL_0039: ldloc.3
 				IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_003f: stloc.s 4
-				IL_0041: ldarg.0
-				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0047: stloc.s 5
-				IL_0049: ldstr "tmp"
-				IL_004e: ldloc.s 5
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0055: stloc.s 5
-				IL_0057: ldloc.s 5
-				IL_0059: ldloc.0
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_005f: stloc.s 5
-				IL_0061: ldloc.s 4
-				IL_0063: ldstr "test"
-				IL_0068: ldloc.s 5
-				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_006f: stloc.s 5
-				IL_0071: ldarg.0
-				IL_0072: ldloc.s 5
-				IL_0074: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0079: ldloc.0
-				IL_007a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007f: stloc.2
-				IL_0080: ldloc.2
-				IL_0081: ldc.r8 1
-				IL_008a: add
-				IL_008b: stloc.2
-				IL_008c: ldloc.2
-				IL_008d: box [System.Runtime]System.Double
-				IL_0092: stloc.1
-				IL_0093: ldloc.1
-				IL_0094: stloc.0
-				IL_0095: br IL_000f
+				IL_0041: ldloc.s 4
+				IL_0043: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				IL_0048: ldarg.0
+				IL_0049: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_004e: ldloc.0
+				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_0059: stloc.s 4
+				IL_005b: ldarg.0
+				IL_005c: ldloc.s 4
+				IL_005e: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0063: ldloc.0
+				IL_0064: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0069: stloc.2
+				IL_006a: ldloc.2
+				IL_006b: ldc.r8 1
+				IL_0074: add
+				IL_0075: stloc.2
+				IL_0076: ldloc.2
+				IL_0077: box [System.Runtime]System.Double
+				IL_007c: stloc.1
+				IL_007d: ldloc.1
+				IL_007e: stloc.0
+				IL_007f: br IL_000f
 			// end loop
 
-			IL_009a: ldnull
-			IL_009b: ret
+			IL_0084: ldnull
+			IL_0085: ret
 		} // end of method FunctionExpression_L322C24::__js_call__
 
 	} // end of class FunctionExpression_L322C24
@@ -6405,7 +5865,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d25
+				// Method begins at RVA 0x56e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6431,9 +5891,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5480
+			// Method begins at RVA 0x4eec
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6443,29 +5903,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L327C5::__js_call__
 
 	} // end of class FunctionExpression_L327C5
@@ -6481,7 +5937,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d2e
+				// Method begins at RVA 0x56ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6507,9 +5963,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x54d0
+			// Method begins at RVA 0x4f30
 			// Header size: 12
-			// Code size: 153 (0x99)
+			// Code size: 137 (0x89)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6531,52 +5987,44 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_0097
+				IL_0024: brfalse IL_0087
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldstr "aaaaaaaaaa"
-				IL_0050: ldstr "g"
-				IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_005a: stloc.s 4
-				IL_005c: ldloc.3
-				IL_005d: ldstr "replace"
-				IL_0062: ldloc.s 4
-				IL_0064: ldstr ""
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_006e: stloc.3
-				IL_006f: ldarg.0
-				IL_0070: ldloc.3
-				IL_0071: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0076: ldloc.0
-				IL_0077: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007c: stloc.2
-				IL_007d: ldloc.2
-				IL_007e: ldc.r8 1
-				IL_0087: add
-				IL_0088: stloc.2
-				IL_0089: ldloc.2
-				IL_008a: box [System.Runtime]System.Double
-				IL_008f: stloc.1
-				IL_0090: ldloc.1
-				IL_0091: stloc.0
-				IL_0092: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldstr "aaaaaaaaaa"
+				IL_0040: ldstr "g"
+				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_004a: stloc.s 4
+				IL_004c: ldloc.3
+				IL_004d: ldstr "replace"
+				IL_0052: ldloc.s 4
+				IL_0054: ldstr ""
+				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_005e: stloc.3
+				IL_005f: ldarg.0
+				IL_0060: ldloc.3
+				IL_0061: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0066: ldloc.0
+				IL_0067: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_006c: stloc.2
+				IL_006d: ldloc.2
+				IL_006e: ldc.r8 1
+				IL_0077: add
+				IL_0078: stloc.2
+				IL_0079: ldloc.2
+				IL_007a: box [System.Runtime]System.Double
+				IL_007f: stloc.1
+				IL_0080: ldloc.1
+				IL_0081: stloc.0
+				IL_0082: br IL_000f
 			// end loop
 
-			IL_0097: ldnull
-			IL_0098: ret
+			IL_0087: ldnull
+			IL_0088: ret
 		} // end of method FunctionExpression_L331C33::__js_call__
 
 	} // end of class FunctionExpression_L331C33
@@ -6592,7 +6040,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d37
+				// Method begins at RVA 0x56f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6618,9 +6066,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5578
+			// Method begins at RVA 0x4fc8
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6630,29 +6078,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L336C5::__js_call__
 
 	} // end of class FunctionExpression_L336C5
@@ -6668,7 +6112,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d40
+				// Method begins at RVA 0x5700
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6694,9 +6138,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x55c8
+			// Method begins at RVA 0x500c
 			// Header size: 12
-			// Code size: 153 (0x99)
+			// Code size: 137 (0x89)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6718,52 +6162,44 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_0097
+				IL_0024: brfalse IL_0087
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldstr "aaaaaaaaaa"
-				IL_0050: ldstr "g"
-				IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_005a: stloc.s 4
-				IL_005c: ldloc.3
-				IL_005d: ldstr "replace"
-				IL_0062: ldloc.s 4
-				IL_0064: ldstr "asdfasdfasdf"
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_006e: stloc.3
-				IL_006f: ldarg.0
-				IL_0070: ldloc.3
-				IL_0071: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0076: ldloc.0
-				IL_0077: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007c: stloc.2
-				IL_007d: ldloc.2
-				IL_007e: ldc.r8 1
-				IL_0087: add
-				IL_0088: stloc.2
-				IL_0089: ldloc.2
-				IL_008a: box [System.Runtime]System.Double
-				IL_008f: stloc.1
-				IL_0090: ldloc.1
-				IL_0091: stloc.0
-				IL_0092: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldstr "aaaaaaaaaa"
+				IL_0040: ldstr "g"
+				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_004a: stloc.s 4
+				IL_004c: ldloc.3
+				IL_004d: ldstr "replace"
+				IL_0052: ldloc.s 4
+				IL_0054: ldstr "asdfasdfasdf"
+				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_005e: stloc.3
+				IL_005f: ldarg.0
+				IL_0060: ldloc.3
+				IL_0061: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0066: ldloc.0
+				IL_0067: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_006c: stloc.2
+				IL_006d: ldloc.2
+				IL_006e: ldc.r8 1
+				IL_0077: add
+				IL_0078: stloc.2
+				IL_0079: ldloc.2
+				IL_007a: box [System.Runtime]System.Double
+				IL_007f: stloc.1
+				IL_0080: ldloc.1
+				IL_0081: stloc.0
+				IL_0082: br IL_000f
 			// end loop
 
-			IL_0097: ldnull
-			IL_0098: ret
+			IL_0087: ldnull
+			IL_0088: ret
 		} // end of method FunctionExpression_L340C35::__js_call__
 
 	} // end of class FunctionExpression_L340C35
@@ -6779,7 +6215,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d49
+				// Method begins at RVA 0x5709
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6805,9 +6241,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5670
+			// Method begins at RVA 0x50a4
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6817,29 +6253,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 100
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L345C5::__js_call__
 
 	} // end of class FunctionExpression_L345C5
@@ -6855,7 +6287,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d52
+				// Method begins at RVA 0x5712
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6881,9 +6313,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x56c0
+			// Method begins at RVA 0x50e8
 			// Header size: 12
-			// Code size: 148 (0x94)
+			// Code size: 132 (0x84)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6905,51 +6337,43 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 100
 				IL_0022: clt
-				IL_0024: brfalse IL_0092
+				IL_0024: brfalse IL_0082
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldstr "aaaaaaaaaa"
-				IL_0050: ldstr "g"
-				IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_005a: stloc.s 4
-				IL_005c: ldloc.3
-				IL_005d: ldstr "match"
-				IL_0062: ldloc.s 4
-				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0069: stloc.3
-				IL_006a: ldarg.0
-				IL_006b: ldloc.3
-				IL_006c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0071: ldloc.0
-				IL_0072: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0077: stloc.2
-				IL_0078: ldloc.2
-				IL_0079: ldc.r8 1
-				IL_0082: add
-				IL_0083: stloc.2
-				IL_0084: ldloc.2
-				IL_0085: box [System.Runtime]System.Double
-				IL_008a: stloc.1
-				IL_008b: ldloc.1
-				IL_008c: stloc.0
-				IL_008d: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldstr "aaaaaaaaaa"
+				IL_0040: ldstr "g"
+				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_004a: stloc.s 4
+				IL_004c: ldloc.3
+				IL_004d: ldstr "match"
+				IL_0052: ldloc.s 4
+				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0059: stloc.3
+				IL_005a: ldarg.0
+				IL_005b: ldloc.3
+				IL_005c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0061: ldloc.0
+				IL_0062: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0067: stloc.2
+				IL_0068: ldloc.2
+				IL_0069: ldc.r8 1
+				IL_0072: add
+				IL_0073: stloc.2
+				IL_0074: ldloc.2
+				IL_0075: box [System.Runtime]System.Double
+				IL_007a: stloc.1
+				IL_007b: ldloc.1
+				IL_007c: stloc.0
+				IL_007d: br IL_000f
 			// end loop
 
-			IL_0092: ldnull
-			IL_0093: ret
+			IL_0082: ldnull
+			IL_0083: ret
 		} // end of method FunctionExpression_L349C32::__js_call__
 
 	} // end of class FunctionExpression_L349C32
@@ -6965,7 +6389,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d5b
+				// Method begins at RVA 0x571b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6991,9 +6415,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5760
+			// Method begins at RVA 0x5178
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7003,29 +6427,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 100
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L354C5::__js_call__
 
 	} // end of class FunctionExpression_L354C5
@@ -7041,7 +6461,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d64
+				// Method begins at RVA 0x5724
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7067,17 +6487,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x57b0
+			// Method begins at RVA 0x51bc
 			// Header size: 12
-			// Code size: 156 (0x9c)
+			// Code size: 134 (0x86)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] float64,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[4] object,
-				[5] object
+				[4] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -7092,7 +6511,7 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 100
 				IL_0022: clt
-				IL_0024: brfalse IL_009a
+				IL_0024: brfalse IL_0084
 
 				IL_0029: ldstr "aaaaaaaaaa"
 				IL_002e: ldstr "g"
@@ -7101,42 +6520,34 @@
 				IL_0039: ldloc.3
 				IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_003f: stloc.s 4
-				IL_0041: ldarg.0
-				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0047: stloc.s 5
-				IL_0049: ldstr "tmp"
-				IL_004e: ldloc.s 5
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0055: stloc.s 5
-				IL_0057: ldloc.s 5
-				IL_0059: ldloc.0
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_005f: stloc.s 5
-				IL_0061: ldloc.s 4
-				IL_0063: ldstr "test"
-				IL_0068: ldloc.s 5
-				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_006f: stloc.s 5
-				IL_0071: ldarg.0
-				IL_0072: ldloc.s 5
-				IL_0074: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0079: ldloc.0
-				IL_007a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007f: stloc.2
-				IL_0080: ldloc.2
-				IL_0081: ldc.r8 1
-				IL_008a: add
-				IL_008b: stloc.2
-				IL_008c: ldloc.2
-				IL_008d: box [System.Runtime]System.Double
-				IL_0092: stloc.1
-				IL_0093: ldloc.1
-				IL_0094: stloc.0
-				IL_0095: br IL_000f
+				IL_0041: ldloc.s 4
+				IL_0043: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				IL_0048: ldarg.0
+				IL_0049: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_004e: ldloc.0
+				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_0059: stloc.s 4
+				IL_005b: ldarg.0
+				IL_005c: ldloc.s 4
+				IL_005e: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0063: ldloc.0
+				IL_0064: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0069: stloc.2
+				IL_006a: ldloc.2
+				IL_006b: ldc.r8 1
+				IL_0074: add
+				IL_0075: stloc.2
+				IL_0076: ldloc.2
+				IL_0077: box [System.Runtime]System.Double
+				IL_007c: stloc.1
+				IL_007d: ldloc.1
+				IL_007e: stloc.0
+				IL_007f: br IL_000f
 			// end loop
 
-			IL_009a: ldnull
-			IL_009b: ret
+			IL_0084: ldnull
+			IL_0085: ret
 		} // end of method FunctionExpression_L358C31::__js_call__
 
 	} // end of class FunctionExpression_L358C31
@@ -7152,7 +6563,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d6d
+				// Method begins at RVA 0x572d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7178,9 +6589,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5858
+			// Method begins at RVA 0x5250
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7190,29 +6601,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L363C5::__js_call__
 
 	} // end of class FunctionExpression_L363C5
@@ -7228,7 +6635,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d76
+				// Method begins at RVA 0x5736
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7254,9 +6661,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x58a8
+			// Method begins at RVA 0x5294
 			// Header size: 12
-			// Code size: 153 (0x99)
+			// Code size: 137 (0x89)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7278,52 +6685,44 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_0097
+				IL_0024: brfalse IL_0087
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldstr "aaaaaaaaaa"
-				IL_0050: ldstr "g"
-				IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_005a: stloc.s 4
-				IL_005c: ldloc.3
-				IL_005d: ldstr "replace"
-				IL_0062: ldloc.s 4
-				IL_0064: ldstr ""
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_006e: stloc.3
-				IL_006f: ldarg.0
-				IL_0070: ldloc.3
-				IL_0071: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0076: ldloc.0
-				IL_0077: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007c: stloc.2
-				IL_007d: ldloc.2
-				IL_007e: ldc.r8 1
-				IL_0087: add
-				IL_0088: stloc.2
-				IL_0089: ldloc.2
-				IL_008a: box [System.Runtime]System.Double
-				IL_008f: stloc.1
-				IL_0090: ldloc.1
-				IL_0091: stloc.0
-				IL_0092: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldstr "aaaaaaaaaa"
+				IL_0040: ldstr "g"
+				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_004a: stloc.s 4
+				IL_004c: ldloc.3
+				IL_004d: ldstr "replace"
+				IL_0052: ldloc.s 4
+				IL_0054: ldstr ""
+				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_005e: stloc.3
+				IL_005f: ldarg.0
+				IL_0060: ldloc.3
+				IL_0061: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0066: ldloc.0
+				IL_0067: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_006c: stloc.2
+				IL_006d: ldloc.2
+				IL_006e: ldc.r8 1
+				IL_0077: add
+				IL_0078: stloc.2
+				IL_0079: ldloc.2
+				IL_007a: box [System.Runtime]System.Double
+				IL_007f: stloc.1
+				IL_0080: ldloc.1
+				IL_0081: stloc.0
+				IL_0082: br IL_000f
 			// end loop
 
-			IL_0097: ldnull
-			IL_0098: ret
+			IL_0087: ldnull
+			IL_0088: ret
 		} // end of method FunctionExpression_L367C40::__js_call__
 
 	} // end of class FunctionExpression_L367C40
@@ -7339,7 +6738,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d7f
+				// Method begins at RVA 0x573f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7365,9 +6764,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5950
+			// Method begins at RVA 0x532c
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7377,29 +6776,25 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
 			IL_0006: stloc.0
-			IL_0007: ldstr "generateTestStrings"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldc.r8 50
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: stloc.0
-			IL_0034: ldarg.0
-			IL_0035: ldloc.0
-			IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_003b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L372C5::__js_call__
 
 	} // end of class FunctionExpression_L372C5
@@ -7415,7 +6810,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d88
+				// Method begins at RVA 0x5748
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7441,9 +6836,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x59a0
+			// Method begins at RVA 0x5370
 			// Header size: 12
-			// Code size: 153 (0x99)
+			// Code size: 137 (0x89)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7465,52 +6860,44 @@
 				IL_0018: ldloc.2
 				IL_0019: ldc.r8 50
 				IL_0022: clt
-				IL_0024: brfalse IL_0097
+				IL_0024: brfalse IL_0087
 
 				IL_0029: ldarg.0
 				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: stloc.3
-				IL_0030: ldstr "tmp"
-				IL_0035: ldloc.3
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003b: stloc.3
-				IL_003c: ldloc.3
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0043: stloc.3
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004a: stloc.3
-				IL_004b: ldstr "aaaaaaaaaa"
-				IL_0050: ldstr "g"
-				IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_005a: stloc.s 4
-				IL_005c: ldloc.3
-				IL_005d: ldstr "replace"
-				IL_0062: ldloc.s 4
-				IL_0064: ldstr "asdfasdfasdf"
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_006e: stloc.3
-				IL_006f: ldarg.0
-				IL_0070: ldloc.3
-				IL_0071: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0076: ldloc.0
-				IL_0077: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007c: stloc.2
-				IL_007d: ldloc.2
-				IL_007e: ldc.r8 1
-				IL_0087: add
-				IL_0088: stloc.2
-				IL_0089: ldloc.2
-				IL_008a: box [System.Runtime]System.Double
-				IL_008f: stloc.1
-				IL_0090: ldloc.1
-				IL_0091: stloc.0
-				IL_0092: br IL_000f
+				IL_002f: ldloc.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003a: stloc.3
+				IL_003b: ldstr "aaaaaaaaaa"
+				IL_0040: ldstr "g"
+				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_004a: stloc.s 4
+				IL_004c: ldloc.3
+				IL_004d: ldstr "replace"
+				IL_0052: ldloc.s 4
+				IL_0054: ldstr "asdfasdfasdf"
+				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_005e: stloc.3
+				IL_005f: ldarg.0
+				IL_0060: ldloc.3
+				IL_0061: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0066: ldloc.0
+				IL_0067: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_006c: stloc.2
+				IL_006d: ldloc.2
+				IL_006e: ldc.r8 1
+				IL_0077: add
+				IL_0078: stloc.2
+				IL_0079: ldloc.2
+				IL_007a: box [System.Runtime]System.Double
+				IL_007f: stloc.1
+				IL_0080: ldloc.1
+				IL_0081: stloc.0
+				IL_0082: br IL_000f
 			// end loop
 
-			IL_0097: ldnull
-			IL_0098: ret
+			IL_0087: ldnull
+			IL_0088: ret
 		} // end of method FunctionExpression_L376C42::__js_call__
 
 	} // end of class FunctionExpression_L376C42
@@ -7545,7 +6932,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5a9d
+			// Method begins at RVA 0x545d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -9525,7 +8912,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x5d91
+		// Method begins at RVA 0x5751
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33f8
+						// Method begins at RVA 0x3354
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33ef
+					// Method begins at RVA 0x334b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33e6
+				// Method begins at RVA 0x3342
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,7 +103,7 @@
 			)
 			// Method begins at RVA 0x2484
 			// Header size: 12
-			// Code size: 378 (0x17a)
+			// Code size: 310 (0x136)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/Scope/Block_L211C0,
@@ -113,13 +113,12 @@
 				[4] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/Scope/Block_L211C0/Block_L218C1,
 				[5] object,
 				[6] object,
-				[7] object,
-				[8] float64,
-				[9] float64,
-				[10] object,
-				[11] object[],
-				[12] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve,
-				[13] object
+				[7] float64,
+				[8] object,
+				[9] object[],
+				[10] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve,
+				[11] float64,
+				[12] object
 			)
 
 			IL_0000: ldarg.3
@@ -135,129 +134,107 @@
 			IL_0025: stloc.1
 			IL_0026: ldarg.0
 			IL_0027: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-			IL_002c: stloc.s 6
-			IL_002e: ldstr "performance"
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0031: stloc.s 6
 			IL_0033: ldloc.s 6
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003a: stloc.s 6
-			IL_003c: ldloc.s 6
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0043: stloc.s 6
-			IL_0045: ldloc.s 6
-			IL_0047: ldstr "now"
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0051: stloc.s 6
-			IL_0053: ldloc.s 6
-			IL_0055: stloc.2
-			IL_0056: ldloc.2
-			IL_0057: stloc.s 6
-			IL_0059: ldstr "NOW_UNITS_PER_SECOND"
-			IL_005e: ldarg.0
-			IL_005f: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
-			IL_0064: box [System.Runtime]System.Double
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_006e: stloc.s 7
-			IL_0070: ldarg.3
-			IL_0071: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0076: stloc.s 8
-			IL_0078: ldloc.s 7
-			IL_007a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_007f: stloc.s 9
-			IL_0081: ldloc.s 8
-			IL_0083: ldloc.s 9
-			IL_0085: mul
-			IL_0086: stloc.s 9
-			IL_0088: ldloc.s 6
-			IL_008a: ldloc.s 9
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0091: stloc.s 10
-			IL_0093: ldloc.s 10
-			IL_0095: stloc.3
-			// loop start (head: IL_0096)
-				IL_0096: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/Scope/Block_L211C0/Block_L218C1::.ctor()
-				IL_009b: stloc.s 4
-				IL_009d: ldc.i4.1
-				IL_009e: newarr [System.Runtime]System.Object
-				IL_00a3: dup
-				IL_00a4: ldc.i4.0
-				IL_00a5: ldarg.0
-				IL_00a6: stelem.ref
-				IL_00a7: stloc.s 11
-				IL_00a9: ldloc.s 11
-				IL_00ab: ldc.i4.1
-				IL_00ac: newarr [System.Runtime]System.Object
-				IL_00b1: dup
-				IL_00b2: ldc.i4.0
-				IL_00b3: ldarg.2
-				IL_00b4: stelem.ref
-				IL_00b5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-				IL_00ba: ldarg.2
-				IL_00bb: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::.ctor(object[], object)
-				IL_00c0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-				IL_00c5: stloc.s 12
-				IL_00c7: ldloc.s 12
-				IL_00c9: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_00ce: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_00d3: ldstr "prototype"
-				IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-				IL_00dd: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-				IL_00e2: ldloc.s 12
-				IL_00e4: stloc.s 5
-				IL_00e6: ldloc.s 5
-				IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ed: stloc.s 6
-				IL_00ef: ldloc.s 6
-				IL_00f1: isinst Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_00f6: dup
-				IL_00f7: brfalse IL_0107
+			IL_0035: ldstr "now"
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_003f: stloc.s 6
+			IL_0041: ldloc.s 6
+			IL_0043: stloc.2
+			IL_0044: ldloc.2
+			IL_0045: stloc.s 6
+			IL_0047: ldarg.0
+			IL_0048: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 6
+			IL_0051: ldarg.3
+			IL_0052: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0057: ldloc.s 7
+			IL_0059: mul
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_005f: stloc.s 8
+			IL_0061: ldloc.s 8
+			IL_0063: stloc.3
+			// loop start (head: IL_0064)
+				IL_0064: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/Scope/Block_L211C0/Block_L218C1::.ctor()
+				IL_0069: stloc.s 4
+				IL_006b: ldc.i4.1
+				IL_006c: newarr [System.Runtime]System.Object
+				IL_0071: dup
+				IL_0072: ldc.i4.0
+				IL_0073: ldarg.0
+				IL_0074: stelem.ref
+				IL_0075: stloc.s 9
+				IL_0077: ldloc.s 9
+				IL_0079: ldc.i4.1
+				IL_007a: newarr [System.Runtime]System.Object
+				IL_007f: dup
+				IL_0080: ldc.i4.0
+				IL_0081: ldarg.2
+				IL_0082: stelem.ref
+				IL_0083: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+				IL_0088: ldarg.2
+				IL_0089: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::.ctor(object[], object)
+				IL_008e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+				IL_0093: stloc.s 10
+				IL_0095: ldloc.s 10
+				IL_0097: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+				IL_009c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+				IL_00a1: ldstr "prototype"
+				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+				IL_00ab: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+				IL_00b0: ldloc.s 10
+				IL_00b2: stloc.s 5
+				IL_00b4: ldloc.s 5
+				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00bb: stloc.s 6
+				IL_00bd: ldloc.s 6
+				IL_00bf: isinst Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+				IL_00c4: dup
+				IL_00c5: brfalse IL_00d5
 
-				IL_00fc: callvirt instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
-				IL_0101: pop
-				IL_0102: br IL_0115
+				IL_00ca: callvirt instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
+				IL_00cf: pop
+				IL_00d0: br IL_00e3
 
-				IL_0107: pop
-				IL_0108: ldloc.s 6
-				IL_010a: ldstr "runSieve"
-				IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0114: pop
+				IL_00d5: pop
+				IL_00d6: ldloc.s 6
+				IL_00d8: ldstr "runSieve"
+				IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_00e2: pop
 
-				IL_0115: ldloc.1
-				IL_0116: ldc.r8 1
-				IL_011f: add
-				IL_0120: stloc.1
-				IL_0121: ldarg.0
-				IL_0122: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-				IL_0127: stloc.s 6
-				IL_0129: ldstr "performance"
-				IL_012e: ldloc.s 6
-				IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0135: stloc.s 6
-				IL_0137: ldloc.s 6
-				IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_013e: stloc.s 6
-				IL_0140: ldloc.s 6
-				IL_0142: ldstr "now"
-				IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_014c: stloc.s 6
-				IL_014e: ldloc.s 6
-				IL_0150: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0155: stloc.s 9
-				IL_0157: ldloc.3
-				IL_0158: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_015d: stloc.s 8
-				IL_015f: ldloc.s 9
-				IL_0161: ldloc.s 8
-				IL_0163: clt
-				IL_0165: brfalse IL_016f
+				IL_00e3: ldloc.1
+				IL_00e4: ldc.r8 1
+				IL_00ed: add
+				IL_00ee: stloc.1
+				IL_00ef: ldarg.0
+				IL_00f0: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+				IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00fa: stloc.s 6
+				IL_00fc: ldloc.s 6
+				IL_00fe: ldstr "now"
+				IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0108: stloc.s 6
+				IL_010a: ldloc.s 6
+				IL_010c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0111: stloc.s 7
+				IL_0113: ldloc.3
+				IL_0114: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0119: stloc.s 11
+				IL_011b: ldloc.s 7
+				IL_011d: ldloc.s 11
+				IL_011f: clt
+				IL_0121: brfalse IL_012b
 
-				IL_016a: br IL_0096
+				IL_0126: br IL_0064
 			// end loop
 
-			IL_016f: ldloc.1
-			IL_0170: box [System.Runtime]System.Double
-			IL_0175: stloc.s 13
-			IL_0177: ldloc.s 13
-			IL_0179: ret
+			IL_012b: ldloc.1
+			IL_012c: box [System.Runtime]System.Double
+			IL_0131: stloc.s 12
+			IL_0133: ldloc.s 12
+			IL_0135: ret
 		} // end of method ArrowFunction_L210C23::__js_call__
 
 	} // end of class ArrowFunction_L210C23
@@ -288,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3401
+				// Method begins at RVA 0x335d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -315,9 +292,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x260c
+			// Method begins at RVA 0x25c8
 			// Header size: 12
-			// Code size: 636 (0x27c)
+			// Code size: 572 (0x23c)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -447,123 +424,103 @@
 
 			IL_011d: ldarg.0
 			IL_011e: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-			IL_0123: stloc.s 11
-			IL_0125: ldstr "performance"
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0128: stloc.s 11
 			IL_012a: ldloc.s 11
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0131: stloc.s 11
-			IL_0133: ldloc.s 11
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013a: stloc.s 11
-			IL_013c: ldloc.s 11
-			IL_013e: ldstr "now"
-			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0148: stloc.s 11
-			IL_014a: ldloc.s 11
-			IL_014c: stloc.s 5
-			IL_014e: ldarg.0
-			IL_014f: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-			IL_0154: ldnull
-			IL_0155: ldloc.0
-			IL_0156: ldloc.1
-			IL_0157: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object, object)
-			IL_015c: stloc.s 11
-			IL_015e: ldloc.s 11
-			IL_0160: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0165: stloc.s 13
-			IL_0167: ldloc.s 13
-			IL_0169: stloc.s 6
-			IL_016b: ldarg.0
-			IL_016c: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-			IL_0171: stloc.s 11
-			IL_0173: ldstr "performance"
-			IL_0178: ldloc.s 11
-			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_017f: stloc.s 11
-			IL_0181: ldloc.s 11
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0188: stloc.s 11
-			IL_018a: ldloc.s 11
-			IL_018c: ldstr "now"
-			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0196: stloc.s 11
-			IL_0198: ldloc.s 11
-			IL_019a: stloc.s 7
-			IL_019c: ldloc.s 7
-			IL_019e: stloc.s 11
-			IL_01a0: ldloc.s 11
-			IL_01a2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01a7: stloc.s 13
-			IL_01a9: ldloc.s 5
-			IL_01ab: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01b0: stloc.s 14
-			IL_01b2: ldloc.s 13
-			IL_01b4: ldloc.s 14
-			IL_01b6: sub
-			IL_01b7: stloc.s 14
-			IL_01b9: ldstr "NOW_UNITS_PER_SECOND"
-			IL_01be: ldarg.0
-			IL_01bf: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
-			IL_01c4: box [System.Runtime]System.Double
-			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01ce: stloc.s 11
-			IL_01d0: ldloc.s 11
-			IL_01d2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01d7: stloc.s 13
-			IL_01d9: ldloc.s 14
-			IL_01db: ldloc.s 13
-			IL_01dd: div
-			IL_01de: stloc.s 13
-			IL_01e0: ldloc.s 13
-			IL_01e2: stloc.s 8
-			IL_01e4: ldstr "console"
-			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01ee: stloc.s 11
-			IL_01f0: ldloc.s 11
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f7: stloc.s 11
-			IL_01f9: ldloc.3
-			IL_01fa: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ff: stloc.s 15
-			IL_0201: ldstr "\nrogiervandam-"
-			IL_0206: ldloc.s 15
-			IL_0208: call string [System.Runtime]System.String::Concat(string, string)
-			IL_020d: stloc.s 15
-			IL_020f: ldloc.s 15
-			IL_0211: ldstr ";"
+			IL_012c: ldstr "now"
+			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0136: stloc.s 11
+			IL_0138: ldloc.s 11
+			IL_013a: stloc.s 5
+			IL_013c: ldarg.0
+			IL_013d: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+			IL_0142: ldnull
+			IL_0143: ldloc.0
+			IL_0144: ldloc.1
+			IL_0145: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object, object)
+			IL_014a: stloc.s 11
+			IL_014c: ldloc.s 11
+			IL_014e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0153: stloc.s 13
+			IL_0155: ldloc.s 13
+			IL_0157: stloc.s 6
+			IL_0159: ldarg.0
+			IL_015a: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0164: stloc.s 11
+			IL_0166: ldloc.s 11
+			IL_0168: ldstr "now"
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0172: stloc.s 11
+			IL_0174: ldloc.s 11
+			IL_0176: stloc.s 7
+			IL_0178: ldloc.s 7
+			IL_017a: stloc.s 11
+			IL_017c: ldloc.s 11
+			IL_017e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0183: stloc.s 13
+			IL_0185: ldloc.s 5
+			IL_0187: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_018c: stloc.s 14
+			IL_018e: ldloc.s 13
+			IL_0190: ldloc.s 14
+			IL_0192: sub
+			IL_0193: stloc.s 14
+			IL_0195: ldloc.s 14
+			IL_0197: ldarg.0
+			IL_0198: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
+			IL_019d: div
+			IL_019e: stloc.s 14
+			IL_01a0: ldloc.s 14
+			IL_01a2: stloc.s 8
+			IL_01a4: ldstr "console"
+			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ae: stloc.s 11
+			IL_01b0: ldloc.s 11
+			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01b7: stloc.s 11
+			IL_01b9: ldloc.3
+			IL_01ba: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01bf: stloc.s 15
+			IL_01c1: ldstr "\nrogiervandam-"
+			IL_01c6: ldloc.s 15
+			IL_01c8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01cd: stloc.s 15
+			IL_01cf: ldloc.s 15
+			IL_01d1: ldstr ";"
+			IL_01d6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01db: stloc.s 15
+			IL_01dd: ldloc.s 6
+			IL_01df: box [System.Runtime]System.Double
+			IL_01e4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01e9: stloc.s 16
+			IL_01eb: ldloc.s 15
+			IL_01ed: ldloc.s 16
+			IL_01ef: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f4: stloc.s 16
+			IL_01f6: ldloc.s 16
+			IL_01f8: ldstr ";"
+			IL_01fd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0202: stloc.s 16
+			IL_0204: ldloc.s 8
+			IL_0206: box [System.Runtime]System.Double
+			IL_020b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0210: stloc.s 15
+			IL_0212: ldloc.s 16
+			IL_0214: ldloc.s 15
 			IL_0216: call string [System.Runtime]System.String::Concat(string, string)
 			IL_021b: stloc.s 15
-			IL_021d: ldloc.s 6
-			IL_021f: box [System.Runtime]System.Double
-			IL_0224: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0229: stloc.s 16
-			IL_022b: ldloc.s 15
-			IL_022d: ldloc.s 16
-			IL_022f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0234: stloc.s 16
-			IL_0236: ldloc.s 16
-			IL_0238: ldstr ";"
-			IL_023d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0242: stloc.s 16
-			IL_0244: ldloc.s 8
-			IL_0246: box [System.Runtime]System.Double
-			IL_024b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0250: stloc.s 15
-			IL_0252: ldloc.s 16
-			IL_0254: ldloc.s 15
-			IL_0256: call string [System.Runtime]System.String::Concat(string, string)
-			IL_025b: stloc.s 15
-			IL_025d: ldloc.s 15
-			IL_025f: ldstr ";1;algorithm=base,faithful=yes,bits=1"
-			IL_0264: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0269: stloc.s 15
-			IL_026b: ldloc.s 11
-			IL_026d: ldstr "log"
-			IL_0272: ldloc.s 15
-			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0279: pop
-			IL_027a: ldnull
-			IL_027b: ret
+			IL_021d: ldloc.s 15
+			IL_021f: ldstr ";1;algorithm=base,faithful=yes,bits=1"
+			IL_0224: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0229: stloc.s 15
+			IL_022b: ldloc.s 11
+			IL_022d: ldstr "log"
+			IL_0232: ldloc.s 15
+			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0239: pop
+			IL_023a: ldnull
+			IL_023b: ret
 		} // end of method ArrowFunction_L229C14::__js_call__
 
 	} // end of class ArrowFunction_L229C14
@@ -579,7 +536,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32d8
+				// Method begins at RVA 0x3234
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -599,7 +556,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32e1
+				// Method begins at RVA 0x323d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -619,7 +576,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32ea
+				// Method begins at RVA 0x3246
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -647,7 +604,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3305
+						// Method begins at RVA 0x3261
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -671,7 +628,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3317
+							// Method begins at RVA 0x3273
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -689,7 +646,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x330e
+						// Method begins at RVA 0x326a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -707,7 +664,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32fc
+					// Method begins at RVA 0x3258
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -735,7 +692,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3332
+							// Method begins at RVA 0x328e
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -753,7 +710,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3329
+						// Method begins at RVA 0x3285
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -771,7 +728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3320
+					// Method begins at RVA 0x327c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -795,7 +752,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3344
+						// Method begins at RVA 0x32a0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -813,7 +770,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x333b
+					// Method begins at RVA 0x3297
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -831,7 +788,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32f3
+				// Method begins at RVA 0x324f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -851,7 +808,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x334d
+				// Method begins at RVA 0x32a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -875,7 +832,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x335f
+					// Method begins at RVA 0x32bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -893,7 +850,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3356
+				// Method begins at RVA 0x32b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -921,7 +878,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28fc
+			// Method begins at RVA 0x2878
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -970,7 +927,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c10
+			// Method begins at RVA 0x2b6c
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -1040,9 +997,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2998
+			// Method begins at RVA 0x2914
 			// Header size: 12
-			// Code size: 620 (0x26c)
+			// Code size: 588 (0x24c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26,
@@ -1064,297 +1021,286 @@
 				[16] float64,
 				[17] float64,
 				[18] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29/Block_L89C36,
-				[19] object,
-				[20] float64
+				[19] float64
 			)
 
-			IL_0000: ldstr "WORD_SIZE"
-			IL_0005: ldarg.0
-			IL_0006: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray::_scopes
-			IL_000b: ldc.i4.0
-			IL_000c: ldelem.ref
-			IL_000d: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-			IL_0012: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::WORD_SIZE
-			IL_0017: box [System.Runtime]System.Double
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0021: stloc.s 19
-			IL_0023: ldloc.s 19
-			IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002a: stloc.s 20
-			IL_002c: ldloc.s 20
-			IL_002e: ldc.r8 2
-			IL_0037: div
-			IL_0038: stloc.s 20
-			IL_003a: ldarg.2
-			IL_003b: ldloc.s 20
-			IL_003d: cgt
-			IL_003f: brfalse IL_0172
+			IL_0000: ldarg.2
+			IL_0001: ldarg.0
+			IL_0002: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray::_scopes
+			IL_0007: ldc.i4.0
+			IL_0008: ldelem.ref
+			IL_0009: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+			IL_000e: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::WORD_SIZE
+			IL_0013: ldc.r8 2
+			IL_001c: div
+			IL_001d: cgt
+			IL_001f: brfalse IL_0152
 
-			IL_0044: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26::.ctor()
-			IL_0049: stloc.0
-			IL_004a: ldarg.1
-			IL_004b: ldc.r8 32
-			IL_0054: ldarg.2
-			IL_0055: mul
-			IL_0056: add
-			IL_0057: stloc.1
-			IL_0058: ldloc.1
-			IL_0059: stloc.s 20
-			IL_005b: ldloc.s 20
-			IL_005d: ldarg.3
-			IL_005e: cgt
-			IL_0060: brfalse IL_0098
+			IL_0024: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26::.ctor()
+			IL_0029: stloc.0
+			IL_002a: ldarg.1
+			IL_002b: ldc.r8 32
+			IL_0034: ldarg.2
+			IL_0035: mul
+			IL_0036: add
+			IL_0037: stloc.1
+			IL_0038: ldloc.1
+			IL_0039: stloc.s 19
+			IL_003b: ldloc.s 19
+			IL_003d: ldarg.3
+			IL_003e: cgt
+			IL_0040: brfalse IL_0078
 
-			IL_0065: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26/Block_L57C39::.ctor()
-			IL_006a: stloc.2
-			IL_006b: ldarg.1
-			IL_006c: stloc.3
-			// loop start (head: IL_006d)
-				IL_006d: ldloc.3
-				IL_006e: stloc.s 20
-				IL_0070: ldloc.s 20
-				IL_0072: ldarg.3
-				IL_0073: clt
-				IL_0075: brfalse IL_0096
+			IL_0045: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26/Block_L57C39::.ctor()
+			IL_004a: stloc.2
+			IL_004b: ldarg.1
+			IL_004c: stloc.3
+			// loop start (head: IL_004d)
+				IL_004d: ldloc.3
+				IL_004e: stloc.s 19
+				IL_0050: ldloc.s 19
+				IL_0052: ldarg.3
+				IL_0053: clt
+				IL_0055: brfalse IL_0076
 
-				IL_007a: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26/Scope_For_L59C9/Block_L59C69::.ctor()
-				IL_007f: stloc.s 4
-				IL_0081: ldarg.0
-				IL_0082: ldloc.3
-				IL_0083: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
-				IL_0088: pop
-				IL_0089: ldloc.3
-				IL_008a: ldarg.2
-				IL_008b: add
-				IL_008c: stloc.s 20
-				IL_008e: ldloc.s 20
-				IL_0090: stloc.3
-				IL_0091: br IL_006d
+				IL_005a: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26/Scope_For_L59C9/Block_L59C69::.ctor()
+				IL_005f: stloc.s 4
+				IL_0061: ldarg.0
+				IL_0062: ldloc.3
+				IL_0063: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
+				IL_0068: pop
+				IL_0069: ldloc.3
+				IL_006a: ldarg.2
+				IL_006b: add
+				IL_006c: stloc.s 19
+				IL_006e: ldloc.s 19
+				IL_0070: stloc.3
+				IL_0071: br IL_004d
 			// end loop
 
-			IL_0096: ldnull
-			IL_0097: ret
+			IL_0076: ldnull
+			IL_0077: ret
 
-			IL_0098: ldarg.3
-			IL_0099: conv.i4
-			IL_009a: conv.u4
-			IL_009b: ldc.r8 5
-			IL_00a4: conv.i4
-			IL_00a5: shr.un
-			IL_00a6: conv.r.un
-			IL_00a7: stloc.s 20
-			IL_00a9: ldloc.s 20
-			IL_00ab: stloc.s 5
-			IL_00ad: ldarg.1
-			IL_00ae: stloc.s 6
-			// loop start (head: IL_00b0)
-				IL_00b0: ldloc.s 6
-				IL_00b2: stloc.s 20
-				IL_00b4: ldloc.s 20
-				IL_00b6: ldloc.1
-				IL_00b7: clt
-				IL_00b9: brfalse IL_0170
+			IL_0078: ldarg.3
+			IL_0079: conv.i4
+			IL_007a: conv.u4
+			IL_007b: ldc.r8 5
+			IL_0084: conv.i4
+			IL_0085: shr.un
+			IL_0086: conv.r.un
+			IL_0087: stloc.s 19
+			IL_0089: ldloc.s 19
+			IL_008b: stloc.s 5
+			IL_008d: ldarg.1
+			IL_008e: stloc.s 6
+			// loop start (head: IL_0090)
+				IL_0090: ldloc.s 6
+				IL_0092: stloc.s 19
+				IL_0094: ldloc.s 19
+				IL_0096: ldloc.1
+				IL_0097: clt
+				IL_0099: brfalse IL_0150
 
-				IL_00be: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75::.ctor()
-				IL_00c3: stloc.s 7
-				IL_00c5: ldloc.s 6
-				IL_00c7: stloc.s 20
-				IL_00c9: ldloc.s 20
-				IL_00cb: conv.i4
-				IL_00cc: conv.u4
-				IL_00cd: ldc.r8 5
-				IL_00d6: conv.i4
-				IL_00d7: shr.un
-				IL_00d8: conv.r.un
-				IL_00d9: stloc.s 20
-				IL_00db: ldloc.s 20
-				IL_00dd: stloc.s 8
-				IL_00df: ldloc.s 6
-				IL_00e1: stloc.s 20
-				IL_00e3: ldloc.s 20
-				IL_00e5: conv.i4
-				IL_00e6: ldc.r8 31
-				IL_00ef: conv.i4
-				IL_00f0: and
-				IL_00f1: conv.r8
-				IL_00f2: stloc.s 20
-				IL_00f4: ldloc.s 20
-				IL_00f6: stloc.s 9
-				IL_00f8: ldc.r8 1
-				IL_0101: conv.i4
-				IL_0102: ldloc.s 9
-				IL_0104: conv.i4
-				IL_0105: shl
-				IL_0106: conv.r8
-				IL_0107: stloc.s 20
-				IL_0109: ldloc.s 20
-				IL_010b: stloc.s 10
-				// loop start (head: IL_010d)
-					IL_010d: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75/Block_L70C7::.ctor()
-					IL_0112: stloc.s 11
-					IL_0114: ldarg.0
-					IL_0115: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-					IL_011a: ldloc.s 8
-					IL_011c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_0121: stloc.s 20
-					IL_0123: ldloc.s 20
-					IL_0125: stloc.s 20
-					IL_0127: ldloc.s 20
-					IL_0129: conv.i4
-					IL_012a: ldloc.s 10
-					IL_012c: conv.i4
-					IL_012d: or
-					IL_012e: conv.r8
-					IL_012f: stloc.s 20
-					IL_0131: ldarg.0
-					IL_0132: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-					IL_0137: ldloc.s 8
-					IL_0139: ldloc.s 20
-					IL_013b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_0140: ldloc.s 8
-					IL_0142: ldarg.2
-					IL_0143: add
-					IL_0144: stloc.s 20
-					IL_0146: ldloc.s 20
-					IL_0148: stloc.s 8
-					IL_014a: ldloc.s 8
-					IL_014c: stloc.s 20
-					IL_014e: ldloc.s 20
-					IL_0150: ldloc.s 5
-					IL_0152: cgt
-					IL_0154: ldc.i4.0
-					IL_0155: ceq
-					IL_0157: brfalse IL_0161
+				IL_009e: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75::.ctor()
+				IL_00a3: stloc.s 7
+				IL_00a5: ldloc.s 6
+				IL_00a7: stloc.s 19
+				IL_00a9: ldloc.s 19
+				IL_00ab: conv.i4
+				IL_00ac: conv.u4
+				IL_00ad: ldc.r8 5
+				IL_00b6: conv.i4
+				IL_00b7: shr.un
+				IL_00b8: conv.r.un
+				IL_00b9: stloc.s 19
+				IL_00bb: ldloc.s 19
+				IL_00bd: stloc.s 8
+				IL_00bf: ldloc.s 6
+				IL_00c1: stloc.s 19
+				IL_00c3: ldloc.s 19
+				IL_00c5: conv.i4
+				IL_00c6: ldc.r8 31
+				IL_00cf: conv.i4
+				IL_00d0: and
+				IL_00d1: conv.r8
+				IL_00d2: stloc.s 19
+				IL_00d4: ldloc.s 19
+				IL_00d6: stloc.s 9
+				IL_00d8: ldc.r8 1
+				IL_00e1: conv.i4
+				IL_00e2: ldloc.s 9
+				IL_00e4: conv.i4
+				IL_00e5: shl
+				IL_00e6: conv.r8
+				IL_00e7: stloc.s 19
+				IL_00e9: ldloc.s 19
+				IL_00eb: stloc.s 10
+				// loop start (head: IL_00ed)
+					IL_00ed: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75/Block_L70C7::.ctor()
+					IL_00f2: stloc.s 11
+					IL_00f4: ldarg.0
+					IL_00f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+					IL_00fa: ldloc.s 8
+					IL_00fc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_0101: stloc.s 19
+					IL_0103: ldloc.s 19
+					IL_0105: stloc.s 19
+					IL_0107: ldloc.s 19
+					IL_0109: conv.i4
+					IL_010a: ldloc.s 10
+					IL_010c: conv.i4
+					IL_010d: or
+					IL_010e: conv.r8
+					IL_010f: stloc.s 19
+					IL_0111: ldarg.0
+					IL_0112: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+					IL_0117: ldloc.s 8
+					IL_0119: ldloc.s 19
+					IL_011b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_0120: ldloc.s 8
+					IL_0122: ldarg.2
+					IL_0123: add
+					IL_0124: stloc.s 19
+					IL_0126: ldloc.s 19
+					IL_0128: stloc.s 8
+					IL_012a: ldloc.s 8
+					IL_012c: stloc.s 19
+					IL_012e: ldloc.s 19
+					IL_0130: ldloc.s 5
+					IL_0132: cgt
+					IL_0134: ldc.i4.0
+					IL_0135: ceq
+					IL_0137: brfalse IL_0141
 
-					IL_015c: br IL_010d
+					IL_013c: br IL_00ed
 				// end loop
 
-				IL_0161: ldloc.s 6
-				IL_0163: ldarg.2
-				IL_0164: add
-				IL_0165: stloc.s 20
-				IL_0167: ldloc.s 20
-				IL_0169: stloc.s 6
-				IL_016b: br IL_00b0
+				IL_0141: ldloc.s 6
+				IL_0143: ldarg.2
+				IL_0144: add
+				IL_0145: stloc.s 19
+				IL_0147: ldloc.s 19
+				IL_0149: stloc.s 6
+				IL_014b: br IL_0090
 			// end loop
 
-			IL_0170: ldnull
-			IL_0171: ret
+			IL_0150: ldnull
+			IL_0151: ret
 
-			IL_0172: ldarg.1
-			IL_0173: stloc.s 12
-			IL_0175: ldloc.s 12
-			IL_0177: stloc.s 20
-			IL_0179: ldloc.s 20
-			IL_017b: conv.i4
-			IL_017c: conv.u4
-			IL_017d: ldc.r8 5
-			IL_0186: conv.i4
-			IL_0187: shr.un
-			IL_0188: conv.r.un
-			IL_0189: stloc.s 20
-			IL_018b: ldloc.s 20
-			IL_018d: stloc.s 13
-			IL_018f: ldarg.0
-			IL_0190: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_0195: ldloc.s 13
-			IL_0197: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_019c: stloc.s 20
-			IL_019e: ldloc.s 20
-			IL_01a0: stloc.s 14
-			// loop start (head: IL_01a2)
-				IL_01a2: ldloc.s 12
-				IL_01a4: stloc.s 20
-				IL_01a6: ldloc.s 20
-				IL_01a8: ldarg.3
-				IL_01a9: clt
-				IL_01ab: brfalse IL_025b
+			IL_0152: ldarg.1
+			IL_0153: stloc.s 12
+			IL_0155: ldloc.s 12
+			IL_0157: stloc.s 19
+			IL_0159: ldloc.s 19
+			IL_015b: conv.i4
+			IL_015c: conv.u4
+			IL_015d: ldc.r8 5
+			IL_0166: conv.i4
+			IL_0167: shr.un
+			IL_0168: conv.r.un
+			IL_0169: stloc.s 19
+			IL_016b: ldloc.s 19
+			IL_016d: stloc.s 13
+			IL_016f: ldarg.0
+			IL_0170: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_0175: ldloc.s 13
+			IL_0177: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_017c: stloc.s 19
+			IL_017e: ldloc.s 19
+			IL_0180: stloc.s 14
+			// loop start (head: IL_0182)
+				IL_0182: ldloc.s 12
+				IL_0184: stloc.s 19
+				IL_0186: ldloc.s 19
+				IL_0188: ldarg.3
+				IL_0189: clt
+				IL_018b: brfalse IL_023b
 
-				IL_01b0: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29::.ctor()
-				IL_01b5: stloc.s 15
-				IL_01b7: ldloc.s 12
-				IL_01b9: stloc.s 20
-				IL_01bb: ldloc.s 20
-				IL_01bd: conv.i4
-				IL_01be: ldc.r8 31
-				IL_01c7: conv.i4
-				IL_01c8: and
-				IL_01c9: conv.r8
-				IL_01ca: stloc.s 20
-				IL_01cc: ldloc.s 20
-				IL_01ce: stloc.s 16
-				IL_01d0: ldc.r8 1
-				IL_01d9: conv.i4
-				IL_01da: ldloc.s 16
-				IL_01dc: conv.i4
-				IL_01dd: shl
-				IL_01de: conv.r8
-				IL_01df: stloc.s 20
-				IL_01e1: ldloc.s 14
-				IL_01e3: conv.i4
-				IL_01e4: ldloc.s 20
-				IL_01e6: conv.i4
-				IL_01e7: or
-				IL_01e8: conv.r8
-				IL_01e9: stloc.s 20
-				IL_01eb: ldloc.s 20
-				IL_01ed: stloc.s 14
-				IL_01ef: ldloc.s 12
-				IL_01f1: ldarg.2
-				IL_01f2: add
-				IL_01f3: stloc.s 20
-				IL_01f5: ldloc.s 20
-				IL_01f7: stloc.s 12
-				IL_01f9: ldloc.s 12
-				IL_01fb: stloc.s 20
-				IL_01fd: ldloc.s 20
-				IL_01ff: conv.i4
-				IL_0200: conv.u4
-				IL_0201: ldc.r8 5
-				IL_020a: conv.i4
-				IL_020b: shr.un
-				IL_020c: conv.r.un
-				IL_020d: stloc.s 20
-				IL_020f: ldloc.s 20
-				IL_0211: stloc.s 17
-				IL_0213: ldloc.s 17
-				IL_0215: stloc.s 20
-				IL_0217: ldloc.s 20
-				IL_0219: ldloc.s 13
-				IL_021b: ceq
-				IL_021d: ldc.i4.0
-				IL_021e: ceq
-				IL_0220: brfalse IL_0256
+				IL_0190: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29::.ctor()
+				IL_0195: stloc.s 15
+				IL_0197: ldloc.s 12
+				IL_0199: stloc.s 19
+				IL_019b: ldloc.s 19
+				IL_019d: conv.i4
+				IL_019e: ldc.r8 31
+				IL_01a7: conv.i4
+				IL_01a8: and
+				IL_01a9: conv.r8
+				IL_01aa: stloc.s 19
+				IL_01ac: ldloc.s 19
+				IL_01ae: stloc.s 16
+				IL_01b0: ldc.r8 1
+				IL_01b9: conv.i4
+				IL_01ba: ldloc.s 16
+				IL_01bc: conv.i4
+				IL_01bd: shl
+				IL_01be: conv.r8
+				IL_01bf: stloc.s 19
+				IL_01c1: ldloc.s 14
+				IL_01c3: conv.i4
+				IL_01c4: ldloc.s 19
+				IL_01c6: conv.i4
+				IL_01c7: or
+				IL_01c8: conv.r8
+				IL_01c9: stloc.s 19
+				IL_01cb: ldloc.s 19
+				IL_01cd: stloc.s 14
+				IL_01cf: ldloc.s 12
+				IL_01d1: ldarg.2
+				IL_01d2: add
+				IL_01d3: stloc.s 19
+				IL_01d5: ldloc.s 19
+				IL_01d7: stloc.s 12
+				IL_01d9: ldloc.s 12
+				IL_01db: stloc.s 19
+				IL_01dd: ldloc.s 19
+				IL_01df: conv.i4
+				IL_01e0: conv.u4
+				IL_01e1: ldc.r8 5
+				IL_01ea: conv.i4
+				IL_01eb: shr.un
+				IL_01ec: conv.r.un
+				IL_01ed: stloc.s 19
+				IL_01ef: ldloc.s 19
+				IL_01f1: stloc.s 17
+				IL_01f3: ldloc.s 17
+				IL_01f5: stloc.s 19
+				IL_01f7: ldloc.s 19
+				IL_01f9: ldloc.s 13
+				IL_01fb: ceq
+				IL_01fd: ldc.i4.0
+				IL_01fe: ceq
+				IL_0200: brfalse IL_0236
 
-				IL_0225: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29/Block_L89C36::.ctor()
-				IL_022a: stloc.s 18
-				IL_022c: ldarg.0
-				IL_022d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-				IL_0232: ldloc.s 13
-				IL_0234: ldloc.s 14
-				IL_0236: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_023b: ldloc.s 17
-				IL_023d: stloc.s 20
-				IL_023f: ldloc.s 20
-				IL_0241: stloc.s 13
-				IL_0243: ldarg.0
-				IL_0244: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-				IL_0249: ldloc.s 13
-				IL_024b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_0250: stloc.s 20
-				IL_0252: ldloc.s 20
-				IL_0254: stloc.s 14
+				IL_0205: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29/Block_L89C36::.ctor()
+				IL_020a: stloc.s 18
+				IL_020c: ldarg.0
+				IL_020d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+				IL_0212: ldloc.s 13
+				IL_0214: ldloc.s 14
+				IL_0216: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_021b: ldloc.s 17
+				IL_021d: stloc.s 19
+				IL_021f: ldloc.s 19
+				IL_0221: stloc.s 13
+				IL_0223: ldarg.0
+				IL_0224: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+				IL_0229: ldloc.s 13
+				IL_022b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_0230: stloc.s 19
+				IL_0232: ldloc.s 19
+				IL_0234: stloc.s 14
 
-				IL_0256: br IL_01a2
+				IL_0236: br IL_0182
 			// end loop
 
-			IL_025b: ldarg.0
-			IL_025c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_0261: ldloc.s 13
-			IL_0263: ldloc.s 14
-			IL_0265: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_026a: ldnull
-			IL_026b: ret
+			IL_023b: ldarg.0
+			IL_023c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_0241: ldloc.s 13
+			IL_0243: ldloc.s 14
+			IL_0245: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_024a: ldnull
+			IL_024b: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -1365,7 +1311,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c74
+			// Method begins at RVA 0x2bd0
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1429,7 +1375,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x294c
+			// Method begins at RVA 0x28c8
 			// Header size: 12
 			// Code size: 62 (0x3e)
 			.maxstack 8
@@ -1479,7 +1425,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3368
+				// Method begins at RVA 0x32c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1499,7 +1445,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3371
+				// Method begins at RVA 0x32cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1523,7 +1469,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3383
+					// Method begins at RVA 0x32df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1541,7 +1487,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x337a
+				// Method begins at RVA 0x32d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1561,7 +1507,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x338c
+				// Method begins at RVA 0x32e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1589,7 +1535,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33a7
+						// Method begins at RVA 0x3303
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1607,7 +1553,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x339e
+					// Method begins at RVA 0x32fa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1625,7 +1571,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3395
+				// Method begins at RVA 0x32f1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1649,7 +1595,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33b9
+					// Method begins at RVA 0x3315
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1673,7 +1619,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33cb
+						// Method begins at RVA 0x3327
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1691,7 +1637,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33c2
+					// Method begins at RVA 0x331e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1709,7 +1655,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33b0
+				// Method begins at RVA 0x330c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1733,7 +1679,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33dd
+					// Method begins at RVA 0x3339
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1751,7 +1697,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33d4
+				// Method begins at RVA 0x3330
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1781,7 +1727,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2894
+			// Method begins at RVA 0x2810
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -1838,7 +1784,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cd0
+			// Method begins at RVA 0x2c2c
 			// Header size: 12
 			// Code size: 318 (0x13e)
 			.maxstack 8
@@ -1985,7 +1931,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30ec
+			// Method begins at RVA 0x3048
 			// Header size: 12
 			// Code size: 170 (0xaa)
 			.maxstack 8
@@ -2074,7 +2020,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31a4
+			// Method begins at RVA 0x3100
 			// Header size: 12
 			// Code size: 287 (0x11f)
 			.maxstack 8
@@ -2205,7 +2151,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e1c
+			// Method begins at RVA 0x2d78
 			// Header size: 12
 			// Code size: 706 (0x2c2)
 			.maxstack 8
@@ -2475,7 +2421,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x32cf
+			// Method begins at RVA 0x322b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2933,7 +2879,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x340a
+		// Method begins at RVA 0x3366
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x72c2
+				// Method begins at RVA 0x63bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x72cb
+				// Method begins at RVA 0x63c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x72dd
+					// Method begins at RVA 0x63d7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x72d4
+				// Method begins at RVA 0x63ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x72ef
+					// Method begins at RVA 0x63e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x72e6
+				// Method begins at RVA 0x63e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -279,7 +279,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7301
+					// Method begins at RVA 0x63fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -299,7 +299,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x730a
+					// Method begins at RVA 0x6404
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -319,7 +319,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7313
+					// Method begins at RVA 0x640d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -339,7 +339,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x731c
+					// Method begins at RVA 0x6416
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -359,7 +359,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7325
+					// Method begins at RVA 0x641f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -379,7 +379,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x732e
+					// Method begins at RVA 0x6428
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -403,7 +403,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7340
+						// Method begins at RVA 0x643a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -421,7 +421,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7337
+					// Method begins at RVA 0x6431
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -439,7 +439,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x72f8
+				// Method begins at RVA 0x63f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -469,7 +469,7 @@
 			)
 			// Method begins at RVA 0x2550
 			// Header size: 12
-			// Code size: 1151 (0x47f)
+			// Code size: 1089 (0x441)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -772,149 +772,127 @@
 
 			IL_02fd: ldarg.0
 			IL_02fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0303: stloc.s 25
-			IL_0305: ldstr "Q"
-			IL_030a: ldloc.s 25
-			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0311: stloc.s 25
-			IL_0313: ldloc.s 25
-			IL_0315: ldstr "LastPx"
-			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_031f: stloc.s 25
-			IL_0321: ldloc.s 25
-			IL_0323: ldloc.s 15
-			IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_032a: stloc.s 29
-			IL_032c: ldloc.s 29
-			IL_032e: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(object)
-			IL_0333: stloc.s 27
-			IL_0335: ldloc.s 27
-			IL_0337: box [System.Runtime]System.Double
-			IL_033c: stloc.s 28
-			IL_033e: ldloc.s 28
-			IL_0340: stloc.s 15
-			IL_0342: ldarg.0
-			IL_0343: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0348: stloc.s 25
-			IL_034a: ldstr "Q"
-			IL_034f: ldloc.s 25
-			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0356: stloc.s 25
-			IL_0358: ldloc.s 25
-			IL_035a: ldstr "LastPx"
-			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0364: stloc.s 25
-			IL_0366: ldloc.s 25
-			IL_0368: stloc.s 22
-			// loop start (head: IL_036a)
-				IL_036a: ldloc.s 22
-				IL_036c: stloc.s 25
-				IL_036e: ldloc.s 25
-				IL_0370: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0375: stloc.s 27
-				IL_0377: ldloc.s 15
-				IL_0379: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_037e: stloc.s 26
-				IL_0380: ldloc.s 27
-				IL_0382: ldloc.s 26
-				IL_0384: clt
-				IL_0386: brfalse IL_0457
+			IL_0303: ldstr "LastPx"
+			IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_030d: ldloc.s 15
+			IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0314: stloc.s 29
+			IL_0316: ldloc.s 29
+			IL_0318: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(object)
+			IL_031d: stloc.s 27
+			IL_031f: ldloc.s 27
+			IL_0321: box [System.Runtime]System.Double
+			IL_0326: stloc.s 28
+			IL_0328: ldloc.s 28
+			IL_032a: stloc.s 15
+			IL_032c: ldarg.0
+			IL_032d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0332: ldstr "LastPx"
+			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_033c: stloc.s 22
+			// loop start (head: IL_033e)
+				IL_033e: ldloc.s 22
+				IL_0340: stloc.s 25
+				IL_0342: ldloc.s 25
+				IL_0344: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0349: stloc.s 27
+				IL_034b: ldloc.s 15
+				IL_034d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0352: stloc.s 26
+				IL_0354: ldloc.s 27
+				IL_0356: ldloc.s 26
+				IL_0358: clt
+				IL_035a: brfalse IL_042b
 
-				IL_038b: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/Scope/Block_L63C28::.ctor()
-				IL_0390: stloc.s 23
-				IL_0392: ldloc.s 13
-				IL_0394: ldloc.s 14
-				IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_039b: stloc.s 29
-				IL_039d: ldloc.s 29
-				IL_039f: stloc.s 13
-				IL_03a1: ldloc.s 13
-				IL_03a3: stloc.s 29
-				IL_03a5: ldloc.s 29
-				IL_03a7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_03ac: stloc.s 26
-				IL_03ae: ldloc.s 12
-				IL_03b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_03b5: stloc.s 27
-				IL_03b7: ldloc.s 26
-				IL_03b9: ldloc.s 27
-				IL_03bb: clt
-				IL_03bd: ldc.i4.0
-				IL_03be: ceq
-				IL_03c0: brfalse IL_0410
+				IL_035f: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/Scope/Block_L63C28::.ctor()
+				IL_0364: stloc.s 23
+				IL_0366: ldloc.s 13
+				IL_0368: ldloc.s 14
+				IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_036f: stloc.s 29
+				IL_0371: ldloc.s 29
+				IL_0373: stloc.s 13
+				IL_0375: ldloc.s 13
+				IL_0377: stloc.s 29
+				IL_0379: ldloc.s 29
+				IL_037b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0380: stloc.s 26
+				IL_0382: ldloc.s 12
+				IL_0384: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0389: stloc.s 27
+				IL_038b: ldloc.s 26
+				IL_038d: ldloc.s 27
+				IL_038f: clt
+				IL_0391: ldc.i4.0
+				IL_0392: ceq
+				IL_0394: brfalse IL_03e4
 
-				IL_03c5: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/Scope/Block_L63C28/Block_L65C24::.ctor()
-				IL_03ca: stloc.s 24
-				IL_03cc: ldloc.s 13
-				IL_03ce: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_03d3: stloc.s 27
-				IL_03d5: ldloc.s 12
-				IL_03d7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_03dc: stloc.s 26
-				IL_03de: ldloc.s 27
-				IL_03e0: ldloc.s 26
-				IL_03e2: sub
-				IL_03e3: stloc.s 26
-				IL_03e5: ldloc.s 26
-				IL_03e7: box [System.Runtime]System.Double
-				IL_03ec: stloc.s 28
-				IL_03ee: ldloc.s 28
-				IL_03f0: stloc.s 13
-				IL_03f2: ldloc.s 6
-				IL_03f4: ldloc.s 8
-				IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_03fb: stloc.s 29
-				IL_03fd: ldloc.s 29
-				IL_03ff: stloc.s 6
-				IL_0401: ldloc.s 7
-				IL_0403: ldloc.s 9
-				IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_040a: stloc.s 29
-				IL_040c: ldloc.s 29
-				IL_040e: stloc.s 7
+				IL_0399: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/Scope/Block_L63C28/Block_L65C24::.ctor()
+				IL_039e: stloc.s 24
+				IL_03a0: ldloc.s 13
+				IL_03a2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_03a7: stloc.s 27
+				IL_03a9: ldloc.s 12
+				IL_03ab: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_03b0: stloc.s 26
+				IL_03b2: ldloc.s 27
+				IL_03b4: ldloc.s 26
+				IL_03b6: sub
+				IL_03b7: stloc.s 26
+				IL_03b9: ldloc.s 26
+				IL_03bb: box [System.Runtime]System.Double
+				IL_03c0: stloc.s 28
+				IL_03c2: ldloc.s 28
+				IL_03c4: stloc.s 13
+				IL_03c6: ldloc.s 6
+				IL_03c8: ldloc.s 8
+				IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_03cf: stloc.s 29
+				IL_03d1: ldloc.s 29
+				IL_03d3: stloc.s 6
+				IL_03d5: ldloc.s 7
+				IL_03d7: ldloc.s 9
+				IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_03de: stloc.s 29
+				IL_03e0: ldloc.s 29
+				IL_03e2: stloc.s 7
 
-				IL_0410: ldloc.s 6
-				IL_0412: ldloc.s 10
-				IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0419: stloc.s 29
-				IL_041b: ldloc.s 29
-				IL_041d: stloc.s 6
-				IL_041f: ldloc.s 7
-				IL_0421: ldloc.s 11
-				IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0428: stloc.s 29
-				IL_042a: ldloc.s 29
-				IL_042c: stloc.s 7
-				IL_042e: ldloc.s 22
-				IL_0430: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0435: stloc.s 26
-				IL_0437: ldloc.s 26
-				IL_0439: ldc.r8 1
-				IL_0442: add
-				IL_0443: stloc.s 26
-				IL_0445: ldloc.s 26
-				IL_0447: box [System.Runtime]System.Double
-				IL_044c: stloc.s 28
-				IL_044e: ldloc.s 28
-				IL_0450: stloc.s 22
-				IL_0452: br IL_036a
+				IL_03e4: ldloc.s 6
+				IL_03e6: ldloc.s 10
+				IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_03ed: stloc.s 29
+				IL_03ef: ldloc.s 29
+				IL_03f1: stloc.s 6
+				IL_03f3: ldloc.s 7
+				IL_03f5: ldloc.s 11
+				IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_03fc: stloc.s 29
+				IL_03fe: ldloc.s 29
+				IL_0400: stloc.s 7
+				IL_0402: ldloc.s 22
+				IL_0404: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0409: stloc.s 26
+				IL_040b: ldloc.s 26
+				IL_040d: ldc.r8 1
+				IL_0416: add
+				IL_0417: stloc.s 26
+				IL_0419: ldloc.s 26
+				IL_041b: box [System.Runtime]System.Double
+				IL_0420: stloc.s 28
+				IL_0422: ldloc.s 28
+				IL_0424: stloc.s 22
+				IL_0426: br IL_033e
 			// end loop
 
-			IL_0457: ldarg.0
-			IL_0458: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_045d: stloc.s 25
-			IL_045f: ldstr "Q"
-			IL_0464: ldloc.s 25
-			IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_046b: stloc.s 25
-			IL_046d: ldloc.s 25
-			IL_046f: ldstr "LastPx"
-			IL_0474: ldloc.s 15
-			IL_0476: ldc.i4.1
-			IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_047c: pop
-			IL_047d: ldnull
-			IL_047e: ret
+			IL_042b: ldarg.0
+			IL_042c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0431: ldstr "LastPx"
+			IL_0436: ldloc.s 15
+			IL_0438: ldc.i4.1
+			IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_043e: pop
+			IL_043f: ldnull
+			IL_0440: ret
 		} // end of method DrawLine::__js_call__
 
 	} // end of class DrawLine
@@ -930,7 +908,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7349
+				// Method begins at RVA 0x6443
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -955,7 +933,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29dc
+			// Method begins at RVA 0x29a0
 			// Header size: 12
 			// Code size: 369 (0x171)
 			.maxstack 8
@@ -1109,7 +1087,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x735b
+					// Method begins at RVA 0x6455
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1127,7 +1105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7352
+				// Method begins at RVA 0x644c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1156,9 +1134,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2b5c
+			// Method begins at RVA 0x2b20
 			// Header size: 12
-			// Code size: 622 (0x26e)
+			// Code size: 604 (0x25c)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1260,140 +1238,134 @@
 
 			IL_00e1: ldarg.0
 			IL_00e2: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcCross
-			IL_00e7: stloc.s 5
-			IL_00e9: ldstr "CalcCross"
-			IL_00ee: ldloc.s 5
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00f5: stloc.s 5
-			IL_00f7: ldloc.s 5
-			IL_00f9: ldc.i4.1
-			IL_00fa: newarr [System.Runtime]System.Object
-			IL_00ff: dup
-			IL_0100: ldc.i4.0
-			IL_0101: ldarg.0
-			IL_0102: stelem.ref
-			IL_0103: ldloc.0
-			IL_0104: ldloc.1
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_010a: stloc.s 5
-			IL_010c: ldloc.s 5
-			IL_010e: stloc.0
-			IL_010f: ldloc.0
-			IL_0110: ldc.r8 0.0
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_011e: stloc.s 5
-			IL_0120: ldloc.0
-			IL_0121: ldc.r8 0.0
-			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_012f: stloc.s 8
-			IL_0131: ldloc.s 5
-			IL_0133: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0138: stloc.s 7
-			IL_013a: ldloc.s 7
-			IL_013c: ldloc.s 8
-			IL_013e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0143: mul
-			IL_0144: stloc.s 7
-			IL_0146: ldloc.0
-			IL_0147: ldc.r8 1
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0155: stloc.s 8
-			IL_0157: ldloc.0
-			IL_0158: ldc.r8 1
-			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0166: stloc.s 5
-			IL_0168: ldloc.s 8
-			IL_016a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_016f: stloc.s 9
-			IL_0171: ldloc.s 7
-			IL_0173: ldloc.s 9
-			IL_0175: ldloc.s 5
-			IL_0177: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_017c: mul
-			IL_017d: add
-			IL_017e: stloc.s 7
-			IL_0180: ldloc.0
-			IL_0181: ldc.r8 2
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_018f: stloc.s 5
-			IL_0191: ldloc.0
-			IL_0192: ldc.r8 2
-			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01a0: stloc.s 8
-			IL_01a2: ldloc.s 5
-			IL_01a4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01a9: stloc.s 9
-			IL_01ab: ldloc.s 7
-			IL_01ad: ldloc.s 9
-			IL_01af: ldloc.s 8
-			IL_01b1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01b6: mul
-			IL_01b7: add
-			IL_01b8: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sqrt(float64)
-			IL_01bd: stloc.s 7
-			IL_01bf: ldloc.s 7
-			IL_01c1: box [System.Runtime]System.Double
-			IL_01c6: stloc.s 6
-			IL_01c8: ldloc.s 6
-			IL_01ca: stloc.s 4
-			IL_01cc: ldc.r8 0.0
-			IL_01d5: box [System.Runtime]System.Double
-			IL_01da: stloc.2
-			// loop start (head: IL_01db)
-				IL_01db: ldloc.2
-				IL_01dc: stloc.s 6
-				IL_01de: ldloc.s 6
-				IL_01e0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01e5: stloc.s 7
-				IL_01e7: ldloc.s 7
-				IL_01e9: ldc.r8 3
-				IL_01f2: clt
-				IL_01f4: brfalse IL_024d
+			IL_00e7: ldc.i4.1
+			IL_00e8: newarr [System.Runtime]System.Object
+			IL_00ed: dup
+			IL_00ee: ldc.i4.0
+			IL_00ef: ldarg.0
+			IL_00f0: stelem.ref
+			IL_00f1: ldloc.0
+			IL_00f2: ldloc.1
+			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_00f8: stloc.s 5
+			IL_00fa: ldloc.s 5
+			IL_00fc: stloc.0
+			IL_00fd: ldloc.0
+			IL_00fe: ldc.r8 0.0
+			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_010c: stloc.s 5
+			IL_010e: ldloc.0
+			IL_010f: ldc.r8 0.0
+			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_011d: stloc.s 8
+			IL_011f: ldloc.s 5
+			IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0126: stloc.s 7
+			IL_0128: ldloc.s 7
+			IL_012a: ldloc.s 8
+			IL_012c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0131: mul
+			IL_0132: stloc.s 7
+			IL_0134: ldloc.0
+			IL_0135: ldc.r8 1
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0143: stloc.s 8
+			IL_0145: ldloc.0
+			IL_0146: ldc.r8 1
+			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0154: stloc.s 5
+			IL_0156: ldloc.s 8
+			IL_0158: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_015d: stloc.s 9
+			IL_015f: ldloc.s 7
+			IL_0161: ldloc.s 9
+			IL_0163: ldloc.s 5
+			IL_0165: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_016a: mul
+			IL_016b: add
+			IL_016c: stloc.s 7
+			IL_016e: ldloc.0
+			IL_016f: ldc.r8 2
+			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_017d: stloc.s 5
+			IL_017f: ldloc.0
+			IL_0180: ldc.r8 2
+			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_018e: stloc.s 8
+			IL_0190: ldloc.s 5
+			IL_0192: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0197: stloc.s 9
+			IL_0199: ldloc.s 7
+			IL_019b: ldloc.s 9
+			IL_019d: ldloc.s 8
+			IL_019f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01a4: mul
+			IL_01a5: add
+			IL_01a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sqrt(float64)
+			IL_01ab: stloc.s 7
+			IL_01ad: ldloc.s 7
+			IL_01af: box [System.Runtime]System.Double
+			IL_01b4: stloc.s 6
+			IL_01b6: ldloc.s 6
+			IL_01b8: stloc.s 4
+			IL_01ba: ldc.r8 0.0
+			IL_01c3: box [System.Runtime]System.Double
+			IL_01c8: stloc.2
+			// loop start (head: IL_01c9)
+				IL_01c9: ldloc.2
+				IL_01ca: stloc.s 6
+				IL_01cc: ldloc.s 6
+				IL_01ce: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01d3: stloc.s 7
+				IL_01d5: ldloc.s 7
+				IL_01d7: ldc.r8 3
+				IL_01e0: clt
+				IL_01e2: brfalse IL_023b
 
-				IL_01f9: ldloc.0
-				IL_01fa: ldloc.2
-				IL_01fb: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0200: stloc.s 7
-				IL_0202: ldloc.s 4
-				IL_0204: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0209: stloc.s 9
-				IL_020b: ldloc.s 7
-				IL_020d: ldloc.s 9
-				IL_020f: div
-				IL_0210: stloc.s 9
-				IL_0212: ldloc.s 9
-				IL_0214: box [System.Runtime]System.Double
-				IL_0219: stloc.s 6
-				IL_021b: ldloc.0
-				IL_021c: ldloc.2
-				IL_021d: ldloc.s 6
-				IL_021f: ldc.i4.1
-				IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_0225: pop
-				IL_0226: ldloc.2
-				IL_0227: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_022c: stloc.s 9
-				IL_022e: ldloc.s 9
-				IL_0230: ldc.r8 1
-				IL_0239: add
-				IL_023a: stloc.s 9
-				IL_023c: ldloc.s 9
-				IL_023e: box [System.Runtime]System.Double
-				IL_0243: stloc.s 6
-				IL_0245: ldloc.s 6
-				IL_0247: stloc.2
-				IL_0248: br IL_01db
+				IL_01e7: ldloc.0
+				IL_01e8: ldloc.2
+				IL_01e9: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_01ee: stloc.s 7
+				IL_01f0: ldloc.s 4
+				IL_01f2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01f7: stloc.s 9
+				IL_01f9: ldloc.s 7
+				IL_01fb: ldloc.s 9
+				IL_01fd: div
+				IL_01fe: stloc.s 9
+				IL_0200: ldloc.s 9
+				IL_0202: box [System.Runtime]System.Double
+				IL_0207: stloc.s 6
+				IL_0209: ldloc.0
+				IL_020a: ldloc.2
+				IL_020b: ldloc.s 6
+				IL_020d: ldc.i4.1
+				IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_0213: pop
+				IL_0214: ldloc.2
+				IL_0215: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_021a: stloc.s 9
+				IL_021c: ldloc.s 9
+				IL_021e: ldc.r8 1
+				IL_0227: add
+				IL_0228: stloc.s 9
+				IL_022a: ldloc.s 9
+				IL_022c: box [System.Runtime]System.Double
+				IL_0231: stloc.s 6
+				IL_0233: ldloc.s 6
+				IL_0235: stloc.2
+				IL_0236: br IL_01c9
 			// end loop
 
-			IL_024d: ldloc.0
-			IL_024e: ldc.r8 3
-			IL_0257: ldc.r8 1
-			IL_0260: ldc.i4.1
-			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-			IL_0266: pop
-			IL_0267: ldloc.0
-			IL_0268: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_026d: ret
+			IL_023b: ldloc.0
+			IL_023c: ldc.r8 3
+			IL_0245: ldc.r8 1
+			IL_024e: ldc.i4.1
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+			IL_0254: pop
+			IL_0255: ldloc.0
+			IL_0256: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_025b: ret
 		} // end of method CalcNormal::__js_call__
 
 	} // end of class CalcNormal
@@ -1409,7 +1381,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7364
+				// Method begins at RVA 0x645e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1435,7 +1407,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2dd8
+			// Method begins at RVA 0x2d88
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -1486,7 +1458,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7376
+					// Method begins at RVA 0x6470
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1504,7 +1476,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x736d
+				// Method begins at RVA 0x6467
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1529,7 +1501,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e28
+			// Method begins at RVA 0x2dd8
 			// Header size: 12
 			// Code size: 557 (0x22d)
 			.maxstack 8
@@ -1748,7 +1720,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x737f
+				// Method begins at RVA 0x6479
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1773,7 +1745,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3064
+			// Method begins at RVA 0x3014
 			// Header size: 12
 			// Code size: 358 (0x166)
 			.maxstack 8
@@ -1923,7 +1895,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7388
+				// Method begins at RVA 0x6482
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1948,7 +1920,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31d8
+			// Method begins at RVA 0x3188
 			// Header size: 12
 			// Code size: 296 (0x128)
 			.maxstack 8
@@ -2082,7 +2054,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x739a
+					// Method begins at RVA 0x6494
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2100,7 +2072,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7391
+				// Method begins at RVA 0x648b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2125,7 +2097,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x330c
+			// Method begins at RVA 0x32bc
 			// Header size: 12
 			// Code size: 316 (0x13c)
 			.maxstack 8
@@ -2272,7 +2244,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x73a3
+				// Method begins at RVA 0x649d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2302,7 +2274,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x3454
+			// Method begins at RVA 0x3404
 			// Header size: 12
 			// Code size: 369 (0x171)
 			.maxstack 8
@@ -2431,7 +2403,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x73ac
+				// Method begins at RVA 0x64a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2459,7 +2431,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x35d4
+			// Method begins at RVA 0x3584
 			// Header size: 12
 			// Code size: 464 (0x1d0)
 			.maxstack 8
@@ -2631,7 +2603,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x73b5
+				// Method begins at RVA 0x64af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2659,7 +2631,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x37b0
+			// Method begins at RVA 0x3760
 			// Header size: 12
 			// Code size: 464 (0x1d0)
 			.maxstack 8
@@ -2831,7 +2803,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x73be
+				// Method begins at RVA 0x64b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2859,7 +2831,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x398c
+			// Method begins at RVA 0x393c
 			// Header size: 12
 			// Code size: 464 (0x1d0)
 			.maxstack 8
@@ -3039,7 +3011,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x73d9
+						// Method begins at RVA 0x64d3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3059,7 +3031,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x73e2
+						// Method begins at RVA 0x64dc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3079,7 +3051,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x73eb
+						// Method begins at RVA 0x64e5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3099,7 +3071,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x73f4
+						// Method begins at RVA 0x64ee
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3117,7 +3089,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x73d0
+					// Method begins at RVA 0x64ca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3141,7 +3113,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7406
+						// Method begins at RVA 0x6500
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3161,7 +3133,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x740f
+						// Method begins at RVA 0x6509
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3181,7 +3153,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7418
+						// Method begins at RVA 0x6512
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3201,7 +3173,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7421
+						// Method begins at RVA 0x651b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3219,7 +3191,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x73fd
+					// Method begins at RVA 0x64f7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3243,7 +3215,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7433
+						// Method begins at RVA 0x652d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3263,7 +3235,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x743c
+						// Method begins at RVA 0x6536
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3283,7 +3255,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7445
+						// Method begins at RVA 0x653f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3303,7 +3275,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x744e
+						// Method begins at RVA 0x6548
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3321,7 +3293,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x742a
+					// Method begins at RVA 0x6524
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3345,7 +3317,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7460
+						// Method begins at RVA 0x655a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3365,7 +3337,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7469
+						// Method begins at RVA 0x6563
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3385,7 +3357,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7472
+						// Method begins at RVA 0x656c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3405,7 +3377,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x747b
+						// Method begins at RVA 0x6575
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3423,7 +3395,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7457
+					// Method begins at RVA 0x6551
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3447,7 +3419,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x748d
+						// Method begins at RVA 0x6587
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3467,7 +3439,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x7496
+						// Method begins at RVA 0x6590
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3487,7 +3459,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x749f
+						// Method begins at RVA 0x6599
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3507,7 +3479,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x74a8
+						// Method begins at RVA 0x65a2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3525,7 +3497,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x7484
+					// Method begins at RVA 0x657e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3549,7 +3521,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x74ba
+						// Method begins at RVA 0x65b4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3569,7 +3541,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x74c3
+						// Method begins at RVA 0x65bd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3589,7 +3561,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x74cc
+						// Method begins at RVA 0x65c6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3609,7 +3581,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x74d5
+						// Method begins at RVA 0x65cf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3627,7 +3599,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x74b1
+					// Method begins at RVA 0x65ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3645,7 +3617,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x73c7
+				// Method begins at RVA 0x64c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3671,9 +3643,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x3b68
+			// Method begins at RVA 0x3b18
 			// Header size: 12
-			// Code size: 7408 (0x1cf0)
+			// Code size: 5096 (0x13e8)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3714,9 +3686,8 @@
 				[35] float64,
 				[36] object[],
 				[37] object,
-				[38] object,
-				[39] bool,
-				[40] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[38] bool,
+				[39] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldc.i4.0
@@ -3730,2333 +3701,1483 @@
 			IL_001e: stloc.1
 			IL_001f: ldarg.0
 			IL_0020: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0025: stloc.s 32
-			IL_0027: ldstr "Q"
-			IL_002c: ldloc.s 32
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0033: stloc.s 32
-			IL_0035: ldloc.s 32
-			IL_0037: ldstr "LastPx"
-			IL_003c: ldc.r8 0.0
-			IL_0045: ldc.i4.1
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_004b: pop
-			// loop start (head: IL_004c)
-				IL_004c: ldloc.1
-				IL_004d: stloc.s 33
-				IL_004f: ldc.r8 1
-				IL_0058: neg
-				IL_0059: stloc.s 34
-				IL_005b: ldloc.s 33
-				IL_005d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0062: stloc.s 35
-				IL_0064: ldloc.s 35
-				IL_0066: ldloc.s 34
-				IL_0068: cgt
-				IL_006a: brfalse IL_0116
+			IL_0025: ldstr "LastPx"
+			IL_002a: ldc.r8 0.0
+			IL_0033: ldc.i4.1
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0039: pop
+			// loop start (head: IL_003a)
+				IL_003a: ldloc.1
+				IL_003b: stloc.s 33
+				IL_003d: ldc.r8 1
+				IL_0046: neg
+				IL_0047: stloc.s 34
+				IL_0049: ldloc.s 33
+				IL_004b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0050: stloc.s 35
+				IL_0052: ldloc.s 35
+				IL_0054: ldloc.s 34
+				IL_0056: cgt
+				IL_0058: brfalse IL_00ce
 
-				IL_006f: ldarg.0
-				IL_0070: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti2
-				IL_0075: stloc.s 32
-				IL_0077: ldstr "VMulti2"
-				IL_007c: ldloc.s 32
-				IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0083: stloc.s 32
-				IL_0085: ldc.i4.1
-				IL_0086: newarr [System.Runtime]System.Object
-				IL_008b: dup
-				IL_008c: ldc.i4.0
-				IL_008d: ldarg.0
-				IL_008e: stelem.ref
-				IL_008f: stloc.s 36
-				IL_0091: ldarg.0
-				IL_0092: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-				IL_0097: stloc.s 37
-				IL_0099: ldstr "MQube"
+				IL_005d: ldarg.0
+				IL_005e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti2
+				IL_0063: stloc.s 32
+				IL_0065: ldc.i4.1
+				IL_0066: newarr [System.Runtime]System.Object
+				IL_006b: dup
+				IL_006c: ldc.i4.0
+				IL_006d: ldarg.0
+				IL_006e: stelem.ref
+				IL_006f: stloc.s 36
+				IL_0071: ldarg.0
+				IL_0072: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+				IL_0077: stloc.s 37
+				IL_0079: ldloc.s 32
+				IL_007b: ldloc.s 36
+				IL_007d: ldloc.s 37
+				IL_007f: ldarg.0
+				IL_0080: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0085: ldstr "Normal"
+				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_008f: ldloc.1
+				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_009a: stloc.s 37
+				IL_009c: ldloc.0
+				IL_009d: ldloc.1
 				IL_009e: ldloc.s 37
-				IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00a5: stloc.s 37
-				IL_00a7: ldarg.0
-				IL_00a8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_00ad: stloc.s 38
-				IL_00af: ldstr "Q"
-				IL_00b4: ldloc.s 38
-				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00bb: stloc.s 38
-				IL_00bd: ldloc.s 38
-				IL_00bf: ldstr "Normal"
-				IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00c9: stloc.s 38
-				IL_00cb: ldloc.s 38
-				IL_00cd: ldloc.1
-				IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00d3: stloc.s 38
-				IL_00d5: ldloc.s 32
-				IL_00d7: ldloc.s 36
-				IL_00d9: ldloc.s 37
-				IL_00db: ldloc.s 38
-				IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_00e2: stloc.s 38
-				IL_00e4: ldloc.0
-				IL_00e5: ldloc.1
-				IL_00e6: ldloc.s 38
-				IL_00e8: ldc.i4.1
-				IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_00ee: pop
-				IL_00ef: ldloc.1
-				IL_00f0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00f5: stloc.s 34
-				IL_00f7: ldloc.s 34
-				IL_00f9: ldc.r8 1
-				IL_0102: sub
-				IL_0103: stloc.s 34
-				IL_0105: ldloc.s 34
-				IL_0107: box [System.Runtime]System.Double
-				IL_010c: stloc.s 33
-				IL_010e: ldloc.s 33
-				IL_0110: stloc.1
-				IL_0111: br IL_004c
+				IL_00a0: ldc.i4.1
+				IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_00a6: pop
+				IL_00a7: ldloc.1
+				IL_00a8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00ad: stloc.s 34
+				IL_00af: ldloc.s 34
+				IL_00b1: ldc.r8 1
+				IL_00ba: sub
+				IL_00bb: stloc.s 34
+				IL_00bd: ldloc.s 34
+				IL_00bf: box [System.Runtime]System.Double
+				IL_00c4: stloc.s 33
+				IL_00c6: ldloc.s 33
+				IL_00c8: stloc.1
+				IL_00c9: br IL_003a
 			// end loop
 
-			IL_0116: ldloc.0
-			IL_0117: ldc.r8 0.0
-			IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0125: ldc.r8 2
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0133: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0138: ldc.r8 0.0
-			IL_0141: clt
-			IL_0143: brfalse IL_0591
+			IL_00ce: ldloc.0
+			IL_00cf: ldc.r8 0.0
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00dd: ldc.r8 2
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00f0: ldc.r8 0.0
+			IL_00f9: clt
+			IL_00fb: brfalse IL_03d9
 
-			IL_0148: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24::.ctor()
-			IL_014d: stloc.2
-			IL_014e: ldarg.0
-			IL_014f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0154: stloc.s 38
-			IL_0156: ldstr "Q"
-			IL_015b: ldloc.s 38
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0162: stloc.s 38
-			IL_0164: ldloc.s 38
-			IL_0166: ldstr "Line"
-			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0170: stloc.s 38
-			IL_0172: ldloc.s 38
-			IL_0174: ldc.r8 0.0
-			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0182: stloc.s 38
-			IL_0184: ldloc.s 38
-			IL_0186: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_018b: ldc.i4.0
-			IL_018c: ceq
-			IL_018e: stloc.s 39
-			IL_0190: ldloc.s 39
-			IL_0192: brfalse IL_025e
+			IL_0100: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24::.ctor()
+			IL_0105: stloc.2
+			IL_0106: ldarg.0
+			IL_0107: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_010c: ldstr "Line"
+			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0116: ldc.r8 0.0
+			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0124: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0129: ldc.i4.0
+			IL_012a: ceq
+			IL_012c: stloc.s 38
+			IL_012e: ldloc.s 38
+			IL_0130: brfalse IL_01ba
 
-			IL_0197: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L199C24::.ctor()
-			IL_019c: stloc.3
-			IL_019d: ldarg.0
-			IL_019e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_01a3: stloc.s 38
-			IL_01a5: ldstr "DrawLine"
-			IL_01aa: ldloc.s 38
-			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01b1: stloc.s 38
+			IL_0135: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L199C24::.ctor()
+			IL_013a: stloc.3
+			IL_013b: ldarg.0
+			IL_013c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0141: stloc.s 37
+			IL_0143: ldc.i4.1
+			IL_0144: newarr [System.Runtime]System.Object
+			IL_0149: dup
+			IL_014a: ldc.i4.0
+			IL_014b: ldarg.0
+			IL_014c: stelem.ref
+			IL_014d: stloc.s 36
+			IL_014f: ldarg.0
+			IL_0150: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0155: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_015a: ldc.r8 0.0
+			IL_0163: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0168: stloc.s 32
+			IL_016a: ldloc.s 37
+			IL_016c: ldloc.s 36
+			IL_016e: ldloc.s 32
+			IL_0170: ldarg.0
+			IL_0171: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0176: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_017b: ldc.r8 1
+			IL_0184: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_018e: pop
+			IL_018f: ldarg.0
+			IL_0190: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0195: ldstr "Line"
+			IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_019f: ldc.r8 0.0
+			IL_01a8: box [System.Runtime]System.Double
+			IL_01ad: ldc.i4.1
+			IL_01ae: box [System.Runtime]System.Boolean
 			IL_01b3: ldc.i4.1
-			IL_01b4: newarr [System.Runtime]System.Object
-			IL_01b9: dup
-			IL_01ba: ldc.i4.0
-			IL_01bb: ldarg.0
-			IL_01bc: stelem.ref
-			IL_01bd: stloc.s 36
-			IL_01bf: ldarg.0
-			IL_01c0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_01c5: stloc.s 37
-			IL_01c7: ldstr "Q"
-			IL_01cc: ldloc.s 37
-			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01d3: stloc.s 37
-			IL_01d5: ldloc.s 37
-			IL_01d7: ldc.r8 0.0
-			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01e5: stloc.s 37
-			IL_01e7: ldarg.0
-			IL_01e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_01ed: stloc.s 32
-			IL_01ef: ldstr "Q"
-			IL_01f4: ldloc.s 32
-			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01fb: stloc.s 32
-			IL_01fd: ldloc.s 32
-			IL_01ff: ldc.r8 1
-			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_020d: stloc.s 32
-			IL_020f: ldloc.s 38
-			IL_0211: ldloc.s 36
-			IL_0213: ldloc.s 37
-			IL_0215: ldloc.s 32
-			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_021c: pop
-			IL_021d: ldarg.0
-			IL_021e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0223: stloc.s 32
-			IL_0225: ldstr "Q"
-			IL_022a: ldloc.s 32
-			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0231: stloc.s 32
-			IL_0233: ldloc.s 32
-			IL_0235: ldstr "Line"
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023f: stloc.s 32
-			IL_0241: ldloc.s 32
-			IL_0243: ldc.r8 0.0
-			IL_024c: box [System.Runtime]System.Double
-			IL_0251: ldc.i4.1
-			IL_0252: box [System.Runtime]System.Boolean
-			IL_0257: ldc.i4.1
-			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_025d: pop
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_01b9: pop
 
-			IL_025e: ldarg.0
-			IL_025f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0264: stloc.s 32
-			IL_0266: ldstr "Q"
-			IL_026b: ldloc.s 32
-			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0272: stloc.s 32
-			IL_0274: ldloc.s 32
-			IL_0276: ldstr "Line"
-			IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0280: stloc.s 32
-			IL_0282: ldloc.s 32
-			IL_0284: ldc.r8 1
-			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0292: stloc.s 32
-			IL_0294: ldloc.s 32
-			IL_0296: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_029b: ldc.i4.0
-			IL_029c: ceq
-			IL_029e: stloc.s 39
-			IL_02a0: ldloc.s 39
-			IL_02a2: brfalse IL_036f
+			IL_01ba: ldarg.0
+			IL_01bb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_01c0: ldstr "Line"
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ca: ldc.r8 1
+			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01d8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01dd: ldc.i4.0
+			IL_01de: ceq
+			IL_01e0: stloc.s 38
+			IL_01e2: ldloc.s 38
+			IL_01e4: brfalse IL_026f
 
-			IL_02a7: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L200C24::.ctor()
-			IL_02ac: stloc.s 4
-			IL_02ae: ldarg.0
-			IL_02af: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_02b4: stloc.s 32
-			IL_02b6: ldstr "DrawLine"
-			IL_02bb: ldloc.s 32
-			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02c2: stloc.s 32
-			IL_02c4: ldc.i4.1
-			IL_02c5: newarr [System.Runtime]System.Object
-			IL_02ca: dup
-			IL_02cb: ldc.i4.0
-			IL_02cc: ldarg.0
-			IL_02cd: stelem.ref
-			IL_02ce: stloc.s 36
-			IL_02d0: ldarg.0
-			IL_02d1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_02d6: stloc.s 37
-			IL_02d8: ldstr "Q"
-			IL_02dd: ldloc.s 37
-			IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02e4: stloc.s 37
-			IL_02e6: ldloc.s 37
-			IL_02e8: ldc.r8 1
-			IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_02f6: stloc.s 37
-			IL_02f8: ldarg.0
-			IL_02f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_02fe: stloc.s 38
-			IL_0300: ldstr "Q"
-			IL_0305: ldloc.s 38
-			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_030c: stloc.s 38
-			IL_030e: ldloc.s 38
-			IL_0310: ldc.r8 2
-			IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_031e: stloc.s 38
-			IL_0320: ldloc.s 32
-			IL_0322: ldloc.s 36
-			IL_0324: ldloc.s 37
-			IL_0326: ldloc.s 38
-			IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_032d: pop
-			IL_032e: ldarg.0
-			IL_032f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0334: stloc.s 38
-			IL_0336: ldstr "Q"
-			IL_033b: ldloc.s 38
-			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0342: stloc.s 38
-			IL_0344: ldloc.s 38
-			IL_0346: ldstr "Line"
-			IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0350: stloc.s 38
-			IL_0352: ldloc.s 38
-			IL_0354: ldc.r8 1
-			IL_035d: box [System.Runtime]System.Double
+			IL_01e9: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L200C24::.ctor()
+			IL_01ee: stloc.s 4
+			IL_01f0: ldarg.0
+			IL_01f1: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_01f6: stloc.s 32
+			IL_01f8: ldc.i4.1
+			IL_01f9: newarr [System.Runtime]System.Object
+			IL_01fe: dup
+			IL_01ff: ldc.i4.0
+			IL_0200: ldarg.0
+			IL_0201: stelem.ref
+			IL_0202: stloc.s 36
+			IL_0204: ldarg.0
+			IL_0205: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_020a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_020f: ldc.r8 1
+			IL_0218: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_021d: stloc.s 37
+			IL_021f: ldloc.s 32
+			IL_0221: ldloc.s 36
+			IL_0223: ldloc.s 37
+			IL_0225: ldarg.0
+			IL_0226: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_022b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0230: ldc.r8 2
+			IL_0239: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0243: pop
+			IL_0244: ldarg.0
+			IL_0245: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_024a: ldstr "Line"
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0254: ldc.r8 1
+			IL_025d: box [System.Runtime]System.Double
+			IL_0262: ldc.i4.1
+			IL_0263: box [System.Runtime]System.Boolean
+			IL_0268: ldc.i4.1
+			IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_026e: pop
+
+			IL_026f: ldarg.0
+			IL_0270: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0275: ldstr "Line"
+			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_027f: ldc.r8 2
+			IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_028d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0292: ldc.i4.0
+			IL_0293: ceq
+			IL_0295: stloc.s 38
+			IL_0297: ldloc.s 38
+			IL_0299: brfalse IL_0324
+
+			IL_029e: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L201C24::.ctor()
+			IL_02a3: stloc.s 5
+			IL_02a5: ldarg.0
+			IL_02a6: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_02ab: stloc.s 37
+			IL_02ad: ldc.i4.1
+			IL_02ae: newarr [System.Runtime]System.Object
+			IL_02b3: dup
+			IL_02b4: ldc.i4.0
+			IL_02b5: ldarg.0
+			IL_02b6: stelem.ref
+			IL_02b7: stloc.s 36
+			IL_02b9: ldarg.0
+			IL_02ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02bf: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_02c4: ldc.r8 2
+			IL_02cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_02d2: stloc.s 32
+			IL_02d4: ldloc.s 37
+			IL_02d6: ldloc.s 36
+			IL_02d8: ldloc.s 32
+			IL_02da: ldarg.0
+			IL_02db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02e0: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_02e5: ldc.r8 3
+			IL_02ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02f8: pop
+			IL_02f9: ldarg.0
+			IL_02fa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02ff: ldstr "Line"
+			IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0309: ldc.r8 2
+			IL_0312: box [System.Runtime]System.Double
+			IL_0317: ldc.i4.1
+			IL_0318: box [System.Runtime]System.Boolean
+			IL_031d: ldc.i4.1
+			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0323: pop
+
+			IL_0324: ldarg.0
+			IL_0325: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_032a: ldstr "Line"
+			IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0334: ldc.r8 3
+			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0342: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0347: ldc.i4.0
+			IL_0348: ceq
+			IL_034a: stloc.s 38
+			IL_034c: ldloc.s 38
+			IL_034e: brfalse IL_03d9
+
+			IL_0353: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L202C24::.ctor()
+			IL_0358: stloc.s 6
+			IL_035a: ldarg.0
+			IL_035b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0360: stloc.s 32
 			IL_0362: ldc.i4.1
-			IL_0363: box [System.Runtime]System.Boolean
-			IL_0368: ldc.i4.1
-			IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_036e: pop
+			IL_0363: newarr [System.Runtime]System.Object
+			IL_0368: dup
+			IL_0369: ldc.i4.0
+			IL_036a: ldarg.0
+			IL_036b: stelem.ref
+			IL_036c: stloc.s 36
+			IL_036e: ldarg.0
+			IL_036f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0374: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0379: ldc.r8 3
+			IL_0382: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0387: stloc.s 37
+			IL_0389: ldloc.s 32
+			IL_038b: ldloc.s 36
+			IL_038d: ldloc.s 37
+			IL_038f: ldarg.0
+			IL_0390: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0395: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_039a: ldc.r8 0.0
+			IL_03a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03ad: pop
+			IL_03ae: ldarg.0
+			IL_03af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_03b4: ldstr "Line"
+			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03be: ldc.r8 3
+			IL_03c7: box [System.Runtime]System.Double
+			IL_03cc: ldc.i4.1
+			IL_03cd: box [System.Runtime]System.Boolean
+			IL_03d2: ldc.i4.1
+			IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_03d8: pop
 
-			IL_036f: ldarg.0
-			IL_0370: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0375: stloc.s 38
-			IL_0377: ldstr "Q"
-			IL_037c: ldloc.s 38
-			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0383: stloc.s 38
-			IL_0385: ldloc.s 38
-			IL_0387: ldstr "Line"
-			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0391: stloc.s 38
-			IL_0393: ldloc.s 38
-			IL_0395: ldc.r8 2
-			IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03a3: stloc.s 38
-			IL_03a5: ldloc.s 38
-			IL_03a7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_03ac: ldc.i4.0
-			IL_03ad: ceq
-			IL_03af: stloc.s 39
-			IL_03b1: ldloc.s 39
-			IL_03b3: brfalse IL_0480
+			IL_03d9: ldloc.0
+			IL_03da: ldc.r8 1
+			IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_03e8: ldc.r8 2
+			IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_03f6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_03fb: ldc.r8 0.0
+			IL_0404: clt
+			IL_0406: brfalse IL_06e6
 
-			IL_03b8: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L201C24::.ctor()
-			IL_03bd: stloc.s 5
-			IL_03bf: ldarg.0
-			IL_03c0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_03c5: stloc.s 38
-			IL_03c7: ldstr "DrawLine"
-			IL_03cc: ldloc.s 38
-			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03d3: stloc.s 38
-			IL_03d5: ldc.i4.1
-			IL_03d6: newarr [System.Runtime]System.Object
-			IL_03db: dup
-			IL_03dc: ldc.i4.0
-			IL_03dd: ldarg.0
-			IL_03de: stelem.ref
-			IL_03df: stloc.s 36
-			IL_03e1: ldarg.0
-			IL_03e2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_03e7: stloc.s 37
-			IL_03e9: ldstr "Q"
-			IL_03ee: ldloc.s 37
-			IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03f5: stloc.s 37
-			IL_03f7: ldloc.s 37
-			IL_03f9: ldc.r8 2
-			IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0407: stloc.s 37
-			IL_0409: ldarg.0
-			IL_040a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_040f: stloc.s 32
-			IL_0411: ldstr "Q"
-			IL_0416: ldloc.s 32
-			IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_041d: stloc.s 32
-			IL_041f: ldloc.s 32
-			IL_0421: ldc.r8 3
-			IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_042f: stloc.s 32
-			IL_0431: ldloc.s 38
-			IL_0433: ldloc.s 36
-			IL_0435: ldloc.s 37
-			IL_0437: ldloc.s 32
-			IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_043e: pop
-			IL_043f: ldarg.0
-			IL_0440: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0445: stloc.s 32
-			IL_0447: ldstr "Q"
-			IL_044c: ldloc.s 32
-			IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0453: stloc.s 32
-			IL_0455: ldloc.s 32
-			IL_0457: ldstr "Line"
-			IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0461: stloc.s 32
-			IL_0463: ldloc.s 32
-			IL_0465: ldc.r8 2
-			IL_046e: box [System.Runtime]System.Double
-			IL_0473: ldc.i4.1
-			IL_0474: box [System.Runtime]System.Boolean
-			IL_0479: ldc.i4.1
-			IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_047f: pop
+			IL_040b: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24::.ctor()
+			IL_0410: stloc.s 7
+			IL_0412: ldarg.0
+			IL_0413: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0418: ldstr "Line"
+			IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0422: ldc.r8 2
+			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0430: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0435: ldc.i4.0
+			IL_0436: ceq
+			IL_0438: stloc.s 38
+			IL_043a: ldloc.s 38
+			IL_043c: brfalse IL_04c7
 
-			IL_0480: ldarg.0
-			IL_0481: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0486: stloc.s 32
-			IL_0488: ldstr "Q"
-			IL_048d: ldloc.s 32
-			IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0494: stloc.s 32
-			IL_0496: ldloc.s 32
-			IL_0498: ldstr "Line"
-			IL_049d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04a2: stloc.s 32
-			IL_04a4: ldloc.s 32
-			IL_04a6: ldc.r8 3
-			IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_04b4: stloc.s 32
-			IL_04b6: ldloc.s 32
-			IL_04b8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_04bd: ldc.i4.0
-			IL_04be: ceq
-			IL_04c0: stloc.s 39
-			IL_04c2: ldloc.s 39
-			IL_04c4: brfalse IL_0591
+			IL_0441: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L205C24::.ctor()
+			IL_0446: stloc.s 8
+			IL_0448: ldarg.0
+			IL_0449: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_044e: stloc.s 37
+			IL_0450: ldc.i4.1
+			IL_0451: newarr [System.Runtime]System.Object
+			IL_0456: dup
+			IL_0457: ldc.i4.0
+			IL_0458: ldarg.0
+			IL_0459: stelem.ref
+			IL_045a: stloc.s 36
+			IL_045c: ldarg.0
+			IL_045d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0462: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0467: ldc.r8 3
+			IL_0470: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0475: stloc.s 32
+			IL_0477: ldloc.s 37
+			IL_0479: ldloc.s 36
+			IL_047b: ldloc.s 32
+			IL_047d: ldarg.0
+			IL_047e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0483: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0488: ldc.r8 2
+			IL_0491: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_049b: pop
+			IL_049c: ldarg.0
+			IL_049d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_04a2: ldstr "Line"
+			IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04ac: ldc.r8 2
+			IL_04b5: box [System.Runtime]System.Double
+			IL_04ba: ldc.i4.1
+			IL_04bb: box [System.Runtime]System.Boolean
+			IL_04c0: ldc.i4.1
+			IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_04c6: pop
 
-			IL_04c9: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L202C24::.ctor()
-			IL_04ce: stloc.s 6
-			IL_04d0: ldarg.0
-			IL_04d1: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_04d6: stloc.s 32
-			IL_04d8: ldstr "DrawLine"
-			IL_04dd: ldloc.s 32
-			IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_04e4: stloc.s 32
-			IL_04e6: ldc.i4.1
-			IL_04e7: newarr [System.Runtime]System.Object
-			IL_04ec: dup
-			IL_04ed: ldc.i4.0
-			IL_04ee: ldarg.0
-			IL_04ef: stelem.ref
-			IL_04f0: stloc.s 36
-			IL_04f2: ldarg.0
-			IL_04f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_04f8: stloc.s 37
-			IL_04fa: ldstr "Q"
-			IL_04ff: ldloc.s 37
-			IL_0501: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0506: stloc.s 37
-			IL_0508: ldloc.s 37
-			IL_050a: ldc.r8 3
-			IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0518: stloc.s 37
-			IL_051a: ldarg.0
-			IL_051b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0520: stloc.s 38
-			IL_0522: ldstr "Q"
-			IL_0527: ldloc.s 38
-			IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_052e: stloc.s 38
-			IL_0530: ldloc.s 38
-			IL_0532: ldc.r8 0.0
-			IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0540: stloc.s 38
-			IL_0542: ldloc.s 32
-			IL_0544: ldloc.s 36
-			IL_0546: ldloc.s 37
-			IL_0548: ldloc.s 38
-			IL_054a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_054f: pop
-			IL_0550: ldarg.0
-			IL_0551: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0556: stloc.s 38
-			IL_0558: ldstr "Q"
-			IL_055d: ldloc.s 38
-			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0564: stloc.s 38
-			IL_0566: ldloc.s 38
-			IL_0568: ldstr "Line"
-			IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0572: stloc.s 38
-			IL_0574: ldloc.s 38
-			IL_0576: ldc.r8 3
-			IL_057f: box [System.Runtime]System.Double
-			IL_0584: ldc.i4.1
-			IL_0585: box [System.Runtime]System.Boolean
-			IL_058a: ldc.i4.1
-			IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0590: pop
+			IL_04c7: ldarg.0
+			IL_04c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_04cd: ldstr "Line"
+			IL_04d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04d7: ldc.r8 9
+			IL_04e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_04e5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04ea: ldc.i4.0
+			IL_04eb: ceq
+			IL_04ed: stloc.s 38
+			IL_04ef: ldloc.s 38
+			IL_04f1: brfalse IL_057c
 
-			IL_0591: ldloc.0
-			IL_0592: ldc.r8 1
-			IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_05a0: ldc.r8 2
-			IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_05ae: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_05b3: ldc.r8 0.0
-			IL_05bc: clt
-			IL_05be: brfalse IL_0a0e
+			IL_04f6: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L206C24::.ctor()
+			IL_04fb: stloc.s 9
+			IL_04fd: ldarg.0
+			IL_04fe: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0503: stloc.s 32
+			IL_0505: ldc.i4.1
+			IL_0506: newarr [System.Runtime]System.Object
+			IL_050b: dup
+			IL_050c: ldc.i4.0
+			IL_050d: ldarg.0
+			IL_050e: stelem.ref
+			IL_050f: stloc.s 36
+			IL_0511: ldarg.0
+			IL_0512: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0517: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_051c: ldc.r8 2
+			IL_0525: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_052a: stloc.s 37
+			IL_052c: ldloc.s 32
+			IL_052e: ldloc.s 36
+			IL_0530: ldloc.s 37
+			IL_0532: ldarg.0
+			IL_0533: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0538: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_053d: ldc.r8 6
+			IL_0546: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0550: pop
+			IL_0551: ldarg.0
+			IL_0552: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0557: ldstr "Line"
+			IL_055c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0561: ldc.r8 9
+			IL_056a: box [System.Runtime]System.Double
+			IL_056f: ldc.i4.1
+			IL_0570: box [System.Runtime]System.Boolean
+			IL_0575: ldc.i4.1
+			IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_057b: pop
 
-			IL_05c3: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24::.ctor()
-			IL_05c8: stloc.s 7
-			IL_05ca: ldarg.0
-			IL_05cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_05d0: stloc.s 38
-			IL_05d2: ldstr "Q"
-			IL_05d7: ldloc.s 38
-			IL_05d9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_05de: stloc.s 38
-			IL_05e0: ldloc.s 38
-			IL_05e2: ldstr "Line"
-			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05ec: stloc.s 38
-			IL_05ee: ldloc.s 38
-			IL_05f0: ldc.r8 2
-			IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_05fe: stloc.s 38
-			IL_0600: ldloc.s 38
-			IL_0602: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0607: ldc.i4.0
-			IL_0608: ceq
-			IL_060a: stloc.s 39
-			IL_060c: ldloc.s 39
-			IL_060e: brfalse IL_06db
+			IL_057c: ldarg.0
+			IL_057d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0582: ldstr "Line"
+			IL_0587: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_058c: ldc.r8 6
+			IL_0595: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_059a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_059f: ldc.i4.0
+			IL_05a0: ceq
+			IL_05a2: stloc.s 38
+			IL_05a4: ldloc.s 38
+			IL_05a6: brfalse IL_0631
 
-			IL_0613: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L205C24::.ctor()
-			IL_0618: stloc.s 8
-			IL_061a: ldarg.0
-			IL_061b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0620: stloc.s 38
-			IL_0622: ldstr "DrawLine"
-			IL_0627: ldloc.s 38
-			IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_062e: stloc.s 38
-			IL_0630: ldc.i4.1
-			IL_0631: newarr [System.Runtime]System.Object
-			IL_0636: dup
-			IL_0637: ldc.i4.0
-			IL_0638: ldarg.0
-			IL_0639: stelem.ref
-			IL_063a: stloc.s 36
-			IL_063c: ldarg.0
-			IL_063d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0642: stloc.s 37
-			IL_0644: ldstr "Q"
-			IL_0649: ldloc.s 37
-			IL_064b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0650: stloc.s 37
-			IL_0652: ldloc.s 37
-			IL_0654: ldc.r8 3
-			IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0662: stloc.s 37
-			IL_0664: ldarg.0
-			IL_0665: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_066a: stloc.s 32
-			IL_066c: ldstr "Q"
-			IL_0671: ldloc.s 32
-			IL_0673: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0678: stloc.s 32
-			IL_067a: ldloc.s 32
-			IL_067c: ldc.r8 2
-			IL_0685: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_068a: stloc.s 32
-			IL_068c: ldloc.s 38
-			IL_068e: ldloc.s 36
-			IL_0690: ldloc.s 37
-			IL_0692: ldloc.s 32
-			IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0699: pop
-			IL_069a: ldarg.0
-			IL_069b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_06a0: stloc.s 32
-			IL_06a2: ldstr "Q"
-			IL_06a7: ldloc.s 32
-			IL_06a9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06ae: stloc.s 32
-			IL_06b0: ldloc.s 32
-			IL_06b2: ldstr "Line"
-			IL_06b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06bc: stloc.s 32
-			IL_06be: ldloc.s 32
-			IL_06c0: ldc.r8 2
-			IL_06c9: box [System.Runtime]System.Double
-			IL_06ce: ldc.i4.1
-			IL_06cf: box [System.Runtime]System.Boolean
-			IL_06d4: ldc.i4.1
-			IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_06da: pop
+			IL_05ab: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L207C24::.ctor()
+			IL_05b0: stloc.s 10
+			IL_05b2: ldarg.0
+			IL_05b3: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_05b8: stloc.s 37
+			IL_05ba: ldc.i4.1
+			IL_05bb: newarr [System.Runtime]System.Object
+			IL_05c0: dup
+			IL_05c1: ldc.i4.0
+			IL_05c2: ldarg.0
+			IL_05c3: stelem.ref
+			IL_05c4: stloc.s 36
+			IL_05c6: ldarg.0
+			IL_05c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_05cc: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_05d1: ldc.r8 6
+			IL_05da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_05df: stloc.s 32
+			IL_05e1: ldloc.s 37
+			IL_05e3: ldloc.s 36
+			IL_05e5: ldloc.s 32
+			IL_05e7: ldarg.0
+			IL_05e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_05ed: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_05f2: ldc.r8 7
+			IL_05fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0600: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0605: pop
+			IL_0606: ldarg.0
+			IL_0607: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_060c: ldstr "Line"
+			IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0616: ldc.r8 6
+			IL_061f: box [System.Runtime]System.Double
+			IL_0624: ldc.i4.1
+			IL_0625: box [System.Runtime]System.Boolean
+			IL_062a: ldc.i4.1
+			IL_062b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0630: pop
 
-			IL_06db: ldarg.0
-			IL_06dc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_06e1: stloc.s 32
-			IL_06e3: ldstr "Q"
-			IL_06e8: ldloc.s 32
-			IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06ef: stloc.s 32
-			IL_06f1: ldloc.s 32
-			IL_06f3: ldstr "Line"
-			IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06fd: stloc.s 32
-			IL_06ff: ldloc.s 32
-			IL_0701: ldc.r8 9
-			IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_070f: stloc.s 32
-			IL_0711: ldloc.s 32
-			IL_0713: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0718: ldc.i4.0
-			IL_0719: ceq
-			IL_071b: stloc.s 39
-			IL_071d: ldloc.s 39
-			IL_071f: brfalse IL_07ec
+			IL_0631: ldarg.0
+			IL_0632: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0637: ldstr "Line"
+			IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0641: ldc.r8 10
+			IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_064f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0654: ldc.i4.0
+			IL_0655: ceq
+			IL_0657: stloc.s 38
+			IL_0659: ldloc.s 38
+			IL_065b: brfalse IL_06e6
 
-			IL_0724: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L206C24::.ctor()
-			IL_0729: stloc.s 9
-			IL_072b: ldarg.0
-			IL_072c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0731: stloc.s 32
-			IL_0733: ldstr "DrawLine"
-			IL_0738: ldloc.s 32
-			IL_073a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_073f: stloc.s 32
-			IL_0741: ldc.i4.1
-			IL_0742: newarr [System.Runtime]System.Object
-			IL_0747: dup
-			IL_0748: ldc.i4.0
-			IL_0749: ldarg.0
-			IL_074a: stelem.ref
-			IL_074b: stloc.s 36
-			IL_074d: ldarg.0
-			IL_074e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0753: stloc.s 37
-			IL_0755: ldstr "Q"
-			IL_075a: ldloc.s 37
-			IL_075c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0761: stloc.s 37
-			IL_0763: ldloc.s 37
-			IL_0765: ldc.r8 2
-			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0773: stloc.s 37
-			IL_0775: ldarg.0
-			IL_0776: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_077b: stloc.s 38
-			IL_077d: ldstr "Q"
-			IL_0782: ldloc.s 38
-			IL_0784: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0789: stloc.s 38
-			IL_078b: ldloc.s 38
-			IL_078d: ldc.r8 6
-			IL_0796: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_079b: stloc.s 38
-			IL_079d: ldloc.s 32
-			IL_079f: ldloc.s 36
-			IL_07a1: ldloc.s 37
-			IL_07a3: ldloc.s 38
-			IL_07a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_07aa: pop
-			IL_07ab: ldarg.0
-			IL_07ac: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_07b1: stloc.s 38
-			IL_07b3: ldstr "Q"
-			IL_07b8: ldloc.s 38
-			IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_07bf: stloc.s 38
-			IL_07c1: ldloc.s 38
-			IL_07c3: ldstr "Line"
-			IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07cd: stloc.s 38
-			IL_07cf: ldloc.s 38
-			IL_07d1: ldc.r8 9
-			IL_07da: box [System.Runtime]System.Double
-			IL_07df: ldc.i4.1
-			IL_07e0: box [System.Runtime]System.Boolean
-			IL_07e5: ldc.i4.1
-			IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_07eb: pop
+			IL_0660: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L208C25::.ctor()
+			IL_0665: stloc.s 11
+			IL_0667: ldarg.0
+			IL_0668: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_066d: stloc.s 32
+			IL_066f: ldc.i4.1
+			IL_0670: newarr [System.Runtime]System.Object
+			IL_0675: dup
+			IL_0676: ldc.i4.0
+			IL_0677: ldarg.0
+			IL_0678: stelem.ref
+			IL_0679: stloc.s 36
+			IL_067b: ldarg.0
+			IL_067c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0681: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0686: ldc.r8 7
+			IL_068f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0694: stloc.s 37
+			IL_0696: ldloc.s 32
+			IL_0698: ldloc.s 36
+			IL_069a: ldloc.s 37
+			IL_069c: ldarg.0
+			IL_069d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_06a2: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_06a7: ldc.r8 3
+			IL_06b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_06b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_06ba: pop
+			IL_06bb: ldarg.0
+			IL_06bc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_06c1: ldstr "Line"
+			IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06cb: ldc.r8 10
+			IL_06d4: box [System.Runtime]System.Double
+			IL_06d9: ldc.i4.1
+			IL_06da: box [System.Runtime]System.Boolean
+			IL_06df: ldc.i4.1
+			IL_06e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_06e5: pop
 
-			IL_07ec: ldarg.0
-			IL_07ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_07f2: stloc.s 38
-			IL_07f4: ldstr "Q"
-			IL_07f9: ldloc.s 38
-			IL_07fb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0800: stloc.s 38
-			IL_0802: ldloc.s 38
-			IL_0804: ldstr "Line"
-			IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_080e: stloc.s 38
-			IL_0810: ldloc.s 38
-			IL_0812: ldc.r8 6
-			IL_081b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0820: stloc.s 38
-			IL_0822: ldloc.s 38
-			IL_0824: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0829: ldc.i4.0
-			IL_082a: ceq
-			IL_082c: stloc.s 39
-			IL_082e: ldloc.s 39
-			IL_0830: brfalse IL_08fd
+			IL_06e6: ldloc.0
+			IL_06e7: ldc.r8 2
+			IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_06f5: ldc.r8 2
+			IL_06fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0703: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0708: ldc.r8 0.0
+			IL_0711: clt
+			IL_0713: brfalse IL_09f3
 
-			IL_0835: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L207C24::.ctor()
-			IL_083a: stloc.s 10
-			IL_083c: ldarg.0
-			IL_083d: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0842: stloc.s 38
-			IL_0844: ldstr "DrawLine"
-			IL_0849: ldloc.s 38
-			IL_084b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0850: stloc.s 38
-			IL_0852: ldc.i4.1
-			IL_0853: newarr [System.Runtime]System.Object
-			IL_0858: dup
-			IL_0859: ldc.i4.0
-			IL_085a: ldarg.0
-			IL_085b: stelem.ref
-			IL_085c: stloc.s 36
+			IL_0718: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24::.ctor()
+			IL_071d: stloc.s 12
+			IL_071f: ldarg.0
+			IL_0720: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0725: ldstr "Line"
+			IL_072a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_072f: ldc.r8 4
+			IL_0738: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_073d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0742: ldc.i4.0
+			IL_0743: ceq
+			IL_0745: stloc.s 38
+			IL_0747: ldloc.s 38
+			IL_0749: brfalse IL_07d4
+
+			IL_074e: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L211C24::.ctor()
+			IL_0753: stloc.s 13
+			IL_0755: ldarg.0
+			IL_0756: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_075b: stloc.s 37
+			IL_075d: ldc.i4.1
+			IL_075e: newarr [System.Runtime]System.Object
+			IL_0763: dup
+			IL_0764: ldc.i4.0
+			IL_0765: ldarg.0
+			IL_0766: stelem.ref
+			IL_0767: stloc.s 36
+			IL_0769: ldarg.0
+			IL_076a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_076f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0774: ldc.r8 4
+			IL_077d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0782: stloc.s 32
+			IL_0784: ldloc.s 37
+			IL_0786: ldloc.s 36
+			IL_0788: ldloc.s 32
+			IL_078a: ldarg.0
+			IL_078b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0790: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0795: ldc.r8 5
+			IL_079e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_07a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_07a8: pop
+			IL_07a9: ldarg.0
+			IL_07aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_07af: ldstr "Line"
+			IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07b9: ldc.r8 4
+			IL_07c2: box [System.Runtime]System.Double
+			IL_07c7: ldc.i4.1
+			IL_07c8: box [System.Runtime]System.Boolean
+			IL_07cd: ldc.i4.1
+			IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_07d3: pop
+
+			IL_07d4: ldarg.0
+			IL_07d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_07da: ldstr "Line"
+			IL_07df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07e4: ldc.r8 5
+			IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_07f2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_07f7: ldc.i4.0
+			IL_07f8: ceq
+			IL_07fa: stloc.s 38
+			IL_07fc: ldloc.s 38
+			IL_07fe: brfalse IL_0889
+
+			IL_0803: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L212C24::.ctor()
+			IL_0808: stloc.s 14
+			IL_080a: ldarg.0
+			IL_080b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0810: stloc.s 32
+			IL_0812: ldc.i4.1
+			IL_0813: newarr [System.Runtime]System.Object
+			IL_0818: dup
+			IL_0819: ldc.i4.0
+			IL_081a: ldarg.0
+			IL_081b: stelem.ref
+			IL_081c: stloc.s 36
+			IL_081e: ldarg.0
+			IL_081f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0824: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0829: ldc.r8 5
+			IL_0832: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0837: stloc.s 37
+			IL_0839: ldloc.s 32
+			IL_083b: ldloc.s 36
+			IL_083d: ldloc.s 37
+			IL_083f: ldarg.0
+			IL_0840: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0845: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_084a: ldc.r8 6
+			IL_0853: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0858: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_085d: pop
 			IL_085e: ldarg.0
 			IL_085f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0864: stloc.s 37
-			IL_0866: ldstr "Q"
-			IL_086b: ldloc.s 37
-			IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0872: stloc.s 37
-			IL_0874: ldloc.s 37
-			IL_0876: ldc.r8 6
-			IL_087f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0884: stloc.s 37
-			IL_0886: ldarg.0
-			IL_0887: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_088c: stloc.s 32
-			IL_088e: ldstr "Q"
-			IL_0893: ldloc.s 32
-			IL_0895: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_089a: stloc.s 32
-			IL_089c: ldloc.s 32
-			IL_089e: ldc.r8 7
-			IL_08a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_08ac: stloc.s 32
-			IL_08ae: ldloc.s 38
-			IL_08b0: ldloc.s 36
-			IL_08b2: ldloc.s 37
-			IL_08b4: ldloc.s 32
-			IL_08b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_08bb: pop
-			IL_08bc: ldarg.0
-			IL_08bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_08c2: stloc.s 32
-			IL_08c4: ldstr "Q"
-			IL_08c9: ldloc.s 32
-			IL_08cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_08d0: stloc.s 32
-			IL_08d2: ldloc.s 32
-			IL_08d4: ldstr "Line"
-			IL_08d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08de: stloc.s 32
-			IL_08e0: ldloc.s 32
-			IL_08e2: ldc.r8 6
-			IL_08eb: box [System.Runtime]System.Double
-			IL_08f0: ldc.i4.1
-			IL_08f1: box [System.Runtime]System.Boolean
-			IL_08f6: ldc.i4.1
-			IL_08f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_08fc: pop
+			IL_0864: ldstr "Line"
+			IL_0869: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_086e: ldc.r8 5
+			IL_0877: box [System.Runtime]System.Double
+			IL_087c: ldc.i4.1
+			IL_087d: box [System.Runtime]System.Boolean
+			IL_0882: ldc.i4.1
+			IL_0883: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0888: pop
 
-			IL_08fd: ldarg.0
-			IL_08fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0903: stloc.s 32
-			IL_0905: ldstr "Q"
-			IL_090a: ldloc.s 32
-			IL_090c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0911: stloc.s 32
-			IL_0913: ldloc.s 32
-			IL_0915: ldstr "Line"
-			IL_091a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_091f: stloc.s 32
-			IL_0921: ldloc.s 32
-			IL_0923: ldc.r8 10
-			IL_092c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0931: stloc.s 32
-			IL_0933: ldloc.s 32
-			IL_0935: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_093a: ldc.i4.0
-			IL_093b: ceq
-			IL_093d: stloc.s 39
-			IL_093f: ldloc.s 39
-			IL_0941: brfalse IL_0a0e
+			IL_0889: ldarg.0
+			IL_088a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_088f: ldstr "Line"
+			IL_0894: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0899: ldc.r8 6
+			IL_08a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_08a7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08ac: ldc.i4.0
+			IL_08ad: ceq
+			IL_08af: stloc.s 38
+			IL_08b1: ldloc.s 38
+			IL_08b3: brfalse IL_093e
 
-			IL_0946: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L208C25::.ctor()
-			IL_094b: stloc.s 11
-			IL_094d: ldarg.0
-			IL_094e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0953: stloc.s 32
-			IL_0955: ldstr "DrawLine"
-			IL_095a: ldloc.s 32
-			IL_095c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0961: stloc.s 32
-			IL_0963: ldc.i4.1
-			IL_0964: newarr [System.Runtime]System.Object
-			IL_0969: dup
-			IL_096a: ldc.i4.0
-			IL_096b: ldarg.0
-			IL_096c: stelem.ref
-			IL_096d: stloc.s 36
-			IL_096f: ldarg.0
-			IL_0970: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0975: stloc.s 37
-			IL_0977: ldstr "Q"
-			IL_097c: ldloc.s 37
-			IL_097e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0983: stloc.s 37
-			IL_0985: ldloc.s 37
-			IL_0987: ldc.r8 7
-			IL_0990: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0995: stloc.s 37
-			IL_0997: ldarg.0
-			IL_0998: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_099d: stloc.s 38
-			IL_099f: ldstr "Q"
-			IL_09a4: ldloc.s 38
-			IL_09a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_09ab: stloc.s 38
-			IL_09ad: ldloc.s 38
-			IL_09af: ldc.r8 3
-			IL_09b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_09bd: stloc.s 38
-			IL_09bf: ldloc.s 32
-			IL_09c1: ldloc.s 36
-			IL_09c3: ldloc.s 37
-			IL_09c5: ldloc.s 38
-			IL_09c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_09cc: pop
-			IL_09cd: ldarg.0
-			IL_09ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_09d3: stloc.s 38
-			IL_09d5: ldstr "Q"
-			IL_09da: ldloc.s 38
-			IL_09dc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_09e1: stloc.s 38
-			IL_09e3: ldloc.s 38
-			IL_09e5: ldstr "Line"
-			IL_09ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09ef: stloc.s 38
-			IL_09f1: ldloc.s 38
-			IL_09f3: ldc.r8 10
-			IL_09fc: box [System.Runtime]System.Double
-			IL_0a01: ldc.i4.1
-			IL_0a02: box [System.Runtime]System.Boolean
-			IL_0a07: ldc.i4.1
-			IL_0a08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0a0d: pop
+			IL_08b8: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L213C24::.ctor()
+			IL_08bd: stloc.s 15
+			IL_08bf: ldarg.0
+			IL_08c0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_08c5: stloc.s 37
+			IL_08c7: ldc.i4.1
+			IL_08c8: newarr [System.Runtime]System.Object
+			IL_08cd: dup
+			IL_08ce: ldc.i4.0
+			IL_08cf: ldarg.0
+			IL_08d0: stelem.ref
+			IL_08d1: stloc.s 36
+			IL_08d3: ldarg.0
+			IL_08d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_08d9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_08de: ldc.r8 6
+			IL_08e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_08ec: stloc.s 32
+			IL_08ee: ldloc.s 37
+			IL_08f0: ldloc.s 36
+			IL_08f2: ldloc.s 32
+			IL_08f4: ldarg.0
+			IL_08f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_08fa: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_08ff: ldc.r8 7
+			IL_0908: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_090d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0912: pop
+			IL_0913: ldarg.0
+			IL_0914: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0919: ldstr "Line"
+			IL_091e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0923: ldc.r8 6
+			IL_092c: box [System.Runtime]System.Double
+			IL_0931: ldc.i4.1
+			IL_0932: box [System.Runtime]System.Boolean
+			IL_0937: ldc.i4.1
+			IL_0938: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_093d: pop
 
-			IL_0a0e: ldloc.0
-			IL_0a0f: ldc.r8 2
-			IL_0a18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0a1d: ldc.r8 2
-			IL_0a26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0a2b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0a30: ldc.r8 0.0
-			IL_0a39: clt
-			IL_0a3b: brfalse IL_0e8b
+			IL_093e: ldarg.0
+			IL_093f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0944: ldstr "Line"
+			IL_0949: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_094e: ldc.r8 7
+			IL_0957: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_095c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0961: ldc.i4.0
+			IL_0962: ceq
+			IL_0964: stloc.s 38
+			IL_0966: ldloc.s 38
+			IL_0968: brfalse IL_09f3
 
-			IL_0a40: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24::.ctor()
-			IL_0a45: stloc.s 12
-			IL_0a47: ldarg.0
-			IL_0a48: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a4d: stloc.s 38
-			IL_0a4f: ldstr "Q"
+			IL_096d: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L214C24::.ctor()
+			IL_0972: stloc.s 16
+			IL_0974: ldarg.0
+			IL_0975: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_097a: stloc.s 32
+			IL_097c: ldc.i4.1
+			IL_097d: newarr [System.Runtime]System.Object
+			IL_0982: dup
+			IL_0983: ldc.i4.0
+			IL_0984: ldarg.0
+			IL_0985: stelem.ref
+			IL_0986: stloc.s 36
+			IL_0988: ldarg.0
+			IL_0989: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_098e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0993: ldc.r8 7
+			IL_099c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_09a1: stloc.s 37
+			IL_09a3: ldloc.s 32
+			IL_09a5: ldloc.s 36
+			IL_09a7: ldloc.s 37
+			IL_09a9: ldarg.0
+			IL_09aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_09af: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_09b4: ldc.r8 4
+			IL_09bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_09c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_09c7: pop
+			IL_09c8: ldarg.0
+			IL_09c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_09ce: ldstr "Line"
+			IL_09d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09d8: ldc.r8 7
+			IL_09e1: box [System.Runtime]System.Double
+			IL_09e6: ldc.i4.1
+			IL_09e7: box [System.Runtime]System.Boolean
+			IL_09ec: ldc.i4.1
+			IL_09ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_09f2: pop
+
+			IL_09f3: ldloc.0
+			IL_09f4: ldc.r8 3
+			IL_09fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0a02: ldc.r8 2
+			IL_0a0b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0a10: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0a15: ldc.r8 0.0
+			IL_0a1e: clt
+			IL_0a20: brfalse IL_0d00
+
+			IL_0a25: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24::.ctor()
+			IL_0a2a: stloc.s 17
+			IL_0a2c: ldarg.0
+			IL_0a2d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0a32: ldstr "Line"
+			IL_0a37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a3c: ldc.r8 4
+			IL_0a45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0a4a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0a4f: ldc.i4.0
+			IL_0a50: ceq
+			IL_0a52: stloc.s 38
 			IL_0a54: ldloc.s 38
-			IL_0a56: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0a5b: stloc.s 38
-			IL_0a5d: ldloc.s 38
-			IL_0a5f: ldstr "Line"
-			IL_0a64: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a69: stloc.s 38
-			IL_0a6b: ldloc.s 38
-			IL_0a6d: ldc.r8 4
-			IL_0a76: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0a7b: stloc.s 38
-			IL_0a7d: ldloc.s 38
-			IL_0a7f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0a84: ldc.i4.0
-			IL_0a85: ceq
-			IL_0a87: stloc.s 39
-			IL_0a89: ldloc.s 39
-			IL_0a8b: brfalse IL_0b58
+			IL_0a56: brfalse IL_0ae1
 
-			IL_0a90: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L211C24::.ctor()
-			IL_0a95: stloc.s 13
+			IL_0a5b: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L217C24::.ctor()
+			IL_0a60: stloc.s 18
+			IL_0a62: ldarg.0
+			IL_0a63: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0a68: stloc.s 37
+			IL_0a6a: ldc.i4.1
+			IL_0a6b: newarr [System.Runtime]System.Object
+			IL_0a70: dup
+			IL_0a71: ldc.i4.0
+			IL_0a72: ldarg.0
+			IL_0a73: stelem.ref
+			IL_0a74: stloc.s 36
+			IL_0a76: ldarg.0
+			IL_0a77: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0a7c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0a81: ldc.r8 4
+			IL_0a8a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0a8f: stloc.s 32
+			IL_0a91: ldloc.s 37
+			IL_0a93: ldloc.s 36
+			IL_0a95: ldloc.s 32
 			IL_0a97: ldarg.0
-			IL_0a98: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0a9d: stloc.s 38
-			IL_0a9f: ldstr "DrawLine"
-			IL_0aa4: ldloc.s 38
-			IL_0aa6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0aab: stloc.s 38
-			IL_0aad: ldc.i4.1
-			IL_0aae: newarr [System.Runtime]System.Object
-			IL_0ab3: dup
-			IL_0ab4: ldc.i4.0
-			IL_0ab5: ldarg.0
-			IL_0ab6: stelem.ref
-			IL_0ab7: stloc.s 36
-			IL_0ab9: ldarg.0
-			IL_0aba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0abf: stloc.s 37
-			IL_0ac1: ldstr "Q"
-			IL_0ac6: ldloc.s 37
-			IL_0ac8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0acd: stloc.s 37
-			IL_0acf: ldloc.s 37
-			IL_0ad1: ldc.r8 4
-			IL_0ada: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0adf: stloc.s 37
+			IL_0a98: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0a9d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0aa2: ldc.r8 5
+			IL_0aab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0ab0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0ab5: pop
+			IL_0ab6: ldarg.0
+			IL_0ab7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0abc: ldstr "Line"
+			IL_0ac1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ac6: ldc.r8 4
+			IL_0acf: box [System.Runtime]System.Double
+			IL_0ad4: ldc.i4.1
+			IL_0ad5: box [System.Runtime]System.Boolean
+			IL_0ada: ldc.i4.1
+			IL_0adb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0ae0: pop
+
 			IL_0ae1: ldarg.0
 			IL_0ae2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ae7: stloc.s 32
-			IL_0ae9: ldstr "Q"
-			IL_0aee: ldloc.s 32
-			IL_0af0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0af5: stloc.s 32
-			IL_0af7: ldloc.s 32
-			IL_0af9: ldc.r8 5
-			IL_0b02: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0b07: stloc.s 32
+			IL_0ae7: ldstr "Line"
+			IL_0aec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0af1: ldc.r8 8
+			IL_0afa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0aff: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0b04: ldc.i4.0
+			IL_0b05: ceq
+			IL_0b07: stloc.s 38
 			IL_0b09: ldloc.s 38
-			IL_0b0b: ldloc.s 36
-			IL_0b0d: ldloc.s 37
-			IL_0b0f: ldloc.s 32
-			IL_0b11: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b16: pop
+			IL_0b0b: brfalse IL_0b96
+
+			IL_0b10: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L218C24::.ctor()
+			IL_0b15: stloc.s 19
 			IL_0b17: ldarg.0
-			IL_0b18: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b18: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
 			IL_0b1d: stloc.s 32
-			IL_0b1f: ldstr "Q"
-			IL_0b24: ldloc.s 32
-			IL_0b26: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0b2b: stloc.s 32
-			IL_0b2d: ldloc.s 32
-			IL_0b2f: ldstr "Line"
-			IL_0b34: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b39: stloc.s 32
-			IL_0b3b: ldloc.s 32
-			IL_0b3d: ldc.r8 4
-			IL_0b46: box [System.Runtime]System.Double
-			IL_0b4b: ldc.i4.1
-			IL_0b4c: box [System.Runtime]System.Boolean
-			IL_0b51: ldc.i4.1
-			IL_0b52: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0b57: pop
+			IL_0b1f: ldc.i4.1
+			IL_0b20: newarr [System.Runtime]System.Object
+			IL_0b25: dup
+			IL_0b26: ldc.i4.0
+			IL_0b27: ldarg.0
+			IL_0b28: stelem.ref
+			IL_0b29: stloc.s 36
+			IL_0b2b: ldarg.0
+			IL_0b2c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b31: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0b36: ldc.r8 5
+			IL_0b3f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0b44: stloc.s 37
+			IL_0b46: ldloc.s 32
+			IL_0b48: ldloc.s 36
+			IL_0b4a: ldloc.s 37
+			IL_0b4c: ldarg.0
+			IL_0b4d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b52: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0b57: ldc.r8 1
+			IL_0b60: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0b65: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b6a: pop
+			IL_0b6b: ldarg.0
+			IL_0b6c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b71: ldstr "Line"
+			IL_0b76: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b7b: ldc.r8 8
+			IL_0b84: box [System.Runtime]System.Double
+			IL_0b89: ldc.i4.1
+			IL_0b8a: box [System.Runtime]System.Boolean
+			IL_0b8f: ldc.i4.1
+			IL_0b90: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0b95: pop
 
-			IL_0b58: ldarg.0
-			IL_0b59: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0b5e: stloc.s 32
-			IL_0b60: ldstr "Q"
-			IL_0b65: ldloc.s 32
-			IL_0b67: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0b6c: stloc.s 32
-			IL_0b6e: ldloc.s 32
-			IL_0b70: ldstr "Line"
-			IL_0b75: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b7a: stloc.s 32
-			IL_0b7c: ldloc.s 32
-			IL_0b7e: ldc.r8 5
-			IL_0b87: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0b8c: stloc.s 32
-			IL_0b8e: ldloc.s 32
-			IL_0b90: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0b95: ldc.i4.0
-			IL_0b96: ceq
-			IL_0b98: stloc.s 39
-			IL_0b9a: ldloc.s 39
-			IL_0b9c: brfalse IL_0c69
+			IL_0b96: ldarg.0
+			IL_0b97: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b9c: ldstr "Line"
+			IL_0ba1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ba6: ldc.r8 0.0
+			IL_0baf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0bb4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0bb9: ldc.i4.0
+			IL_0bba: ceq
+			IL_0bbc: stloc.s 38
+			IL_0bbe: ldloc.s 38
+			IL_0bc0: brfalse IL_0c4b
 
-			IL_0ba1: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L212C24::.ctor()
-			IL_0ba6: stloc.s 14
-			IL_0ba8: ldarg.0
-			IL_0ba9: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0bae: stloc.s 32
-			IL_0bb0: ldstr "DrawLine"
-			IL_0bb5: ldloc.s 32
-			IL_0bb7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0bbc: stloc.s 32
-			IL_0bbe: ldc.i4.1
-			IL_0bbf: newarr [System.Runtime]System.Object
-			IL_0bc4: dup
-			IL_0bc5: ldc.i4.0
-			IL_0bc6: ldarg.0
-			IL_0bc7: stelem.ref
-			IL_0bc8: stloc.s 36
-			IL_0bca: ldarg.0
-			IL_0bcb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0bd0: stloc.s 37
-			IL_0bd2: ldstr "Q"
-			IL_0bd7: ldloc.s 37
-			IL_0bd9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0bde: stloc.s 37
-			IL_0be0: ldloc.s 37
-			IL_0be2: ldc.r8 5
-			IL_0beb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0bf0: stloc.s 37
-			IL_0bf2: ldarg.0
-			IL_0bf3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0bf8: stloc.s 38
-			IL_0bfa: ldstr "Q"
-			IL_0bff: ldloc.s 38
-			IL_0c01: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0c06: stloc.s 38
-			IL_0c08: ldloc.s 38
-			IL_0c0a: ldc.r8 6
-			IL_0c13: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0c18: stloc.s 38
-			IL_0c1a: ldloc.s 32
-			IL_0c1c: ldloc.s 36
-			IL_0c1e: ldloc.s 37
-			IL_0c20: ldloc.s 38
-			IL_0c22: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0c27: pop
-			IL_0c28: ldarg.0
-			IL_0c29: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c2e: stloc.s 38
-			IL_0c30: ldstr "Q"
-			IL_0c35: ldloc.s 38
-			IL_0c37: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0c3c: stloc.s 38
-			IL_0c3e: ldloc.s 38
-			IL_0c40: ldstr "Line"
-			IL_0c45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c4a: stloc.s 38
-			IL_0c4c: ldloc.s 38
-			IL_0c4e: ldc.r8 5
-			IL_0c57: box [System.Runtime]System.Double
-			IL_0c5c: ldc.i4.1
-			IL_0c5d: box [System.Runtime]System.Boolean
-			IL_0c62: ldc.i4.1
-			IL_0c63: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0c68: pop
+			IL_0bc5: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L219C24::.ctor()
+			IL_0bca: stloc.s 20
+			IL_0bcc: ldarg.0
+			IL_0bcd: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0bd2: stloc.s 37
+			IL_0bd4: ldc.i4.1
+			IL_0bd5: newarr [System.Runtime]System.Object
+			IL_0bda: dup
+			IL_0bdb: ldc.i4.0
+			IL_0bdc: ldarg.0
+			IL_0bdd: stelem.ref
+			IL_0bde: stloc.s 36
+			IL_0be0: ldarg.0
+			IL_0be1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0be6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0beb: ldc.r8 1
+			IL_0bf4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0bf9: stloc.s 32
+			IL_0bfb: ldloc.s 37
+			IL_0bfd: ldloc.s 36
+			IL_0bff: ldloc.s 32
+			IL_0c01: ldarg.0
+			IL_0c02: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c07: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0c0c: ldc.r8 0.0
+			IL_0c15: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0c1a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0c1f: pop
+			IL_0c20: ldarg.0
+			IL_0c21: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c26: ldstr "Line"
+			IL_0c2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c30: ldc.r8 0.0
+			IL_0c39: box [System.Runtime]System.Double
+			IL_0c3e: ldc.i4.1
+			IL_0c3f: box [System.Runtime]System.Boolean
+			IL_0c44: ldc.i4.1
+			IL_0c45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0c4a: pop
 
-			IL_0c69: ldarg.0
-			IL_0c6a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c6f: stloc.s 38
-			IL_0c71: ldstr "Q"
-			IL_0c76: ldloc.s 38
-			IL_0c78: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0c7d: stloc.s 38
-			IL_0c7f: ldloc.s 38
-			IL_0c81: ldstr "Line"
-			IL_0c86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c8b: stloc.s 38
-			IL_0c8d: ldloc.s 38
-			IL_0c8f: ldc.r8 6
-			IL_0c98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0c9d: stloc.s 38
-			IL_0c9f: ldloc.s 38
-			IL_0ca1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0ca6: ldc.i4.0
-			IL_0ca7: ceq
-			IL_0ca9: stloc.s 39
-			IL_0cab: ldloc.s 39
-			IL_0cad: brfalse IL_0d7a
+			IL_0c4b: ldarg.0
+			IL_0c4c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c51: ldstr "Line"
+			IL_0c56: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c5b: ldc.r8 11
+			IL_0c64: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0c69: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0c6e: ldc.i4.0
+			IL_0c6f: ceq
+			IL_0c71: stloc.s 38
+			IL_0c73: ldloc.s 38
+			IL_0c75: brfalse IL_0d00
 
-			IL_0cb2: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L213C24::.ctor()
-			IL_0cb7: stloc.s 15
-			IL_0cb9: ldarg.0
-			IL_0cba: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0cbf: stloc.s 38
-			IL_0cc1: ldstr "DrawLine"
-			IL_0cc6: ldloc.s 38
-			IL_0cc8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0ccd: stloc.s 38
-			IL_0ccf: ldc.i4.1
-			IL_0cd0: newarr [System.Runtime]System.Object
-			IL_0cd5: dup
-			IL_0cd6: ldc.i4.0
-			IL_0cd7: ldarg.0
-			IL_0cd8: stelem.ref
-			IL_0cd9: stloc.s 36
-			IL_0cdb: ldarg.0
-			IL_0cdc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ce1: stloc.s 37
-			IL_0ce3: ldstr "Q"
-			IL_0ce8: ldloc.s 37
-			IL_0cea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0cef: stloc.s 37
-			IL_0cf1: ldloc.s 37
-			IL_0cf3: ldc.r8 6
-			IL_0cfc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0d01: stloc.s 37
-			IL_0d03: ldarg.0
-			IL_0d04: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d09: stloc.s 32
-			IL_0d0b: ldstr "Q"
-			IL_0d10: ldloc.s 32
-			IL_0d12: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0d17: stloc.s 32
-			IL_0d19: ldloc.s 32
-			IL_0d1b: ldc.r8 7
-			IL_0d24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0d29: stloc.s 32
-			IL_0d2b: ldloc.s 38
-			IL_0d2d: ldloc.s 36
-			IL_0d2f: ldloc.s 37
-			IL_0d31: ldloc.s 32
-			IL_0d33: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0d38: pop
+			IL_0c7a: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L220C25::.ctor()
+			IL_0c7f: stloc.s 21
+			IL_0c81: ldarg.0
+			IL_0c82: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0c87: stloc.s 32
+			IL_0c89: ldc.i4.1
+			IL_0c8a: newarr [System.Runtime]System.Object
+			IL_0c8f: dup
+			IL_0c90: ldc.i4.0
+			IL_0c91: ldarg.0
+			IL_0c92: stelem.ref
+			IL_0c93: stloc.s 36
+			IL_0c95: ldarg.0
+			IL_0c96: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c9b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0ca0: ldc.r8 0.0
+			IL_0ca9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0cae: stloc.s 37
+			IL_0cb0: ldloc.s 32
+			IL_0cb2: ldloc.s 36
+			IL_0cb4: ldloc.s 37
+			IL_0cb6: ldarg.0
+			IL_0cb7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0cbc: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0cc1: ldc.r8 4
+			IL_0cca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0ccf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0cd4: pop
+			IL_0cd5: ldarg.0
+			IL_0cd6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0cdb: ldstr "Line"
+			IL_0ce0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ce5: ldc.r8 11
+			IL_0cee: box [System.Runtime]System.Double
+			IL_0cf3: ldc.i4.1
+			IL_0cf4: box [System.Runtime]System.Boolean
+			IL_0cf9: ldc.i4.1
+			IL_0cfa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0cff: pop
+
+			IL_0d00: ldloc.0
+			IL_0d01: ldc.r8 4
+			IL_0d0a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0d0f: ldc.r8 2
+			IL_0d18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0d1d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0d22: ldc.r8 0.0
+			IL_0d2b: clt
+			IL_0d2d: brfalse IL_100d
+
+			IL_0d32: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24::.ctor()
+			IL_0d37: stloc.s 22
 			IL_0d39: ldarg.0
 			IL_0d3a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d3f: stloc.s 32
-			IL_0d41: ldstr "Q"
-			IL_0d46: ldloc.s 32
-			IL_0d48: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0d4d: stloc.s 32
-			IL_0d4f: ldloc.s 32
-			IL_0d51: ldstr "Line"
-			IL_0d56: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d5b: stloc.s 32
-			IL_0d5d: ldloc.s 32
-			IL_0d5f: ldc.r8 6
-			IL_0d68: box [System.Runtime]System.Double
-			IL_0d6d: ldc.i4.1
-			IL_0d6e: box [System.Runtime]System.Boolean
-			IL_0d73: ldc.i4.1
-			IL_0d74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0d79: pop
+			IL_0d3f: ldstr "Line"
+			IL_0d44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d49: ldc.r8 11
+			IL_0d52: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0d57: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0d5c: ldc.i4.0
+			IL_0d5d: ceq
+			IL_0d5f: stloc.s 38
+			IL_0d61: ldloc.s 38
+			IL_0d63: brfalse IL_0dee
 
-			IL_0d7a: ldarg.0
-			IL_0d7b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d80: stloc.s 32
-			IL_0d82: ldstr "Q"
-			IL_0d87: ldloc.s 32
-			IL_0d89: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0d8e: stloc.s 32
-			IL_0d90: ldloc.s 32
-			IL_0d92: ldstr "Line"
-			IL_0d97: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d68: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L223C25::.ctor()
+			IL_0d6d: stloc.s 23
+			IL_0d6f: ldarg.0
+			IL_0d70: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0d75: stloc.s 37
+			IL_0d77: ldc.i4.1
+			IL_0d78: newarr [System.Runtime]System.Object
+			IL_0d7d: dup
+			IL_0d7e: ldc.i4.0
+			IL_0d7f: ldarg.0
+			IL_0d80: stelem.ref
+			IL_0d81: stloc.s 36
+			IL_0d83: ldarg.0
+			IL_0d84: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0d89: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0d8e: ldc.r8 4
+			IL_0d97: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 			IL_0d9c: stloc.s 32
-			IL_0d9e: ldloc.s 32
-			IL_0da0: ldc.r8 7
-			IL_0da9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0dae: stloc.s 32
-			IL_0db0: ldloc.s 32
-			IL_0db2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0db7: ldc.i4.0
-			IL_0db8: ceq
-			IL_0dba: stloc.s 39
-			IL_0dbc: ldloc.s 39
-			IL_0dbe: brfalse IL_0e8b
+			IL_0d9e: ldloc.s 37
+			IL_0da0: ldloc.s 36
+			IL_0da2: ldloc.s 32
+			IL_0da4: ldarg.0
+			IL_0da5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0daa: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0daf: ldc.r8 0.0
+			IL_0db8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0dbd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0dc2: pop
+			IL_0dc3: ldarg.0
+			IL_0dc4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0dc9: ldstr "Line"
+			IL_0dce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dd3: ldc.r8 11
+			IL_0ddc: box [System.Runtime]System.Double
+			IL_0de1: ldc.i4.1
+			IL_0de2: box [System.Runtime]System.Boolean
+			IL_0de7: ldc.i4.1
+			IL_0de8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0ded: pop
 
-			IL_0dc3: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L214C24::.ctor()
-			IL_0dc8: stloc.s 16
-			IL_0dca: ldarg.0
-			IL_0dcb: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0dd0: stloc.s 32
-			IL_0dd2: ldstr "DrawLine"
-			IL_0dd7: ldloc.s 32
-			IL_0dd9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0dde: stloc.s 32
-			IL_0de0: ldc.i4.1
-			IL_0de1: newarr [System.Runtime]System.Object
-			IL_0de6: dup
-			IL_0de7: ldc.i4.0
-			IL_0de8: ldarg.0
-			IL_0de9: stelem.ref
-			IL_0dea: stloc.s 36
-			IL_0dec: ldarg.0
-			IL_0ded: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0df2: stloc.s 37
-			IL_0df4: ldstr "Q"
-			IL_0df9: ldloc.s 37
-			IL_0dfb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0e00: stloc.s 37
-			IL_0e02: ldloc.s 37
-			IL_0e04: ldc.r8 7
-			IL_0e0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e12: stloc.s 37
-			IL_0e14: ldarg.0
-			IL_0e15: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e1a: stloc.s 38
-			IL_0e1c: ldstr "Q"
-			IL_0e21: ldloc.s 38
-			IL_0e23: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0e28: stloc.s 38
-			IL_0e2a: ldloc.s 38
-			IL_0e2c: ldc.r8 4
-			IL_0e35: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e3a: stloc.s 38
-			IL_0e3c: ldloc.s 32
-			IL_0e3e: ldloc.s 36
-			IL_0e40: ldloc.s 37
-			IL_0e42: ldloc.s 38
-			IL_0e44: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0e49: pop
-			IL_0e4a: ldarg.0
-			IL_0e4b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e50: stloc.s 38
-			IL_0e52: ldstr "Q"
-			IL_0e57: ldloc.s 38
-			IL_0e59: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0e5e: stloc.s 38
-			IL_0e60: ldloc.s 38
-			IL_0e62: ldstr "Line"
-			IL_0e67: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e6c: stloc.s 38
-			IL_0e6e: ldloc.s 38
-			IL_0e70: ldc.r8 7
-			IL_0e79: box [System.Runtime]System.Double
-			IL_0e7e: ldc.i4.1
-			IL_0e7f: box [System.Runtime]System.Boolean
-			IL_0e84: ldc.i4.1
-			IL_0e85: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0e8a: pop
+			IL_0dee: ldarg.0
+			IL_0def: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0df4: ldstr "Line"
+			IL_0df9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dfe: ldc.r8 3
+			IL_0e07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e0c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0e11: ldc.i4.0
+			IL_0e12: ceq
+			IL_0e14: stloc.s 38
+			IL_0e16: ldloc.s 38
+			IL_0e18: brfalse IL_0ea3
 
-			IL_0e8b: ldloc.0
-			IL_0e8c: ldc.r8 3
-			IL_0e95: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e9a: ldc.r8 2
-			IL_0ea3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0ea8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0ead: ldc.r8 0.0
-			IL_0eb6: clt
-			IL_0eb8: brfalse IL_1308
+			IL_0e1d: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L224C24::.ctor()
+			IL_0e22: stloc.s 24
+			IL_0e24: ldarg.0
+			IL_0e25: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0e2a: stloc.s 32
+			IL_0e2c: ldc.i4.1
+			IL_0e2d: newarr [System.Runtime]System.Object
+			IL_0e32: dup
+			IL_0e33: ldc.i4.0
+			IL_0e34: ldarg.0
+			IL_0e35: stelem.ref
+			IL_0e36: stloc.s 36
+			IL_0e38: ldarg.0
+			IL_0e39: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e3e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e43: ldc.r8 0.0
+			IL_0e4c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0e51: stloc.s 37
+			IL_0e53: ldloc.s 32
+			IL_0e55: ldloc.s 36
+			IL_0e57: ldloc.s 37
+			IL_0e59: ldarg.0
+			IL_0e5a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e5f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e64: ldc.r8 3
+			IL_0e6d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0e72: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0e77: pop
+			IL_0e78: ldarg.0
+			IL_0e79: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e7e: ldstr "Line"
+			IL_0e83: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e88: ldc.r8 3
+			IL_0e91: box [System.Runtime]System.Double
+			IL_0e96: ldc.i4.1
+			IL_0e97: box [System.Runtime]System.Boolean
+			IL_0e9c: ldc.i4.1
+			IL_0e9d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0ea2: pop
 
-			IL_0ebd: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24::.ctor()
-			IL_0ec2: stloc.s 17
-			IL_0ec4: ldarg.0
-			IL_0ec5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0eca: stloc.s 38
-			IL_0ecc: ldstr "Q"
-			IL_0ed1: ldloc.s 38
-			IL_0ed3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0ed8: stloc.s 38
-			IL_0eda: ldloc.s 38
-			IL_0edc: ldstr "Line"
-			IL_0ee1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ee6: stloc.s 38
-			IL_0ee8: ldloc.s 38
-			IL_0eea: ldc.r8 4
-			IL_0ef3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0ef8: stloc.s 38
-			IL_0efa: ldloc.s 38
-			IL_0efc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0f01: ldc.i4.0
-			IL_0f02: ceq
-			IL_0f04: stloc.s 39
-			IL_0f06: ldloc.s 39
-			IL_0f08: brfalse IL_0fd5
+			IL_0ea3: ldarg.0
+			IL_0ea4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0ea9: ldstr "Line"
+			IL_0eae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0eb3: ldc.r8 10
+			IL_0ebc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0ec1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0ec6: ldc.i4.0
+			IL_0ec7: ceq
+			IL_0ec9: stloc.s 38
+			IL_0ecb: ldloc.s 38
+			IL_0ecd: brfalse IL_0f58
 
-			IL_0f0d: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L217C24::.ctor()
-			IL_0f12: stloc.s 18
-			IL_0f14: ldarg.0
-			IL_0f15: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0f1a: stloc.s 38
-			IL_0f1c: ldstr "DrawLine"
-			IL_0f21: ldloc.s 38
-			IL_0f23: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0f28: stloc.s 38
-			IL_0f2a: ldc.i4.1
-			IL_0f2b: newarr [System.Runtime]System.Object
-			IL_0f30: dup
-			IL_0f31: ldc.i4.0
-			IL_0f32: ldarg.0
-			IL_0f33: stelem.ref
-			IL_0f34: stloc.s 36
-			IL_0f36: ldarg.0
-			IL_0f37: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f3c: stloc.s 37
-			IL_0f3e: ldstr "Q"
-			IL_0f43: ldloc.s 37
-			IL_0f45: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0f4a: stloc.s 37
-			IL_0f4c: ldloc.s 37
-			IL_0f4e: ldc.r8 4
-			IL_0f57: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0f5c: stloc.s 37
-			IL_0f5e: ldarg.0
-			IL_0f5f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f64: stloc.s 32
-			IL_0f66: ldstr "Q"
-			IL_0f6b: ldloc.s 32
-			IL_0f6d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0f72: stloc.s 32
-			IL_0f74: ldloc.s 32
-			IL_0f76: ldc.r8 5
-			IL_0f7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0f84: stloc.s 32
-			IL_0f86: ldloc.s 38
-			IL_0f88: ldloc.s 36
-			IL_0f8a: ldloc.s 37
-			IL_0f8c: ldloc.s 32
-			IL_0f8e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0f93: pop
-			IL_0f94: ldarg.0
-			IL_0f95: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f9a: stloc.s 32
-			IL_0f9c: ldstr "Q"
-			IL_0fa1: ldloc.s 32
-			IL_0fa3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0fa8: stloc.s 32
-			IL_0faa: ldloc.s 32
-			IL_0fac: ldstr "Line"
-			IL_0fb1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0fb6: stloc.s 32
-			IL_0fb8: ldloc.s 32
-			IL_0fba: ldc.r8 4
-			IL_0fc3: box [System.Runtime]System.Double
-			IL_0fc8: ldc.i4.1
-			IL_0fc9: box [System.Runtime]System.Boolean
-			IL_0fce: ldc.i4.1
-			IL_0fcf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0fd4: pop
+			IL_0ed2: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L225C25::.ctor()
+			IL_0ed7: stloc.s 25
+			IL_0ed9: ldarg.0
+			IL_0eda: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0edf: stloc.s 37
+			IL_0ee1: ldc.i4.1
+			IL_0ee2: newarr [System.Runtime]System.Object
+			IL_0ee7: dup
+			IL_0ee8: ldc.i4.0
+			IL_0ee9: ldarg.0
+			IL_0eea: stelem.ref
+			IL_0eeb: stloc.s 36
+			IL_0eed: ldarg.0
+			IL_0eee: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0ef3: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0ef8: ldc.r8 3
+			IL_0f01: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0f06: stloc.s 32
+			IL_0f08: ldloc.s 37
+			IL_0f0a: ldloc.s 36
+			IL_0f0c: ldloc.s 32
+			IL_0f0e: ldarg.0
+			IL_0f0f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0f14: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0f19: ldc.r8 7
+			IL_0f22: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0f27: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0f2c: pop
+			IL_0f2d: ldarg.0
+			IL_0f2e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0f33: ldstr "Line"
+			IL_0f38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f3d: ldc.r8 10
+			IL_0f46: box [System.Runtime]System.Double
+			IL_0f4b: ldc.i4.1
+			IL_0f4c: box [System.Runtime]System.Boolean
+			IL_0f51: ldc.i4.1
+			IL_0f52: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0f57: pop
 
-			IL_0fd5: ldarg.0
-			IL_0fd6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0fdb: stloc.s 32
-			IL_0fdd: ldstr "Q"
-			IL_0fe2: ldloc.s 32
-			IL_0fe4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0fe9: stloc.s 32
-			IL_0feb: ldloc.s 32
-			IL_0fed: ldstr "Line"
-			IL_0ff2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ff7: stloc.s 32
-			IL_0ff9: ldloc.s 32
-			IL_0ffb: ldc.r8 8
-			IL_1004: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1009: stloc.s 32
-			IL_100b: ldloc.s 32
-			IL_100d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_1012: ldc.i4.0
-			IL_1013: ceq
-			IL_1015: stloc.s 39
-			IL_1017: ldloc.s 39
-			IL_1019: brfalse IL_10e6
+			IL_0f58: ldarg.0
+			IL_0f59: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0f5e: ldstr "Line"
+			IL_0f63: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f68: ldc.r8 7
+			IL_0f71: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0f76: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0f7b: ldc.i4.0
+			IL_0f7c: ceq
+			IL_0f7e: stloc.s 38
+			IL_0f80: ldloc.s 38
+			IL_0f82: brfalse IL_100d
 
-			IL_101e: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L218C24::.ctor()
-			IL_1023: stloc.s 19
-			IL_1025: ldarg.0
-			IL_1026: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_102b: stloc.s 32
-			IL_102d: ldstr "DrawLine"
-			IL_1032: ldloc.s 32
-			IL_1034: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1039: stloc.s 32
-			IL_103b: ldc.i4.1
-			IL_103c: newarr [System.Runtime]System.Object
-			IL_1041: dup
-			IL_1042: ldc.i4.0
-			IL_1043: ldarg.0
-			IL_1044: stelem.ref
-			IL_1045: stloc.s 36
-			IL_1047: ldarg.0
-			IL_1048: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_104d: stloc.s 37
-			IL_104f: ldstr "Q"
-			IL_1054: ldloc.s 37
-			IL_1056: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_105b: stloc.s 37
-			IL_105d: ldloc.s 37
-			IL_105f: ldc.r8 5
-			IL_1068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_106d: stloc.s 37
-			IL_106f: ldarg.0
-			IL_1070: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1075: stloc.s 38
-			IL_1077: ldstr "Q"
-			IL_107c: ldloc.s 38
-			IL_107e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1083: stloc.s 38
-			IL_1085: ldloc.s 38
-			IL_1087: ldc.r8 1
-			IL_1090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1095: stloc.s 38
-			IL_1097: ldloc.s 32
-			IL_1099: ldloc.s 36
-			IL_109b: ldloc.s 37
-			IL_109d: ldloc.s 38
-			IL_109f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_10a4: pop
-			IL_10a5: ldarg.0
-			IL_10a6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_10ab: stloc.s 38
-			IL_10ad: ldstr "Q"
-			IL_10b2: ldloc.s 38
-			IL_10b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_10b9: stloc.s 38
-			IL_10bb: ldloc.s 38
-			IL_10bd: ldstr "Line"
-			IL_10c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_10c7: stloc.s 38
-			IL_10c9: ldloc.s 38
-			IL_10cb: ldc.r8 8
-			IL_10d4: box [System.Runtime]System.Double
-			IL_10d9: ldc.i4.1
-			IL_10da: box [System.Runtime]System.Boolean
-			IL_10df: ldc.i4.1
-			IL_10e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_10e5: pop
+			IL_0f87: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L226C24::.ctor()
+			IL_0f8c: stloc.s 26
+			IL_0f8e: ldarg.0
+			IL_0f8f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0f94: stloc.s 32
+			IL_0f96: ldc.i4.1
+			IL_0f97: newarr [System.Runtime]System.Object
+			IL_0f9c: dup
+			IL_0f9d: ldc.i4.0
+			IL_0f9e: ldarg.0
+			IL_0f9f: stelem.ref
+			IL_0fa0: stloc.s 36
+			IL_0fa2: ldarg.0
+			IL_0fa3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0fa8: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0fad: ldc.r8 7
+			IL_0fb6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0fbb: stloc.s 37
+			IL_0fbd: ldloc.s 32
+			IL_0fbf: ldloc.s 36
+			IL_0fc1: ldloc.s 37
+			IL_0fc3: ldarg.0
+			IL_0fc4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0fc9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0fce: ldc.r8 4
+			IL_0fd7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0fdc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0fe1: pop
+			IL_0fe2: ldarg.0
+			IL_0fe3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0fe8: ldstr "Line"
+			IL_0fed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ff2: ldc.r8 7
+			IL_0ffb: box [System.Runtime]System.Double
+			IL_1000: ldc.i4.1
+			IL_1001: box [System.Runtime]System.Boolean
+			IL_1006: ldc.i4.1
+			IL_1007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_100c: pop
 
-			IL_10e6: ldarg.0
-			IL_10e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_10ec: stloc.s 38
-			IL_10ee: ldstr "Q"
-			IL_10f3: ldloc.s 38
-			IL_10f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_10fa: stloc.s 38
-			IL_10fc: ldloc.s 38
-			IL_10fe: ldstr "Line"
-			IL_1103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1108: stloc.s 38
-			IL_110a: ldloc.s 38
-			IL_110c: ldc.r8 0.0
-			IL_1115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_111a: stloc.s 38
-			IL_111c: ldloc.s 38
-			IL_111e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_1123: ldc.i4.0
-			IL_1124: ceq
-			IL_1126: stloc.s 39
-			IL_1128: ldloc.s 39
-			IL_112a: brfalse IL_11f7
+			IL_100d: ldloc.0
+			IL_100e: ldc.r8 5
+			IL_1017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_101c: ldc.r8 2
+			IL_1025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_102a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_102f: ldc.r8 0.0
+			IL_1038: clt
+			IL_103a: brfalse IL_131a
 
-			IL_112f: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L219C24::.ctor()
-			IL_1134: stloc.s 20
-			IL_1136: ldarg.0
-			IL_1137: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_113c: stloc.s 38
-			IL_113e: ldstr "DrawLine"
-			IL_1143: ldloc.s 38
-			IL_1145: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_114a: stloc.s 38
-			IL_114c: ldc.i4.1
-			IL_114d: newarr [System.Runtime]System.Object
-			IL_1152: dup
-			IL_1153: ldc.i4.0
-			IL_1154: ldarg.0
-			IL_1155: stelem.ref
-			IL_1156: stloc.s 36
-			IL_1158: ldarg.0
-			IL_1159: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_103f: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24::.ctor()
+			IL_1044: stloc.s 27
+			IL_1046: ldarg.0
+			IL_1047: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_104c: ldstr "Line"
+			IL_1051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1056: ldc.r8 8
+			IL_105f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1064: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_1069: ldc.i4.0
+			IL_106a: ceq
+			IL_106c: stloc.s 38
+			IL_106e: ldloc.s 38
+			IL_1070: brfalse IL_10fb
+
+			IL_1075: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L229C24::.ctor()
+			IL_107a: stloc.s 28
+			IL_107c: ldarg.0
+			IL_107d: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_1082: stloc.s 37
+			IL_1084: ldc.i4.1
+			IL_1085: newarr [System.Runtime]System.Object
+			IL_108a: dup
+			IL_108b: ldc.i4.0
+			IL_108c: ldarg.0
+			IL_108d: stelem.ref
+			IL_108e: stloc.s 36
+			IL_1090: ldarg.0
+			IL_1091: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1096: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_109b: ldc.r8 1
+			IL_10a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_10a9: stloc.s 32
+			IL_10ab: ldloc.s 37
+			IL_10ad: ldloc.s 36
+			IL_10af: ldloc.s 32
+			IL_10b1: ldarg.0
+			IL_10b2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_10b7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_10bc: ldc.r8 5
+			IL_10c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_10ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_10cf: pop
+			IL_10d0: ldarg.0
+			IL_10d1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_10d6: ldstr "Line"
+			IL_10db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_10e0: ldc.r8 8
+			IL_10e9: box [System.Runtime]System.Double
+			IL_10ee: ldc.i4.1
+			IL_10ef: box [System.Runtime]System.Boolean
+			IL_10f4: ldc.i4.1
+			IL_10f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_10fa: pop
+
+			IL_10fb: ldarg.0
+			IL_10fc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1101: ldstr "Line"
+			IL_1106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_110b: ldc.r8 5
+			IL_1114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1119: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_111e: ldc.i4.0
+			IL_111f: ceq
+			IL_1121: stloc.s 38
+			IL_1123: ldloc.s 38
+			IL_1125: brfalse IL_11b0
+
+			IL_112a: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L230C24::.ctor()
+			IL_112f: stloc.s 29
+			IL_1131: ldarg.0
+			IL_1132: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_1137: stloc.s 32
+			IL_1139: ldc.i4.1
+			IL_113a: newarr [System.Runtime]System.Object
+			IL_113f: dup
+			IL_1140: ldc.i4.0
+			IL_1141: ldarg.0
+			IL_1142: stelem.ref
+			IL_1143: stloc.s 36
+			IL_1145: ldarg.0
+			IL_1146: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_114b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1150: ldc.r8 5
+			IL_1159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 			IL_115e: stloc.s 37
-			IL_1160: ldstr "Q"
-			IL_1165: ldloc.s 37
-			IL_1167: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_116c: stloc.s 37
-			IL_116e: ldloc.s 37
-			IL_1170: ldc.r8 1
-			IL_1179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_117e: stloc.s 37
-			IL_1180: ldarg.0
-			IL_1181: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1186: stloc.s 32
-			IL_1188: ldstr "Q"
-			IL_118d: ldloc.s 32
-			IL_118f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1194: stloc.s 32
-			IL_1196: ldloc.s 32
-			IL_1198: ldc.r8 0.0
-			IL_11a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_11a6: stloc.s 32
-			IL_11a8: ldloc.s 38
-			IL_11aa: ldloc.s 36
-			IL_11ac: ldloc.s 37
-			IL_11ae: ldloc.s 32
-			IL_11b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_11b5: pop
-			IL_11b6: ldarg.0
-			IL_11b7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_11bc: stloc.s 32
-			IL_11be: ldstr "Q"
-			IL_11c3: ldloc.s 32
-			IL_11c5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_11ca: stloc.s 32
-			IL_11cc: ldloc.s 32
-			IL_11ce: ldstr "Line"
-			IL_11d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_11d8: stloc.s 32
-			IL_11da: ldloc.s 32
-			IL_11dc: ldc.r8 0.0
-			IL_11e5: box [System.Runtime]System.Double
-			IL_11ea: ldc.i4.1
-			IL_11eb: box [System.Runtime]System.Boolean
-			IL_11f0: ldc.i4.1
-			IL_11f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_11f6: pop
+			IL_1160: ldloc.s 32
+			IL_1162: ldloc.s 36
+			IL_1164: ldloc.s 37
+			IL_1166: ldarg.0
+			IL_1167: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_116c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1171: ldc.r8 6
+			IL_117a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_117f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_1184: pop
+			IL_1185: ldarg.0
+			IL_1186: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_118b: ldstr "Line"
+			IL_1190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1195: ldc.r8 5
+			IL_119e: box [System.Runtime]System.Double
+			IL_11a3: ldc.i4.1
+			IL_11a4: box [System.Runtime]System.Boolean
+			IL_11a9: ldc.i4.1
+			IL_11aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_11af: pop
 
-			IL_11f7: ldarg.0
-			IL_11f8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_11fd: stloc.s 32
-			IL_11ff: ldstr "Q"
-			IL_1204: ldloc.s 32
-			IL_1206: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_120b: stloc.s 32
-			IL_120d: ldloc.s 32
-			IL_120f: ldstr "Line"
-			IL_1214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1219: stloc.s 32
-			IL_121b: ldloc.s 32
-			IL_121d: ldc.r8 11
-			IL_1226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_122b: stloc.s 32
-			IL_122d: ldloc.s 32
-			IL_122f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_1234: ldc.i4.0
-			IL_1235: ceq
-			IL_1237: stloc.s 39
-			IL_1239: ldloc.s 39
-			IL_123b: brfalse IL_1308
+			IL_11b0: ldarg.0
+			IL_11b1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_11b6: ldstr "Line"
+			IL_11bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_11c0: ldc.r8 9
+			IL_11c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_11ce: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_11d3: ldc.i4.0
+			IL_11d4: ceq
+			IL_11d6: stloc.s 38
+			IL_11d8: ldloc.s 38
+			IL_11da: brfalse IL_1265
 
-			IL_1240: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L220C25::.ctor()
-			IL_1245: stloc.s 21
-			IL_1247: ldarg.0
-			IL_1248: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_124d: stloc.s 32
-			IL_124f: ldstr "DrawLine"
-			IL_1254: ldloc.s 32
-			IL_1256: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_125b: stloc.s 32
-			IL_125d: ldc.i4.1
-			IL_125e: newarr [System.Runtime]System.Object
-			IL_1263: dup
-			IL_1264: ldc.i4.0
+			IL_11df: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L231C24::.ctor()
+			IL_11e4: stloc.s 30
+			IL_11e6: ldarg.0
+			IL_11e7: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_11ec: stloc.s 37
+			IL_11ee: ldc.i4.1
+			IL_11ef: newarr [System.Runtime]System.Object
+			IL_11f4: dup
+			IL_11f5: ldc.i4.0
+			IL_11f6: ldarg.0
+			IL_11f7: stelem.ref
+			IL_11f8: stloc.s 36
+			IL_11fa: ldarg.0
+			IL_11fb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1200: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1205: ldc.r8 6
+			IL_120e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1213: stloc.s 32
+			IL_1215: ldloc.s 37
+			IL_1217: ldloc.s 36
+			IL_1219: ldloc.s 32
+			IL_121b: ldarg.0
+			IL_121c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1221: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1226: ldc.r8 2
+			IL_122f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1234: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_1239: pop
+			IL_123a: ldarg.0
+			IL_123b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1240: ldstr "Line"
+			IL_1245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_124a: ldc.r8 9
+			IL_1253: box [System.Runtime]System.Double
+			IL_1258: ldc.i4.1
+			IL_1259: box [System.Runtime]System.Boolean
+			IL_125e: ldc.i4.1
+			IL_125f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_1264: pop
+
 			IL_1265: ldarg.0
-			IL_1266: stelem.ref
-			IL_1267: stloc.s 36
-			IL_1269: ldarg.0
-			IL_126a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_126f: stloc.s 37
-			IL_1271: ldstr "Q"
-			IL_1276: ldloc.s 37
-			IL_1278: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_127d: stloc.s 37
-			IL_127f: ldloc.s 37
-			IL_1281: ldc.r8 0.0
-			IL_128a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_128f: stloc.s 37
-			IL_1291: ldarg.0
-			IL_1292: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1297: stloc.s 38
-			IL_1299: ldstr "Q"
-			IL_129e: ldloc.s 38
-			IL_12a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_12a5: stloc.s 38
-			IL_12a7: ldloc.s 38
-			IL_12a9: ldc.r8 4
-			IL_12b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_12b7: stloc.s 38
-			IL_12b9: ldloc.s 32
-			IL_12bb: ldloc.s 36
-			IL_12bd: ldloc.s 37
-			IL_12bf: ldloc.s 38
-			IL_12c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_12c6: pop
-			IL_12c7: ldarg.0
-			IL_12c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_12cd: stloc.s 38
-			IL_12cf: ldstr "Q"
-			IL_12d4: ldloc.s 38
-			IL_12d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_12db: stloc.s 38
-			IL_12dd: ldloc.s 38
-			IL_12df: ldstr "Line"
-			IL_12e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_12e9: stloc.s 38
-			IL_12eb: ldloc.s 38
-			IL_12ed: ldc.r8 11
-			IL_12f6: box [System.Runtime]System.Double
-			IL_12fb: ldc.i4.1
-			IL_12fc: box [System.Runtime]System.Boolean
-			IL_1301: ldc.i4.1
-			IL_1302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_1307: pop
+			IL_1266: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_126b: ldstr "Line"
+			IL_1270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1275: ldc.r8 1
+			IL_127e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1283: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_1288: ldc.i4.0
+			IL_1289: ceq
+			IL_128b: stloc.s 38
+			IL_128d: ldloc.s 38
+			IL_128f: brfalse IL_131a
 
-			IL_1308: ldloc.0
-			IL_1309: ldc.r8 4
-			IL_1312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1317: ldc.r8 2
-			IL_1320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1325: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_132a: ldc.r8 0.0
-			IL_1333: clt
-			IL_1335: brfalse IL_1785
+			IL_1294: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L232C24::.ctor()
+			IL_1299: stloc.s 31
+			IL_129b: ldarg.0
+			IL_129c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_12a1: stloc.s 32
+			IL_12a3: ldc.i4.1
+			IL_12a4: newarr [System.Runtime]System.Object
+			IL_12a9: dup
+			IL_12aa: ldc.i4.0
+			IL_12ab: ldarg.0
+			IL_12ac: stelem.ref
+			IL_12ad: stloc.s 36
+			IL_12af: ldarg.0
+			IL_12b0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_12b5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_12ba: ldc.r8 2
+			IL_12c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_12c8: stloc.s 37
+			IL_12ca: ldloc.s 32
+			IL_12cc: ldloc.s 36
+			IL_12ce: ldloc.s 37
+			IL_12d0: ldarg.0
+			IL_12d1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_12d6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_12db: ldc.r8 1
+			IL_12e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_12e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_12ee: pop
+			IL_12ef: ldarg.0
+			IL_12f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_12f5: ldstr "Line"
+			IL_12fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_12ff: ldc.r8 1
+			IL_1308: box [System.Runtime]System.Double
+			IL_130d: ldc.i4.1
+			IL_130e: box [System.Runtime]System.Boolean
+			IL_1313: ldc.i4.1
+			IL_1314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_1319: pop
 
-			IL_133a: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24::.ctor()
-			IL_133f: stloc.s 22
-			IL_1341: ldarg.0
-			IL_1342: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1347: stloc.s 38
-			IL_1349: ldstr "Q"
-			IL_134e: ldloc.s 38
-			IL_1350: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1355: stloc.s 38
-			IL_1357: ldloc.s 38
-			IL_1359: ldstr "Line"
-			IL_135e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1363: stloc.s 38
-			IL_1365: ldloc.s 38
-			IL_1367: ldc.r8 11
-			IL_1370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1375: stloc.s 38
-			IL_1377: ldloc.s 38
-			IL_1379: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_131a: ldarg.0
+			IL_131b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1320: stloc.s 37
+			IL_1322: ldc.i4.s 12
+			IL_1324: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_1329: dup
+			IL_132a: ldc.i4.0
+			IL_132b: box [System.Runtime]System.Boolean
+			IL_1330: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1335: dup
+			IL_1336: ldc.i4.0
+			IL_1337: box [System.Runtime]System.Boolean
+			IL_133c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1341: dup
+			IL_1342: ldc.i4.0
+			IL_1343: box [System.Runtime]System.Boolean
+			IL_1348: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_134d: dup
+			IL_134e: ldc.i4.0
+			IL_134f: box [System.Runtime]System.Boolean
+			IL_1354: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1359: dup
+			IL_135a: ldc.i4.0
+			IL_135b: box [System.Runtime]System.Boolean
+			IL_1360: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1365: dup
+			IL_1366: ldc.i4.0
+			IL_1367: box [System.Runtime]System.Boolean
+			IL_136c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1371: dup
+			IL_1372: ldc.i4.0
+			IL_1373: box [System.Runtime]System.Boolean
+			IL_1378: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_137d: dup
 			IL_137e: ldc.i4.0
-			IL_137f: ceq
-			IL_1381: stloc.s 39
-			IL_1383: ldloc.s 39
-			IL_1385: brfalse IL_1452
-
-			IL_138a: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L223C25::.ctor()
-			IL_138f: stloc.s 23
-			IL_1391: ldarg.0
-			IL_1392: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_1397: stloc.s 38
-			IL_1399: ldstr "DrawLine"
-			IL_139e: ldloc.s 38
-			IL_13a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_13a5: stloc.s 38
-			IL_13a7: ldc.i4.1
-			IL_13a8: newarr [System.Runtime]System.Object
+			IL_137f: box [System.Runtime]System.Boolean
+			IL_1384: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1389: dup
+			IL_138a: ldc.i4.0
+			IL_138b: box [System.Runtime]System.Boolean
+			IL_1390: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1395: dup
+			IL_1396: ldc.i4.0
+			IL_1397: box [System.Runtime]System.Boolean
+			IL_139c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_13a1: dup
+			IL_13a2: ldc.i4.0
+			IL_13a3: box [System.Runtime]System.Boolean
+			IL_13a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_13ad: dup
 			IL_13ae: ldc.i4.0
-			IL_13af: ldarg.0
-			IL_13b0: stelem.ref
-			IL_13b1: stloc.s 36
-			IL_13b3: ldarg.0
-			IL_13b4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_13b9: stloc.s 37
-			IL_13bb: ldstr "Q"
-			IL_13c0: ldloc.s 37
-			IL_13c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_13c7: stloc.s 37
-			IL_13c9: ldloc.s 37
-			IL_13cb: ldc.r8 4
-			IL_13d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_13d9: stloc.s 37
-			IL_13db: ldarg.0
-			IL_13dc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_13e1: stloc.s 32
-			IL_13e3: ldstr "Q"
-			IL_13e8: ldloc.s 32
-			IL_13ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_13ef: stloc.s 32
-			IL_13f1: ldloc.s 32
-			IL_13f3: ldc.r8 0.0
-			IL_13fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1401: stloc.s 32
-			IL_1403: ldloc.s 38
-			IL_1405: ldloc.s 36
-			IL_1407: ldloc.s 37
-			IL_1409: ldloc.s 32
-			IL_140b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_1410: pop
-			IL_1411: ldarg.0
-			IL_1412: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1417: stloc.s 32
-			IL_1419: ldstr "Q"
-			IL_141e: ldloc.s 32
-			IL_1420: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1425: stloc.s 32
-			IL_1427: ldloc.s 32
-			IL_1429: ldstr "Line"
-			IL_142e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1433: stloc.s 32
-			IL_1435: ldloc.s 32
-			IL_1437: ldc.r8 11
-			IL_1440: box [System.Runtime]System.Double
-			IL_1445: ldc.i4.1
-			IL_1446: box [System.Runtime]System.Boolean
-			IL_144b: ldc.i4.1
-			IL_144c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_1451: pop
-
-			IL_1452: ldarg.0
-			IL_1453: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1458: stloc.s 32
-			IL_145a: ldstr "Q"
-			IL_145f: ldloc.s 32
-			IL_1461: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1466: stloc.s 32
-			IL_1468: ldloc.s 32
-			IL_146a: ldstr "Line"
-			IL_146f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1474: stloc.s 32
-			IL_1476: ldloc.s 32
-			IL_1478: ldc.r8 3
-			IL_1481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1486: stloc.s 32
-			IL_1488: ldloc.s 32
-			IL_148a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_148f: ldc.i4.0
-			IL_1490: ceq
-			IL_1492: stloc.s 39
-			IL_1494: ldloc.s 39
-			IL_1496: brfalse IL_1563
-
-			IL_149b: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L224C24::.ctor()
-			IL_14a0: stloc.s 24
-			IL_14a2: ldarg.0
-			IL_14a3: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_14a8: stloc.s 32
-			IL_14aa: ldstr "DrawLine"
-			IL_14af: ldloc.s 32
-			IL_14b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_14b6: stloc.s 32
-			IL_14b8: ldc.i4.1
-			IL_14b9: newarr [System.Runtime]System.Object
-			IL_14be: dup
-			IL_14bf: ldc.i4.0
-			IL_14c0: ldarg.0
-			IL_14c1: stelem.ref
-			IL_14c2: stloc.s 36
-			IL_14c4: ldarg.0
-			IL_14c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_14ca: stloc.s 37
-			IL_14cc: ldstr "Q"
-			IL_14d1: ldloc.s 37
-			IL_14d3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_14d8: stloc.s 37
-			IL_14da: ldloc.s 37
-			IL_14dc: ldc.r8 0.0
-			IL_14e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_14ea: stloc.s 37
-			IL_14ec: ldarg.0
-			IL_14ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_14f2: stloc.s 38
-			IL_14f4: ldstr "Q"
-			IL_14f9: ldloc.s 38
-			IL_14fb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1500: stloc.s 38
-			IL_1502: ldloc.s 38
-			IL_1504: ldc.r8 3
-			IL_150d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1512: stloc.s 38
-			IL_1514: ldloc.s 32
-			IL_1516: ldloc.s 36
-			IL_1518: ldloc.s 37
-			IL_151a: ldloc.s 38
-			IL_151c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_1521: pop
-			IL_1522: ldarg.0
-			IL_1523: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1528: stloc.s 38
-			IL_152a: ldstr "Q"
-			IL_152f: ldloc.s 38
-			IL_1531: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1536: stloc.s 38
-			IL_1538: ldloc.s 38
-			IL_153a: ldstr "Line"
-			IL_153f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1544: stloc.s 38
-			IL_1546: ldloc.s 38
-			IL_1548: ldc.r8 3
-			IL_1551: box [System.Runtime]System.Double
-			IL_1556: ldc.i4.1
-			IL_1557: box [System.Runtime]System.Boolean
-			IL_155c: ldc.i4.1
-			IL_155d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_1562: pop
-
-			IL_1563: ldarg.0
-			IL_1564: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1569: stloc.s 38
-			IL_156b: ldstr "Q"
-			IL_1570: ldloc.s 38
-			IL_1572: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1577: stloc.s 38
-			IL_1579: ldloc.s 38
-			IL_157b: ldstr "Line"
-			IL_1580: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1585: stloc.s 38
-			IL_1587: ldloc.s 38
-			IL_1589: ldc.r8 10
-			IL_1592: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1597: stloc.s 38
-			IL_1599: ldloc.s 38
-			IL_159b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_15a0: ldc.i4.0
-			IL_15a1: ceq
-			IL_15a3: stloc.s 39
-			IL_15a5: ldloc.s 39
-			IL_15a7: brfalse IL_1674
-
-			IL_15ac: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L225C25::.ctor()
-			IL_15b1: stloc.s 25
-			IL_15b3: ldarg.0
-			IL_15b4: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_15b9: stloc.s 38
-			IL_15bb: ldstr "DrawLine"
-			IL_15c0: ldloc.s 38
-			IL_15c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_15c7: stloc.s 38
-			IL_15c9: ldc.i4.1
-			IL_15ca: newarr [System.Runtime]System.Object
-			IL_15cf: dup
-			IL_15d0: ldc.i4.0
-			IL_15d1: ldarg.0
-			IL_15d2: stelem.ref
-			IL_15d3: stloc.s 36
-			IL_15d5: ldarg.0
-			IL_15d6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_15db: stloc.s 37
-			IL_15dd: ldstr "Q"
-			IL_15e2: ldloc.s 37
-			IL_15e4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_15e9: stloc.s 37
-			IL_15eb: ldloc.s 37
-			IL_15ed: ldc.r8 3
-			IL_15f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_15fb: stloc.s 37
-			IL_15fd: ldarg.0
-			IL_15fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1603: stloc.s 32
-			IL_1605: ldstr "Q"
-			IL_160a: ldloc.s 32
-			IL_160c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1611: stloc.s 32
-			IL_1613: ldloc.s 32
-			IL_1615: ldc.r8 7
-			IL_161e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1623: stloc.s 32
-			IL_1625: ldloc.s 38
-			IL_1627: ldloc.s 36
-			IL_1629: ldloc.s 37
-			IL_162b: ldloc.s 32
-			IL_162d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_1632: pop
-			IL_1633: ldarg.0
-			IL_1634: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1639: stloc.s 32
-			IL_163b: ldstr "Q"
-			IL_1640: ldloc.s 32
-			IL_1642: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1647: stloc.s 32
-			IL_1649: ldloc.s 32
-			IL_164b: ldstr "Line"
-			IL_1650: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1655: stloc.s 32
-			IL_1657: ldloc.s 32
-			IL_1659: ldc.r8 10
-			IL_1662: box [System.Runtime]System.Double
-			IL_1667: ldc.i4.1
-			IL_1668: box [System.Runtime]System.Boolean
-			IL_166d: ldc.i4.1
-			IL_166e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_1673: pop
-
-			IL_1674: ldarg.0
-			IL_1675: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_167a: stloc.s 32
-			IL_167c: ldstr "Q"
-			IL_1681: ldloc.s 32
-			IL_1683: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1688: stloc.s 32
-			IL_168a: ldloc.s 32
-			IL_168c: ldstr "Line"
-			IL_1691: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1696: stloc.s 32
-			IL_1698: ldloc.s 32
-			IL_169a: ldc.r8 7
-			IL_16a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_16a8: stloc.s 32
-			IL_16aa: ldloc.s 32
-			IL_16ac: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_16b1: ldc.i4.0
-			IL_16b2: ceq
-			IL_16b4: stloc.s 39
-			IL_16b6: ldloc.s 39
-			IL_16b8: brfalse IL_1785
-
-			IL_16bd: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L226C24::.ctor()
-			IL_16c2: stloc.s 26
-			IL_16c4: ldarg.0
-			IL_16c5: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_16ca: stloc.s 32
-			IL_16cc: ldstr "DrawLine"
-			IL_16d1: ldloc.s 32
-			IL_16d3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_16d8: stloc.s 32
-			IL_16da: ldc.i4.1
-			IL_16db: newarr [System.Runtime]System.Object
-			IL_16e0: dup
-			IL_16e1: ldc.i4.0
-			IL_16e2: ldarg.0
-			IL_16e3: stelem.ref
-			IL_16e4: stloc.s 36
-			IL_16e6: ldarg.0
-			IL_16e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_16ec: stloc.s 37
-			IL_16ee: ldstr "Q"
-			IL_16f3: ldloc.s 37
-			IL_16f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_16fa: stloc.s 37
-			IL_16fc: ldloc.s 37
-			IL_16fe: ldc.r8 7
-			IL_1707: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_170c: stloc.s 37
-			IL_170e: ldarg.0
-			IL_170f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1714: stloc.s 38
-			IL_1716: ldstr "Q"
-			IL_171b: ldloc.s 38
-			IL_171d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1722: stloc.s 38
-			IL_1724: ldloc.s 38
-			IL_1726: ldc.r8 4
-			IL_172f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1734: stloc.s 38
-			IL_1736: ldloc.s 32
-			IL_1738: ldloc.s 36
-			IL_173a: ldloc.s 37
-			IL_173c: ldloc.s 38
-			IL_173e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_1743: pop
-			IL_1744: ldarg.0
-			IL_1745: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_174a: stloc.s 38
-			IL_174c: ldstr "Q"
-			IL_1751: ldloc.s 38
-			IL_1753: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1758: stloc.s 38
-			IL_175a: ldloc.s 38
-			IL_175c: ldstr "Line"
-			IL_1761: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1766: stloc.s 38
-			IL_1768: ldloc.s 38
-			IL_176a: ldc.r8 7
-			IL_1773: box [System.Runtime]System.Double
-			IL_1778: ldc.i4.1
-			IL_1779: box [System.Runtime]System.Boolean
-			IL_177e: ldc.i4.1
-			IL_177f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_1784: pop
-
-			IL_1785: ldloc.0
-			IL_1786: ldc.r8 5
-			IL_178f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1794: ldc.r8 2
-			IL_179d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_17a2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_17a7: ldc.r8 0.0
-			IL_17b0: clt
-			IL_17b2: brfalse IL_1c02
-
-			IL_17b7: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24::.ctor()
-			IL_17bc: stloc.s 27
-			IL_17be: ldarg.0
-			IL_17bf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_17c4: stloc.s 38
-			IL_17c6: ldstr "Q"
-			IL_17cb: ldloc.s 38
-			IL_17cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_17d2: stloc.s 38
-			IL_17d4: ldloc.s 38
-			IL_17d6: ldstr "Line"
-			IL_17db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_17e0: stloc.s 38
-			IL_17e2: ldloc.s 38
-			IL_17e4: ldc.r8 8
-			IL_17ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_17f2: stloc.s 38
-			IL_17f4: ldloc.s 38
-			IL_17f6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_17fb: ldc.i4.0
-			IL_17fc: ceq
-			IL_17fe: stloc.s 39
-			IL_1800: ldloc.s 39
-			IL_1802: brfalse IL_18cf
-
-			IL_1807: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L229C24::.ctor()
-			IL_180c: stloc.s 28
-			IL_180e: ldarg.0
-			IL_180f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_1814: stloc.s 38
-			IL_1816: ldstr "DrawLine"
-			IL_181b: ldloc.s 38
-			IL_181d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1822: stloc.s 38
-			IL_1824: ldc.i4.1
-			IL_1825: newarr [System.Runtime]System.Object
-			IL_182a: dup
-			IL_182b: ldc.i4.0
-			IL_182c: ldarg.0
-			IL_182d: stelem.ref
-			IL_182e: stloc.s 36
-			IL_1830: ldarg.0
-			IL_1831: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1836: stloc.s 37
-			IL_1838: ldstr "Q"
-			IL_183d: ldloc.s 37
-			IL_183f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1844: stloc.s 37
-			IL_1846: ldloc.s 37
-			IL_1848: ldc.r8 1
-			IL_1851: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1856: stloc.s 37
-			IL_1858: ldarg.0
-			IL_1859: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_185e: stloc.s 32
-			IL_1860: ldstr "Q"
-			IL_1865: ldloc.s 32
-			IL_1867: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_186c: stloc.s 32
-			IL_186e: ldloc.s 32
-			IL_1870: ldc.r8 5
-			IL_1879: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_187e: stloc.s 32
-			IL_1880: ldloc.s 38
-			IL_1882: ldloc.s 36
-			IL_1884: ldloc.s 37
-			IL_1886: ldloc.s 32
-			IL_1888: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_188d: pop
-			IL_188e: ldarg.0
-			IL_188f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1894: stloc.s 32
-			IL_1896: ldstr "Q"
-			IL_189b: ldloc.s 32
-			IL_189d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_18a2: stloc.s 32
-			IL_18a4: ldloc.s 32
-			IL_18a6: ldstr "Line"
-			IL_18ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_18b0: stloc.s 32
-			IL_18b2: ldloc.s 32
-			IL_18b4: ldc.r8 8
-			IL_18bd: box [System.Runtime]System.Double
-			IL_18c2: ldc.i4.1
-			IL_18c3: box [System.Runtime]System.Boolean
-			IL_18c8: ldc.i4.1
-			IL_18c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_18ce: pop
-
-			IL_18cf: ldarg.0
-			IL_18d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_18d5: stloc.s 32
-			IL_18d7: ldstr "Q"
-			IL_18dc: ldloc.s 32
-			IL_18de: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_18e3: stloc.s 32
-			IL_18e5: ldloc.s 32
-			IL_18e7: ldstr "Line"
-			IL_18ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_18f1: stloc.s 32
-			IL_18f3: ldloc.s 32
-			IL_18f5: ldc.r8 5
-			IL_18fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1903: stloc.s 32
-			IL_1905: ldloc.s 32
-			IL_1907: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_190c: ldc.i4.0
-			IL_190d: ceq
-			IL_190f: stloc.s 39
-			IL_1911: ldloc.s 39
-			IL_1913: brfalse IL_19e0
-
-			IL_1918: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L230C24::.ctor()
-			IL_191d: stloc.s 29
-			IL_191f: ldarg.0
-			IL_1920: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_1925: stloc.s 32
-			IL_1927: ldstr "DrawLine"
-			IL_192c: ldloc.s 32
-			IL_192e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1933: stloc.s 32
-			IL_1935: ldc.i4.1
-			IL_1936: newarr [System.Runtime]System.Object
-			IL_193b: dup
-			IL_193c: ldc.i4.0
-			IL_193d: ldarg.0
-			IL_193e: stelem.ref
-			IL_193f: stloc.s 36
-			IL_1941: ldarg.0
-			IL_1942: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1947: stloc.s 37
-			IL_1949: ldstr "Q"
-			IL_194e: ldloc.s 37
-			IL_1950: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1955: stloc.s 37
-			IL_1957: ldloc.s 37
-			IL_1959: ldc.r8 5
-			IL_1962: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1967: stloc.s 37
-			IL_1969: ldarg.0
-			IL_196a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_196f: stloc.s 38
-			IL_1971: ldstr "Q"
-			IL_1976: ldloc.s 38
-			IL_1978: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_197d: stloc.s 38
-			IL_197f: ldloc.s 38
-			IL_1981: ldc.r8 6
-			IL_198a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_198f: stloc.s 38
-			IL_1991: ldloc.s 32
-			IL_1993: ldloc.s 36
-			IL_1995: ldloc.s 37
-			IL_1997: ldloc.s 38
-			IL_1999: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_199e: pop
-			IL_199f: ldarg.0
-			IL_19a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_19a5: stloc.s 38
-			IL_19a7: ldstr "Q"
-			IL_19ac: ldloc.s 38
-			IL_19ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_19b3: stloc.s 38
-			IL_19b5: ldloc.s 38
-			IL_19b7: ldstr "Line"
-			IL_19bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_19c1: stloc.s 38
-			IL_19c3: ldloc.s 38
-			IL_19c5: ldc.r8 5
-			IL_19ce: box [System.Runtime]System.Double
-			IL_19d3: ldc.i4.1
-			IL_19d4: box [System.Runtime]System.Boolean
-			IL_19d9: ldc.i4.1
-			IL_19da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_19df: pop
-
-			IL_19e0: ldarg.0
-			IL_19e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_19e6: stloc.s 38
-			IL_19e8: ldstr "Q"
-			IL_19ed: ldloc.s 38
-			IL_19ef: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_19f4: stloc.s 38
-			IL_19f6: ldloc.s 38
-			IL_19f8: ldstr "Line"
-			IL_19fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1a02: stloc.s 38
-			IL_1a04: ldloc.s 38
-			IL_1a06: ldc.r8 9
-			IL_1a0f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1a14: stloc.s 38
-			IL_1a16: ldloc.s 38
-			IL_1a18: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_1a1d: ldc.i4.0
-			IL_1a1e: ceq
-			IL_1a20: stloc.s 39
-			IL_1a22: ldloc.s 39
-			IL_1a24: brfalse IL_1af1
-
-			IL_1a29: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L231C24::.ctor()
-			IL_1a2e: stloc.s 30
-			IL_1a30: ldarg.0
-			IL_1a31: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_1a36: stloc.s 38
-			IL_1a38: ldstr "DrawLine"
-			IL_1a3d: ldloc.s 38
-			IL_1a3f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1a44: stloc.s 38
-			IL_1a46: ldc.i4.1
-			IL_1a47: newarr [System.Runtime]System.Object
-			IL_1a4c: dup
-			IL_1a4d: ldc.i4.0
-			IL_1a4e: ldarg.0
-			IL_1a4f: stelem.ref
-			IL_1a50: stloc.s 36
-			IL_1a52: ldarg.0
-			IL_1a53: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1a58: stloc.s 37
-			IL_1a5a: ldstr "Q"
-			IL_1a5f: ldloc.s 37
-			IL_1a61: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1a66: stloc.s 37
-			IL_1a68: ldloc.s 37
-			IL_1a6a: ldc.r8 6
-			IL_1a73: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1a78: stloc.s 37
-			IL_1a7a: ldarg.0
-			IL_1a7b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1a80: stloc.s 32
-			IL_1a82: ldstr "Q"
-			IL_1a87: ldloc.s 32
-			IL_1a89: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1a8e: stloc.s 32
-			IL_1a90: ldloc.s 32
-			IL_1a92: ldc.r8 2
-			IL_1a9b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1aa0: stloc.s 32
-			IL_1aa2: ldloc.s 38
-			IL_1aa4: ldloc.s 36
-			IL_1aa6: ldloc.s 37
-			IL_1aa8: ldloc.s 32
-			IL_1aaa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_1aaf: pop
-			IL_1ab0: ldarg.0
-			IL_1ab1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1ab6: stloc.s 32
-			IL_1ab8: ldstr "Q"
-			IL_1abd: ldloc.s 32
-			IL_1abf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1ac4: stloc.s 32
-			IL_1ac6: ldloc.s 32
-			IL_1ac8: ldstr "Line"
-			IL_1acd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1ad2: stloc.s 32
-			IL_1ad4: ldloc.s 32
-			IL_1ad6: ldc.r8 9
-			IL_1adf: box [System.Runtime]System.Double
-			IL_1ae4: ldc.i4.1
-			IL_1ae5: box [System.Runtime]System.Boolean
-			IL_1aea: ldc.i4.1
-			IL_1aeb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_1af0: pop
-
-			IL_1af1: ldarg.0
-			IL_1af2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1af7: stloc.s 32
-			IL_1af9: ldstr "Q"
-			IL_1afe: ldloc.s 32
-			IL_1b00: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1b05: stloc.s 32
-			IL_1b07: ldloc.s 32
-			IL_1b09: ldstr "Line"
-			IL_1b0e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1b13: stloc.s 32
-			IL_1b15: ldloc.s 32
-			IL_1b17: ldc.r8 1
-			IL_1b20: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1b25: stloc.s 32
-			IL_1b27: ldloc.s 32
-			IL_1b29: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_1b2e: ldc.i4.0
-			IL_1b2f: ceq
-			IL_1b31: stloc.s 39
-			IL_1b33: ldloc.s 39
-			IL_1b35: brfalse IL_1c02
-
-			IL_1b3a: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L232C24::.ctor()
-			IL_1b3f: stloc.s 31
-			IL_1b41: ldarg.0
-			IL_1b42: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_1b47: stloc.s 32
-			IL_1b49: ldstr "DrawLine"
-			IL_1b4e: ldloc.s 32
-			IL_1b50: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1b55: stloc.s 32
-			IL_1b57: ldc.i4.1
-			IL_1b58: newarr [System.Runtime]System.Object
-			IL_1b5d: dup
-			IL_1b5e: ldc.i4.0
-			IL_1b5f: ldarg.0
-			IL_1b60: stelem.ref
-			IL_1b61: stloc.s 36
-			IL_1b63: ldarg.0
-			IL_1b64: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1b69: stloc.s 37
-			IL_1b6b: ldstr "Q"
-			IL_1b70: ldloc.s 37
-			IL_1b72: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1b77: stloc.s 37
-			IL_1b79: ldloc.s 37
-			IL_1b7b: ldc.r8 2
-			IL_1b84: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1b89: stloc.s 37
-			IL_1b8b: ldarg.0
-			IL_1b8c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1b91: stloc.s 38
-			IL_1b93: ldstr "Q"
-			IL_1b98: ldloc.s 38
-			IL_1b9a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1b9f: stloc.s 38
-			IL_1ba1: ldloc.s 38
-			IL_1ba3: ldc.r8 1
-			IL_1bac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1bb1: stloc.s 38
-			IL_1bb3: ldloc.s 32
-			IL_1bb5: ldloc.s 36
-			IL_1bb7: ldloc.s 37
-			IL_1bb9: ldloc.s 38
-			IL_1bbb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_1bc0: pop
-			IL_1bc1: ldarg.0
-			IL_1bc2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1bc7: stloc.s 38
-			IL_1bc9: ldstr "Q"
-			IL_1bce: ldloc.s 38
-			IL_1bd0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1bd5: stloc.s 38
-			IL_1bd7: ldloc.s 38
-			IL_1bd9: ldstr "Line"
-			IL_1bde: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1be3: stloc.s 38
-			IL_1be5: ldloc.s 38
-			IL_1be7: ldc.r8 1
-			IL_1bf0: box [System.Runtime]System.Double
-			IL_1bf5: ldc.i4.1
-			IL_1bf6: box [System.Runtime]System.Boolean
-			IL_1bfb: ldc.i4.1
-			IL_1bfc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_1c01: pop
-
-			IL_1c02: ldarg.0
-			IL_1c03: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1c08: stloc.s 38
-			IL_1c0a: ldstr "Q"
-			IL_1c0f: ldloc.s 38
-			IL_1c11: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1c16: stloc.s 38
-			IL_1c18: ldc.i4.s 12
-			IL_1c1a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_1c1f: dup
-			IL_1c20: ldc.i4.0
-			IL_1c21: box [System.Runtime]System.Boolean
-			IL_1c26: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1c2b: dup
-			IL_1c2c: ldc.i4.0
-			IL_1c2d: box [System.Runtime]System.Boolean
-			IL_1c32: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1c37: dup
-			IL_1c38: ldc.i4.0
-			IL_1c39: box [System.Runtime]System.Boolean
-			IL_1c3e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1c43: dup
-			IL_1c44: ldc.i4.0
-			IL_1c45: box [System.Runtime]System.Boolean
-			IL_1c4a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1c4f: dup
-			IL_1c50: ldc.i4.0
-			IL_1c51: box [System.Runtime]System.Boolean
-			IL_1c56: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1c5b: dup
-			IL_1c5c: ldc.i4.0
-			IL_1c5d: box [System.Runtime]System.Boolean
-			IL_1c62: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1c67: dup
-			IL_1c68: ldc.i4.0
-			IL_1c69: box [System.Runtime]System.Boolean
-			IL_1c6e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1c73: dup
-			IL_1c74: ldc.i4.0
-			IL_1c75: box [System.Runtime]System.Boolean
-			IL_1c7a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1c7f: dup
-			IL_1c80: ldc.i4.0
-			IL_1c81: box [System.Runtime]System.Boolean
-			IL_1c86: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1c8b: dup
-			IL_1c8c: ldc.i4.0
-			IL_1c8d: box [System.Runtime]System.Boolean
-			IL_1c92: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1c97: dup
-			IL_1c98: ldc.i4.0
-			IL_1c99: box [System.Runtime]System.Boolean
-			IL_1c9e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1ca3: dup
-			IL_1ca4: ldc.i4.0
-			IL_1ca5: box [System.Runtime]System.Boolean
-			IL_1caa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1caf: stloc.s 40
-			IL_1cb1: ldloc.s 38
-			IL_1cb3: ldstr "Line"
-			IL_1cb8: ldloc.s 40
-			IL_1cba: ldc.i4.1
-			IL_1cbb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_1cc0: pop
-			IL_1cc1: ldarg.0
-			IL_1cc2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1cc7: stloc.s 38
-			IL_1cc9: ldstr "Q"
-			IL_1cce: ldloc.s 38
-			IL_1cd0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1cd5: stloc.s 38
-			IL_1cd7: ldloc.s 38
-			IL_1cd9: ldstr "LastPx"
-			IL_1cde: ldc.r8 0.0
-			IL_1ce7: ldc.i4.1
-			IL_1ce8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_1ced: pop
-			IL_1cee: ldnull
-			IL_1cef: ret
+			IL_13af: box [System.Runtime]System.Boolean
+			IL_13b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_13b9: stloc.s 39
+			IL_13bb: ldloc.s 37
+			IL_13bd: ldstr "Line"
+			IL_13c2: ldloc.s 39
+			IL_13c4: ldc.i4.1
+			IL_13c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_13ca: pop
+			IL_13cb: ldarg.0
+			IL_13cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_13d1: ldstr "LastPx"
+			IL_13d6: ldc.r8 0.0
+			IL_13df: ldc.i4.1
+			IL_13e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_13e5: pop
+			IL_13e6: ldnull
+			IL_13e7: ret
 		} // end of method DrawQube::__js_call__
 
 	} // end of class DrawQube
@@ -6076,7 +5197,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x74e7
+					// Method begins at RVA 0x65e1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6094,7 +5215,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x74de
+				// Method begins at RVA 0x65d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6120,9 +5241,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x5864
+			// Method begins at RVA 0x4f0c
 			// Header size: 12
-			// Code size: 1636 (0x664)
+			// Code size: 1124 (0x464)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -6131,591 +5252,404 @@
 				[3] object,
 				[4] object,
 				[5] float64,
-				[6] float64,
-				[7] string,
-				[8] object[],
+				[6] string,
+				[7] object[],
+				[8] object,
 				[9] object,
 				[10] object,
-				[11] object,
+				[11] object[],
 				[12] object,
-				[13] object[],
+				[13] object,
 				[14] object,
-				[15] object,
-				[16] object
+				[15] float64
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_0006: stloc.3
-			IL_0007: ldstr "Testing"
-			IL_000c: ldloc.3
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.3
-			IL_0013: ldloc.3
-			IL_0014: ldstr "LoopCount"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.3
-			IL_001f: ldarg.0
-			IL_0020: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_0025: stloc.s 4
-			IL_0027: ldstr "Testing"
-			IL_002c: ldloc.s 4
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0033: stloc.s 4
-			IL_0035: ldloc.s 4
-			IL_0037: ldstr "LoopMax"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.s 4
-			IL_0043: ldloc.3
-			IL_0044: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0049: stloc.s 5
-			IL_004b: ldloc.s 4
-			IL_004d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0006: ldstr "LoopCount"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: stloc.3
+			IL_0011: ldarg.0
+			IL_0012: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_0017: ldstr "LoopMax"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0021: stloc.s 4
+			IL_0023: ldloc.3
+			IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0029: stloc.s 5
+			IL_002b: ldloc.s 5
+			IL_002d: ldloc.s 4
+			IL_002f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0034: cgt
+			IL_0036: brfalse IL_003d
+
+			IL_003b: ldnull
+			IL_003c: ret
+
+			IL_003d: ldarg.0
+			IL_003e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_0043: ldstr "LoopCount"
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_004d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0052: stloc.s 6
-			IL_0054: ldloc.s 5
-			IL_0056: ldloc.s 6
-			IL_0058: cgt
-			IL_005a: brfalse IL_0061
+			IL_0054: ldloc.s 6
+			IL_0056: stloc.0
+			// loop start (head: IL_0057)
+				IL_0057: ldloc.0
+				IL_0058: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_005d: conv.r8
+				IL_005e: ldc.r8 3
+				IL_0067: clt
+				IL_0069: brfalse IL_0083
 
-			IL_005f: ldnull
-			IL_0060: ret
-
-			IL_0061: ldarg.0
-			IL_0062: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_0067: stloc.s 4
-			IL_0069: ldstr "Testing"
-			IL_006e: ldloc.s 4
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0075: stloc.s 4
-			IL_0077: ldloc.s 4
-			IL_0079: ldstr "LoopCount"
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0083: stloc.s 4
-			IL_0085: ldloc.s 4
-			IL_0087: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_008c: stloc.s 7
-			IL_008e: ldloc.s 7
-			IL_0090: stloc.0
-			// loop start (head: IL_0091)
-				IL_0091: ldloc.0
-				IL_0092: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_0097: conv.r8
-				IL_0098: ldc.r8 3
-				IL_00a1: clt
-				IL_00a3: brfalse IL_00bd
-
-				IL_00a8: ldstr "0"
-				IL_00ad: ldloc.0
-				IL_00ae: call string [System.Runtime]System.String::Concat(string, string)
-				IL_00b3: stloc.s 7
-				IL_00b5: ldloc.s 7
-				IL_00b7: stloc.0
-				IL_00b8: br IL_0091
+				IL_006e: ldstr "0"
+				IL_0073: ldloc.0
+				IL_0074: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0079: stloc.s 6
+				IL_007b: ldloc.s 6
+				IL_007d: stloc.0
+				IL_007e: br IL_0057
 			// end loop
 
-			IL_00bd: ldarg.0
-			IL_00be: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
-			IL_00c3: stloc.s 4
-			IL_00c5: ldstr "Translate"
-			IL_00ca: ldloc.s 4
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00d1: stloc.s 4
-			IL_00d3: ldc.i4.1
-			IL_00d4: newarr [System.Runtime]System.Object
-			IL_00d9: dup
-			IL_00da: ldc.i4.0
-			IL_00db: ldarg.0
-			IL_00dc: stelem.ref
-			IL_00dd: stloc.s 8
-			IL_00df: ldarg.0
-			IL_00e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::I
-			IL_00e5: stloc.3
-			IL_00e6: ldstr "I"
-			IL_00eb: ldloc.3
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00f1: stloc.3
-			IL_00f2: ldarg.0
-			IL_00f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_00f8: stloc.s 9
-			IL_00fa: ldstr "Q"
-			IL_00ff: ldloc.s 9
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0106: stloc.s 9
-			IL_0108: ldloc.s 9
-			IL_010a: ldc.r8 8
-			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0118: stloc.s 9
-			IL_011a: ldloc.s 9
-			IL_011c: ldstr "V"
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0126: stloc.s 9
-			IL_0128: ldloc.s 9
-			IL_012a: ldc.r8 0.0
-			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0138: stloc.s 9
-			IL_013a: ldloc.s 9
-			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-			IL_0141: stloc.s 10
-			IL_0143: ldarg.0
-			IL_0144: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0149: stloc.s 9
-			IL_014b: ldstr "Q"
-			IL_0150: ldloc.s 9
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0157: stloc.s 9
-			IL_0159: ldloc.s 9
-			IL_015b: ldc.r8 8
-			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0169: stloc.s 9
-			IL_016b: ldloc.s 9
-			IL_016d: ldstr "V"
-			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0177: stloc.s 9
-			IL_0179: ldloc.s 9
-			IL_017b: ldc.r8 1
-			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0189: stloc.s 9
-			IL_018b: ldloc.s 9
-			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-			IL_0192: stloc.s 11
-			IL_0194: ldarg.0
-			IL_0195: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_019a: stloc.s 9
-			IL_019c: ldstr "Q"
-			IL_01a1: ldloc.s 9
-			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01a8: stloc.s 9
-			IL_01aa: ldloc.s 9
-			IL_01ac: ldc.r8 8
-			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01ba: stloc.s 9
-			IL_01bc: ldloc.s 9
-			IL_01be: ldstr "V"
-			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c8: stloc.s 9
-			IL_01ca: ldloc.s 9
-			IL_01cc: ldc.r8 2
-			IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01da: stloc.s 9
-			IL_01dc: ldloc.s 9
-			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-			IL_01e3: stloc.s 12
-			IL_01e5: ldc.i4.4
-			IL_01e6: newarr [System.Runtime]System.Object
-			IL_01eb: dup
-			IL_01ec: ldc.i4.0
-			IL_01ed: ldloc.3
-			IL_01ee: stelem.ref
-			IL_01ef: dup
-			IL_01f0: ldc.i4.1
-			IL_01f1: ldloc.s 10
-			IL_01f3: stelem.ref
-			IL_01f4: dup
-			IL_01f5: ldc.i4.2
-			IL_01f6: ldloc.s 11
-			IL_01f8: stelem.ref
-			IL_01f9: dup
-			IL_01fa: ldc.i4.3
-			IL_01fb: ldloc.s 12
-			IL_01fd: stelem.ref
-			IL_01fe: stloc.s 13
-			IL_0200: ldloc.s 4
-			IL_0202: ldloc.s 8
-			IL_0204: ldloc.s 13
-			IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_020b: stloc.s 4
+			IL_0083: ldarg.0
+			IL_0084: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
+			IL_0089: stloc.s 4
+			IL_008b: ldc.i4.1
+			IL_008c: newarr [System.Runtime]System.Object
+			IL_0091: dup
+			IL_0092: ldc.i4.0
+			IL_0093: ldarg.0
+			IL_0094: stelem.ref
+			IL_0095: stloc.s 7
+			IL_0097: ldarg.0
+			IL_0098: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::I
+			IL_009d: stloc.3
+			IL_009e: ldarg.0
+			IL_009f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_00a4: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00a9: ldc.r8 8
+			IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_00b7: ldstr "V"
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c1: ldc.r8 0.0
+			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
+			IL_00d4: stloc.s 8
+			IL_00d6: ldarg.0
+			IL_00d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_00dc: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00e1: ldc.r8 8
+			IL_00ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_00ef: ldstr "V"
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f9: ldc.r8 1
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
+			IL_010c: stloc.s 9
+			IL_010e: ldarg.0
+			IL_010f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0114: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0119: ldc.r8 8
+			IL_0122: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0127: ldstr "V"
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0131: ldc.r8 2
+			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
+			IL_0144: stloc.s 10
+			IL_0146: ldc.i4.4
+			IL_0147: newarr [System.Runtime]System.Object
+			IL_014c: dup
+			IL_014d: ldc.i4.0
+			IL_014e: ldloc.3
+			IL_014f: stelem.ref
+			IL_0150: dup
+			IL_0151: ldc.i4.1
+			IL_0152: ldloc.s 8
+			IL_0154: stelem.ref
+			IL_0155: dup
+			IL_0156: ldc.i4.2
+			IL_0157: ldloc.s 9
+			IL_0159: stelem.ref
+			IL_015a: dup
+			IL_015b: ldc.i4.3
+			IL_015c: ldloc.s 10
+			IL_015e: stelem.ref
+			IL_015f: stloc.s 11
+			IL_0161: ldloc.s 4
+			IL_0163: ldloc.s 7
+			IL_0165: ldloc.s 11
+			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_016c: stloc.s 4
+			IL_016e: ldarg.0
+			IL_016f: ldloc.s 4
+			IL_0171: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0176: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_017b: ldarg.0
+			IL_017c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::RotateX
+			IL_0181: stloc.s 4
+			IL_0183: ldc.i4.1
+			IL_0184: newarr [System.Runtime]System.Object
+			IL_0189: dup
+			IL_018a: ldc.i4.0
+			IL_018b: ldarg.0
+			IL_018c: stelem.ref
+			IL_018d: stloc.s 11
+			IL_018f: ldarg.0
+			IL_0190: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0195: stloc.3
+			IL_0196: ldloc.s 4
+			IL_0198: ldloc.s 11
+			IL_019a: ldloc.3
+			IL_019b: ldc.r8 1
+			IL_01a4: box [System.Runtime]System.Double
+			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01ae: stloc.3
+			IL_01af: ldarg.0
+			IL_01b0: ldloc.3
+			IL_01b1: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01b6: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_01bb: ldarg.0
+			IL_01bc: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::RotateY
+			IL_01c1: stloc.3
+			IL_01c2: ldc.i4.1
+			IL_01c3: newarr [System.Runtime]System.Object
+			IL_01c8: dup
+			IL_01c9: ldc.i4.0
+			IL_01ca: ldarg.0
+			IL_01cb: stelem.ref
+			IL_01cc: stloc.s 11
+			IL_01ce: ldarg.0
+			IL_01cf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_01d4: stloc.s 4
+			IL_01d6: ldloc.3
+			IL_01d7: ldloc.s 11
+			IL_01d9: ldloc.s 4
+			IL_01db: ldc.r8 3
+			IL_01e4: box [System.Runtime]System.Double
+			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01ee: stloc.s 4
+			IL_01f0: ldarg.0
+			IL_01f1: ldloc.s 4
+			IL_01f3: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01f8: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_01fd: ldarg.0
+			IL_01fe: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::RotateZ
+			IL_0203: stloc.s 4
+			IL_0205: ldc.i4.1
+			IL_0206: newarr [System.Runtime]System.Object
+			IL_020b: dup
+			IL_020c: ldc.i4.0
 			IL_020d: ldarg.0
-			IL_020e: ldloc.s 4
-			IL_0210: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0215: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_021a: ldarg.0
-			IL_021b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::RotateX
-			IL_0220: stloc.s 4
-			IL_0222: ldstr "RotateX"
-			IL_0227: ldloc.s 4
-			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_022e: stloc.s 4
-			IL_0230: ldc.i4.1
-			IL_0231: newarr [System.Runtime]System.Object
-			IL_0236: dup
-			IL_0237: ldc.i4.0
-			IL_0238: ldarg.0
-			IL_0239: stelem.ref
-			IL_023a: stloc.s 13
-			IL_023c: ldarg.0
-			IL_023d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0242: stloc.3
-			IL_0243: ldstr "MTrans"
-			IL_0248: ldloc.3
-			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_024e: stloc.3
-			IL_024f: ldloc.s 4
-			IL_0251: ldloc.s 13
-			IL_0253: ldloc.3
-			IL_0254: ldc.r8 1
-			IL_025d: box [System.Runtime]System.Double
-			IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0267: stloc.3
-			IL_0268: ldarg.0
-			IL_0269: ldloc.3
-			IL_026a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_026f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0274: ldarg.0
-			IL_0275: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::RotateY
-			IL_027a: stloc.3
-			IL_027b: ldstr "RotateY"
-			IL_0280: ldloc.3
-			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0286: stloc.3
-			IL_0287: ldc.i4.1
-			IL_0288: newarr [System.Runtime]System.Object
-			IL_028d: dup
-			IL_028e: ldc.i4.0
-			IL_028f: ldarg.0
-			IL_0290: stelem.ref
-			IL_0291: stloc.s 13
-			IL_0293: ldarg.0
-			IL_0294: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0299: stloc.s 4
-			IL_029b: ldstr "MTrans"
-			IL_02a0: ldloc.s 4
-			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02a7: stloc.s 4
-			IL_02a9: ldloc.3
-			IL_02aa: ldloc.s 13
-			IL_02ac: ldloc.s 4
-			IL_02ae: ldc.r8 3
-			IL_02b7: box [System.Runtime]System.Double
-			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02c1: stloc.s 4
-			IL_02c3: ldarg.0
-			IL_02c4: ldloc.s 4
-			IL_02c6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_02cb: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_02d0: ldarg.0
-			IL_02d1: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::RotateZ
-			IL_02d6: stloc.s 4
-			IL_02d8: ldstr "RotateZ"
-			IL_02dd: ldloc.s 4
-			IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02e4: stloc.s 4
-			IL_02e6: ldc.i4.1
-			IL_02e7: newarr [System.Runtime]System.Object
-			IL_02ec: dup
-			IL_02ed: ldc.i4.0
-			IL_02ee: ldarg.0
-			IL_02ef: stelem.ref
-			IL_02f0: stloc.s 13
-			IL_02f2: ldarg.0
-			IL_02f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_02f8: stloc.3
-			IL_02f9: ldstr "MTrans"
-			IL_02fe: ldloc.3
-			IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0304: stloc.3
-			IL_0305: ldloc.s 4
-			IL_0307: ldloc.s 13
-			IL_0309: ldloc.3
-			IL_030a: ldc.r8 5
-			IL_0313: box [System.Runtime]System.Double
-			IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_031d: stloc.3
-			IL_031e: ldarg.0
-			IL_031f: ldloc.3
-			IL_0320: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0325: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_032a: ldarg.0
-			IL_032b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
-			IL_0330: stloc.3
-			IL_0331: ldstr "Translate"
-			IL_0336: ldloc.3
-			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_033c: stloc.3
-			IL_033d: ldc.i4.1
-			IL_033e: newarr [System.Runtime]System.Object
-			IL_0343: dup
-			IL_0344: ldc.i4.0
-			IL_0345: ldarg.0
-			IL_0346: stelem.ref
-			IL_0347: stloc.s 13
-			IL_0349: ldarg.0
-			IL_034a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_034f: stloc.s 4
-			IL_0351: ldstr "MTrans"
-			IL_0356: ldloc.s 4
-			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_035d: stloc.s 4
-			IL_035f: ldarg.0
-			IL_0360: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0365: stloc.s 9
-			IL_0367: ldstr "Q"
-			IL_036c: ldloc.s 9
-			IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0373: stloc.s 9
-			IL_0375: ldloc.s 9
-			IL_0377: ldc.r8 8
-			IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0385: stloc.s 9
-			IL_0387: ldloc.s 9
-			IL_0389: ldstr "V"
-			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0393: stloc.s 9
-			IL_0395: ldloc.s 9
-			IL_0397: ldc.r8 0.0
-			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03a5: stloc.s 9
-			IL_03a7: ldarg.0
-			IL_03a8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_03ad: stloc.s 14
-			IL_03af: ldstr "Q"
-			IL_03b4: ldloc.s 14
-			IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03bb: stloc.s 14
-			IL_03bd: ldloc.s 14
-			IL_03bf: ldc.r8 8
-			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03cd: stloc.s 14
-			IL_03cf: ldloc.s 14
-			IL_03d1: ldstr "V"
-			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03db: stloc.s 14
-			IL_03dd: ldloc.s 14
-			IL_03df: ldc.r8 1
-			IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03ed: stloc.s 14
-			IL_03ef: ldarg.0
-			IL_03f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_03f5: stloc.s 15
-			IL_03f7: ldstr "Q"
-			IL_03fc: ldloc.s 15
-			IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0403: stloc.s 15
-			IL_0405: ldloc.s 15
-			IL_0407: ldc.r8 8
-			IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0415: stloc.s 15
-			IL_0417: ldloc.s 15
-			IL_0419: ldstr "V"
-			IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0423: stloc.s 15
-			IL_0425: ldloc.s 15
-			IL_0427: ldc.r8 2
-			IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0435: stloc.s 15
-			IL_0437: ldc.i4.4
-			IL_0438: newarr [System.Runtime]System.Object
-			IL_043d: dup
-			IL_043e: ldc.i4.0
-			IL_043f: ldloc.s 4
-			IL_0441: stelem.ref
-			IL_0442: dup
-			IL_0443: ldc.i4.1
-			IL_0444: ldloc.s 9
-			IL_0446: stelem.ref
-			IL_0447: dup
-			IL_0448: ldc.i4.2
-			IL_0449: ldloc.s 14
-			IL_044b: stelem.ref
-			IL_044c: dup
-			IL_044d: ldc.i4.3
-			IL_044e: ldloc.s 15
-			IL_0450: stelem.ref
-			IL_0451: stloc.s 8
-			IL_0453: ldloc.3
-			IL_0454: ldloc.s 13
-			IL_0456: ldloc.s 8
-			IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_045d: stloc.3
-			IL_045e: ldarg.0
-			IL_045f: ldloc.3
-			IL_0460: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0465: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_046a: ldarg.0
-			IL_046b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
-			IL_0470: stloc.3
-			IL_0471: ldstr "MMulti"
-			IL_0476: ldloc.3
-			IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_047c: stloc.3
-			IL_047d: ldc.i4.1
-			IL_047e: newarr [System.Runtime]System.Object
-			IL_0483: dup
-			IL_0484: ldc.i4.0
-			IL_0485: ldarg.0
-			IL_0486: stelem.ref
-			IL_0487: stloc.s 8
-			IL_0489: ldarg.0
-			IL_048a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_048f: stloc.s 15
-			IL_0491: ldstr "MTrans"
-			IL_0496: ldloc.s 15
-			IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_049d: stloc.s 15
-			IL_049f: ldarg.0
-			IL_04a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_04a5: stloc.s 14
-			IL_04a7: ldstr "MQube"
-			IL_04ac: ldloc.s 14
-			IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_04b3: stloc.s 14
-			IL_04b5: ldloc.3
-			IL_04b6: ldloc.s 8
-			IL_04b8: ldloc.s 15
-			IL_04ba: ldloc.s 14
-			IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04c1: stloc.s 14
-			IL_04c3: ldarg.0
-			IL_04c4: ldloc.s 14
-			IL_04c6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_04cb: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_04d0: ldc.r8 8
-			IL_04d9: box [System.Runtime]System.Double
-			IL_04de: stloc.1
-			// loop start (head: IL_04df)
-				IL_04df: ldloc.1
-				IL_04e0: stloc.s 16
-				IL_04e2: ldc.r8 1
-				IL_04eb: neg
-				IL_04ec: stloc.s 6
-				IL_04ee: ldloc.s 16
-				IL_04f0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_04f5: stloc.s 5
-				IL_04f7: ldloc.s 5
-				IL_04f9: ldloc.s 6
-				IL_04fb: cgt
-				IL_04fd: brfalse IL_05d0
+			IL_020e: stelem.ref
+			IL_020f: stloc.s 11
+			IL_0211: ldarg.0
+			IL_0212: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0217: stloc.3
+			IL_0218: ldloc.s 4
+			IL_021a: ldloc.s 11
+			IL_021c: ldloc.3
+			IL_021d: ldc.r8 5
+			IL_0226: box [System.Runtime]System.Double
+			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0230: stloc.3
+			IL_0231: ldarg.0
+			IL_0232: ldloc.3
+			IL_0233: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0238: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_023d: ldarg.0
+			IL_023e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
+			IL_0243: stloc.3
+			IL_0244: ldc.i4.1
+			IL_0245: newarr [System.Runtime]System.Object
+			IL_024a: dup
+			IL_024b: ldc.i4.0
+			IL_024c: ldarg.0
+			IL_024d: stelem.ref
+			IL_024e: stloc.s 11
+			IL_0250: ldarg.0
+			IL_0251: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0256: stloc.s 4
+			IL_0258: ldarg.0
+			IL_0259: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_025e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0263: ldc.r8 8
+			IL_026c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0271: ldstr "V"
+			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_027b: ldc.r8 0.0
+			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0289: stloc.s 12
+			IL_028b: ldarg.0
+			IL_028c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0291: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0296: ldc.r8 8
+			IL_029f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_02a4: ldstr "V"
+			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ae: ldc.r8 1
+			IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_02bc: stloc.s 13
+			IL_02be: ldloc.3
+			IL_02bf: ldloc.s 11
+			IL_02c1: ldc.i4.4
+			IL_02c2: newarr [System.Runtime]System.Object
+			IL_02c7: dup
+			IL_02c8: ldc.i4.0
+			IL_02c9: ldloc.s 4
+			IL_02cb: stelem.ref
+			IL_02cc: dup
+			IL_02cd: ldc.i4.1
+			IL_02ce: ldloc.s 12
+			IL_02d0: stelem.ref
+			IL_02d1: dup
+			IL_02d2: ldc.i4.2
+			IL_02d3: ldloc.s 13
+			IL_02d5: stelem.ref
+			IL_02d6: dup
+			IL_02d7: ldc.i4.3
+			IL_02d8: ldarg.0
+			IL_02d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02de: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_02e3: ldc.r8 8
+			IL_02ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_02f1: ldstr "V"
+			IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02fb: ldc.r8 2
+			IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0309: stelem.ref
+			IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_030f: stloc.3
+			IL_0310: ldarg.0
+			IL_0311: ldloc.3
+			IL_0312: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0317: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_031c: ldc.i4.1
+			IL_031d: newarr [System.Runtime]System.Object
+			IL_0322: dup
+			IL_0323: ldc.i4.0
+			IL_0324: ldarg.0
+			IL_0325: stelem.ref
+			IL_0326: stloc.s 11
+			IL_0328: ldarg.0
+			IL_0329: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_032e: stloc.3
+			IL_032f: ldarg.0
+			IL_0330: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
+			IL_0335: ldloc.s 11
+			IL_0337: ldloc.3
+			IL_0338: ldarg.0
+			IL_0339: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0343: stloc.3
+			IL_0344: ldarg.0
+			IL_0345: ldloc.3
+			IL_0346: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_034b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0350: ldc.r8 8
+			IL_0359: box [System.Runtime]System.Double
+			IL_035e: stloc.1
+			// loop start (head: IL_035f)
+				IL_035f: ldloc.1
+				IL_0360: stloc.s 14
+				IL_0362: ldc.r8 1
+				IL_036b: neg
+				IL_036c: stloc.s 5
+				IL_036e: ldloc.s 14
+				IL_0370: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0375: stloc.s 15
+				IL_0377: ldloc.s 15
+				IL_0379: ldloc.s 5
+				IL_037b: cgt
+				IL_037d: brfalse IL_040a
 
-				IL_0502: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/Scope/Block_L249C24::.ctor()
-				IL_0507: stloc.2
-				IL_0508: ldarg.0
-				IL_0509: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_050e: stloc.s 14
-				IL_0510: ldstr "Q"
-				IL_0515: ldloc.s 14
-				IL_0517: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_051c: stloc.s 14
-				IL_051e: ldloc.s 14
-				IL_0520: ldloc.1
-				IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0526: stloc.s 14
-				IL_0528: ldarg.0
-				IL_0529: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
-				IL_052e: stloc.s 15
-				IL_0530: ldstr "VMulti"
-				IL_0535: ldloc.s 15
-				IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_053c: stloc.s 15
-				IL_053e: ldc.i4.1
-				IL_053f: newarr [System.Runtime]System.Object
-				IL_0544: dup
-				IL_0545: ldc.i4.0
-				IL_0546: ldarg.0
-				IL_0547: stelem.ref
-				IL_0548: stloc.s 8
-				IL_054a: ldarg.0
-				IL_054b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-				IL_0550: stloc.3
-				IL_0551: ldstr "MTrans"
-				IL_0556: ldloc.3
-				IL_0557: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_055c: stloc.3
-				IL_055d: ldarg.0
-				IL_055e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0563: stloc.s 9
-				IL_0565: ldstr "Q"
-				IL_056a: ldloc.s 9
-				IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0571: stloc.s 9
-				IL_0573: ldloc.s 9
-				IL_0575: ldloc.1
-				IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_057b: stloc.s 9
-				IL_057d: ldloc.s 9
-				IL_057f: ldstr "V"
-				IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0589: stloc.s 9
-				IL_058b: ldloc.s 15
-				IL_058d: ldloc.s 8
-				IL_058f: ldloc.3
-				IL_0590: ldloc.s 9
-				IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_0597: stloc.s 9
-				IL_0599: ldloc.s 14
-				IL_059b: ldstr "V"
-				IL_05a0: ldloc.s 9
-				IL_05a2: ldc.i4.1
-				IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_05a8: pop
-				IL_05a9: ldloc.1
-				IL_05aa: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_05af: stloc.s 6
-				IL_05b1: ldloc.s 6
-				IL_05b3: ldc.r8 1
-				IL_05bc: sub
-				IL_05bd: stloc.s 6
-				IL_05bf: ldloc.s 6
-				IL_05c1: box [System.Runtime]System.Double
-				IL_05c6: stloc.s 16
-				IL_05c8: ldloc.s 16
-				IL_05ca: stloc.1
-				IL_05cb: br IL_04df
+				IL_0382: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/Scope/Block_L249C24::.ctor()
+				IL_0387: stloc.2
+				IL_0388: ldarg.0
+				IL_0389: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_038e: ldloc.1
+				IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0394: stloc.3
+				IL_0395: ldarg.0
+				IL_0396: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
+				IL_039b: stloc.s 13
+				IL_039d: ldc.i4.1
+				IL_039e: newarr [System.Runtime]System.Object
+				IL_03a3: dup
+				IL_03a4: ldc.i4.0
+				IL_03a5: ldarg.0
+				IL_03a6: stelem.ref
+				IL_03a7: stloc.s 11
+				IL_03a9: ldarg.0
+				IL_03aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+				IL_03af: stloc.s 12
+				IL_03b1: ldloc.s 13
+				IL_03b3: ldloc.s 11
+				IL_03b5: ldloc.s 12
+				IL_03b7: ldarg.0
+				IL_03b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_03bd: ldloc.1
+				IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_03c3: ldstr "V"
+				IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_03d2: stloc.s 12
+				IL_03d4: ldloc.3
+				IL_03d5: ldstr "V"
+				IL_03da: ldloc.s 12
+				IL_03dc: ldc.i4.1
+				IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_03e2: pop
+				IL_03e3: ldloc.1
+				IL_03e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_03e9: stloc.s 5
+				IL_03eb: ldloc.s 5
+				IL_03ed: ldc.r8 1
+				IL_03f6: sub
+				IL_03f7: stloc.s 5
+				IL_03f9: ldloc.s 5
+				IL_03fb: box [System.Runtime]System.Double
+				IL_0400: stloc.s 14
+				IL_0402: ldloc.s 14
+				IL_0404: stloc.1
+				IL_0405: br IL_035f
 			// end loop
 
-			IL_05d0: ldarg.0
-			IL_05d1: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
-			IL_05d6: stloc.s 9
-			IL_05d8: ldstr "DrawQube"
-			IL_05dd: ldloc.s 9
-			IL_05df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_05e4: stloc.s 9
-			IL_05e6: ldloc.s 9
-			IL_05e8: ldc.i4.1
-			IL_05e9: newarr [System.Runtime]System.Object
-			IL_05ee: dup
-			IL_05ef: ldc.i4.0
-			IL_05f0: ldarg.0
-			IL_05f1: stelem.ref
-			IL_05f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_05f7: pop
-			IL_05f8: ldarg.0
-			IL_05f9: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_05fe: stloc.s 9
-			IL_0600: ldstr "Testing"
-			IL_0605: ldloc.s 9
-			IL_0607: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_060c: stloc.s 9
-			IL_060e: ldloc.s 9
-			IL_0610: ldstr "LoopCount"
-			IL_0615: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_061a: stloc.s 6
-			IL_061c: ldloc.s 6
-			IL_061e: ldc.r8 1
-			IL_0627: add
-			IL_0628: stloc.s 6
-			IL_062a: ldloc.s 9
-			IL_062c: ldstr "LoopCount"
-			IL_0631: ldloc.s 6
-			IL_0633: ldc.i4.1
-			IL_0634: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0639: pop
-			IL_063a: ldarg.0
-			IL_063b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
-			IL_0640: stloc.s 9
-			IL_0642: ldstr "Loop"
-			IL_0647: ldloc.s 9
-			IL_0649: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_064e: stloc.s 9
-			IL_0650: ldloc.s 9
-			IL_0652: ldc.i4.1
-			IL_0653: newarr [System.Runtime]System.Object
-			IL_0658: dup
-			IL_0659: ldc.i4.0
-			IL_065a: ldarg.0
-			IL_065b: stelem.ref
-			IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0661: pop
-			IL_0662: ldnull
-			IL_0663: ret
+			IL_040a: ldarg.0
+			IL_040b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
+			IL_0410: ldc.i4.1
+			IL_0411: newarr [System.Runtime]System.Object
+			IL_0416: dup
+			IL_0417: ldc.i4.0
+			IL_0418: ldarg.0
+			IL_0419: stelem.ref
+			IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_041f: pop
+			IL_0420: ldarg.0
+			IL_0421: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_0426: stloc.s 12
+			IL_0428: ldloc.s 12
+			IL_042a: ldstr "LoopCount"
+			IL_042f: ldloc.s 12
+			IL_0431: ldstr "LoopCount"
+			IL_0436: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_043b: ldc.r8 1
+			IL_0444: add
+			IL_0445: ldc.i4.1
+			IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_044b: pop
+			IL_044c: ldarg.0
+			IL_044d: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
+			IL_0452: ldc.i4.1
+			IL_0453: newarr [System.Runtime]System.Object
+			IL_0458: dup
+			IL_0459: ldc.i4.0
+			IL_045a: ldarg.0
+			IL_045b: stelem.ref
+			IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0461: pop
+			IL_0462: ldnull
+			IL_0463: ret
 		} // end of method Loop::__js_call__
 
 	} // end of class Loop
@@ -6735,7 +5669,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x74f9
+					// Method begins at RVA 0x65f3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6753,7 +5687,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x74f0
+				// Method begins at RVA 0x65ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6780,9 +5714,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x5ed4
+			// Method begins at RVA 0x537c
 			// Header size: 12
-			// Code size: 4955 (0x135b)
+			// Code size: 4037 (0xfc5)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6797,1570 +5731,1247 @@
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[10] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[11] float64,
-				[12] float64,
-				[13] object[],
+				[12] object[],
+				[13] object,
 				[14] object,
-				[15] object,
-				[16] object,
-				[17] object,
-				[18] object[]
+				[15] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
 			IL_0006: stloc.2
-			IL_0007: ldstr "Origin"
-			IL_000c: ldloc.2
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.2
-			IL_0013: ldc.i4.4
-			IL_0014: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0019: dup
-			IL_001a: ldc.r8 150
-			IL_0023: box [System.Runtime]System.Double
-			IL_0028: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_002d: dup
-			IL_002e: ldc.r8 150
-			IL_0037: box [System.Runtime]System.Double
-			IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0041: dup
-			IL_0042: ldc.r8 20
-			IL_004b: box [System.Runtime]System.Double
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0055: dup
-			IL_0056: ldc.r8 1
-			IL_005f: box [System.Runtime]System.Double
-			IL_0064: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0069: stloc.3
-			IL_006a: ldloc.2
-			IL_006b: ldstr "V"
-			IL_0070: ldloc.3
-			IL_0071: ldc.i4.1
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0077: pop
-			IL_0078: ldarg.0
-			IL_0079: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_007e: stloc.2
-			IL_007f: ldstr "Testing"
-			IL_0084: ldloc.2
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_008a: stloc.2
-			IL_008b: ldloc.2
-			IL_008c: ldstr "LoopCount"
-			IL_0091: ldc.r8 0.0
-			IL_009a: ldc.i4.1
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_00a0: pop
-			IL_00a1: ldarg.0
-			IL_00a2: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_00a7: stloc.2
-			IL_00a8: ldstr "Testing"
-			IL_00ad: ldloc.2
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00b3: stloc.2
-			IL_00b4: ldloc.2
-			IL_00b5: ldstr "LoopMax"
-			IL_00ba: ldc.r8 50
-			IL_00c3: ldc.i4.1
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_00c9: pop
-			IL_00ca: ldarg.0
-			IL_00cb: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_00d0: stloc.2
-			IL_00d1: ldstr "Testing"
-			IL_00d6: ldloc.2
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00dc: stloc.2
-			IL_00dd: ldloc.2
-			IL_00de: ldstr "TimeMax"
+			IL_0007: ldc.i4.4
+			IL_0008: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_000d: dup
+			IL_000e: ldc.r8 150
+			IL_0017: box [System.Runtime]System.Double
+			IL_001c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0021: dup
+			IL_0022: ldc.r8 150
+			IL_002b: box [System.Runtime]System.Double
+			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0035: dup
+			IL_0036: ldc.r8 20
+			IL_003f: box [System.Runtime]System.Double
+			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0049: dup
+			IL_004a: ldc.r8 1
+			IL_0053: box [System.Runtime]System.Double
+			IL_0058: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_005d: stloc.3
+			IL_005e: ldloc.2
+			IL_005f: ldstr "V"
+			IL_0064: ldloc.3
+			IL_0065: ldc.i4.1
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_006b: pop
+			IL_006c: ldarg.0
+			IL_006d: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_0072: ldstr "LoopCount"
+			IL_0077: ldc.r8 0.0
+			IL_0080: ldc.i4.1
+			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0086: pop
+			IL_0087: ldarg.0
+			IL_0088: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_008d: ldstr "LoopMax"
+			IL_0092: ldc.r8 50
+			IL_009b: ldc.i4.1
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_00a1: pop
+			IL_00a2: ldarg.0
+			IL_00a3: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_00a8: ldstr "TimeMax"
+			IL_00ad: ldc.r8 0.0
+			IL_00b6: ldc.i4.1
+			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_00bc: pop
+			IL_00bd: ldarg.0
+			IL_00be: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_00c3: ldstr "TimeAvg"
+			IL_00c8: ldc.r8 0.0
+			IL_00d1: ldc.i4.1
+			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_00d7: pop
+			IL_00d8: ldarg.0
+			IL_00d9: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_00de: ldstr "TimeMin"
 			IL_00e3: ldc.r8 0.0
 			IL_00ec: ldc.i4.1
 			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
 			IL_00f2: pop
 			IL_00f3: ldarg.0
 			IL_00f4: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_00f9: stloc.2
-			IL_00fa: ldstr "Testing"
-			IL_00ff: ldloc.2
-			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0105: stloc.2
-			IL_0106: ldloc.2
-			IL_0107: ldstr "TimeAvg"
-			IL_010c: ldc.r8 0.0
-			IL_0115: ldc.i4.1
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_011b: pop
-			IL_011c: ldarg.0
-			IL_011d: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_0122: stloc.2
-			IL_0123: ldstr "Testing"
-			IL_0128: ldloc.2
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_012e: stloc.2
-			IL_012f: ldloc.2
-			IL_0130: ldstr "TimeMin"
-			IL_0135: ldc.r8 0.0
-			IL_013e: ldc.i4.1
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0144: pop
-			IL_0145: ldarg.0
-			IL_0146: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_014b: stloc.2
-			IL_014c: ldstr "Testing"
-			IL_0151: ldloc.2
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0157: stloc.2
-			IL_0158: ldloc.2
-			IL_0159: ldstr "TimeTemp"
+			IL_00f9: ldstr "TimeTemp"
+			IL_00fe: ldc.r8 0.0
+			IL_0107: ldc.i4.1
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_010d: pop
+			IL_010e: ldarg.0
+			IL_010f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_0114: ldstr "TimeTotal"
+			IL_0119: ldc.r8 0.0
+			IL_0122: ldc.i4.1
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0128: pop
+			IL_0129: ldarg.0
+			IL_012a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_012f: stloc.2
+			IL_0130: ldloc.2
+			IL_0131: ldstr "Init"
+			IL_0136: ldc.i4.0
+			IL_0137: box [System.Runtime]System.Boolean
+			IL_013c: ldc.i4.1
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0142: pop
+			IL_0143: ldc.i4.4
+			IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0149: dup
+			IL_014a: ldc.r8 1
+			IL_0153: box [System.Runtime]System.Double
+			IL_0158: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_015d: dup
 			IL_015e: ldc.r8 0.0
-			IL_0167: ldc.i4.1
-			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_016d: pop
-			IL_016e: ldarg.0
-			IL_016f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_0174: stloc.2
-			IL_0175: ldstr "Testing"
-			IL_017a: ldloc.2
-			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0180: stloc.2
-			IL_0181: ldloc.2
-			IL_0182: ldstr "TimeTotal"
-			IL_0187: ldc.r8 0.0
-			IL_0190: ldc.i4.1
-			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0196: pop
-			IL_0197: ldarg.0
-			IL_0198: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_019d: stloc.2
-			IL_019e: ldstr "Testing"
-			IL_01a3: ldloc.2
-			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01a9: stloc.2
-			IL_01aa: ldloc.2
-			IL_01ab: ldstr "Init"
-			IL_01b0: ldc.i4.0
-			IL_01b1: box [System.Runtime]System.Boolean
-			IL_01b6: ldc.i4.1
-			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_01bc: pop
-			IL_01bd: ldc.i4.4
-			IL_01be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_01c3: dup
-			IL_01c4: ldc.r8 1
-			IL_01cd: box [System.Runtime]System.Double
-			IL_01d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01d7: dup
-			IL_01d8: ldc.r8 0.0
-			IL_01e1: box [System.Runtime]System.Double
-			IL_01e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01eb: dup
-			IL_01ec: ldc.r8 0.0
-			IL_01f5: box [System.Runtime]System.Double
-			IL_01fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01ff: dup
-			IL_0200: ldc.r8 0.0
-			IL_0209: box [System.Runtime]System.Double
-			IL_020e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0213: stloc.3
-			IL_0214: ldc.i4.4
-			IL_0215: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_021a: dup
-			IL_021b: ldc.r8 0.0
-			IL_0224: box [System.Runtime]System.Double
-			IL_0229: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_022e: dup
-			IL_022f: ldc.r8 1
-			IL_0238: box [System.Runtime]System.Double
-			IL_023d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0242: dup
-			IL_0243: ldc.r8 0.0
-			IL_024c: box [System.Runtime]System.Double
-			IL_0251: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0256: dup
-			IL_0257: ldc.r8 0.0
-			IL_0260: box [System.Runtime]System.Double
-			IL_0265: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_026a: stloc.s 4
-			IL_026c: ldc.i4.4
-			IL_026d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0272: dup
-			IL_0273: ldc.r8 0.0
-			IL_027c: box [System.Runtime]System.Double
-			IL_0281: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0286: dup
-			IL_0287: ldc.r8 0.0
-			IL_0290: box [System.Runtime]System.Double
-			IL_0295: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_029a: dup
-			IL_029b: ldc.r8 1
-			IL_02a4: box [System.Runtime]System.Double
-			IL_02a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02ae: dup
-			IL_02af: ldc.r8 0.0
-			IL_02b8: box [System.Runtime]System.Double
-			IL_02bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02c2: stloc.s 5
-			IL_02c4: ldarg.0
-			IL_02c5: ldc.i4.4
-			IL_02c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02cb: dup
-			IL_02cc: ldloc.3
-			IL_02cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02d2: dup
-			IL_02d3: ldloc.s 4
-			IL_02d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02da: dup
-			IL_02db: ldloc.s 5
-			IL_02dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02e2: dup
-			IL_02e3: ldc.i4.4
-			IL_02e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02e9: dup
-			IL_02ea: ldc.r8 0.0
-			IL_02f3: box [System.Runtime]System.Double
-			IL_02f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02fd: dup
-			IL_02fe: ldc.r8 0.0
-			IL_0307: box [System.Runtime]System.Double
-			IL_030c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0311: dup
-			IL_0312: ldc.r8 0.0
-			IL_031b: box [System.Runtime]System.Double
-			IL_0320: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0325: dup
-			IL_0326: ldc.r8 1
-			IL_032f: box [System.Runtime]System.Double
-			IL_0334: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0339: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_033e: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0343: ldc.i4.4
-			IL_0344: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0349: dup
-			IL_034a: ldc.r8 1
-			IL_0353: box [System.Runtime]System.Double
-			IL_0358: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_035d: dup
-			IL_035e: ldc.r8 0.0
-			IL_0367: box [System.Runtime]System.Double
-			IL_036c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0371: dup
-			IL_0372: ldc.r8 0.0
-			IL_037b: box [System.Runtime]System.Double
-			IL_0380: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0385: dup
-			IL_0386: ldc.r8 0.0
-			IL_038f: box [System.Runtime]System.Double
-			IL_0394: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0399: stloc.s 5
-			IL_039b: ldc.i4.4
-			IL_039c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_03a1: dup
-			IL_03a2: ldc.r8 0.0
-			IL_03ab: box [System.Runtime]System.Double
-			IL_03b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03b5: dup
-			IL_03b6: ldc.r8 1
-			IL_03bf: box [System.Runtime]System.Double
-			IL_03c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03c9: dup
-			IL_03ca: ldc.r8 0.0
-			IL_03d3: box [System.Runtime]System.Double
-			IL_03d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03dd: dup
-			IL_03de: ldc.r8 0.0
-			IL_03e7: box [System.Runtime]System.Double
-			IL_03ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03f1: stloc.s 4
-			IL_03f3: ldc.i4.4
-			IL_03f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_03f9: dup
-			IL_03fa: ldc.r8 0.0
-			IL_0403: box [System.Runtime]System.Double
-			IL_0408: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_040d: dup
-			IL_040e: ldc.r8 0.0
-			IL_0417: box [System.Runtime]System.Double
-			IL_041c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0421: dup
-			IL_0422: ldc.r8 1
-			IL_042b: box [System.Runtime]System.Double
-			IL_0430: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0435: dup
-			IL_0436: ldc.r8 0.0
-			IL_043f: box [System.Runtime]System.Double
-			IL_0444: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0449: stloc.3
-			IL_044a: ldarg.0
-			IL_044b: ldc.i4.4
-			IL_044c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0451: dup
-			IL_0452: ldloc.s 5
-			IL_0454: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0459: dup
-			IL_045a: ldloc.s 4
-			IL_045c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0461: dup
-			IL_0462: ldloc.3
-			IL_0463: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0468: dup
-			IL_0469: ldc.i4.4
-			IL_046a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_046f: dup
-			IL_0470: ldc.r8 0.0
-			IL_0479: box [System.Runtime]System.Double
-			IL_047e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0483: dup
-			IL_0484: ldc.r8 0.0
-			IL_048d: box [System.Runtime]System.Double
-			IL_0492: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0497: dup
-			IL_0498: ldc.r8 0.0
-			IL_04a1: box [System.Runtime]System.Double
-			IL_04a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_04ab: dup
-			IL_04ac: ldc.r8 1
-			IL_04b5: box [System.Runtime]System.Double
-			IL_04ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_04bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_04c4: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_04c9: ldc.i4.4
-			IL_04ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_04cf: dup
-			IL_04d0: ldc.r8 1
-			IL_04d9: box [System.Runtime]System.Double
-			IL_04de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_04e3: dup
-			IL_04e4: ldc.r8 0.0
-			IL_04ed: box [System.Runtime]System.Double
-			IL_04f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_04f7: dup
-			IL_04f8: ldc.r8 0.0
-			IL_0501: box [System.Runtime]System.Double
-			IL_0506: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_050b: dup
-			IL_050c: ldc.r8 0.0
-			IL_0515: box [System.Runtime]System.Double
-			IL_051a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_051f: stloc.3
-			IL_0520: ldc.i4.4
-			IL_0521: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0526: dup
-			IL_0527: ldc.r8 0.0
-			IL_0530: box [System.Runtime]System.Double
-			IL_0535: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_053a: dup
-			IL_053b: ldc.r8 1
-			IL_0544: box [System.Runtime]System.Double
-			IL_0549: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_054e: dup
-			IL_054f: ldc.r8 0.0
-			IL_0558: box [System.Runtime]System.Double
-			IL_055d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0562: dup
-			IL_0563: ldc.r8 0.0
-			IL_056c: box [System.Runtime]System.Double
-			IL_0571: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0576: stloc.s 4
-			IL_0578: ldc.i4.4
-			IL_0579: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_057e: dup
-			IL_057f: ldc.r8 0.0
-			IL_0588: box [System.Runtime]System.Double
-			IL_058d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0592: dup
-			IL_0593: ldc.r8 0.0
-			IL_059c: box [System.Runtime]System.Double
-			IL_05a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05a6: dup
-			IL_05a7: ldc.r8 1
-			IL_05b0: box [System.Runtime]System.Double
-			IL_05b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05ba: dup
-			IL_05bb: ldc.r8 0.0
-			IL_05c4: box [System.Runtime]System.Double
-			IL_05c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05ce: stloc.s 5
-			IL_05d0: ldarg.0
-			IL_05d1: ldc.i4.4
-			IL_05d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_05d7: dup
-			IL_05d8: ldloc.3
-			IL_05d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05de: dup
-			IL_05df: ldloc.s 4
-			IL_05e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05e6: dup
-			IL_05e7: ldloc.s 5
-			IL_05e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05ee: dup
-			IL_05ef: ldc.i4.4
-			IL_05f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_05f5: dup
-			IL_05f6: ldc.r8 0.0
-			IL_05ff: box [System.Runtime]System.Double
-			IL_0604: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0609: dup
-			IL_060a: ldc.r8 0.0
-			IL_0613: box [System.Runtime]System.Double
-			IL_0618: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_061d: dup
-			IL_061e: ldc.r8 0.0
-			IL_0627: box [System.Runtime]System.Double
-			IL_062c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0631: dup
-			IL_0632: ldc.r8 1
-			IL_063b: box [System.Runtime]System.Double
-			IL_0640: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0645: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_064a: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::I
-			IL_064f: ldarg.0
-			IL_0650: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0655: stloc.2
-			IL_0656: ldstr "Q"
-			IL_065b: ldloc.2
-			IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0661: stloc.2
-			IL_0662: ldarg.0
-			IL_0663: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_0668: stloc.s 6
-			IL_066a: ldstr "CreateP"
-			IL_066f: ldloc.s 6
-			IL_0671: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0676: stloc.s 6
-			IL_0678: ldarg.2
-			IL_0679: neg
-			IL_067a: box [System.Runtime]System.Double
-			IL_067f: stloc.s 7
-			IL_0681: ldarg.2
-			IL_0682: neg
-			IL_0683: box [System.Runtime]System.Double
-			IL_0688: stloc.s 8
-			IL_068a: ldloc.s 6
-			IL_068c: ldc.i4.3
-			IL_068d: newarr [System.Runtime]System.Object
-			IL_0692: dup
-			IL_0693: ldc.i4.0
-			IL_0694: ldloc.s 7
-			IL_0696: stelem.ref
-			IL_0697: dup
-			IL_0698: ldc.i4.1
-			IL_0699: ldloc.s 8
-			IL_069b: stelem.ref
-			IL_069c: dup
-			IL_069d: ldc.i4.2
-			IL_069e: ldarg.2
-			IL_069f: box [System.Runtime]System.Double
-			IL_06a4: stelem.ref
-			IL_06a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_06aa: stloc.s 6
-			IL_06ac: ldloc.2
-			IL_06ad: ldc.r8 0.0
-			IL_06b6: box [System.Runtime]System.Double
-			IL_06bb: ldloc.s 6
-			IL_06bd: ldc.i4.1
-			IL_06be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_06c3: pop
-			IL_06c4: ldarg.0
-			IL_06c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_06ca: stloc.s 6
-			IL_06cc: ldstr "Q"
-			IL_06d1: ldloc.s 6
-			IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06d8: stloc.s 6
-			IL_06da: ldarg.0
-			IL_06db: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_06e0: stloc.2
-			IL_06e1: ldstr "CreateP"
-			IL_06e6: ldloc.2
-			IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06ec: stloc.2
-			IL_06ed: ldarg.2
-			IL_06ee: neg
-			IL_06ef: box [System.Runtime]System.Double
-			IL_06f4: stloc.s 8
-			IL_06f6: ldloc.2
-			IL_06f7: ldc.i4.3
-			IL_06f8: newarr [System.Runtime]System.Object
+			IL_0167: box [System.Runtime]System.Double
+			IL_016c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0171: dup
+			IL_0172: ldc.r8 0.0
+			IL_017b: box [System.Runtime]System.Double
+			IL_0180: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0185: dup
+			IL_0186: ldc.r8 0.0
+			IL_018f: box [System.Runtime]System.Double
+			IL_0194: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0199: stloc.3
+			IL_019a: ldc.i4.4
+			IL_019b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01a0: dup
+			IL_01a1: ldc.r8 0.0
+			IL_01aa: box [System.Runtime]System.Double
+			IL_01af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01b4: dup
+			IL_01b5: ldc.r8 1
+			IL_01be: box [System.Runtime]System.Double
+			IL_01c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01c8: dup
+			IL_01c9: ldc.r8 0.0
+			IL_01d2: box [System.Runtime]System.Double
+			IL_01d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01dc: dup
+			IL_01dd: ldc.r8 0.0
+			IL_01e6: box [System.Runtime]System.Double
+			IL_01eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01f0: stloc.s 4
+			IL_01f2: ldc.i4.4
+			IL_01f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01f8: dup
+			IL_01f9: ldc.r8 0.0
+			IL_0202: box [System.Runtime]System.Double
+			IL_0207: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_020c: dup
+			IL_020d: ldc.r8 0.0
+			IL_0216: box [System.Runtime]System.Double
+			IL_021b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0220: dup
+			IL_0221: ldc.r8 1
+			IL_022a: box [System.Runtime]System.Double
+			IL_022f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0234: dup
+			IL_0235: ldc.r8 0.0
+			IL_023e: box [System.Runtime]System.Double
+			IL_0243: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0248: stloc.s 5
+			IL_024a: ldarg.0
+			IL_024b: ldc.i4.4
+			IL_024c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0251: dup
+			IL_0252: ldloc.3
+			IL_0253: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0258: dup
+			IL_0259: ldloc.s 4
+			IL_025b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0260: dup
+			IL_0261: ldloc.s 5
+			IL_0263: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0268: dup
+			IL_0269: ldc.i4.4
+			IL_026a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_026f: dup
+			IL_0270: ldc.r8 0.0
+			IL_0279: box [System.Runtime]System.Double
+			IL_027e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0283: dup
+			IL_0284: ldc.r8 0.0
+			IL_028d: box [System.Runtime]System.Double
+			IL_0292: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0297: dup
+			IL_0298: ldc.r8 0.0
+			IL_02a1: box [System.Runtime]System.Double
+			IL_02a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02ab: dup
+			IL_02ac: ldc.r8 1
+			IL_02b5: box [System.Runtime]System.Double
+			IL_02ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02c4: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_02c9: ldc.i4.4
+			IL_02ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02cf: dup
+			IL_02d0: ldc.r8 1
+			IL_02d9: box [System.Runtime]System.Double
+			IL_02de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02e3: dup
+			IL_02e4: ldc.r8 0.0
+			IL_02ed: box [System.Runtime]System.Double
+			IL_02f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02f7: dup
+			IL_02f8: ldc.r8 0.0
+			IL_0301: box [System.Runtime]System.Double
+			IL_0306: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_030b: dup
+			IL_030c: ldc.r8 0.0
+			IL_0315: box [System.Runtime]System.Double
+			IL_031a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_031f: stloc.s 5
+			IL_0321: ldc.i4.4
+			IL_0322: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0327: dup
+			IL_0328: ldc.r8 0.0
+			IL_0331: box [System.Runtime]System.Double
+			IL_0336: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_033b: dup
+			IL_033c: ldc.r8 1
+			IL_0345: box [System.Runtime]System.Double
+			IL_034a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_034f: dup
+			IL_0350: ldc.r8 0.0
+			IL_0359: box [System.Runtime]System.Double
+			IL_035e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0363: dup
+			IL_0364: ldc.r8 0.0
+			IL_036d: box [System.Runtime]System.Double
+			IL_0372: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0377: stloc.s 4
+			IL_0379: ldc.i4.4
+			IL_037a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_037f: dup
+			IL_0380: ldc.r8 0.0
+			IL_0389: box [System.Runtime]System.Double
+			IL_038e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0393: dup
+			IL_0394: ldc.r8 0.0
+			IL_039d: box [System.Runtime]System.Double
+			IL_03a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03a7: dup
+			IL_03a8: ldc.r8 1
+			IL_03b1: box [System.Runtime]System.Double
+			IL_03b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03bb: dup
+			IL_03bc: ldc.r8 0.0
+			IL_03c5: box [System.Runtime]System.Double
+			IL_03ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03cf: stloc.3
+			IL_03d0: ldarg.0
+			IL_03d1: ldc.i4.4
+			IL_03d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_03d7: dup
+			IL_03d8: ldloc.s 5
+			IL_03da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03df: dup
+			IL_03e0: ldloc.s 4
+			IL_03e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03e7: dup
+			IL_03e8: ldloc.3
+			IL_03e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03ee: dup
+			IL_03ef: ldc.i4.4
+			IL_03f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_03f5: dup
+			IL_03f6: ldc.r8 0.0
+			IL_03ff: box [System.Runtime]System.Double
+			IL_0404: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0409: dup
+			IL_040a: ldc.r8 0.0
+			IL_0413: box [System.Runtime]System.Double
+			IL_0418: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_041d: dup
+			IL_041e: ldc.r8 0.0
+			IL_0427: box [System.Runtime]System.Double
+			IL_042c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0431: dup
+			IL_0432: ldc.r8 1
+			IL_043b: box [System.Runtime]System.Double
+			IL_0440: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0445: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_044a: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_044f: ldc.i4.4
+			IL_0450: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0455: dup
+			IL_0456: ldc.r8 1
+			IL_045f: box [System.Runtime]System.Double
+			IL_0464: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0469: dup
+			IL_046a: ldc.r8 0.0
+			IL_0473: box [System.Runtime]System.Double
+			IL_0478: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_047d: dup
+			IL_047e: ldc.r8 0.0
+			IL_0487: box [System.Runtime]System.Double
+			IL_048c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0491: dup
+			IL_0492: ldc.r8 0.0
+			IL_049b: box [System.Runtime]System.Double
+			IL_04a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_04a5: stloc.3
+			IL_04a6: ldc.i4.4
+			IL_04a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_04ac: dup
+			IL_04ad: ldc.r8 0.0
+			IL_04b6: box [System.Runtime]System.Double
+			IL_04bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_04c0: dup
+			IL_04c1: ldc.r8 1
+			IL_04ca: box [System.Runtime]System.Double
+			IL_04cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_04d4: dup
+			IL_04d5: ldc.r8 0.0
+			IL_04de: box [System.Runtime]System.Double
+			IL_04e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_04e8: dup
+			IL_04e9: ldc.r8 0.0
+			IL_04f2: box [System.Runtime]System.Double
+			IL_04f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_04fc: stloc.s 4
+			IL_04fe: ldc.i4.4
+			IL_04ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0504: dup
+			IL_0505: ldc.r8 0.0
+			IL_050e: box [System.Runtime]System.Double
+			IL_0513: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0518: dup
+			IL_0519: ldc.r8 0.0
+			IL_0522: box [System.Runtime]System.Double
+			IL_0527: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_052c: dup
+			IL_052d: ldc.r8 1
+			IL_0536: box [System.Runtime]System.Double
+			IL_053b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0540: dup
+			IL_0541: ldc.r8 0.0
+			IL_054a: box [System.Runtime]System.Double
+			IL_054f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0554: stloc.s 5
+			IL_0556: ldarg.0
+			IL_0557: ldc.i4.4
+			IL_0558: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_055d: dup
+			IL_055e: ldloc.3
+			IL_055f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0564: dup
+			IL_0565: ldloc.s 4
+			IL_0567: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_056c: dup
+			IL_056d: ldloc.s 5
+			IL_056f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0574: dup
+			IL_0575: ldc.i4.4
+			IL_0576: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_057b: dup
+			IL_057c: ldc.r8 0.0
+			IL_0585: box [System.Runtime]System.Double
+			IL_058a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_058f: dup
+			IL_0590: ldc.r8 0.0
+			IL_0599: box [System.Runtime]System.Double
+			IL_059e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05a3: dup
+			IL_05a4: ldc.r8 0.0
+			IL_05ad: box [System.Runtime]System.Double
+			IL_05b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05b7: dup
+			IL_05b8: ldc.r8 1
+			IL_05c1: box [System.Runtime]System.Double
+			IL_05c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05d0: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::I
+			IL_05d5: ldarg.0
+			IL_05d6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_05db: stloc.2
+			IL_05dc: ldarg.0
+			IL_05dd: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_05e2: stloc.s 6
+			IL_05e4: ldarg.2
+			IL_05e5: neg
+			IL_05e6: box [System.Runtime]System.Double
+			IL_05eb: stloc.s 7
+			IL_05ed: ldarg.2
+			IL_05ee: neg
+			IL_05ef: box [System.Runtime]System.Double
+			IL_05f4: stloc.s 8
+			IL_05f6: ldloc.s 6
+			IL_05f8: ldc.i4.3
+			IL_05f9: newarr [System.Runtime]System.Object
+			IL_05fe: dup
+			IL_05ff: ldc.i4.0
+			IL_0600: ldloc.s 7
+			IL_0602: stelem.ref
+			IL_0603: dup
+			IL_0604: ldc.i4.1
+			IL_0605: ldloc.s 8
+			IL_0607: stelem.ref
+			IL_0608: dup
+			IL_0609: ldc.i4.2
+			IL_060a: ldarg.2
+			IL_060b: box [System.Runtime]System.Double
+			IL_0610: stelem.ref
+			IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0616: stloc.s 6
+			IL_0618: ldloc.2
+			IL_0619: ldc.r8 0.0
+			IL_0622: box [System.Runtime]System.Double
+			IL_0627: ldloc.s 6
+			IL_0629: ldc.i4.1
+			IL_062a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_062f: pop
+			IL_0630: ldarg.0
+			IL_0631: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0636: stloc.s 6
+			IL_0638: ldarg.0
+			IL_0639: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_063e: stloc.2
+			IL_063f: ldarg.2
+			IL_0640: neg
+			IL_0641: box [System.Runtime]System.Double
+			IL_0646: stloc.s 8
+			IL_0648: ldloc.2
+			IL_0649: ldc.i4.3
+			IL_064a: newarr [System.Runtime]System.Object
+			IL_064f: dup
+			IL_0650: ldc.i4.0
+			IL_0651: ldloc.s 8
+			IL_0653: stelem.ref
+			IL_0654: dup
+			IL_0655: ldc.i4.1
+			IL_0656: ldarg.2
+			IL_0657: box [System.Runtime]System.Double
+			IL_065c: stelem.ref
+			IL_065d: dup
+			IL_065e: ldc.i4.2
+			IL_065f: ldarg.2
+			IL_0660: box [System.Runtime]System.Double
+			IL_0665: stelem.ref
+			IL_0666: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_066b: stloc.2
+			IL_066c: ldloc.s 6
+			IL_066e: ldc.r8 1
+			IL_0677: box [System.Runtime]System.Double
+			IL_067c: ldloc.2
+			IL_067d: ldc.i4.1
+			IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0683: pop
+			IL_0684: ldarg.0
+			IL_0685: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_068a: stloc.2
+			IL_068b: ldarg.0
+			IL_068c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_0691: stloc.s 6
+			IL_0693: ldloc.s 6
+			IL_0695: ldc.i4.3
+			IL_0696: newarr [System.Runtime]System.Object
+			IL_069b: dup
+			IL_069c: ldc.i4.0
+			IL_069d: ldarg.2
+			IL_069e: box [System.Runtime]System.Double
+			IL_06a3: stelem.ref
+			IL_06a4: dup
+			IL_06a5: ldc.i4.1
+			IL_06a6: ldarg.2
+			IL_06a7: box [System.Runtime]System.Double
+			IL_06ac: stelem.ref
+			IL_06ad: dup
+			IL_06ae: ldc.i4.2
+			IL_06af: ldarg.2
+			IL_06b0: box [System.Runtime]System.Double
+			IL_06b5: stelem.ref
+			IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_06bb: stloc.s 6
+			IL_06bd: ldloc.2
+			IL_06be: ldc.r8 2
+			IL_06c7: box [System.Runtime]System.Double
+			IL_06cc: ldloc.s 6
+			IL_06ce: ldc.i4.1
+			IL_06cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_06d4: pop
+			IL_06d5: ldarg.0
+			IL_06d6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_06db: stloc.s 6
+			IL_06dd: ldarg.0
+			IL_06de: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_06e3: stloc.2
+			IL_06e4: ldarg.2
+			IL_06e5: neg
+			IL_06e6: box [System.Runtime]System.Double
+			IL_06eb: stloc.s 8
+			IL_06ed: ldloc.2
+			IL_06ee: ldc.i4.3
+			IL_06ef: newarr [System.Runtime]System.Object
+			IL_06f4: dup
+			IL_06f5: ldc.i4.0
+			IL_06f6: ldarg.2
+			IL_06f7: box [System.Runtime]System.Double
+			IL_06fc: stelem.ref
 			IL_06fd: dup
-			IL_06fe: ldc.i4.0
+			IL_06fe: ldc.i4.1
 			IL_06ff: ldloc.s 8
 			IL_0701: stelem.ref
 			IL_0702: dup
-			IL_0703: ldc.i4.1
+			IL_0703: ldc.i4.2
 			IL_0704: ldarg.2
 			IL_0705: box [System.Runtime]System.Double
 			IL_070a: stelem.ref
-			IL_070b: dup
-			IL_070c: ldc.i4.2
-			IL_070d: ldarg.2
-			IL_070e: box [System.Runtime]System.Double
-			IL_0713: stelem.ref
-			IL_0714: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0719: stloc.2
-			IL_071a: ldloc.s 6
-			IL_071c: ldc.r8 1
-			IL_0725: box [System.Runtime]System.Double
-			IL_072a: ldloc.2
-			IL_072b: ldc.i4.1
-			IL_072c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0731: pop
-			IL_0732: ldarg.0
-			IL_0733: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0738: stloc.2
-			IL_0739: ldstr "Q"
-			IL_073e: ldloc.2
-			IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0744: stloc.2
-			IL_0745: ldarg.0
-			IL_0746: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_074b: stloc.s 6
-			IL_074d: ldstr "CreateP"
-			IL_0752: ldloc.s 6
-			IL_0754: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0759: stloc.s 6
-			IL_075b: ldloc.s 6
-			IL_075d: ldc.i4.3
-			IL_075e: newarr [System.Runtime]System.Object
-			IL_0763: dup
-			IL_0764: ldc.i4.0
-			IL_0765: ldarg.2
-			IL_0766: box [System.Runtime]System.Double
-			IL_076b: stelem.ref
-			IL_076c: dup
-			IL_076d: ldc.i4.1
-			IL_076e: ldarg.2
-			IL_076f: box [System.Runtime]System.Double
-			IL_0774: stelem.ref
-			IL_0775: dup
-			IL_0776: ldc.i4.2
-			IL_0777: ldarg.2
-			IL_0778: box [System.Runtime]System.Double
-			IL_077d: stelem.ref
-			IL_077e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0783: stloc.s 6
-			IL_0785: ldloc.2
-			IL_0786: ldc.r8 2
-			IL_078f: box [System.Runtime]System.Double
-			IL_0794: ldloc.s 6
-			IL_0796: ldc.i4.1
-			IL_0797: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_079c: pop
-			IL_079d: ldarg.0
-			IL_079e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_07a3: stloc.s 6
-			IL_07a5: ldstr "Q"
-			IL_07aa: ldloc.s 6
-			IL_07ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_07b1: stloc.s 6
-			IL_07b3: ldarg.0
-			IL_07b4: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_07b9: stloc.2
-			IL_07ba: ldstr "CreateP"
-			IL_07bf: ldloc.2
-			IL_07c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_07c5: stloc.2
-			IL_07c6: ldarg.2
-			IL_07c7: neg
-			IL_07c8: box [System.Runtime]System.Double
-			IL_07cd: stloc.s 8
-			IL_07cf: ldloc.2
-			IL_07d0: ldc.i4.3
-			IL_07d1: newarr [System.Runtime]System.Object
-			IL_07d6: dup
-			IL_07d7: ldc.i4.0
-			IL_07d8: ldarg.2
-			IL_07d9: box [System.Runtime]System.Double
-			IL_07de: stelem.ref
-			IL_07df: dup
-			IL_07e0: ldc.i4.1
-			IL_07e1: ldloc.s 8
-			IL_07e3: stelem.ref
-			IL_07e4: dup
-			IL_07e5: ldc.i4.2
-			IL_07e6: ldarg.2
-			IL_07e7: box [System.Runtime]System.Double
-			IL_07ec: stelem.ref
-			IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_07f2: stloc.2
-			IL_07f3: ldloc.s 6
-			IL_07f5: ldc.r8 3
-			IL_07fe: box [System.Runtime]System.Double
-			IL_0803: ldloc.2
-			IL_0804: ldc.i4.1
-			IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_080a: pop
-			IL_080b: ldarg.0
-			IL_080c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0811: stloc.2
-			IL_0812: ldstr "Q"
-			IL_0817: ldloc.2
-			IL_0818: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_081d: stloc.2
-			IL_081e: ldarg.0
-			IL_081f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_0824: stloc.s 6
-			IL_0826: ldstr "CreateP"
-			IL_082b: ldloc.s 6
-			IL_082d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
+			IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0710: stloc.2
+			IL_0711: ldloc.s 6
+			IL_0713: ldc.r8 3
+			IL_071c: box [System.Runtime]System.Double
+			IL_0721: ldloc.2
+			IL_0722: ldc.i4.1
+			IL_0723: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0728: pop
+			IL_0729: ldarg.0
+			IL_072a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_072f: stloc.2
+			IL_0730: ldarg.0
+			IL_0731: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_0736: stloc.s 6
+			IL_0738: ldarg.2
+			IL_0739: neg
+			IL_073a: box [System.Runtime]System.Double
+			IL_073f: stloc.s 8
+			IL_0741: ldarg.2
+			IL_0742: neg
+			IL_0743: box [System.Runtime]System.Double
+			IL_0748: stloc.s 7
+			IL_074a: ldloc.s 6
+			IL_074c: ldc.i4.3
+			IL_074d: newarr [System.Runtime]System.Object
+			IL_0752: dup
+			IL_0753: ldc.i4.0
+			IL_0754: ldloc.s 8
+			IL_0756: stelem.ref
+			IL_0757: dup
+			IL_0758: ldc.i4.1
+			IL_0759: ldloc.s 7
+			IL_075b: stelem.ref
+			IL_075c: dup
+			IL_075d: ldc.i4.2
+			IL_075e: ldarg.2
+			IL_075f: neg
+			IL_0760: box [System.Runtime]System.Double
+			IL_0765: stelem.ref
+			IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_076b: stloc.s 6
+			IL_076d: ldloc.2
+			IL_076e: ldc.r8 4
+			IL_0777: box [System.Runtime]System.Double
+			IL_077c: ldloc.s 6
+			IL_077e: ldc.i4.1
+			IL_077f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0784: pop
+			IL_0785: ldarg.0
+			IL_0786: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_078b: stloc.s 6
+			IL_078d: ldarg.0
+			IL_078e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_0793: stloc.2
+			IL_0794: ldarg.2
+			IL_0795: neg
+			IL_0796: box [System.Runtime]System.Double
+			IL_079b: stloc.s 7
+			IL_079d: ldloc.2
+			IL_079e: ldc.i4.3
+			IL_079f: newarr [System.Runtime]System.Object
+			IL_07a4: dup
+			IL_07a5: ldc.i4.0
+			IL_07a6: ldloc.s 7
+			IL_07a8: stelem.ref
+			IL_07a9: dup
+			IL_07aa: ldc.i4.1
+			IL_07ab: ldarg.2
+			IL_07ac: box [System.Runtime]System.Double
+			IL_07b1: stelem.ref
+			IL_07b2: dup
+			IL_07b3: ldc.i4.2
+			IL_07b4: ldarg.2
+			IL_07b5: neg
+			IL_07b6: box [System.Runtime]System.Double
+			IL_07bb: stelem.ref
+			IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_07c1: stloc.2
+			IL_07c2: ldloc.s 6
+			IL_07c4: ldc.r8 5
+			IL_07cd: box [System.Runtime]System.Double
+			IL_07d2: ldloc.2
+			IL_07d3: ldc.i4.1
+			IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_07d9: pop
+			IL_07da: ldarg.0
+			IL_07db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_07e0: stloc.2
+			IL_07e1: ldarg.0
+			IL_07e2: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_07e7: stloc.s 6
+			IL_07e9: ldloc.s 6
+			IL_07eb: ldc.i4.3
+			IL_07ec: newarr [System.Runtime]System.Object
+			IL_07f1: dup
+			IL_07f2: ldc.i4.0
+			IL_07f3: ldarg.2
+			IL_07f4: box [System.Runtime]System.Double
+			IL_07f9: stelem.ref
+			IL_07fa: dup
+			IL_07fb: ldc.i4.1
+			IL_07fc: ldarg.2
+			IL_07fd: box [System.Runtime]System.Double
+			IL_0802: stelem.ref
+			IL_0803: dup
+			IL_0804: ldc.i4.2
+			IL_0805: ldarg.2
+			IL_0806: neg
+			IL_0807: box [System.Runtime]System.Double
+			IL_080c: stelem.ref
+			IL_080d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0812: stloc.s 6
+			IL_0814: ldloc.2
+			IL_0815: ldc.r8 6
+			IL_081e: box [System.Runtime]System.Double
+			IL_0823: ldloc.s 6
+			IL_0825: ldc.i4.1
+			IL_0826: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_082b: pop
+			IL_082c: ldarg.0
+			IL_082d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0832: stloc.s 6
-			IL_0834: ldarg.2
-			IL_0835: neg
-			IL_0836: box [System.Runtime]System.Double
-			IL_083b: stloc.s 8
-			IL_083d: ldarg.2
-			IL_083e: neg
-			IL_083f: box [System.Runtime]System.Double
-			IL_0844: stloc.s 7
-			IL_0846: ldloc.s 6
-			IL_0848: ldc.i4.3
-			IL_0849: newarr [System.Runtime]System.Object
-			IL_084e: dup
-			IL_084f: ldc.i4.0
-			IL_0850: ldloc.s 8
-			IL_0852: stelem.ref
-			IL_0853: dup
-			IL_0854: ldc.i4.1
-			IL_0855: ldloc.s 7
-			IL_0857: stelem.ref
-			IL_0858: dup
-			IL_0859: ldc.i4.2
-			IL_085a: ldarg.2
-			IL_085b: neg
-			IL_085c: box [System.Runtime]System.Double
-			IL_0861: stelem.ref
-			IL_0862: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0867: stloc.s 6
-			IL_0869: ldloc.2
-			IL_086a: ldc.r8 4
-			IL_0873: box [System.Runtime]System.Double
-			IL_0878: ldloc.s 6
+			IL_0834: ldarg.0
+			IL_0835: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_083a: stloc.2
+			IL_083b: ldarg.2
+			IL_083c: neg
+			IL_083d: box [System.Runtime]System.Double
+			IL_0842: stloc.s 7
+			IL_0844: ldloc.2
+			IL_0845: ldc.i4.3
+			IL_0846: newarr [System.Runtime]System.Object
+			IL_084b: dup
+			IL_084c: ldc.i4.0
+			IL_084d: ldarg.2
+			IL_084e: box [System.Runtime]System.Double
+			IL_0853: stelem.ref
+			IL_0854: dup
+			IL_0855: ldc.i4.1
+			IL_0856: ldloc.s 7
+			IL_0858: stelem.ref
+			IL_0859: dup
+			IL_085a: ldc.i4.2
+			IL_085b: ldarg.2
+			IL_085c: neg
+			IL_085d: box [System.Runtime]System.Double
+			IL_0862: stelem.ref
+			IL_0863: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0868: stloc.2
+			IL_0869: ldloc.s 6
+			IL_086b: ldc.r8 7
+			IL_0874: box [System.Runtime]System.Double
+			IL_0879: ldloc.2
 			IL_087a: ldc.i4.1
 			IL_087b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
 			IL_0880: pop
 			IL_0881: ldarg.0
 			IL_0882: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0887: stloc.s 6
-			IL_0889: ldstr "Q"
-			IL_088e: ldloc.s 6
-			IL_0890: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0895: stloc.s 6
-			IL_0897: ldarg.0
-			IL_0898: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_089d: stloc.2
-			IL_089e: ldstr "CreateP"
-			IL_08a3: ldloc.2
-			IL_08a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_08a9: stloc.2
-			IL_08aa: ldarg.2
-			IL_08ab: neg
-			IL_08ac: box [System.Runtime]System.Double
-			IL_08b1: stloc.s 7
-			IL_08b3: ldloc.2
-			IL_08b4: ldc.i4.3
-			IL_08b5: newarr [System.Runtime]System.Object
+			IL_0887: stloc.2
+			IL_0888: ldarg.0
+			IL_0889: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_088e: stloc.s 6
+			IL_0890: ldloc.s 6
+			IL_0892: ldc.i4.3
+			IL_0893: newarr [System.Runtime]System.Object
+			IL_0898: dup
+			IL_0899: ldc.i4.0
+			IL_089a: ldc.r8 0.0
+			IL_08a3: box [System.Runtime]System.Double
+			IL_08a8: stelem.ref
+			IL_08a9: dup
+			IL_08aa: ldc.i4.1
+			IL_08ab: ldc.r8 0.0
+			IL_08b4: box [System.Runtime]System.Double
+			IL_08b9: stelem.ref
 			IL_08ba: dup
-			IL_08bb: ldc.i4.0
-			IL_08bc: ldloc.s 7
-			IL_08be: stelem.ref
-			IL_08bf: dup
-			IL_08c0: ldc.i4.1
-			IL_08c1: ldarg.2
-			IL_08c2: box [System.Runtime]System.Double
-			IL_08c7: stelem.ref
-			IL_08c8: dup
-			IL_08c9: ldc.i4.2
-			IL_08ca: ldarg.2
-			IL_08cb: neg
-			IL_08cc: box [System.Runtime]System.Double
-			IL_08d1: stelem.ref
-			IL_08d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_08d7: stloc.2
-			IL_08d8: ldloc.s 6
-			IL_08da: ldc.r8 5
-			IL_08e3: box [System.Runtime]System.Double
-			IL_08e8: ldloc.2
-			IL_08e9: ldc.i4.1
-			IL_08ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_08ef: pop
-			IL_08f0: ldarg.0
-			IL_08f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_08f6: stloc.2
-			IL_08f7: ldstr "Q"
-			IL_08fc: ldloc.2
-			IL_08fd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0902: stloc.2
-			IL_0903: ldarg.0
-			IL_0904: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_0909: stloc.s 6
-			IL_090b: ldstr "CreateP"
-			IL_0910: ldloc.s 6
-			IL_0912: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0917: stloc.s 6
-			IL_0919: ldloc.s 6
-			IL_091b: ldc.i4.3
-			IL_091c: newarr [System.Runtime]System.Object
-			IL_0921: dup
-			IL_0922: ldc.i4.0
-			IL_0923: ldarg.2
-			IL_0924: box [System.Runtime]System.Double
-			IL_0929: stelem.ref
-			IL_092a: dup
-			IL_092b: ldc.i4.1
-			IL_092c: ldarg.2
-			IL_092d: box [System.Runtime]System.Double
-			IL_0932: stelem.ref
-			IL_0933: dup
-			IL_0934: ldc.i4.2
-			IL_0935: ldarg.2
-			IL_0936: neg
-			IL_0937: box [System.Runtime]System.Double
-			IL_093c: stelem.ref
-			IL_093d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0942: stloc.s 6
-			IL_0944: ldloc.2
-			IL_0945: ldc.r8 6
-			IL_094e: box [System.Runtime]System.Double
-			IL_0953: ldloc.s 6
-			IL_0955: ldc.i4.1
-			IL_0956: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_095b: pop
-			IL_095c: ldarg.0
-			IL_095d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0962: stloc.s 6
-			IL_0964: ldstr "Q"
-			IL_0969: ldloc.s 6
-			IL_096b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0970: stloc.s 6
-			IL_0972: ldarg.0
-			IL_0973: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_0978: stloc.2
-			IL_0979: ldstr "CreateP"
-			IL_097e: ldloc.2
-			IL_097f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0984: stloc.2
-			IL_0985: ldarg.2
-			IL_0986: neg
-			IL_0987: box [System.Runtime]System.Double
-			IL_098c: stloc.s 7
-			IL_098e: ldloc.2
-			IL_098f: ldc.i4.3
-			IL_0990: newarr [System.Runtime]System.Object
-			IL_0995: dup
-			IL_0996: ldc.i4.0
-			IL_0997: ldarg.2
-			IL_0998: box [System.Runtime]System.Double
-			IL_099d: stelem.ref
-			IL_099e: dup
-			IL_099f: ldc.i4.1
-			IL_09a0: ldloc.s 7
-			IL_09a2: stelem.ref
-			IL_09a3: dup
-			IL_09a4: ldc.i4.2
-			IL_09a5: ldarg.2
-			IL_09a6: neg
-			IL_09a7: box [System.Runtime]System.Double
-			IL_09ac: stelem.ref
-			IL_09ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_09b2: stloc.2
-			IL_09b3: ldloc.s 6
-			IL_09b5: ldc.r8 7
-			IL_09be: box [System.Runtime]System.Double
-			IL_09c3: ldloc.2
-			IL_09c4: ldc.i4.1
-			IL_09c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_09ca: pop
-			IL_09cb: ldarg.0
-			IL_09cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_09d1: stloc.2
-			IL_09d2: ldstr "Q"
-			IL_09d7: ldloc.2
-			IL_09d8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_09dd: stloc.2
-			IL_09de: ldarg.0
-			IL_09df: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_09e4: stloc.s 6
-			IL_09e6: ldstr "CreateP"
-			IL_09eb: ldloc.s 6
-			IL_09ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_09f2: stloc.s 6
-			IL_09f4: ldloc.s 6
-			IL_09f6: ldc.i4.3
-			IL_09f7: newarr [System.Runtime]System.Object
-			IL_09fc: dup
-			IL_09fd: ldc.i4.0
-			IL_09fe: ldc.r8 0.0
-			IL_0a07: box [System.Runtime]System.Double
-			IL_0a0c: stelem.ref
-			IL_0a0d: dup
-			IL_0a0e: ldc.i4.1
-			IL_0a0f: ldc.r8 0.0
-			IL_0a18: box [System.Runtime]System.Double
-			IL_0a1d: stelem.ref
-			IL_0a1e: dup
-			IL_0a1f: ldc.i4.2
-			IL_0a20: ldc.r8 0.0
-			IL_0a29: box [System.Runtime]System.Double
-			IL_0a2e: stelem.ref
-			IL_0a2f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0a34: stloc.s 6
-			IL_0a36: ldloc.2
-			IL_0a37: ldc.r8 8
-			IL_0a40: box [System.Runtime]System.Double
-			IL_0a45: ldloc.s 6
-			IL_0a47: ldc.i4.1
-			IL_0a48: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0a4d: pop
-			IL_0a4e: ldarg.0
-			IL_0a4f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a54: stloc.s 6
-			IL_0a56: ldstr "Q"
-			IL_0a5b: ldloc.s 6
-			IL_0a5d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0a62: stloc.s 6
-			IL_0a64: ldc.i4.3
-			IL_0a65: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_08bb: ldc.i4.2
+			IL_08bc: ldc.r8 0.0
+			IL_08c5: box [System.Runtime]System.Double
+			IL_08ca: stelem.ref
+			IL_08cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_08d0: stloc.s 6
+			IL_08d2: ldloc.2
+			IL_08d3: ldc.r8 8
+			IL_08dc: box [System.Runtime]System.Double
+			IL_08e1: ldloc.s 6
+			IL_08e3: ldc.i4.1
+			IL_08e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_08e9: pop
+			IL_08ea: ldarg.0
+			IL_08eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_08f0: stloc.s 6
+			IL_08f2: ldc.i4.3
+			IL_08f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_08f8: dup
+			IL_08f9: ldc.r8 0.0
+			IL_0902: box [System.Runtime]System.Double
+			IL_0907: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_090c: dup
+			IL_090d: ldc.r8 1
+			IL_0916: box [System.Runtime]System.Double
+			IL_091b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0920: dup
+			IL_0921: ldc.r8 2
+			IL_092a: box [System.Runtime]System.Double
+			IL_092f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0934: stloc.s 5
+			IL_0936: ldc.i4.3
+			IL_0937: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_093c: dup
+			IL_093d: ldc.r8 3
+			IL_0946: box [System.Runtime]System.Double
+			IL_094b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0950: dup
+			IL_0951: ldc.r8 2
+			IL_095a: box [System.Runtime]System.Double
+			IL_095f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0964: dup
+			IL_0965: ldc.r8 6
+			IL_096e: box [System.Runtime]System.Double
+			IL_0973: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0978: stloc.s 4
+			IL_097a: ldc.i4.3
+			IL_097b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0980: dup
+			IL_0981: ldc.r8 7
+			IL_098a: box [System.Runtime]System.Double
+			IL_098f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0994: dup
+			IL_0995: ldc.r8 6
+			IL_099e: box [System.Runtime]System.Double
+			IL_09a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_09a8: dup
+			IL_09a9: ldc.r8 5
+			IL_09b2: box [System.Runtime]System.Double
+			IL_09b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_09bc: stloc.3
+			IL_09bd: ldc.i4.3
+			IL_09be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_09c3: dup
+			IL_09c4: ldc.r8 4
+			IL_09cd: box [System.Runtime]System.Double
+			IL_09d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_09d7: dup
+			IL_09d8: ldc.r8 5
+			IL_09e1: box [System.Runtime]System.Double
+			IL_09e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_09eb: dup
+			IL_09ec: ldc.r8 1
+			IL_09f5: box [System.Runtime]System.Double
+			IL_09fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_09ff: stloc.s 9
+			IL_0a01: ldc.i4.3
+			IL_0a02: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0a07: dup
+			IL_0a08: ldc.r8 4
+			IL_0a11: box [System.Runtime]System.Double
+			IL_0a16: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0a1b: dup
+			IL_0a1c: ldc.r8 0.0
+			IL_0a25: box [System.Runtime]System.Double
+			IL_0a2a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0a2f: dup
+			IL_0a30: ldc.r8 3
+			IL_0a39: box [System.Runtime]System.Double
+			IL_0a3e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0a43: stloc.s 10
+			IL_0a45: ldc.i4.6
+			IL_0a46: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0a4b: dup
+			IL_0a4c: ldloc.s 5
+			IL_0a4e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0a53: dup
+			IL_0a54: ldloc.s 4
+			IL_0a56: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0a5b: dup
+			IL_0a5c: ldloc.3
+			IL_0a5d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0a62: dup
+			IL_0a63: ldloc.s 9
+			IL_0a65: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0a6a: dup
-			IL_0a6b: ldc.r8 0.0
-			IL_0a74: box [System.Runtime]System.Double
-			IL_0a79: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0a7e: dup
-			IL_0a7f: ldc.r8 1
-			IL_0a88: box [System.Runtime]System.Double
-			IL_0a8d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0a92: dup
-			IL_0a93: ldc.r8 2
-			IL_0a9c: box [System.Runtime]System.Double
-			IL_0aa1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0aa6: stloc.s 5
-			IL_0aa8: ldc.i4.3
-			IL_0aa9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0aae: dup
-			IL_0aaf: ldc.r8 3
-			IL_0ab8: box [System.Runtime]System.Double
-			IL_0abd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0ac2: dup
-			IL_0ac3: ldc.r8 2
-			IL_0acc: box [System.Runtime]System.Double
-			IL_0ad1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0ad6: dup
-			IL_0ad7: ldc.r8 6
-			IL_0ae0: box [System.Runtime]System.Double
-			IL_0ae5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0aea: stloc.s 4
-			IL_0aec: ldc.i4.3
-			IL_0aed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0af2: dup
-			IL_0af3: ldc.r8 7
-			IL_0afc: box [System.Runtime]System.Double
-			IL_0b01: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0b06: dup
-			IL_0b07: ldc.r8 6
-			IL_0b10: box [System.Runtime]System.Double
-			IL_0b15: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0b1a: dup
-			IL_0b1b: ldc.r8 5
-			IL_0b24: box [System.Runtime]System.Double
-			IL_0b29: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0b2e: stloc.3
-			IL_0b2f: ldc.i4.3
-			IL_0b30: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0b35: dup
-			IL_0b36: ldc.r8 4
-			IL_0b3f: box [System.Runtime]System.Double
-			IL_0b44: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0b49: dup
-			IL_0b4a: ldc.r8 5
-			IL_0b53: box [System.Runtime]System.Double
-			IL_0b58: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0b5d: dup
-			IL_0b5e: ldc.r8 1
-			IL_0b67: box [System.Runtime]System.Double
-			IL_0b6c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0b71: stloc.s 9
-			IL_0b73: ldc.i4.3
-			IL_0b74: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0b79: dup
-			IL_0b7a: ldc.r8 4
-			IL_0b83: box [System.Runtime]System.Double
-			IL_0b88: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0b8d: dup
-			IL_0b8e: ldc.r8 0.0
-			IL_0b97: box [System.Runtime]System.Double
-			IL_0b9c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0ba1: dup
-			IL_0ba2: ldc.r8 3
-			IL_0bab: box [System.Runtime]System.Double
-			IL_0bb0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0bb5: stloc.s 10
-			IL_0bb7: ldc.i4.6
-			IL_0bb8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0bbd: dup
-			IL_0bbe: ldloc.s 5
-			IL_0bc0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0bc5: dup
-			IL_0bc6: ldloc.s 4
-			IL_0bc8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0bcd: dup
-			IL_0bce: ldloc.3
-			IL_0bcf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0bd4: dup
-			IL_0bd5: ldloc.s 9
-			IL_0bd7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0bdc: dup
-			IL_0bdd: ldloc.s 10
-			IL_0bdf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0be4: dup
-			IL_0be5: ldc.i4.3
-			IL_0be6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0beb: dup
-			IL_0bec: ldc.r8 1
-			IL_0bf5: box [System.Runtime]System.Double
-			IL_0bfa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0bff: dup
-			IL_0c00: ldc.r8 5
-			IL_0c09: box [System.Runtime]System.Double
-			IL_0c0e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c13: dup
-			IL_0c14: ldc.r8 6
-			IL_0c1d: box [System.Runtime]System.Double
-			IL_0c22: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c27: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c2c: stloc.s 10
-			IL_0c2e: ldloc.s 6
-			IL_0c30: ldstr "Edge"
-			IL_0c35: ldloc.s 10
-			IL_0c37: ldc.i4.1
-			IL_0c38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0c3d: pop
-			IL_0c3e: ldarg.0
-			IL_0c3f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c44: stloc.s 6
-			IL_0c46: ldstr "Q"
-			IL_0c4b: ldloc.s 6
-			IL_0c4d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0c52: stloc.s 6
-			IL_0c54: ldc.i4.0
-			IL_0c55: newarr [System.Runtime]System.Object
-			IL_0c5a: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::Construct(object[])
-			IL_0c5f: stloc.2
-			IL_0c60: ldloc.s 6
-			IL_0c62: ldstr "Normal"
-			IL_0c67: ldloc.2
-			IL_0c68: ldc.i4.1
-			IL_0c69: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0c6e: pop
-			IL_0c6f: ldc.r8 0.0
-			IL_0c78: box [System.Runtime]System.Double
-			IL_0c7d: stloc.0
-			// loop start (head: IL_0c7e)
-				IL_0c7e: ldloc.0
-				IL_0c7f: stloc.s 7
-				IL_0c81: ldarg.0
-				IL_0c82: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0c87: stloc.2
-				IL_0c88: ldstr "Q"
-				IL_0c8d: ldloc.2
-				IL_0c8e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0c93: stloc.2
-				IL_0c94: ldloc.2
-				IL_0c95: ldstr "Edge"
-				IL_0c9a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0c9f: stloc.2
-				IL_0ca0: ldloc.2
-				IL_0ca1: ldstr "length"
-				IL_0ca6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0cab: stloc.2
-				IL_0cac: ldloc.s 7
-				IL_0cae: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0cb3: stloc.s 11
-				IL_0cb5: ldloc.2
-				IL_0cb6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0cbb: stloc.s 12
-				IL_0cbd: ldloc.s 11
-				IL_0cbf: ldloc.s 12
-				IL_0cc1: clt
-				IL_0cc3: brfalse IL_0e99
+			IL_0a6b: ldloc.s 10
+			IL_0a6d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0a72: dup
+			IL_0a73: ldc.i4.3
+			IL_0a74: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0a79: dup
+			IL_0a7a: ldc.r8 1
+			IL_0a83: box [System.Runtime]System.Double
+			IL_0a88: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0a8d: dup
+			IL_0a8e: ldc.r8 5
+			IL_0a97: box [System.Runtime]System.Double
+			IL_0a9c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0aa1: dup
+			IL_0aa2: ldc.r8 6
+			IL_0aab: box [System.Runtime]System.Double
+			IL_0ab0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0ab5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0aba: stloc.s 10
+			IL_0abc: ldloc.s 6
+			IL_0abe: ldstr "Edge"
+			IL_0ac3: ldloc.s 10
+			IL_0ac5: ldc.i4.1
+			IL_0ac6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0acb: pop
+			IL_0acc: ldc.i4.0
+			IL_0acd: newarr [System.Runtime]System.Object
+			IL_0ad2: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::Construct(object[])
+			IL_0ad7: stloc.s 6
+			IL_0ad9: ldarg.0
+			IL_0ada: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0adf: ldstr "Normal"
+			IL_0ae4: ldloc.s 6
+			IL_0ae6: ldc.i4.1
+			IL_0ae7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0aec: pop
+			IL_0aed: ldc.r8 0.0
+			IL_0af6: box [System.Runtime]System.Double
+			IL_0afb: stloc.0
+			// loop start (head: IL_0afc)
+				IL_0afc: ldloc.0
+				IL_0afd: stloc.s 7
+				IL_0aff: ldarg.0
+				IL_0b00: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b05: ldstr "Edge"
+				IL_0b0a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b0f: ldstr "length"
+				IL_0b14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b19: stloc.s 6
+				IL_0b1b: ldloc.s 7
+				IL_0b1d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0b22: stloc.s 11
+				IL_0b24: ldloc.s 11
+				IL_0b26: ldloc.s 6
+				IL_0b28: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0b2d: clt
+				IL_0b2f: brfalse IL_0c55
 
-				IL_0cc8: ldarg.0
-				IL_0cc9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0cce: stloc.2
-				IL_0ccf: ldstr "Q"
-				IL_0cd4: ldloc.2
-				IL_0cd5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0cda: stloc.2
-				IL_0cdb: ldloc.2
-				IL_0cdc: ldstr "Normal"
-				IL_0ce1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0ce6: stloc.2
-				IL_0ce7: ldarg.0
-				IL_0ce8: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcNormal
-				IL_0ced: stloc.s 6
-				IL_0cef: ldstr "CalcNormal"
-				IL_0cf4: ldloc.s 6
-				IL_0cf6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0cfb: stloc.s 6
-				IL_0cfd: ldc.i4.1
-				IL_0cfe: newarr [System.Runtime]System.Object
-				IL_0d03: dup
-				IL_0d04: ldc.i4.0
-				IL_0d05: ldarg.0
-				IL_0d06: stelem.ref
-				IL_0d07: stloc.s 13
-				IL_0d09: ldarg.0
-				IL_0d0a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0d0f: stloc.s 14
-				IL_0d11: ldstr "Q"
-				IL_0d16: ldloc.s 14
-				IL_0d18: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0d1d: stloc.s 14
-				IL_0d1f: ldarg.0
-				IL_0d20: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0d25: stloc.s 15
-				IL_0d27: ldstr "Q"
-				IL_0d2c: ldloc.s 15
-				IL_0d2e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0d33: stloc.s 15
-				IL_0d35: ldloc.s 15
-				IL_0d37: ldstr "Edge"
-				IL_0d3c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0d41: stloc.s 15
-				IL_0d43: ldloc.s 15
-				IL_0d45: ldloc.0
-				IL_0d46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0d4b: stloc.s 15
-				IL_0d4d: ldloc.s 15
-				IL_0d4f: ldc.r8 0.0
-				IL_0d58: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0d5d: stloc.s 15
-				IL_0d5f: ldloc.s 14
-				IL_0d61: ldloc.s 15
-				IL_0d63: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0d68: stloc.s 15
-				IL_0d6a: ldloc.s 15
-				IL_0d6c: ldstr "V"
-				IL_0d71: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0d76: stloc.s 15
-				IL_0d78: ldarg.0
-				IL_0d79: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0d7e: stloc.s 14
-				IL_0d80: ldstr "Q"
-				IL_0d85: ldloc.s 14
-				IL_0d87: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0d8c: stloc.s 14
-				IL_0d8e: ldarg.0
-				IL_0d8f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0d94: stloc.s 16
-				IL_0d96: ldstr "Q"
-				IL_0d9b: ldloc.s 16
-				IL_0d9d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0da2: stloc.s 16
-				IL_0da4: ldloc.s 16
-				IL_0da6: ldstr "Edge"
-				IL_0dab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0db0: stloc.s 16
-				IL_0db2: ldloc.s 16
-				IL_0db4: ldloc.0
-				IL_0db5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0dba: stloc.s 16
-				IL_0dbc: ldloc.s 16
-				IL_0dbe: ldc.r8 1
-				IL_0dc7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0dcc: stloc.s 16
-				IL_0dce: ldloc.s 14
-				IL_0dd0: ldloc.s 16
-				IL_0dd2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0dd7: stloc.s 16
-				IL_0dd9: ldloc.s 16
-				IL_0ddb: ldstr "V"
-				IL_0de0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0de5: stloc.s 16
-				IL_0de7: ldarg.0
-				IL_0de8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0ded: stloc.s 14
-				IL_0def: ldstr "Q"
-				IL_0df4: ldloc.s 14
-				IL_0df6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0dfb: stloc.s 14
-				IL_0dfd: ldarg.0
-				IL_0dfe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0e03: stloc.s 17
-				IL_0e05: ldstr "Q"
-				IL_0e0a: ldloc.s 17
-				IL_0e0c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0e11: stloc.s 17
-				IL_0e13: ldloc.s 17
-				IL_0e15: ldstr "Edge"
-				IL_0e1a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0e1f: stloc.s 17
-				IL_0e21: ldloc.s 17
-				IL_0e23: ldloc.0
-				IL_0e24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0e29: stloc.s 17
-				IL_0e2b: ldloc.s 17
-				IL_0e2d: ldc.r8 2
-				IL_0e36: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0e3b: stloc.s 17
-				IL_0e3d: ldloc.s 14
-				IL_0e3f: ldloc.s 17
-				IL_0e41: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0e46: stloc.s 17
-				IL_0e48: ldloc.s 17
-				IL_0e4a: ldstr "V"
-				IL_0e4f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0e54: stloc.s 17
-				IL_0e56: ldloc.s 6
-				IL_0e58: ldloc.s 13
-				IL_0e5a: ldloc.s 15
-				IL_0e5c: ldloc.s 16
-				IL_0e5e: ldloc.s 17
-				IL_0e60: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_0e65: stloc.s 17
-				IL_0e67: ldloc.2
-				IL_0e68: ldloc.0
-				IL_0e69: ldloc.s 17
-				IL_0e6b: ldc.i4.1
-				IL_0e6c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_0e71: pop
-				IL_0e72: ldloc.0
-				IL_0e73: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0e78: stloc.s 12
-				IL_0e7a: ldloc.s 12
-				IL_0e7c: ldc.r8 1
-				IL_0e85: add
-				IL_0e86: stloc.s 12
-				IL_0e88: ldloc.s 12
-				IL_0e8a: box [System.Runtime]System.Double
-				IL_0e8f: stloc.s 7
-				IL_0e91: ldloc.s 7
-				IL_0e93: stloc.0
-				IL_0e94: br IL_0c7e
+				IL_0b34: ldarg.0
+				IL_0b35: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b3a: ldstr "Normal"
+				IL_0b3f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b44: stloc.s 6
+				IL_0b46: ldarg.0
+				IL_0b47: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcNormal
+				IL_0b4c: stloc.2
+				IL_0b4d: ldc.i4.1
+				IL_0b4e: newarr [System.Runtime]System.Object
+				IL_0b53: dup
+				IL_0b54: ldc.i4.0
+				IL_0b55: ldarg.0
+				IL_0b56: stelem.ref
+				IL_0b57: stloc.s 12
+				IL_0b59: ldarg.0
+				IL_0b5a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b5f: stloc.s 13
+				IL_0b61: ldloc.s 13
+				IL_0b63: ldarg.0
+				IL_0b64: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b69: ldstr "Edge"
+				IL_0b6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b73: ldloc.0
+				IL_0b74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0b79: ldc.r8 0.0
+				IL_0b82: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0b87: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0b8c: ldstr "V"
+				IL_0b91: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b96: stloc.s 13
+				IL_0b98: ldarg.0
+				IL_0b99: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b9e: stloc.s 14
+				IL_0ba0: ldloc.s 14
+				IL_0ba2: ldarg.0
+				IL_0ba3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0ba8: ldstr "Edge"
+				IL_0bad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0bb2: ldloc.0
+				IL_0bb3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0bb8: ldc.r8 1
+				IL_0bc1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0bc6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0bcb: ldstr "V"
+				IL_0bd0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0bd5: stloc.s 14
+				IL_0bd7: ldarg.0
+				IL_0bd8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0bdd: stloc.s 15
+				IL_0bdf: ldloc.2
+				IL_0be0: ldloc.s 12
+				IL_0be2: ldloc.s 13
+				IL_0be4: ldloc.s 14
+				IL_0be6: ldloc.s 15
+				IL_0be8: ldarg.0
+				IL_0be9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0bee: ldstr "Edge"
+				IL_0bf3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0bf8: ldloc.0
+				IL_0bf9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0bfe: ldc.r8 2
+				IL_0c07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0c0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0c11: ldstr "V"
+				IL_0c16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0c1b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_0c20: stloc.s 14
+				IL_0c22: ldloc.s 6
+				IL_0c24: ldloc.0
+				IL_0c25: ldloc.s 14
+				IL_0c27: ldc.i4.1
+				IL_0c28: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_0c2d: pop
+				IL_0c2e: ldloc.0
+				IL_0c2f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0c34: stloc.s 11
+				IL_0c36: ldloc.s 11
+				IL_0c38: ldc.r8 1
+				IL_0c41: add
+				IL_0c42: stloc.s 11
+				IL_0c44: ldloc.s 11
+				IL_0c46: box [System.Runtime]System.Double
+				IL_0c4b: stloc.s 7
+				IL_0c4d: ldloc.s 7
+				IL_0c4f: stloc.0
+				IL_0c50: br IL_0afc
 			// end loop
 
-			IL_0e99: ldarg.0
-			IL_0e9a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e9f: stloc.s 17
-			IL_0ea1: ldstr "Q"
-			IL_0ea6: ldloc.s 17
-			IL_0ea8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0ead: stloc.s 17
-			IL_0eaf: ldc.i4.s 12
-			IL_0eb1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0eb6: dup
-			IL_0eb7: ldc.i4.0
-			IL_0eb8: box [System.Runtime]System.Boolean
-			IL_0ebd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0ec2: dup
-			IL_0ec3: ldc.i4.0
-			IL_0ec4: box [System.Runtime]System.Boolean
-			IL_0ec9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0ece: dup
-			IL_0ecf: ldc.i4.0
-			IL_0ed0: box [System.Runtime]System.Boolean
-			IL_0ed5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0eda: dup
-			IL_0edb: ldc.i4.0
-			IL_0edc: box [System.Runtime]System.Boolean
-			IL_0ee1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0ee6: dup
-			IL_0ee7: ldc.i4.0
-			IL_0ee8: box [System.Runtime]System.Boolean
-			IL_0eed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0ef2: dup
-			IL_0ef3: ldc.i4.0
-			IL_0ef4: box [System.Runtime]System.Boolean
-			IL_0ef9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0efe: dup
-			IL_0eff: ldc.i4.0
-			IL_0f00: box [System.Runtime]System.Boolean
-			IL_0f05: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0f0a: dup
-			IL_0f0b: ldc.i4.0
-			IL_0f0c: box [System.Runtime]System.Boolean
-			IL_0f11: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0f16: dup
-			IL_0f17: ldc.i4.0
-			IL_0f18: box [System.Runtime]System.Boolean
-			IL_0f1d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0f22: dup
-			IL_0f23: ldc.i4.0
-			IL_0f24: box [System.Runtime]System.Boolean
-			IL_0f29: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0f2e: dup
-			IL_0f2f: ldc.i4.0
-			IL_0f30: box [System.Runtime]System.Boolean
-			IL_0f35: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0f3a: dup
-			IL_0f3b: ldc.i4.0
-			IL_0f3c: box [System.Runtime]System.Boolean
-			IL_0f41: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0f46: stloc.s 10
-			IL_0f48: ldloc.s 17
-			IL_0f4a: ldstr "Line"
-			IL_0f4f: ldloc.s 10
-			IL_0f51: ldc.i4.1
-			IL_0f52: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0f57: pop
-			IL_0f58: ldarg.0
-			IL_0f59: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f5e: stloc.s 17
-			IL_0f60: ldstr "Q"
-			IL_0f65: ldloc.s 17
-			IL_0f67: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0f6c: stloc.s 17
-			IL_0f6e: ldc.r8 9
-			IL_0f77: ldc.r8 2
-			IL_0f80: mul
-			IL_0f81: stloc.s 12
-			IL_0f83: ldloc.s 12
-			IL_0f85: ldarg.2
-			IL_0f86: mul
-			IL_0f87: stloc.s 12
-			IL_0f89: ldloc.s 17
-			IL_0f8b: ldstr "NumPx"
-			IL_0f90: ldloc.s 12
-			IL_0f92: ldc.i4.1
-			IL_0f93: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0f98: pop
-			IL_0f99: ldc.r8 0.0
-			IL_0fa2: box [System.Runtime]System.Double
-			IL_0fa7: stloc.0
-			// loop start (head: IL_0fa8)
-				IL_0fa8: ldloc.0
-				IL_0fa9: stloc.s 7
-				IL_0fab: ldarg.0
-				IL_0fac: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0fb1: stloc.s 17
-				IL_0fb3: ldstr "Q"
-				IL_0fb8: ldloc.s 17
-				IL_0fba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0fbf: stloc.s 17
-				IL_0fc1: ldloc.s 17
-				IL_0fc3: ldstr "NumPx"
-				IL_0fc8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0fcd: stloc.s 17
-				IL_0fcf: ldloc.s 7
-				IL_0fd1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0fd6: stloc.s 12
-				IL_0fd8: ldloc.s 17
-				IL_0fda: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0fdf: stloc.s 11
-				IL_0fe1: ldloc.s 12
-				IL_0fe3: ldloc.s 11
-				IL_0fe5: clt
-				IL_0fe7: brfalse IL_106a
+			IL_0c55: ldarg.0
+			IL_0c56: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c5b: stloc.s 14
+			IL_0c5d: ldc.i4.s 12
+			IL_0c5f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0c64: dup
+			IL_0c65: ldc.i4.0
+			IL_0c66: box [System.Runtime]System.Boolean
+			IL_0c6b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c70: dup
+			IL_0c71: ldc.i4.0
+			IL_0c72: box [System.Runtime]System.Boolean
+			IL_0c77: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c7c: dup
+			IL_0c7d: ldc.i4.0
+			IL_0c7e: box [System.Runtime]System.Boolean
+			IL_0c83: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c88: dup
+			IL_0c89: ldc.i4.0
+			IL_0c8a: box [System.Runtime]System.Boolean
+			IL_0c8f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c94: dup
+			IL_0c95: ldc.i4.0
+			IL_0c96: box [System.Runtime]System.Boolean
+			IL_0c9b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0ca0: dup
+			IL_0ca1: ldc.i4.0
+			IL_0ca2: box [System.Runtime]System.Boolean
+			IL_0ca7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0cac: dup
+			IL_0cad: ldc.i4.0
+			IL_0cae: box [System.Runtime]System.Boolean
+			IL_0cb3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0cb8: dup
+			IL_0cb9: ldc.i4.0
+			IL_0cba: box [System.Runtime]System.Boolean
+			IL_0cbf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0cc4: dup
+			IL_0cc5: ldc.i4.0
+			IL_0cc6: box [System.Runtime]System.Boolean
+			IL_0ccb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0cd0: dup
+			IL_0cd1: ldc.i4.0
+			IL_0cd2: box [System.Runtime]System.Boolean
+			IL_0cd7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0cdc: dup
+			IL_0cdd: ldc.i4.0
+			IL_0cde: box [System.Runtime]System.Boolean
+			IL_0ce3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0ce8: dup
+			IL_0ce9: ldc.i4.0
+			IL_0cea: box [System.Runtime]System.Boolean
+			IL_0cef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0cf4: stloc.s 10
+			IL_0cf6: ldloc.s 14
+			IL_0cf8: ldstr "Line"
+			IL_0cfd: ldloc.s 10
+			IL_0cff: ldc.i4.1
+			IL_0d00: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0d05: pop
+			IL_0d06: ldarg.0
+			IL_0d07: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0d0c: stloc.s 14
+			IL_0d0e: ldc.r8 9
+			IL_0d17: ldc.r8 2
+			IL_0d20: mul
+			IL_0d21: stloc.s 11
+			IL_0d23: ldloc.s 11
+			IL_0d25: ldarg.2
+			IL_0d26: mul
+			IL_0d27: stloc.s 11
+			IL_0d29: ldloc.s 14
+			IL_0d2b: ldstr "NumPx"
+			IL_0d30: ldloc.s 11
+			IL_0d32: ldc.i4.1
+			IL_0d33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0d38: pop
+			IL_0d39: ldc.r8 0.0
+			IL_0d42: box [System.Runtime]System.Double
+			IL_0d47: stloc.0
+			// loop start (head: IL_0d48)
+				IL_0d48: ldloc.0
+				IL_0d49: stloc.s 7
+				IL_0d4b: ldarg.0
+				IL_0d4c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0d51: ldstr "NumPx"
+				IL_0d56: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0d5b: stloc.s 14
+				IL_0d5d: ldloc.s 7
+				IL_0d5f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0d64: stloc.s 11
+				IL_0d66: ldloc.s 11
+				IL_0d68: ldloc.s 14
+				IL_0d6a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0d6f: clt
+				IL_0d71: brfalse IL_0de6
 
-				IL_0fec: ldarg.0
-				IL_0fed: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-				IL_0ff2: stloc.s 17
-				IL_0ff4: ldstr "CreateP"
-				IL_0ff9: ldloc.s 17
-				IL_0ffb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_1000: stloc.s 17
-				IL_1002: ldloc.s 17
-				IL_1004: ldc.i4.3
-				IL_1005: newarr [System.Runtime]System.Object
-				IL_100a: dup
-				IL_100b: ldc.i4.0
-				IL_100c: ldc.r8 0.0
-				IL_1015: box [System.Runtime]System.Double
-				IL_101a: stelem.ref
-				IL_101b: dup
-				IL_101c: ldc.i4.1
-				IL_101d: ldc.r8 0.0
-				IL_1026: box [System.Runtime]System.Double
-				IL_102b: stelem.ref
-				IL_102c: dup
-				IL_102d: ldc.i4.2
-				IL_102e: ldc.r8 0.0
-				IL_1037: box [System.Runtime]System.Double
-				IL_103c: stelem.ref
-				IL_103d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-				IL_1042: pop
-				IL_1043: ldloc.0
-				IL_1044: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_1049: stloc.s 11
-				IL_104b: ldloc.s 11
-				IL_104d: ldc.r8 1
-				IL_1056: add
-				IL_1057: stloc.s 11
-				IL_1059: ldloc.s 11
-				IL_105b: box [System.Runtime]System.Double
-				IL_1060: stloc.s 7
-				IL_1062: ldloc.s 7
-				IL_1064: stloc.0
-				IL_1065: br IL_0fa8
+				IL_0d76: ldarg.0
+				IL_0d77: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+				IL_0d7c: stloc.s 14
+				IL_0d7e: ldloc.s 14
+				IL_0d80: ldc.i4.3
+				IL_0d81: newarr [System.Runtime]System.Object
+				IL_0d86: dup
+				IL_0d87: ldc.i4.0
+				IL_0d88: ldc.r8 0.0
+				IL_0d91: box [System.Runtime]System.Double
+				IL_0d96: stelem.ref
+				IL_0d97: dup
+				IL_0d98: ldc.i4.1
+				IL_0d99: ldc.r8 0.0
+				IL_0da2: box [System.Runtime]System.Double
+				IL_0da7: stelem.ref
+				IL_0da8: dup
+				IL_0da9: ldc.i4.2
+				IL_0daa: ldc.r8 0.0
+				IL_0db3: box [System.Runtime]System.Double
+				IL_0db8: stelem.ref
+				IL_0db9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+				IL_0dbe: pop
+				IL_0dbf: ldloc.0
+				IL_0dc0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0dc5: stloc.s 11
+				IL_0dc7: ldloc.s 11
+				IL_0dc9: ldc.r8 1
+				IL_0dd2: add
+				IL_0dd3: stloc.s 11
+				IL_0dd5: ldloc.s 11
+				IL_0dd7: box [System.Runtime]System.Double
+				IL_0ddc: stloc.s 7
+				IL_0dde: ldloc.s 7
+				IL_0de0: stloc.0
+				IL_0de1: br IL_0d48
 			// end loop
 
-			IL_106a: ldarg.0
-			IL_106b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
-			IL_1070: stloc.s 17
-			IL_1072: ldstr "Translate"
-			IL_1077: ldloc.s 17
-			IL_1079: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_107e: stloc.s 17
-			IL_1080: ldc.i4.1
-			IL_1081: newarr [System.Runtime]System.Object
-			IL_1086: dup
-			IL_1087: ldc.i4.0
-			IL_1088: ldarg.0
-			IL_1089: stelem.ref
-			IL_108a: stloc.s 13
-			IL_108c: ldarg.0
-			IL_108d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_1092: stloc.2
-			IL_1093: ldstr "MTrans"
-			IL_1098: ldloc.2
-			IL_1099: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_109e: stloc.2
-			IL_109f: ldarg.0
-			IL_10a0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_10a5: stloc.s 16
-			IL_10a7: ldstr "Origin"
-			IL_10ac: ldloc.s 16
-			IL_10ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_10b3: stloc.s 16
-			IL_10b5: ldloc.s 16
-			IL_10b7: ldstr "V"
-			IL_10bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_10c1: stloc.s 16
-			IL_10c3: ldloc.s 16
-			IL_10c5: ldc.r8 0.0
-			IL_10ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_10d3: stloc.s 16
-			IL_10d5: ldarg.0
-			IL_10d6: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_10db: stloc.s 15
-			IL_10dd: ldstr "Origin"
-			IL_10e2: ldloc.s 15
-			IL_10e4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_10e9: stloc.s 15
-			IL_10eb: ldloc.s 15
-			IL_10ed: ldstr "V"
-			IL_10f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_10f7: stloc.s 15
-			IL_10f9: ldloc.s 15
-			IL_10fb: ldc.r8 1
-			IL_1104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1109: stloc.s 15
-			IL_110b: ldarg.0
-			IL_110c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_1111: stloc.s 6
-			IL_1113: ldstr "Origin"
-			IL_1118: ldloc.s 6
-			IL_111a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_111f: stloc.s 6
-			IL_1121: ldloc.s 6
-			IL_1123: ldstr "V"
-			IL_1128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_112d: stloc.s 6
-			IL_112f: ldloc.s 6
-			IL_1131: ldc.r8 2
-			IL_113a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_113f: stloc.s 6
-			IL_1141: ldc.i4.4
-			IL_1142: newarr [System.Runtime]System.Object
-			IL_1147: dup
-			IL_1148: ldc.i4.0
-			IL_1149: ldloc.2
-			IL_114a: stelem.ref
-			IL_114b: dup
-			IL_114c: ldc.i4.1
-			IL_114d: ldloc.s 16
-			IL_114f: stelem.ref
-			IL_1150: dup
-			IL_1151: ldc.i4.2
-			IL_1152: ldloc.s 15
-			IL_1154: stelem.ref
-			IL_1155: dup
-			IL_1156: ldc.i4.3
-			IL_1157: ldloc.s 6
-			IL_1159: stelem.ref
-			IL_115a: stloc.s 18
-			IL_115c: ldloc.s 17
-			IL_115e: ldloc.s 13
-			IL_1160: ldloc.s 18
-			IL_1162: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_1167: stloc.s 17
-			IL_1169: ldarg.0
-			IL_116a: ldloc.s 17
-			IL_116c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_1171: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_1176: ldarg.0
-			IL_1177: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
-			IL_117c: stloc.s 17
-			IL_117e: ldstr "MMulti"
-			IL_1183: ldloc.s 17
-			IL_1185: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_118a: stloc.s 17
-			IL_118c: ldc.i4.1
-			IL_118d: newarr [System.Runtime]System.Object
-			IL_1192: dup
-			IL_1193: ldc.i4.0
-			IL_1194: ldarg.0
-			IL_1195: stelem.ref
-			IL_1196: stloc.s 18
-			IL_1198: ldarg.0
-			IL_1199: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_119e: stloc.s 6
-			IL_11a0: ldstr "MTrans"
-			IL_11a5: ldloc.s 6
-			IL_11a7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_11ac: stloc.s 6
-			IL_11ae: ldarg.0
-			IL_11af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_11b4: stloc.s 15
-			IL_11b6: ldstr "MQube"
-			IL_11bb: ldloc.s 15
-			IL_11bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_11c2: stloc.s 15
-			IL_11c4: ldloc.s 17
-			IL_11c6: ldloc.s 18
-			IL_11c8: ldloc.s 6
-			IL_11ca: ldloc.s 15
-			IL_11cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_11d1: stloc.s 15
-			IL_11d3: ldarg.0
-			IL_11d4: ldloc.s 15
-			IL_11d6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_11db: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_11e0: ldc.r8 0.0
-			IL_11e9: box [System.Runtime]System.Double
-			IL_11ee: stloc.0
-			// loop start (head: IL_11ef)
-				IL_11ef: ldloc.0
-				IL_11f0: stloc.s 7
-				IL_11f2: ldloc.s 7
-				IL_11f4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_11f9: stloc.s 11
-				IL_11fb: ldloc.s 11
-				IL_11fd: ldc.r8 9
-				IL_1206: clt
-				IL_1208: brfalse IL_12df
+			IL_0de6: ldarg.0
+			IL_0de7: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
+			IL_0dec: stloc.s 14
+			IL_0dee: ldc.i4.1
+			IL_0def: newarr [System.Runtime]System.Object
+			IL_0df4: dup
+			IL_0df5: ldc.i4.0
+			IL_0df6: ldarg.0
+			IL_0df7: stelem.ref
+			IL_0df8: stloc.s 12
+			IL_0dfa: ldarg.0
+			IL_0dfb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0e00: stloc.s 6
+			IL_0e02: ldarg.0
+			IL_0e03: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0e08: ldstr "V"
+			IL_0e0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e12: ldc.r8 0.0
+			IL_0e1b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e20: stloc.s 13
+			IL_0e22: ldarg.0
+			IL_0e23: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0e28: ldstr "V"
+			IL_0e2d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e32: ldc.r8 1
+			IL_0e3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e40: stloc.2
+			IL_0e41: ldloc.s 14
+			IL_0e43: ldloc.s 12
+			IL_0e45: ldc.i4.4
+			IL_0e46: newarr [System.Runtime]System.Object
+			IL_0e4b: dup
+			IL_0e4c: ldc.i4.0
+			IL_0e4d: ldloc.s 6
+			IL_0e4f: stelem.ref
+			IL_0e50: dup
+			IL_0e51: ldc.i4.1
+			IL_0e52: ldloc.s 13
+			IL_0e54: stelem.ref
+			IL_0e55: dup
+			IL_0e56: ldc.i4.2
+			IL_0e57: ldloc.2
+			IL_0e58: stelem.ref
+			IL_0e59: dup
+			IL_0e5a: ldc.i4.3
+			IL_0e5b: ldarg.0
+			IL_0e5c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0e61: ldstr "V"
+			IL_0e66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e6b: ldc.r8 2
+			IL_0e74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e79: stelem.ref
+			IL_0e7a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0e7f: stloc.s 14
+			IL_0e81: ldarg.0
+			IL_0e82: ldloc.s 14
+			IL_0e84: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e89: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0e8e: ldc.i4.1
+			IL_0e8f: newarr [System.Runtime]System.Object
+			IL_0e94: dup
+			IL_0e95: ldc.i4.0
+			IL_0e96: ldarg.0
+			IL_0e97: stelem.ref
+			IL_0e98: stloc.s 12
+			IL_0e9a: ldarg.0
+			IL_0e9b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0ea0: stloc.s 14
+			IL_0ea2: ldarg.0
+			IL_0ea3: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
+			IL_0ea8: ldloc.s 12
+			IL_0eaa: ldloc.s 14
+			IL_0eac: ldarg.0
+			IL_0ead: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0eb2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0eb7: stloc.s 14
+			IL_0eb9: ldarg.0
+			IL_0eba: ldloc.s 14
+			IL_0ebc: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0ec1: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0ec6: ldc.r8 0.0
+			IL_0ecf: box [System.Runtime]System.Double
+			IL_0ed4: stloc.0
+			// loop start (head: IL_0ed5)
+				IL_0ed5: ldloc.0
+				IL_0ed6: stloc.s 7
+				IL_0ed8: ldloc.s 7
+				IL_0eda: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0edf: stloc.s 11
+				IL_0ee1: ldloc.s 11
+				IL_0ee3: ldc.r8 9
+				IL_0eec: clt
+				IL_0eee: brfalse IL_0f7b
 
-				IL_120d: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Init/Scope/Block_L324C23::.ctor()
-				IL_1212: stloc.1
-				IL_1213: ldarg.0
-				IL_1214: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_1219: stloc.s 15
-				IL_121b: ldstr "Q"
-				IL_1220: ldloc.s 15
-				IL_1222: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_1227: stloc.s 15
-				IL_1229: ldloc.s 15
-				IL_122b: ldloc.0
-				IL_122c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_1231: stloc.s 15
-				IL_1233: ldarg.0
-				IL_1234: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
-				IL_1239: stloc.s 6
-				IL_123b: ldstr "VMulti"
-				IL_1240: ldloc.s 6
-				IL_1242: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_1247: stloc.s 6
-				IL_1249: ldc.i4.1
-				IL_124a: newarr [System.Runtime]System.Object
-				IL_124f: dup
-				IL_1250: ldc.i4.0
-				IL_1251: ldarg.0
-				IL_1252: stelem.ref
-				IL_1253: stloc.s 18
-				IL_1255: ldarg.0
-				IL_1256: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-				IL_125b: stloc.s 17
-				IL_125d: ldstr "MTrans"
-				IL_1262: ldloc.s 17
-				IL_1264: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_1269: stloc.s 17
-				IL_126b: ldarg.0
-				IL_126c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_1271: stloc.s 16
-				IL_1273: ldstr "Q"
-				IL_1278: ldloc.s 16
-				IL_127a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_127f: stloc.s 16
-				IL_1281: ldloc.s 16
-				IL_1283: ldloc.0
-				IL_1284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_1289: stloc.s 16
-				IL_128b: ldloc.s 16
-				IL_128d: ldstr "V"
-				IL_1292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_1297: stloc.s 16
-				IL_1299: ldloc.s 6
-				IL_129b: ldloc.s 18
-				IL_129d: ldloc.s 17
-				IL_129f: ldloc.s 16
-				IL_12a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_12a6: stloc.s 16
-				IL_12a8: ldloc.s 15
-				IL_12aa: ldstr "V"
-				IL_12af: ldloc.s 16
-				IL_12b1: ldc.i4.1
-				IL_12b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_12b7: pop
-				IL_12b8: ldloc.0
-				IL_12b9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_12be: stloc.s 11
-				IL_12c0: ldloc.s 11
-				IL_12c2: ldc.r8 1
-				IL_12cb: add
-				IL_12cc: stloc.s 11
-				IL_12ce: ldloc.s 11
-				IL_12d0: box [System.Runtime]System.Double
-				IL_12d5: stloc.s 7
-				IL_12d7: ldloc.s 7
-				IL_12d9: stloc.0
-				IL_12da: br IL_11ef
+				IL_0ef3: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Init/Scope/Block_L324C23::.ctor()
+				IL_0ef8: stloc.1
+				IL_0ef9: ldarg.0
+				IL_0efa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0eff: ldloc.0
+				IL_0f00: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0f05: stloc.s 14
+				IL_0f07: ldarg.0
+				IL_0f08: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
+				IL_0f0d: stloc.2
+				IL_0f0e: ldc.i4.1
+				IL_0f0f: newarr [System.Runtime]System.Object
+				IL_0f14: dup
+				IL_0f15: ldc.i4.0
+				IL_0f16: ldarg.0
+				IL_0f17: stelem.ref
+				IL_0f18: stloc.s 12
+				IL_0f1a: ldarg.0
+				IL_0f1b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+				IL_0f20: stloc.s 13
+				IL_0f22: ldloc.2
+				IL_0f23: ldloc.s 12
+				IL_0f25: ldloc.s 13
+				IL_0f27: ldarg.0
+				IL_0f28: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0f2d: ldloc.0
+				IL_0f2e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0f33: ldstr "V"
+				IL_0f38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0f3d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_0f42: stloc.s 13
+				IL_0f44: ldloc.s 14
+				IL_0f46: ldstr "V"
+				IL_0f4b: ldloc.s 13
+				IL_0f4d: ldc.i4.1
+				IL_0f4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0f53: pop
+				IL_0f54: ldloc.0
+				IL_0f55: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0f5a: stloc.s 11
+				IL_0f5c: ldloc.s 11
+				IL_0f5e: ldc.r8 1
+				IL_0f67: add
+				IL_0f68: stloc.s 11
+				IL_0f6a: ldloc.s 11
+				IL_0f6c: box [System.Runtime]System.Double
+				IL_0f71: stloc.s 7
+				IL_0f73: ldloc.s 7
+				IL_0f75: stloc.0
+				IL_0f76: br IL_0ed5
 			// end loop
 
-			IL_12df: ldarg.0
-			IL_12e0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
-			IL_12e5: stloc.s 16
-			IL_12e7: ldstr "DrawQube"
-			IL_12ec: ldloc.s 16
-			IL_12ee: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_12f3: stloc.s 16
-			IL_12f5: ldloc.s 16
-			IL_12f7: ldc.i4.1
-			IL_12f8: newarr [System.Runtime]System.Object
-			IL_12fd: dup
-			IL_12fe: ldc.i4.0
-			IL_12ff: ldarg.0
-			IL_1300: stelem.ref
-			IL_1301: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_1306: pop
-			IL_1307: ldarg.0
-			IL_1308: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_130d: stloc.s 16
-			IL_130f: ldstr "Testing"
-			IL_1314: ldloc.s 16
-			IL_1316: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_131b: stloc.s 16
-			IL_131d: ldloc.s 16
-			IL_131f: ldstr "Init"
-			IL_1324: ldc.i4.1
-			IL_1325: box [System.Runtime]System.Boolean
-			IL_132a: ldc.i4.1
-			IL_132b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_1330: pop
-			IL_1331: ldarg.0
-			IL_1332: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
-			IL_1337: stloc.s 16
-			IL_1339: ldstr "Loop"
-			IL_133e: ldloc.s 16
-			IL_1340: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_1345: stloc.s 16
-			IL_1347: ldloc.s 16
-			IL_1349: ldc.i4.1
-			IL_134a: newarr [System.Runtime]System.Object
-			IL_134f: dup
-			IL_1350: ldc.i4.0
-			IL_1351: ldarg.0
-			IL_1352: stelem.ref
-			IL_1353: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_1358: pop
-			IL_1359: ldnull
-			IL_135a: ret
+			IL_0f7b: ldarg.0
+			IL_0f7c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
+			IL_0f81: ldc.i4.1
+			IL_0f82: newarr [System.Runtime]System.Object
+			IL_0f87: dup
+			IL_0f88: ldc.i4.0
+			IL_0f89: ldarg.0
+			IL_0f8a: stelem.ref
+			IL_0f8b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0f90: pop
+			IL_0f91: ldarg.0
+			IL_0f92: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_0f97: stloc.s 13
+			IL_0f99: ldloc.s 13
+			IL_0f9b: ldstr "Init"
+			IL_0fa0: ldc.i4.1
+			IL_0fa1: box [System.Runtime]System.Boolean
+			IL_0fa6: ldc.i4.1
+			IL_0fa7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0fac: pop
+			IL_0fad: ldarg.0
+			IL_0fae: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
+			IL_0fb3: ldc.i4.1
+			IL_0fb4: newarr [System.Runtime]System.Object
+			IL_0fb9: dup
+			IL_0fba: ldc.i4.0
+			IL_0fbb: ldarg.0
+			IL_0fbc: stelem.ref
+			IL_0fbd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0fc2: pop
+			IL_0fc3: ldnull
+			IL_0fc4: ret
 		} // end of method Init::__js_call__
 
 	} // end of class Init
@@ -8376,7 +6987,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x7502
+				// Method begins at RVA 0x65fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8402,9 +7013,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x723c
+			// Method begins at RVA 0x6350
 			// Header size: 12
-			// Code size: 113 (0x71)
+			// Code size: 87 (0x57)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -8415,48 +7026,38 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Init
 			IL_0006: stloc.1
-			IL_0007: ldstr "Init"
-			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.2
-			IL_001e: ldloc.1
-			IL_001f: ldloc.2
-			IL_0020: ldc.r8 20
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0033: pop
-			IL_0034: ldarg.0
-			IL_0035: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_003a: stloc.1
-			IL_003b: ldstr "Q"
-			IL_0040: ldloc.1
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0046: stloc.1
-			IL_0047: ldloc.1
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-			IL_004d: stloc.1
-			IL_004e: ldloc.1
-			IL_004f: stloc.0
-			IL_0050: ldstr "console"
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_005a: stloc.1
-			IL_005b: ldloc.1
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0061: stloc.1
-			IL_0062: ldloc.1
-			IL_0063: ldstr "log"
-			IL_0068: ldloc.0
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_006e: pop
-			IL_006f: ldnull
-			IL_0070: ret
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.2
+			IL_0012: ldloc.1
+			IL_0013: ldloc.2
+			IL_0014: ldc.r8 20
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: pop
+			IL_0028: ldarg.0
+			IL_0029: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+			IL_0033: stloc.1
+			IL_0034: ldloc.1
+			IL_0035: stloc.0
+			IL_0036: ldstr "console"
+			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0040: stloc.1
+			IL_0041: ldloc.1
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0047: stloc.1
+			IL_0048: ldloc.1
+			IL_0049: ldstr "log"
+			IL_004e: ldloc.0
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0054: pop
+			IL_0055: ldnull
+			IL_0056: ret
 		} // end of method FunctionExpression_L334C23::__js_call__
 
 	} // end of class FunctionExpression_L334C23
@@ -8505,7 +7106,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x72b9
+			// Method begins at RVA 0x63b3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -8990,7 +7591,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x750b
+		// Method begins at RVA 0x6605
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3d6a
+				// Method begins at RVA 0x39d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,7 +47,7 @@
 			)
 			// Method begins at RVA 0x24bc
 			// Header size: 12
-			// Code size: 46 (0x2e)
+			// Code size: 32 (0x20)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -55,22 +55,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::fs
-			IL_0006: stloc.0
-			IL_0007: ldstr "fs"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "readFileSync"
-			IL_0020: ldarg.2
-			IL_0021: ldstr "utf8"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_002b: stloc.0
-			IL_002c: ldloc.0
-			IL_002d: ret
+			IL_000d: ldstr "readFileSync"
+			IL_0012: ldarg.2
+			IL_0013: ldstr "utf8"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_001d: stloc.0
+			IL_001e: ldloc.0
+			IL_001f: ret
 		} // end of method readFile::__js_call__
 
 	} // end of class readFile
@@ -86,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3d73
+				// Method begins at RVA 0x39d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,9 +108,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x24f8
+			// Method begins at RVA 0x24e8
 			// Header size: 12
-			// Code size: 47 (0x2f)
+			// Code size: 33 (0x21)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -124,23 +118,17 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::fs
-			IL_0006: stloc.0
-			IL_0007: ldstr "fs"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "writeFileSync"
-			IL_0020: ldarg.2
-			IL_0021: ldarg.3
-			IL_0022: ldstr "utf8"
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_002c: pop
-			IL_002d: ldnull
-			IL_002e: ret
+			IL_000d: ldstr "writeFileSync"
+			IL_0012: ldarg.2
+			IL_0013: ldarg.3
+			IL_0014: ldstr "utf8"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_001e: pop
+			IL_001f: ldnull
+			IL_0020: ret
 		} // end of method writeFile::__js_call__
 
 	} // end of class writeFile
@@ -156,7 +144,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3d7c
+				// Method begins at RVA 0x39e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +168,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2534
+			// Method begins at RVA 0x2518
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -268,7 +256,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d8e
+					// Method begins at RVA 0x39f4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -292,7 +280,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3bf0
+				// Method begins at RVA 0x3874
 				// Header size: 12
 				// Code size: 30 (0x1e)
 				.maxstack 8
@@ -332,7 +320,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d97
+					// Method begins at RVA 0x39fd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -356,7 +344,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3c1c
+				// Method begins at RVA 0x38a0
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -388,7 +376,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3da0
+					// Method begins at RVA 0x3a06
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -406,7 +394,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3d85
+				// Method begins at RVA 0x39eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -431,7 +419,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25c4
+			// Method begins at RVA 0x25a8
 			// Header size: 12
 			// Code size: 950 (0x3b6)
 			.maxstack 8
@@ -831,7 +819,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3da9
+				// Method begins at RVA 0x3a0f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -859,7 +847,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2998
+			// Method begins at RVA 0x297c
 			// Header size: 12
 			// Code size: 224 (0xe0)
 			.maxstack 8
@@ -906,9 +894,9 @@
 			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_004f: stloc.3
 			IL_0050: ldloc.3
-			IL_0051: ldstr "test"
+			IL_0051: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			IL_0056: ldarg.2
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0057: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 			IL_005c: stloc.3
 			IL_005d: ldloc.3
 			IL_005e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
@@ -938,9 +926,9 @@
 			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0099: stloc.3
 			IL_009a: ldloc.3
-			IL_009b: ldstr "test"
+			IL_009b: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			IL_00a0: ldarg.2
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 			IL_00a6: stloc.3
 			IL_00a7: ldloc.3
 			IL_00a8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
@@ -989,7 +977,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3dbb
+					// Method begins at RVA 0x3a21
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1007,7 +995,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3db2
+				// Method begins at RVA 0x3a18
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1032,7 +1020,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a84
+			// Method begins at RVA 0x2a68
 			// Header size: 12
 			// Code size: 195 (0xc3)
 			.maxstack 8
@@ -1132,7 +1120,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3dcd
+					// Method begins at RVA 0x3a33
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1150,7 +1138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3dc4
+				// Method begins at RVA 0x3a2a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1175,7 +1163,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b54
+			// Method begins at RVA 0x2b38
 			// Header size: 12
 			// Code size: 171 (0xab)
 			.maxstack 8
@@ -1199,9 +1187,9 @@
 			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0018: stloc.s 4
 			IL_001a: ldloc.s 4
-			IL_001c: ldstr "test"
+			IL_001c: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			IL_0021: ldarg.1
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0022: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 			IL_0027: stloc.s 4
 			IL_0029: ldloc.s 4
 			IL_002b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
@@ -1272,7 +1260,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ddf
+					// Method begins at RVA 0x3a45
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1290,7 +1278,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3dd6
+				// Method begins at RVA 0x3a3c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1317,7 +1305,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2c0c
+			// Method begins at RVA 0x2bf0
 			// Header size: 12
 			// Code size: 569 (0x239)
 			.maxstack 8
@@ -1545,7 +1533,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3de8
+				// Method begins at RVA 0x3a4e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1569,7 +1557,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e54
+			// Method begins at RVA 0x2e38
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -1594,9 +1582,9 @@
 			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0029: stloc.2
 			IL_002a: ldloc.1
-			IL_002b: ldstr "test"
+			IL_002b: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			IL_0030: ldloc.2
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0031: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 			IL_0036: stloc.2
 			IL_0037: ldloc.2
 			IL_0038: ret
@@ -1625,7 +1613,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3dfa
+					// Method begins at RVA 0x3a60
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1650,9 +1638,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3c38
+				// Method begins at RVA 0x38bc
 				// Header size: 12
-				// Code size: 150 (0x96)
+				// Code size: 136 (0x88)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -1688,51 +1676,45 @@
 				IL_003b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_0040: stloc.2
 				IL_0041: ldloc.2
-				IL_0042: brfalse IL_0094
+				IL_0042: brfalse IL_0086
 
-				IL_0047: ldarg.0
-				IL_0048: ldc.i4.0
-				IL_0049: ldelem.ref
-				IL_004a: castclass Modules.Compile_Scripts_BumpVersion/Scope
-				IL_004f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
-				IL_0054: stloc.0
-				IL_0055: ldstr "isPlaceholder"
-				IL_005a: ldloc.0
-				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0060: stloc.0
-				IL_0061: ldc.i4.2
-				IL_0062: newarr [System.Runtime]System.Object
-				IL_0067: dup
-				IL_0068: ldc.i4.0
-				IL_0069: ldarg.0
-				IL_006a: ldc.i4.0
-				IL_006b: ldelem.ref
-				IL_006c: stelem.ref
-				IL_006d: dup
-				IL_006e: ldc.i4.1
-				IL_006f: ldarg.0
-				IL_0070: ldc.i4.1
-				IL_0071: ldelem.ref
-				IL_0072: stelem.ref
-				IL_0073: stloc.s 4
-				IL_0075: ldloc.0
-				IL_0076: ldloc.s 4
-				IL_0078: ldarg.2
-				IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_007e: stloc.0
-				IL_007f: ldloc.0
-				IL_0080: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0085: ldc.i4.0
-				IL_0086: ceq
-				IL_0088: stloc.2
-				IL_0089: ldloc.2
-				IL_008a: box [System.Runtime]System.Boolean
-				IL_008f: stloc.s 5
-				IL_0091: ldloc.s 5
-				IL_0093: ret
+				IL_0047: ldc.i4.2
+				IL_0048: newarr [System.Runtime]System.Object
+				IL_004d: dup
+				IL_004e: ldc.i4.0
+				IL_004f: ldarg.0
+				IL_0050: ldc.i4.0
+				IL_0051: ldelem.ref
+				IL_0052: stelem.ref
+				IL_0053: dup
+				IL_0054: ldc.i4.1
+				IL_0055: ldarg.0
+				IL_0056: ldc.i4.1
+				IL_0057: ldelem.ref
+				IL_0058: stelem.ref
+				IL_0059: stloc.s 4
+				IL_005b: ldarg.0
+				IL_005c: ldc.i4.0
+				IL_005d: ldelem.ref
+				IL_005e: castclass Modules.Compile_Scripts_BumpVersion/Scope
+				IL_0063: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
+				IL_0068: ldloc.s 4
+				IL_006a: ldarg.2
+				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0070: stloc.0
+				IL_0071: ldloc.0
+				IL_0072: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0077: ldc.i4.0
+				IL_0078: ceq
+				IL_007a: stloc.2
+				IL_007b: ldloc.2
+				IL_007c: box [System.Runtime]System.Boolean
+				IL_0081: stloc.s 5
+				IL_0083: ldloc.s 5
+				IL_0085: ret
 
-				IL_0094: ldloc.3
-				IL_0095: ret
+				IL_0086: ldloc.3
+				IL_0087: ret
 			} // end of method ArrowFunction_L113C44::__js_call__
 
 		} // end of class ArrowFunction_L113C44
@@ -1744,7 +1726,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3df1
+				// Method begins at RVA 0x3a57
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1772,7 +1754,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2e9c
+			// Method begins at RVA 0x2e80
 			// Header size: 12
 			// Code size: 375 (0x177)
 			.maxstack 8
@@ -1939,7 +1921,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e15
+					// Method begins at RVA 0x3a7b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1964,15 +1946,15 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3cdc
+				// Method begins at RVA 0x3950
 				// Header size: 12
-				// Code size: 121 (0x79)
+				// Code size: 107 (0x6b)
 				.maxstack 8
 				.locals init (
 					[0] object,
 					[1] bool,
-					[2] object,
-					[3] object[],
+					[2] object[],
+					[3] object,
 					[4] object
 				)
 
@@ -1991,51 +1973,45 @@
 				IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_0025: stloc.1
 				IL_0026: ldloc.1
-				IL_0027: brfalse IL_0077
+				IL_0027: brfalse IL_0069
 
-				IL_002c: ldarg.0
-				IL_002d: ldc.i4.0
-				IL_002e: ldelem.ref
-				IL_002f: castclass Modules.Compile_Scripts_BumpVersion/Scope
-				IL_0034: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
-				IL_0039: stloc.2
-				IL_003a: ldstr "isPlaceholder"
-				IL_003f: ldloc.2
-				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0045: stloc.2
-				IL_0046: ldc.i4.2
-				IL_0047: newarr [System.Runtime]System.Object
-				IL_004c: dup
-				IL_004d: ldc.i4.0
-				IL_004e: ldarg.0
-				IL_004f: ldc.i4.0
-				IL_0050: ldelem.ref
-				IL_0051: stelem.ref
-				IL_0052: dup
-				IL_0053: ldc.i4.1
-				IL_0054: ldarg.0
-				IL_0055: ldc.i4.1
-				IL_0056: ldelem.ref
-				IL_0057: stelem.ref
-				IL_0058: stloc.3
-				IL_0059: ldloc.2
-				IL_005a: ldloc.3
-				IL_005b: ldarg.2
-				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0061: stloc.2
-				IL_0062: ldloc.2
-				IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0068: ldc.i4.0
-				IL_0069: ceq
-				IL_006b: stloc.1
-				IL_006c: ldloc.1
-				IL_006d: box [System.Runtime]System.Boolean
-				IL_0072: stloc.s 4
-				IL_0074: ldloc.s 4
-				IL_0076: ret
+				IL_002c: ldc.i4.2
+				IL_002d: newarr [System.Runtime]System.Object
+				IL_0032: dup
+				IL_0033: ldc.i4.0
+				IL_0034: ldarg.0
+				IL_0035: ldc.i4.0
+				IL_0036: ldelem.ref
+				IL_0037: stelem.ref
+				IL_0038: dup
+				IL_0039: ldc.i4.1
+				IL_003a: ldarg.0
+				IL_003b: ldc.i4.1
+				IL_003c: ldelem.ref
+				IL_003d: stelem.ref
+				IL_003e: stloc.2
+				IL_003f: ldarg.0
+				IL_0040: ldc.i4.0
+				IL_0041: ldelem.ref
+				IL_0042: castclass Modules.Compile_Scripts_BumpVersion/Scope
+				IL_0047: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
+				IL_004c: ldloc.2
+				IL_004d: ldarg.2
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0053: stloc.3
+				IL_0054: ldloc.3
+				IL_0055: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_005a: ldc.i4.0
+				IL_005b: ceq
+				IL_005d: stloc.1
+				IL_005e: ldloc.1
+				IL_005f: box [System.Runtime]System.Boolean
+				IL_0064: stloc.s 4
+				IL_0066: ldloc.s 4
+				IL_0068: ret
 
-				IL_0077: ldloc.0
-				IL_0078: ret
+				IL_0069: ldloc.0
+				IL_006a: ret
 			} // end of method ArrowFunction_L136C51::__js_call__
 
 		} // end of class ArrowFunction_L136C51
@@ -2051,7 +2027,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e0c
+					// Method begins at RVA 0x3a72
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2071,7 +2047,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e1e
+					// Method begins at RVA 0x3a84
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2089,7 +2065,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e03
+				// Method begins at RVA 0x3a69
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2115,9 +2091,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x3020
+			// Method begins at RVA 0x3004
 			// Header size: 12
-			// Code size: 3011 (0xbc3)
+			// Code size: 2147 (0x863)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/perform/Scope,
@@ -2154,10 +2130,10 @@
 				[31] object,
 				[32] object,
 				[33] object[],
-				[34] object,
-				[35] bool,
-				[36] string,
-				[37] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[34] bool,
+				[35] string,
+				[36] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[37] object,
 				[38] object,
 				[39] object,
 				[40] object,
@@ -2196,1075 +2172,787 @@
 			IL_0069: stloc.s 32
 			IL_006b: ldloc.s 32
 			IL_006d: stloc.2
-			IL_006e: ldarg.0
-			IL_006f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0074: stloc.s 32
-			IL_0076: ldstr "readFile"
-			IL_007b: ldloc.s 32
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0082: stloc.s 32
-			IL_0084: ldc.i4.1
-			IL_0085: newarr [System.Runtime]System.Object
-			IL_008a: dup
-			IL_008b: ldc.i4.0
-			IL_008c: ldarg.0
-			IL_008d: stelem.ref
-			IL_008e: stloc.s 33
-			IL_0090: ldarg.0
-			IL_0091: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_0096: stloc.s 34
-			IL_0098: ldstr "CSPROJ_PATH"
-			IL_009d: ldloc.s 34
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a4: stloc.s 34
-			IL_00a6: ldloc.s 32
-			IL_00a8: ldloc.s 33
-			IL_00aa: ldloc.s 34
+			IL_006e: ldc.i4.1
+			IL_006f: newarr [System.Runtime]System.Object
+			IL_0074: dup
+			IL_0075: ldc.i4.0
+			IL_0076: ldarg.0
+			IL_0077: stelem.ref
+			IL_0078: stloc.s 33
+			IL_007a: ldarg.0
+			IL_007b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_0080: ldloc.s 33
+			IL_0082: ldarg.0
+			IL_0083: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_008d: stloc.s 32
+			IL_008f: ldloc.s 32
+			IL_0091: stloc.3
+			IL_0092: ldc.i4.1
+			IL_0093: newarr [System.Runtime]System.Object
+			IL_0098: dup
+			IL_0099: ldc.i4.0
+			IL_009a: ldarg.0
+			IL_009b: stelem.ref
+			IL_009c: stloc.s 33
+			IL_009e: ldarg.0
+			IL_009f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_00a4: ldloc.s 33
+			IL_00a6: ldarg.0
+			IL_00a7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
 			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00b1: stloc.s 34
-			IL_00b3: ldloc.s 34
-			IL_00b5: stloc.3
-			IL_00b6: ldarg.0
-			IL_00b7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_00bc: stloc.s 34
-			IL_00be: ldstr "readFile"
-			IL_00c3: ldloc.s 34
-			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ca: stloc.s 34
-			IL_00cc: ldc.i4.1
-			IL_00cd: newarr [System.Runtime]System.Object
-			IL_00d2: dup
-			IL_00d3: ldc.i4.0
-			IL_00d4: ldarg.0
-			IL_00d5: stelem.ref
-			IL_00d6: stloc.s 33
-			IL_00d8: ldarg.0
-			IL_00d9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_00de: stloc.s 32
-			IL_00e0: ldstr "CORE_CSPROJ_PATH"
-			IL_00e5: ldloc.s 32
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ec: stloc.s 32
-			IL_00ee: ldloc.s 34
-			IL_00f0: ldloc.s 33
-			IL_00f2: ldloc.s 32
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00f9: stloc.s 32
-			IL_00fb: ldloc.s 32
-			IL_00fd: stloc.s 4
-			IL_00ff: ldarg.0
-			IL_0100: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0105: stloc.s 32
-			IL_0107: ldstr "readFile"
-			IL_010c: ldloc.s 32
-			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0113: stloc.s 32
-			IL_0115: ldc.i4.1
-			IL_0116: newarr [System.Runtime]System.Object
-			IL_011b: dup
-			IL_011c: ldc.i4.0
-			IL_011d: ldarg.0
-			IL_011e: stelem.ref
-			IL_011f: stloc.s 33
-			IL_0121: ldarg.0
-			IL_0122: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_0127: stloc.s 34
-			IL_0129: ldstr "SDK_CSPROJ_PATH"
-			IL_012e: ldloc.s 34
-			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0135: stloc.s 34
-			IL_0137: ldloc.s 32
-			IL_0139: ldloc.s 33
-			IL_013b: ldloc.s 34
-			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0142: stloc.s 34
-			IL_0144: ldloc.s 34
-			IL_0146: stloc.s 5
-			IL_0148: ldarg.0
-			IL_0149: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_014e: stloc.s 34
-			IL_0150: ldstr "readFile"
-			IL_0155: ldloc.s 34
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_015c: stloc.s 34
-			IL_015e: ldc.i4.1
-			IL_015f: newarr [System.Runtime]System.Object
-			IL_0164: dup
-			IL_0165: ldc.i4.0
-			IL_0166: ldarg.0
-			IL_0167: stelem.ref
-			IL_0168: stloc.s 33
-			IL_016a: ldarg.0
-			IL_016b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_0170: stloc.s 32
-			IL_0172: ldstr "RUNTIME_CSPROJ_PATH"
-			IL_0177: ldloc.s 32
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_017e: stloc.s 32
-			IL_0180: ldloc.s 34
-			IL_0182: ldloc.s 33
-			IL_0184: ldloc.s 32
-			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_018b: stloc.s 32
-			IL_018d: ldloc.s 32
-			IL_018f: stloc.s 6
-			IL_0191: ldarg.0
-			IL_0192: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0197: stloc.s 32
-			IL_0199: ldstr "readFile"
-			IL_019e: ldloc.s 32
-			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01a5: stloc.s 32
-			IL_01a7: ldc.i4.1
-			IL_01a8: newarr [System.Runtime]System.Object
-			IL_01ad: dup
-			IL_01ae: ldc.i4.0
-			IL_01af: ldarg.0
-			IL_01b0: stelem.ref
-			IL_01b1: stloc.s 33
-			IL_01b3: ldarg.0
-			IL_01b4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_01b9: stloc.s 34
-			IL_01bb: ldstr "SAMPLES_PROPS_PATH"
-			IL_01c0: ldloc.s 34
-			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01c7: stloc.s 34
-			IL_01c9: ldloc.s 32
-			IL_01cb: ldloc.s 33
-			IL_01cd: ldloc.s 34
-			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01d4: stloc.s 34
-			IL_01d6: ldloc.s 34
-			IL_01d8: stloc.s 7
-			IL_01da: ldarg.0
-			IL_01db: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_01e0: stloc.s 34
-			IL_01e2: ldstr "readFile"
-			IL_01e7: ldloc.s 34
-			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01ee: stloc.s 34
-			IL_01f0: ldc.i4.1
-			IL_01f1: newarr [System.Runtime]System.Object
-			IL_01f6: dup
-			IL_01f7: ldc.i4.0
-			IL_01f8: ldarg.0
-			IL_01f9: stelem.ref
-			IL_01fa: stloc.s 33
-			IL_01fc: ldarg.0
-			IL_01fd: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_0202: stloc.s 32
-			IL_0204: ldstr "CHANGELOG_PATH"
-			IL_0209: ldloc.s 32
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0210: stloc.s 32
-			IL_0212: ldloc.s 34
-			IL_0214: ldloc.s 33
-			IL_0216: ldloc.s 32
-			IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_021d: stloc.s 32
-			IL_021f: ldloc.s 32
-			IL_0221: stloc.s 8
-			IL_0223: ldarg.0
-			IL_0224: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::parseCurrentVersion
-			IL_0229: stloc.s 32
-			IL_022b: ldstr "parseCurrentVersion"
-			IL_0230: ldloc.s 32
-			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0237: stloc.s 32
-			IL_0239: ldloc.s 32
-			IL_023b: ldc.i4.1
-			IL_023c: newarr [System.Runtime]System.Object
-			IL_0241: dup
-			IL_0242: ldc.i4.0
-			IL_0243: ldarg.0
-			IL_0244: stelem.ref
-			IL_0245: ldloc.3
-			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_024b: stloc.s 32
-			IL_024d: ldloc.s 32
-			IL_024f: stloc.s 9
-			IL_0251: ldarg.0
-			IL_0252: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::resolveTargetVersion
-			IL_0257: stloc.s 32
-			IL_0259: ldstr "resolveTargetVersion"
-			IL_025e: ldloc.s 32
-			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0265: stloc.s 32
-			IL_0267: ldloc.s 32
-			IL_0269: ldc.i4.1
-			IL_026a: newarr [System.Runtime]System.Object
-			IL_026f: dup
-			IL_0270: ldc.i4.0
-			IL_0271: ldarg.0
-			IL_0272: stelem.ref
-			IL_0273: ldloc.1
-			IL_0274: ldloc.s 9
-			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_027b: stloc.s 32
-			IL_027d: ldloc.s 32
-			IL_027f: stloc.s 10
-			IL_0281: ldloc.s 9
-			IL_0283: stloc.s 32
-			IL_0285: ldloc.s 32
-			IL_0287: ldloc.s 10
-			IL_0289: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_028e: stloc.s 35
-			IL_0290: ldloc.s 35
-			IL_0292: brfalse IL_0317
+			IL_00b1: stloc.s 32
+			IL_00b3: ldloc.s 32
+			IL_00b5: stloc.s 4
+			IL_00b7: ldc.i4.1
+			IL_00b8: newarr [System.Runtime]System.Object
+			IL_00bd: dup
+			IL_00be: ldc.i4.0
+			IL_00bf: ldarg.0
+			IL_00c0: stelem.ref
+			IL_00c1: stloc.s 33
+			IL_00c3: ldarg.0
+			IL_00c4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_00c9: ldloc.s 33
+			IL_00cb: ldarg.0
+			IL_00cc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00d6: stloc.s 32
+			IL_00d8: ldloc.s 32
+			IL_00da: stloc.s 5
+			IL_00dc: ldc.i4.1
+			IL_00dd: newarr [System.Runtime]System.Object
+			IL_00e2: dup
+			IL_00e3: ldc.i4.0
+			IL_00e4: ldarg.0
+			IL_00e5: stelem.ref
+			IL_00e6: stloc.s 33
+			IL_00e8: ldarg.0
+			IL_00e9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_00ee: ldloc.s 33
+			IL_00f0: ldarg.0
+			IL_00f1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00fb: stloc.s 32
+			IL_00fd: ldloc.s 32
+			IL_00ff: stloc.s 6
+			IL_0101: ldc.i4.1
+			IL_0102: newarr [System.Runtime]System.Object
+			IL_0107: dup
+			IL_0108: ldc.i4.0
+			IL_0109: ldarg.0
+			IL_010a: stelem.ref
+			IL_010b: stloc.s 33
+			IL_010d: ldarg.0
+			IL_010e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_0113: ldloc.s 33
+			IL_0115: ldarg.0
+			IL_0116: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0120: stloc.s 32
+			IL_0122: ldloc.s 32
+			IL_0124: stloc.s 7
+			IL_0126: ldc.i4.1
+			IL_0127: newarr [System.Runtime]System.Object
+			IL_012c: dup
+			IL_012d: ldc.i4.0
+			IL_012e: ldarg.0
+			IL_012f: stelem.ref
+			IL_0130: stloc.s 33
+			IL_0132: ldarg.0
+			IL_0133: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_0138: ldloc.s 33
+			IL_013a: ldarg.0
+			IL_013b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0145: stloc.s 32
+			IL_0147: ldloc.s 32
+			IL_0149: stloc.s 8
+			IL_014b: ldarg.0
+			IL_014c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::parseCurrentVersion
+			IL_0151: ldc.i4.1
+			IL_0152: newarr [System.Runtime]System.Object
+			IL_0157: dup
+			IL_0158: ldc.i4.0
+			IL_0159: ldarg.0
+			IL_015a: stelem.ref
+			IL_015b: ldloc.3
+			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0161: stloc.s 32
+			IL_0163: ldloc.s 32
+			IL_0165: stloc.s 9
+			IL_0167: ldarg.0
+			IL_0168: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::resolveTargetVersion
+			IL_016d: ldc.i4.1
+			IL_016e: newarr [System.Runtime]System.Object
+			IL_0173: dup
+			IL_0174: ldc.i4.0
+			IL_0175: ldarg.0
+			IL_0176: stelem.ref
+			IL_0177: ldloc.1
+			IL_0178: ldloc.s 9
+			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_017f: stloc.s 32
+			IL_0181: ldloc.s 32
+			IL_0183: stloc.s 10
+			IL_0185: ldloc.s 9
+			IL_0187: stloc.s 32
+			IL_0189: ldloc.s 32
+			IL_018b: ldloc.s 10
+			IL_018d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0192: stloc.s 34
+			IL_0194: ldloc.s 34
+			IL_0196: brfalse IL_021b
 
-			IL_0297: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L130C36::.ctor()
-			IL_029c: stloc.s 11
-			IL_029e: ldstr "console"
-			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02a8: stloc.s 32
-			IL_02aa: ldloc.s 32
-			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02b1: stloc.s 32
-			IL_02b3: ldloc.s 9
-			IL_02b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02ba: stloc.s 36
-			IL_02bc: ldstr "Version unchanged ("
-			IL_02c1: ldloc.s 36
-			IL_02c3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02c8: stloc.s 36
-			IL_02ca: ldloc.s 36
-			IL_02cc: ldstr "); aborting."
-			IL_02d1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02d6: stloc.s 36
-			IL_02d8: ldloc.s 32
-			IL_02da: ldstr "error"
-			IL_02df: ldloc.s 36
-			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02e6: pop
-			IL_02e7: ldstr "process"
-			IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02f1: stloc.s 32
-			IL_02f3: ldloc.s 32
-			IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02fa: stloc.s 32
-			IL_02fc: ldloc.s 32
-			IL_02fe: ldstr "exit"
-			IL_0303: ldc.r8 1
-			IL_030c: box [System.Runtime]System.Double
-			IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0316: pop
+			IL_019b: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L130C36::.ctor()
+			IL_01a0: stloc.s 11
+			IL_01a2: ldstr "console"
+			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ac: stloc.s 32
+			IL_01ae: ldloc.s 32
+			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01b5: stloc.s 32
+			IL_01b7: ldloc.s 9
+			IL_01b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01be: stloc.s 35
+			IL_01c0: ldstr "Version unchanged ("
+			IL_01c5: ldloc.s 35
+			IL_01c7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01cc: stloc.s 35
+			IL_01ce: ldloc.s 35
+			IL_01d0: ldstr "); aborting."
+			IL_01d5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01da: stloc.s 35
+			IL_01dc: ldloc.s 32
+			IL_01de: ldstr "error"
+			IL_01e3: ldloc.s 35
+			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01ea: pop
+			IL_01eb: ldstr "process"
+			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01f5: stloc.s 32
+			IL_01f7: ldloc.s 32
+			IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01fe: stloc.s 32
+			IL_0200: ldloc.s 32
+			IL_0202: ldstr "exit"
+			IL_0207: ldc.r8 1
+			IL_0210: box [System.Runtime]System.Double
+			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_021a: pop
 
-			IL_0317: ldarg.0
-			IL_0318: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::extractUnreleased
-			IL_031d: stloc.s 32
-			IL_031f: ldstr "extractUnreleased"
-			IL_0324: ldloc.s 32
-			IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_032b: stloc.s 32
-			IL_032d: ldloc.s 32
-			IL_032f: ldc.i4.1
-			IL_0330: newarr [System.Runtime]System.Object
-			IL_0335: dup
-			IL_0336: ldc.i4.0
-			IL_0337: ldarg.0
-			IL_0338: stelem.ref
-			IL_0339: ldloc.s 8
-			IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0340: stloc.s 32
-			IL_0342: ldloc.s 32
-			IL_0344: brfalse IL_0355
+			IL_021b: ldarg.0
+			IL_021c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::extractUnreleased
+			IL_0221: ldc.i4.1
+			IL_0222: newarr [System.Runtime]System.Object
+			IL_0227: dup
+			IL_0228: ldc.i4.0
+			IL_0229: ldarg.0
+			IL_022a: stelem.ref
+			IL_022b: ldloc.s 8
+			IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0232: stloc.s 32
+			IL_0234: ldloc.s 32
+			IL_0236: brfalse IL_0247
 
-			IL_0349: ldloc.s 32
-			IL_034b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0350: brfalse IL_0366
+			IL_023b: ldloc.s 32
+			IL_023d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0242: brfalse IL_0258
 
-			IL_0355: ldloc.s 32
-			IL_0357: ldstr ""
-			IL_035c: ldstr "body"
-			IL_0361: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_0247: ldloc.s 32
+			IL_0249: ldstr ""
+			IL_024e: ldstr "body"
+			IL_0253: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_0366: ldloc.s 32
-			IL_0368: ldstr "body"
-			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0372: stloc.s 12
-			IL_0374: ldloc.s 32
-			IL_0376: ldstr "start"
-			IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0380: stloc.s 13
-			IL_0382: ldloc.s 32
-			IL_0384: ldstr "end"
-			IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_038e: stloc.s 14
-			IL_0390: ldloc.s 12
-			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0397: stloc.s 32
-			IL_0399: ldstr "\\r?\\n"
-			IL_039e: ldstr ""
-			IL_03a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0258: ldloc.s 32
+			IL_025a: ldstr "body"
+			IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0264: stloc.s 12
+			IL_0266: ldloc.s 32
+			IL_0268: ldstr "start"
+			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0272: stloc.s 13
+			IL_0274: ldloc.s 32
+			IL_0276: ldstr "end"
+			IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0280: stloc.s 14
+			IL_0282: ldloc.s 12
+			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0289: stloc.s 32
+			IL_028b: ldstr "\\r?\\n"
+			IL_0290: ldstr ""
+			IL_0295: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_029a: stloc.s 36
+			IL_029c: ldloc.s 32
+			IL_029e: ldstr "split"
+			IL_02a3: ldloc.s 36
+			IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02aa: stloc.s 32
+			IL_02ac: ldloc.s 32
+			IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02b3: stloc.s 32
+			IL_02b5: ldnull
+			IL_02b6: ldftn object Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51::__js_call__(object[], object, object)
+			IL_02bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_02c1: ldc.i4.2
+			IL_02c2: newarr [System.Runtime]System.Object
+			IL_02c7: dup
+			IL_02c8: ldc.i4.0
+			IL_02c9: ldarg.0
+			IL_02ca: stelem.ref
+			IL_02cb: dup
+			IL_02cc: ldc.i4.1
+			IL_02cd: ldloc.0
+			IL_02ce: stelem.ref
+			IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_02d9: ldc.i4.1
+			IL_02da: conv.r8
+			IL_02db: ldstr ""
+			IL_02e0: ldc.i4.0
+			IL_02e1: ldc.i4.1
+			IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_02ec: stloc.s 37
+			IL_02ee: ldloc.s 32
+			IL_02f0: ldstr "some"
+			IL_02f5: ldloc.s 37
+			IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02fc: stloc.s 37
+			IL_02fe: ldloc.s 37
+			IL_0300: stloc.s 15
+			IL_0302: ldloc.s 15
+			IL_0304: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0309: ldc.i4.0
+			IL_030a: ceq
+			IL_030c: stloc.s 34
+			IL_030e: ldloc.s 34
+			IL_0310: box [System.Runtime]System.Boolean
+			IL_0315: stloc.s 38
+			IL_0317: ldloc.s 38
+			IL_0319: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_031e: stloc.s 34
+			IL_0320: ldloc.s 34
+			IL_0322: brfalse IL_032f
+
+			IL_0327: ldloc.2
+			IL_0328: stloc.s 40
+			IL_032a: br IL_0333
+
+			IL_032f: ldloc.s 38
+			IL_0331: stloc.s 40
+
+			IL_0333: ldloc.s 40
+			IL_0335: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_033a: stloc.s 34
+			IL_033c: ldloc.s 34
+			IL_033e: brfalse IL_04b7
+
+			IL_0343: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L137C35::.ctor()
+			IL_0348: stloc.s 16
+			IL_034a: ldstr "console"
+			IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0354: stloc.s 37
+			IL_0356: ldloc.s 37
+			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_035d: stloc.s 37
+			IL_035f: ldloc.s 37
+			IL_0361: ldstr "log"
+			IL_0366: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
+			IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0370: pop
+			IL_0371: ldarg.0
+			IL_0372: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0377: ldc.i4.1
+			IL_0378: newarr [System.Runtime]System.Object
+			IL_037d: dup
+			IL_037e: ldc.i4.0
+			IL_037f: ldarg.0
+			IL_0380: stelem.ref
+			IL_0381: ldloc.3
+			IL_0382: ldloc.s 10
+			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0389: stloc.s 37
+			IL_038b: ldloc.s 37
+			IL_038d: stloc.s 17
+			IL_038f: ldarg.0
+			IL_0390: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0395: ldc.i4.1
+			IL_0396: newarr [System.Runtime]System.Object
+			IL_039b: dup
+			IL_039c: ldc.i4.0
+			IL_039d: ldarg.0
+			IL_039e: stelem.ref
+			IL_039f: ldloc.s 4
+			IL_03a1: ldloc.s 10
+			IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 			IL_03a8: stloc.s 37
-			IL_03aa: ldloc.s 32
-			IL_03ac: ldstr "split"
-			IL_03b1: ldloc.s 37
-			IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03b8: stloc.s 32
-			IL_03ba: ldloc.s 32
-			IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03c1: stloc.s 32
-			IL_03c3: ldnull
-			IL_03c4: ldftn object Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51::__js_call__(object[], object, object)
-			IL_03ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_03cf: ldc.i4.2
-			IL_03d0: newarr [System.Runtime]System.Object
-			IL_03d5: dup
-			IL_03d6: ldc.i4.0
-			IL_03d7: ldarg.0
-			IL_03d8: stelem.ref
+			IL_03aa: ldloc.s 37
+			IL_03ac: stloc.s 18
+			IL_03ae: ldarg.0
+			IL_03af: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_03b4: ldc.i4.1
+			IL_03b5: newarr [System.Runtime]System.Object
+			IL_03ba: dup
+			IL_03bb: ldc.i4.0
+			IL_03bc: ldarg.0
+			IL_03bd: stelem.ref
+			IL_03be: ldloc.s 5
+			IL_03c0: ldloc.s 10
+			IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03c7: stloc.s 37
+			IL_03c9: ldloc.s 37
+			IL_03cb: stloc.s 19
+			IL_03cd: ldarg.0
+			IL_03ce: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_03d3: ldc.i4.1
+			IL_03d4: newarr [System.Runtime]System.Object
 			IL_03d9: dup
-			IL_03da: ldc.i4.1
-			IL_03db: ldloc.0
+			IL_03da: ldc.i4.0
+			IL_03db: ldarg.0
 			IL_03dc: stelem.ref
-			IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_03e7: ldc.i4.1
-			IL_03e8: conv.r8
-			IL_03e9: ldstr ""
-			IL_03ee: ldc.i4.0
-			IL_03ef: ldc.i4.1
-			IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_03fa: stloc.s 34
-			IL_03fc: ldloc.s 32
-			IL_03fe: ldstr "some"
-			IL_0403: ldloc.s 34
-			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_040a: stloc.s 34
-			IL_040c: ldloc.s 34
-			IL_040e: stloc.s 15
-			IL_0410: ldloc.s 15
-			IL_0412: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0417: ldc.i4.0
-			IL_0418: ceq
-			IL_041a: stloc.s 35
-			IL_041c: ldloc.s 35
-			IL_041e: box [System.Runtime]System.Boolean
-			IL_0423: stloc.s 38
-			IL_0425: ldloc.s 38
-			IL_0427: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_042c: stloc.s 35
-			IL_042e: ldloc.s 35
-			IL_0430: brfalse IL_043d
-
-			IL_0435: ldloc.2
-			IL_0436: stloc.s 40
-			IL_0438: br IL_0441
-
-			IL_043d: ldloc.s 38
-			IL_043f: stloc.s 40
-
-			IL_0441: ldloc.s 40
-			IL_0443: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0448: stloc.s 35
-			IL_044a: ldloc.s 35
-			IL_044c: brfalse IL_06d3
-
-			IL_0451: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L137C35::.ctor()
-			IL_0456: stloc.s 16
-			IL_0458: ldstr "console"
-			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0462: stloc.s 34
-			IL_0464: ldloc.s 34
-			IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_046b: stloc.s 34
-			IL_046d: ldloc.s 34
-			IL_046f: ldstr "log"
-			IL_0474: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
-			IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_047e: pop
-			IL_047f: ldarg.0
-			IL_0480: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0485: stloc.s 34
-			IL_0487: ldstr "updateCsprojVersion"
-			IL_048c: ldloc.s 34
-			IL_048e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0493: stloc.s 34
-			IL_0495: ldloc.s 34
-			IL_0497: ldc.i4.1
-			IL_0498: newarr [System.Runtime]System.Object
-			IL_049d: dup
-			IL_049e: ldc.i4.0
+			IL_03dd: ldloc.s 6
+			IL_03df: ldloc.s 10
+			IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03e6: stloc.s 37
+			IL_03e8: ldloc.s 37
+			IL_03ea: stloc.s 20
+			IL_03ec: ldarg.0
+			IL_03ed: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
+			IL_03f2: ldc.i4.1
+			IL_03f3: newarr [System.Runtime]System.Object
+			IL_03f8: dup
+			IL_03f9: ldc.i4.0
+			IL_03fa: ldarg.0
+			IL_03fb: stelem.ref
+			IL_03fc: ldloc.s 7
+			IL_03fe: ldloc.s 10
+			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0405: stloc.s 37
+			IL_0407: ldloc.s 37
+			IL_0409: stloc.s 21
+			IL_040b: ldc.i4.1
+			IL_040c: newarr [System.Runtime]System.Object
+			IL_0411: dup
+			IL_0412: ldc.i4.0
+			IL_0413: ldarg.0
+			IL_0414: stelem.ref
+			IL_0415: stloc.s 33
+			IL_0417: ldarg.0
+			IL_0418: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_041d: ldloc.s 33
+			IL_041f: ldarg.0
+			IL_0420: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_0425: ldloc.s 17
+			IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_042c: pop
+			IL_042d: ldc.i4.1
+			IL_042e: newarr [System.Runtime]System.Object
+			IL_0433: dup
+			IL_0434: ldc.i4.0
+			IL_0435: ldarg.0
+			IL_0436: stelem.ref
+			IL_0437: stloc.s 33
+			IL_0439: ldarg.0
+			IL_043a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_043f: ldloc.s 33
+			IL_0441: ldarg.0
+			IL_0442: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_0447: ldloc.s 18
+			IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_044e: pop
+			IL_044f: ldc.i4.1
+			IL_0450: newarr [System.Runtime]System.Object
+			IL_0455: dup
+			IL_0456: ldc.i4.0
+			IL_0457: ldarg.0
+			IL_0458: stelem.ref
+			IL_0459: stloc.s 33
+			IL_045b: ldarg.0
+			IL_045c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0461: ldloc.s 33
+			IL_0463: ldarg.0
+			IL_0464: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_0469: ldloc.s 19
+			IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0470: pop
+			IL_0471: ldc.i4.1
+			IL_0472: newarr [System.Runtime]System.Object
+			IL_0477: dup
+			IL_0478: ldc.i4.0
+			IL_0479: ldarg.0
+			IL_047a: stelem.ref
+			IL_047b: stloc.s 33
+			IL_047d: ldarg.0
+			IL_047e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0483: ldloc.s 33
+			IL_0485: ldarg.0
+			IL_0486: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_048b: ldloc.s 20
+			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0492: pop
+			IL_0493: ldc.i4.1
+			IL_0494: newarr [System.Runtime]System.Object
+			IL_0499: dup
+			IL_049a: ldc.i4.0
+			IL_049b: ldarg.0
+			IL_049c: stelem.ref
+			IL_049d: stloc.s 33
 			IL_049f: ldarg.0
-			IL_04a0: stelem.ref
-			IL_04a1: ldloc.3
-			IL_04a2: ldloc.s 10
-			IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04a9: stloc.s 34
-			IL_04ab: ldloc.s 34
-			IL_04ad: stloc.s 17
-			IL_04af: ldarg.0
-			IL_04b0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_04b5: stloc.s 34
-			IL_04b7: ldstr "updateCsprojVersion"
-			IL_04bc: ldloc.s 34
-			IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_04c3: stloc.s 34
-			IL_04c5: ldloc.s 34
-			IL_04c7: ldc.i4.1
-			IL_04c8: newarr [System.Runtime]System.Object
-			IL_04cd: dup
-			IL_04ce: ldc.i4.0
-			IL_04cf: ldarg.0
-			IL_04d0: stelem.ref
-			IL_04d1: ldloc.s 4
-			IL_04d3: ldloc.s 10
-			IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04da: stloc.s 34
-			IL_04dc: ldloc.s 34
-			IL_04de: stloc.s 18
-			IL_04e0: ldarg.0
-			IL_04e1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_04e6: stloc.s 34
-			IL_04e8: ldstr "updateCsprojVersion"
-			IL_04ed: ldloc.s 34
-			IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_04f4: stloc.s 34
-			IL_04f6: ldloc.s 34
-			IL_04f8: ldc.i4.1
-			IL_04f9: newarr [System.Runtime]System.Object
-			IL_04fe: dup
-			IL_04ff: ldc.i4.0
-			IL_0500: ldarg.0
-			IL_0501: stelem.ref
-			IL_0502: ldloc.s 5
-			IL_0504: ldloc.s 10
-			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_050b: stloc.s 34
-			IL_050d: ldloc.s 34
-			IL_050f: stloc.s 19
-			IL_0511: ldarg.0
-			IL_0512: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0517: stloc.s 34
-			IL_0519: ldstr "updateCsprojVersion"
-			IL_051e: ldloc.s 34
-			IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0525: stloc.s 34
-			IL_0527: ldloc.s 34
-			IL_0529: ldc.i4.1
-			IL_052a: newarr [System.Runtime]System.Object
-			IL_052f: dup
-			IL_0530: ldc.i4.0
-			IL_0531: ldarg.0
-			IL_0532: stelem.ref
-			IL_0533: ldloc.s 6
-			IL_0535: ldloc.s 10
-			IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_053c: stloc.s 34
-			IL_053e: ldloc.s 34
-			IL_0540: stloc.s 20
-			IL_0542: ldarg.0
-			IL_0543: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
-			IL_0548: stloc.s 34
-			IL_054a: ldstr "updateSamplesPropsVersion"
-			IL_054f: ldloc.s 34
-			IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0556: stloc.s 34
-			IL_0558: ldloc.s 34
-			IL_055a: ldc.i4.1
-			IL_055b: newarr [System.Runtime]System.Object
-			IL_0560: dup
-			IL_0561: ldc.i4.0
-			IL_0562: ldarg.0
-			IL_0563: stelem.ref
-			IL_0564: ldloc.s 7
-			IL_0566: ldloc.s 10
-			IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_056d: stloc.s 34
-			IL_056f: ldloc.s 34
-			IL_0571: stloc.s 21
-			IL_0573: ldarg.0
-			IL_0574: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0579: stloc.s 34
-			IL_057b: ldstr "writeFile"
-			IL_0580: ldloc.s 34
-			IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0587: stloc.s 34
-			IL_0589: ldc.i4.1
-			IL_058a: newarr [System.Runtime]System.Object
-			IL_058f: dup
-			IL_0590: ldc.i4.0
-			IL_0591: ldarg.0
-			IL_0592: stelem.ref
-			IL_0593: stloc.s 33
-			IL_0595: ldarg.0
-			IL_0596: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_059b: stloc.s 32
-			IL_059d: ldstr "CSPROJ_PATH"
-			IL_05a2: ldloc.s 32
-			IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_05a9: stloc.s 32
-			IL_05ab: ldloc.s 34
-			IL_05ad: ldloc.s 33
-			IL_05af: ldloc.s 32
-			IL_05b1: ldloc.s 17
-			IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05b8: pop
-			IL_05b9: ldarg.0
-			IL_05ba: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_05bf: stloc.s 32
-			IL_05c1: ldstr "writeFile"
-			IL_05c6: ldloc.s 32
-			IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_05cd: stloc.s 32
+			IL_04a0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_04a5: ldloc.s 33
+			IL_04a7: ldarg.0
+			IL_04a8: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_04ad: ldloc.s 21
+			IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04b4: pop
+			IL_04b5: ldnull
+			IL_04b6: ret
+
+			IL_04b7: ldarg.0
+			IL_04b8: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
+			IL_04bd: ldc.i4.1
+			IL_04be: newarr [System.Runtime]System.Object
+			IL_04c3: dup
+			IL_04c4: ldc.i4.0
+			IL_04c5: ldarg.0
+			IL_04c6: stelem.ref
+			IL_04c7: ldloc.s 10
+			IL_04c9: ldloc.s 12
+			IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04d0: stloc.s 37
+			IL_04d2: ldloc.s 37
+			IL_04d4: stloc.s 22
+			IL_04d6: ldloc.s 8
+			IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04dd: stloc.s 37
+			IL_04df: ldloc.s 37
+			IL_04e1: ldstr "slice"
+			IL_04e6: ldc.r8 0.0
+			IL_04ef: box [System.Runtime]System.Double
+			IL_04f4: ldloc.s 13
+			IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04fb: stloc.s 37
+			IL_04fd: ldloc.s 37
+			IL_04ff: stloc.s 23
+			IL_0501: ldloc.s 8
+			IL_0503: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0508: stloc.s 37
+			IL_050a: ldloc.s 37
+			IL_050c: ldstr "slice"
+			IL_0511: ldloc.s 14
+			IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0518: stloc.s 37
+			IL_051a: ldloc.s 37
+			IL_051c: stloc.s 24
+			IL_051e: ldstr "\n_Nothing yet._\n\n"
+			IL_0523: stloc.s 25
+			IL_0525: ldloc.s 23
+			IL_0527: stloc.s 37
+			IL_0529: ldloc.s 37
+			IL_052b: ldloc.s 25
+			IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0532: stloc.s 40
+			IL_0534: ldloc.s 40
+			IL_0536: ldloc.s 22
+			IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_053d: stloc.s 40
+			IL_053f: ldloc.s 40
+			IL_0541: ldloc.s 24
+			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0548: stloc.s 40
+			IL_054a: ldloc.s 40
+			IL_054c: stloc.s 26
+			IL_054e: ldarg.0
+			IL_054f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0554: ldc.i4.1
+			IL_0555: newarr [System.Runtime]System.Object
+			IL_055a: dup
+			IL_055b: ldc.i4.0
+			IL_055c: ldarg.0
+			IL_055d: stelem.ref
+			IL_055e: ldloc.3
+			IL_055f: ldloc.s 10
+			IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0566: stloc.s 37
+			IL_0568: ldloc.s 37
+			IL_056a: stloc.s 27
+			IL_056c: ldarg.0
+			IL_056d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0572: ldc.i4.1
+			IL_0573: newarr [System.Runtime]System.Object
+			IL_0578: dup
+			IL_0579: ldc.i4.0
+			IL_057a: ldarg.0
+			IL_057b: stelem.ref
+			IL_057c: ldloc.s 4
+			IL_057e: ldloc.s 10
+			IL_0580: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0585: stloc.s 37
+			IL_0587: ldloc.s 37
+			IL_0589: stloc.s 28
+			IL_058b: ldarg.0
+			IL_058c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0591: ldc.i4.1
+			IL_0592: newarr [System.Runtime]System.Object
+			IL_0597: dup
+			IL_0598: ldc.i4.0
+			IL_0599: ldarg.0
+			IL_059a: stelem.ref
+			IL_059b: ldloc.s 5
+			IL_059d: ldloc.s 10
+			IL_059f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05a4: stloc.s 37
+			IL_05a6: ldloc.s 37
+			IL_05a8: stloc.s 29
+			IL_05aa: ldarg.0
+			IL_05ab: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_05b0: ldc.i4.1
+			IL_05b1: newarr [System.Runtime]System.Object
+			IL_05b6: dup
+			IL_05b7: ldc.i4.0
+			IL_05b8: ldarg.0
+			IL_05b9: stelem.ref
+			IL_05ba: ldloc.s 6
+			IL_05bc: ldloc.s 10
+			IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05c3: stloc.s 37
+			IL_05c5: ldloc.s 37
+			IL_05c7: stloc.s 30
+			IL_05c9: ldarg.0
+			IL_05ca: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
 			IL_05cf: ldc.i4.1
 			IL_05d0: newarr [System.Runtime]System.Object
 			IL_05d5: dup
 			IL_05d6: ldc.i4.0
 			IL_05d7: ldarg.0
 			IL_05d8: stelem.ref
-			IL_05d9: stloc.s 33
-			IL_05db: ldarg.0
-			IL_05dc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_05e1: stloc.s 34
-			IL_05e3: ldstr "CORE_CSPROJ_PATH"
-			IL_05e8: ldloc.s 34
-			IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_05ef: stloc.s 34
-			IL_05f1: ldloc.s 32
-			IL_05f3: ldloc.s 33
-			IL_05f5: ldloc.s 34
-			IL_05f7: ldloc.s 18
-			IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05fe: pop
-			IL_05ff: ldarg.0
-			IL_0600: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0605: stloc.s 34
-			IL_0607: ldstr "writeFile"
-			IL_060c: ldloc.s 34
-			IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0613: stloc.s 34
-			IL_0615: ldc.i4.1
-			IL_0616: newarr [System.Runtime]System.Object
-			IL_061b: dup
-			IL_061c: ldc.i4.0
-			IL_061d: ldarg.0
-			IL_061e: stelem.ref
-			IL_061f: stloc.s 33
-			IL_0621: ldarg.0
-			IL_0622: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_0627: stloc.s 32
-			IL_0629: ldstr "SDK_CSPROJ_PATH"
-			IL_062e: ldloc.s 32
-			IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0635: stloc.s 32
-			IL_0637: ldloc.s 34
-			IL_0639: ldloc.s 33
-			IL_063b: ldloc.s 32
-			IL_063d: ldloc.s 19
-			IL_063f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0644: pop
-			IL_0645: ldarg.0
-			IL_0646: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_064b: stloc.s 32
-			IL_064d: ldstr "writeFile"
-			IL_0652: ldloc.s 32
-			IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0659: stloc.s 32
-			IL_065b: ldc.i4.1
-			IL_065c: newarr [System.Runtime]System.Object
-			IL_0661: dup
-			IL_0662: ldc.i4.0
-			IL_0663: ldarg.0
-			IL_0664: stelem.ref
-			IL_0665: stloc.s 33
-			IL_0667: ldarg.0
-			IL_0668: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_066d: stloc.s 34
-			IL_066f: ldstr "RUNTIME_CSPROJ_PATH"
-			IL_0674: ldloc.s 34
-			IL_0676: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_067b: stloc.s 34
-			IL_067d: ldloc.s 32
-			IL_067f: ldloc.s 33
-			IL_0681: ldloc.s 34
-			IL_0683: ldloc.s 20
-			IL_0685: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_068a: pop
-			IL_068b: ldarg.0
-			IL_068c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0691: stloc.s 34
-			IL_0693: ldstr "writeFile"
-			IL_0698: ldloc.s 34
-			IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_069f: stloc.s 34
-			IL_06a1: ldc.i4.1
-			IL_06a2: newarr [System.Runtime]System.Object
-			IL_06a7: dup
-			IL_06a8: ldc.i4.0
-			IL_06a9: ldarg.0
-			IL_06aa: stelem.ref
-			IL_06ab: stloc.s 33
-			IL_06ad: ldarg.0
-			IL_06ae: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_06b3: stloc.s 32
-			IL_06b5: ldstr "SAMPLES_PROPS_PATH"
-			IL_06ba: ldloc.s 32
-			IL_06bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06c1: stloc.s 32
-			IL_06c3: ldloc.s 34
-			IL_06c5: ldloc.s 33
-			IL_06c7: ldloc.s 32
-			IL_06c9: ldloc.s 21
-			IL_06cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06d0: pop
-			IL_06d1: ldnull
-			IL_06d2: ret
-
-			IL_06d3: ldarg.0
-			IL_06d4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
-			IL_06d9: stloc.s 32
-			IL_06db: ldstr "generateReleaseSection"
-			IL_06e0: ldloc.s 32
-			IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06e7: stloc.s 32
-			IL_06e9: ldloc.s 32
-			IL_06eb: ldc.i4.1
-			IL_06ec: newarr [System.Runtime]System.Object
-			IL_06f1: dup
-			IL_06f2: ldc.i4.0
-			IL_06f3: ldarg.0
-			IL_06f4: stelem.ref
-			IL_06f5: ldloc.s 10
-			IL_06f7: ldloc.s 12
-			IL_06f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06fe: stloc.s 32
-			IL_0700: ldloc.s 32
-			IL_0702: stloc.s 22
-			IL_0704: ldloc.s 8
-			IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_070b: stloc.s 32
-			IL_070d: ldloc.s 32
-			IL_070f: ldstr "slice"
-			IL_0714: ldc.r8 0.0
-			IL_071d: box [System.Runtime]System.Double
-			IL_0722: ldloc.s 13
-			IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0729: stloc.s 32
-			IL_072b: ldloc.s 32
-			IL_072d: stloc.s 23
-			IL_072f: ldloc.s 8
-			IL_0731: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0736: stloc.s 32
-			IL_0738: ldloc.s 32
-			IL_073a: ldstr "slice"
-			IL_073f: ldloc.s 14
-			IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0746: stloc.s 32
-			IL_0748: ldloc.s 32
-			IL_074a: stloc.s 24
-			IL_074c: ldstr "\n_Nothing yet._\n\n"
-			IL_0751: stloc.s 25
-			IL_0753: ldloc.s 23
-			IL_0755: stloc.s 32
-			IL_0757: ldloc.s 32
-			IL_0759: ldloc.s 25
-			IL_075b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0760: stloc.s 40
-			IL_0762: ldloc.s 40
-			IL_0764: ldloc.s 22
-			IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_076b: stloc.s 40
-			IL_076d: ldloc.s 40
-			IL_076f: ldloc.s 24
-			IL_0771: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0776: stloc.s 40
-			IL_0778: ldloc.s 40
-			IL_077a: stloc.s 26
-			IL_077c: ldarg.0
-			IL_077d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0782: stloc.s 32
-			IL_0784: ldstr "updateCsprojVersion"
-			IL_0789: ldloc.s 32
-			IL_078b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0790: stloc.s 32
-			IL_0792: ldloc.s 32
-			IL_0794: ldc.i4.1
-			IL_0795: newarr [System.Runtime]System.Object
-			IL_079a: dup
-			IL_079b: ldc.i4.0
-			IL_079c: ldarg.0
-			IL_079d: stelem.ref
-			IL_079e: ldloc.3
-			IL_079f: ldloc.s 10
-			IL_07a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_07a6: stloc.s 32
-			IL_07a8: ldloc.s 32
-			IL_07aa: stloc.s 27
-			IL_07ac: ldarg.0
-			IL_07ad: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_07b2: stloc.s 32
-			IL_07b4: ldstr "updateCsprojVersion"
-			IL_07b9: ldloc.s 32
-			IL_07bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_07c0: stloc.s 32
-			IL_07c2: ldloc.s 32
-			IL_07c4: ldc.i4.1
-			IL_07c5: newarr [System.Runtime]System.Object
-			IL_07ca: dup
-			IL_07cb: ldc.i4.0
-			IL_07cc: ldarg.0
-			IL_07cd: stelem.ref
-			IL_07ce: ldloc.s 4
-			IL_07d0: ldloc.s 10
-			IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_07d7: stloc.s 32
-			IL_07d9: ldloc.s 32
-			IL_07db: stloc.s 28
-			IL_07dd: ldarg.0
-			IL_07de: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_07e3: stloc.s 32
-			IL_07e5: ldstr "updateCsprojVersion"
-			IL_07ea: ldloc.s 32
-			IL_07ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_07f1: stloc.s 32
-			IL_07f3: ldloc.s 32
-			IL_07f5: ldc.i4.1
-			IL_07f6: newarr [System.Runtime]System.Object
-			IL_07fb: dup
-			IL_07fc: ldc.i4.0
-			IL_07fd: ldarg.0
-			IL_07fe: stelem.ref
-			IL_07ff: ldloc.s 5
-			IL_0801: ldloc.s 10
-			IL_0803: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0808: stloc.s 32
-			IL_080a: ldloc.s 32
-			IL_080c: stloc.s 29
-			IL_080e: ldarg.0
-			IL_080f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0814: stloc.s 32
-			IL_0816: ldstr "updateCsprojVersion"
-			IL_081b: ldloc.s 32
-			IL_081d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0822: stloc.s 32
-			IL_0824: ldloc.s 32
-			IL_0826: ldc.i4.1
-			IL_0827: newarr [System.Runtime]System.Object
-			IL_082c: dup
-			IL_082d: ldc.i4.0
-			IL_082e: ldarg.0
-			IL_082f: stelem.ref
-			IL_0830: ldloc.s 6
-			IL_0832: ldloc.s 10
-			IL_0834: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0839: stloc.s 32
-			IL_083b: ldloc.s 32
-			IL_083d: stloc.s 30
-			IL_083f: ldarg.0
-			IL_0840: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
-			IL_0845: stloc.s 32
-			IL_0847: ldstr "updateSamplesPropsVersion"
-			IL_084c: ldloc.s 32
-			IL_084e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0853: stloc.s 32
-			IL_0855: ldloc.s 32
-			IL_0857: ldc.i4.1
-			IL_0858: newarr [System.Runtime]System.Object
-			IL_085d: dup
-			IL_085e: ldc.i4.0
-			IL_085f: ldarg.0
-			IL_0860: stelem.ref
-			IL_0861: ldloc.s 7
-			IL_0863: ldloc.s 10
-			IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_086a: stloc.s 32
-			IL_086c: ldloc.s 32
-			IL_086e: stloc.s 31
-			IL_0870: ldarg.0
-			IL_0871: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0876: stloc.s 32
-			IL_0878: ldstr "writeFile"
-			IL_087d: ldloc.s 32
-			IL_087f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0884: stloc.s 32
-			IL_0886: ldc.i4.1
-			IL_0887: newarr [System.Runtime]System.Object
-			IL_088c: dup
-			IL_088d: ldc.i4.0
-			IL_088e: ldarg.0
-			IL_088f: stelem.ref
-			IL_0890: stloc.s 33
-			IL_0892: ldarg.0
-			IL_0893: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_0898: stloc.s 34
-			IL_089a: ldstr "CHANGELOG_PATH"
-			IL_089f: ldloc.s 34
-			IL_08a1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_08a6: stloc.s 34
-			IL_08a8: ldloc.s 32
-			IL_08aa: ldloc.s 33
-			IL_08ac: ldloc.s 34
-			IL_08ae: ldloc.s 26
-			IL_08b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_08b5: pop
-			IL_08b6: ldarg.0
-			IL_08b7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_08bc: stloc.s 34
-			IL_08be: ldstr "writeFile"
-			IL_08c3: ldloc.s 34
-			IL_08c5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_08ca: stloc.s 34
-			IL_08cc: ldc.i4.1
-			IL_08cd: newarr [System.Runtime]System.Object
-			IL_08d2: dup
-			IL_08d3: ldc.i4.0
-			IL_08d4: ldarg.0
-			IL_08d5: stelem.ref
-			IL_08d6: stloc.s 33
-			IL_08d8: ldarg.0
-			IL_08d9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_08de: stloc.s 32
-			IL_08e0: ldstr "CSPROJ_PATH"
-			IL_08e5: ldloc.s 32
-			IL_08e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_08ec: stloc.s 32
-			IL_08ee: ldloc.s 34
-			IL_08f0: ldloc.s 33
-			IL_08f2: ldloc.s 32
-			IL_08f4: ldloc.s 27
-			IL_08f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_08fb: pop
-			IL_08fc: ldarg.0
-			IL_08fd: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0902: stloc.s 32
-			IL_0904: ldstr "writeFile"
-			IL_0909: ldloc.s 32
-			IL_090b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0910: stloc.s 32
-			IL_0912: ldc.i4.1
-			IL_0913: newarr [System.Runtime]System.Object
-			IL_0918: dup
-			IL_0919: ldc.i4.0
-			IL_091a: ldarg.0
-			IL_091b: stelem.ref
-			IL_091c: stloc.s 33
-			IL_091e: ldarg.0
-			IL_091f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0924: stloc.s 34
-			IL_0926: ldstr "CORE_CSPROJ_PATH"
-			IL_092b: ldloc.s 34
-			IL_092d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0932: stloc.s 34
-			IL_0934: ldloc.s 32
-			IL_0936: ldloc.s 33
-			IL_0938: ldloc.s 34
-			IL_093a: ldloc.s 28
-			IL_093c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0941: pop
-			IL_0942: ldarg.0
-			IL_0943: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0948: stloc.s 34
-			IL_094a: ldstr "writeFile"
-			IL_094f: ldloc.s 34
-			IL_0951: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0956: stloc.s 34
-			IL_0958: ldc.i4.1
-			IL_0959: newarr [System.Runtime]System.Object
-			IL_095e: dup
-			IL_095f: ldc.i4.0
-			IL_0960: ldarg.0
-			IL_0961: stelem.ref
-			IL_0962: stloc.s 33
-			IL_0964: ldarg.0
-			IL_0965: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_096a: stloc.s 32
-			IL_096c: ldstr "SDK_CSPROJ_PATH"
-			IL_0971: ldloc.s 32
-			IL_0973: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0978: stloc.s 32
-			IL_097a: ldloc.s 34
-			IL_097c: ldloc.s 33
-			IL_097e: ldloc.s 32
-			IL_0980: ldloc.s 29
-			IL_0982: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0987: pop
-			IL_0988: ldarg.0
-			IL_0989: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_098e: stloc.s 32
-			IL_0990: ldstr "writeFile"
-			IL_0995: ldloc.s 32
-			IL_0997: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_099c: stloc.s 32
-			IL_099e: ldc.i4.1
-			IL_099f: newarr [System.Runtime]System.Object
-			IL_09a4: dup
-			IL_09a5: ldc.i4.0
-			IL_09a6: ldarg.0
-			IL_09a7: stelem.ref
-			IL_09a8: stloc.s 33
-			IL_09aa: ldarg.0
-			IL_09ab: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_09b0: stloc.s 34
-			IL_09b2: ldstr "RUNTIME_CSPROJ_PATH"
-			IL_09b7: ldloc.s 34
-			IL_09b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_09be: stloc.s 34
-			IL_09c0: ldloc.s 32
-			IL_09c2: ldloc.s 33
-			IL_09c4: ldloc.s 34
-			IL_09c6: ldloc.s 30
-			IL_09c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_09cd: pop
-			IL_09ce: ldarg.0
-			IL_09cf: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_09d4: stloc.s 34
-			IL_09d6: ldstr "writeFile"
-			IL_09db: ldloc.s 34
-			IL_09dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_09e2: stloc.s 34
-			IL_09e4: ldc.i4.1
-			IL_09e5: newarr [System.Runtime]System.Object
-			IL_09ea: dup
-			IL_09eb: ldc.i4.0
-			IL_09ec: ldarg.0
-			IL_09ed: stelem.ref
-			IL_09ee: stloc.s 33
-			IL_09f0: ldarg.0
-			IL_09f1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_09f6: stloc.s 32
-			IL_09f8: ldstr "SAMPLES_PROPS_PATH"
-			IL_09fd: ldloc.s 32
-			IL_09ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0a04: stloc.s 32
-			IL_0a06: ldloc.s 34
-			IL_0a08: ldloc.s 33
-			IL_0a0a: ldloc.s 32
-			IL_0a0c: ldloc.s 31
-			IL_0a0e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0a13: pop
-			IL_0a14: ldstr "console"
-			IL_0a19: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a1e: stloc.s 32
-			IL_0a20: ldloc.s 32
-			IL_0a22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a27: stloc.s 32
-			IL_0a29: ldloc.s 9
-			IL_0a2b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a30: stloc.s 36
-			IL_0a32: ldstr "Bumped version: "
-			IL_0a37: ldloc.s 36
-			IL_0a39: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a3e: stloc.s 36
-			IL_0a40: ldloc.s 36
-			IL_0a42: ldstr " -> "
-			IL_0a47: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a4c: stloc.s 36
-			IL_0a4e: ldloc.s 10
-			IL_0a50: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a55: stloc.s 41
-			IL_0a57: ldloc.s 36
-			IL_0a59: ldloc.s 41
-			IL_0a5b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a60: stloc.s 41
-			IL_0a62: ldloc.s 32
-			IL_0a64: ldstr "log"
-			IL_0a69: ldloc.s 41
-			IL_0a6b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0a70: pop
-			IL_0a71: ldstr "console"
-			IL_0a76: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a7b: stloc.s 32
-			IL_0a7d: ldloc.s 32
-			IL_0a7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a84: stloc.s 32
-			IL_0a86: ldloc.s 32
-			IL_0a88: ldstr "log"
-			IL_0a8d: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_0a92: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0a97: pop
-			IL_0a98: ldstr "console"
-			IL_0a9d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0aa2: stloc.s 32
-			IL_0aa4: ldloc.s 32
-			IL_0aa6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0aab: stloc.s 32
-			IL_0aad: ldloc.s 32
-			IL_0aaf: ldstr "log"
-			IL_0ab4: ldstr "\nNext steps:"
-			IL_0ab9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0abe: pop
-			IL_0abf: ldstr "console"
-			IL_0ac4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ac9: stloc.s 32
-			IL_0acb: ldloc.s 32
-			IL_0acd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0ad2: stloc.s 32
-			IL_0ad4: ldloc.s 32
-			IL_0ad6: ldstr "log"
-			IL_0adb: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_0ae0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0ae5: pop
-			IL_0ae6: ldstr "console"
-			IL_0aeb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0af0: stloc.s 32
-			IL_0af2: ldloc.s 32
-			IL_0af4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0af9: stloc.s 32
-			IL_0afb: ldloc.s 10
-			IL_0afd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b02: stloc.s 41
-			IL_0b04: ldstr "  git commit -m \"chore(release): cut "
-			IL_0b09: ldloc.s 41
-			IL_0b0b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b10: stloc.s 41
-			IL_0b12: ldloc.s 41
-			IL_0b14: ldstr "\""
-			IL_0b19: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b1e: stloc.s 41
-			IL_0b20: ldloc.s 32
-			IL_0b22: ldstr "log"
-			IL_0b27: ldloc.s 41
-			IL_0b29: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0b2e: pop
-			IL_0b2f: ldstr "console"
-			IL_0b34: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b39: stloc.s 32
-			IL_0b3b: ldloc.s 32
-			IL_0b3d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b42: stloc.s 32
-			IL_0b44: ldloc.s 10
-			IL_0b46: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b4b: stloc.s 41
-			IL_0b4d: ldstr "  git tag -a v"
-			IL_0b52: ldloc.s 41
-			IL_0b54: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b59: stloc.s 41
-			IL_0b5b: ldloc.s 41
-			IL_0b5d: ldstr " -m \"Release "
-			IL_0b62: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b67: stloc.s 41
-			IL_0b69: ldloc.s 10
-			IL_0b6b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b70: stloc.s 36
-			IL_0b72: ldloc.s 41
-			IL_0b74: ldloc.s 36
-			IL_0b76: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b7b: stloc.s 36
-			IL_0b7d: ldloc.s 36
-			IL_0b7f: ldstr "\""
-			IL_0b84: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b89: stloc.s 36
-			IL_0b8b: ldloc.s 32
-			IL_0b8d: ldstr "log"
-			IL_0b92: ldloc.s 36
-			IL_0b94: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0b99: pop
-			IL_0b9a: ldstr "console"
-			IL_0b9f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ba4: stloc.s 32
-			IL_0ba6: ldloc.s 32
-			IL_0ba8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0bad: stloc.s 32
-			IL_0baf: ldloc.s 32
-			IL_0bb1: ldstr "log"
-			IL_0bb6: ldstr "  git push && git push --tags"
-			IL_0bbb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0bc0: pop
-			IL_0bc1: ldnull
-			IL_0bc2: ret
+			IL_05d9: ldloc.s 7
+			IL_05db: ldloc.s 10
+			IL_05dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05e2: stloc.s 37
+			IL_05e4: ldloc.s 37
+			IL_05e6: stloc.s 31
+			IL_05e8: ldc.i4.1
+			IL_05e9: newarr [System.Runtime]System.Object
+			IL_05ee: dup
+			IL_05ef: ldc.i4.0
+			IL_05f0: ldarg.0
+			IL_05f1: stelem.ref
+			IL_05f2: stloc.s 33
+			IL_05f4: ldarg.0
+			IL_05f5: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_05fa: ldloc.s 33
+			IL_05fc: ldarg.0
+			IL_05fd: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_0602: ldloc.s 26
+			IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0609: pop
+			IL_060a: ldc.i4.1
+			IL_060b: newarr [System.Runtime]System.Object
+			IL_0610: dup
+			IL_0611: ldc.i4.0
+			IL_0612: ldarg.0
+			IL_0613: stelem.ref
+			IL_0614: stloc.s 33
+			IL_0616: ldarg.0
+			IL_0617: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_061c: ldloc.s 33
+			IL_061e: ldarg.0
+			IL_061f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_0624: ldloc.s 27
+			IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_062b: pop
+			IL_062c: ldc.i4.1
+			IL_062d: newarr [System.Runtime]System.Object
+			IL_0632: dup
+			IL_0633: ldc.i4.0
+			IL_0634: ldarg.0
+			IL_0635: stelem.ref
+			IL_0636: stloc.s 33
+			IL_0638: ldarg.0
+			IL_0639: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_063e: ldloc.s 33
+			IL_0640: ldarg.0
+			IL_0641: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_0646: ldloc.s 28
+			IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_064d: pop
+			IL_064e: ldc.i4.1
+			IL_064f: newarr [System.Runtime]System.Object
+			IL_0654: dup
+			IL_0655: ldc.i4.0
+			IL_0656: ldarg.0
+			IL_0657: stelem.ref
+			IL_0658: stloc.s 33
+			IL_065a: ldarg.0
+			IL_065b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0660: ldloc.s 33
+			IL_0662: ldarg.0
+			IL_0663: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_0668: ldloc.s 29
+			IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_066f: pop
+			IL_0670: ldc.i4.1
+			IL_0671: newarr [System.Runtime]System.Object
+			IL_0676: dup
+			IL_0677: ldc.i4.0
+			IL_0678: ldarg.0
+			IL_0679: stelem.ref
+			IL_067a: stloc.s 33
+			IL_067c: ldarg.0
+			IL_067d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0682: ldloc.s 33
+			IL_0684: ldarg.0
+			IL_0685: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_068a: ldloc.s 30
+			IL_068c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0691: pop
+			IL_0692: ldc.i4.1
+			IL_0693: newarr [System.Runtime]System.Object
+			IL_0698: dup
+			IL_0699: ldc.i4.0
+			IL_069a: ldarg.0
+			IL_069b: stelem.ref
+			IL_069c: stloc.s 33
+			IL_069e: ldarg.0
+			IL_069f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_06a4: ldloc.s 33
+			IL_06a6: ldarg.0
+			IL_06a7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_06ac: ldloc.s 31
+			IL_06ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_06b3: pop
+			IL_06b4: ldstr "console"
+			IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06be: stloc.s 37
+			IL_06c0: ldloc.s 37
+			IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06c7: stloc.s 37
+			IL_06c9: ldloc.s 9
+			IL_06cb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06d0: stloc.s 35
+			IL_06d2: ldstr "Bumped version: "
+			IL_06d7: ldloc.s 35
+			IL_06d9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06de: stloc.s 35
+			IL_06e0: ldloc.s 35
+			IL_06e2: ldstr " -> "
+			IL_06e7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06ec: stloc.s 35
+			IL_06ee: ldloc.s 10
+			IL_06f0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06f5: stloc.s 41
+			IL_06f7: ldloc.s 35
+			IL_06f9: ldloc.s 41
+			IL_06fb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0700: stloc.s 41
+			IL_0702: ldloc.s 37
+			IL_0704: ldstr "log"
+			IL_0709: ldloc.s 41
+			IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0710: pop
+			IL_0711: ldstr "console"
+			IL_0716: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_071b: stloc.s 37
+			IL_071d: ldloc.s 37
+			IL_071f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0724: stloc.s 37
+			IL_0726: ldloc.s 37
+			IL_0728: ldstr "log"
+			IL_072d: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0737: pop
+			IL_0738: ldstr "console"
+			IL_073d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0742: stloc.s 37
+			IL_0744: ldloc.s 37
+			IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_074b: stloc.s 37
+			IL_074d: ldloc.s 37
+			IL_074f: ldstr "log"
+			IL_0754: ldstr "\nNext steps:"
+			IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_075e: pop
+			IL_075f: ldstr "console"
+			IL_0764: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0769: stloc.s 37
+			IL_076b: ldloc.s 37
+			IL_076d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0772: stloc.s 37
+			IL_0774: ldloc.s 37
+			IL_0776: ldstr "log"
+			IL_077b: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_0780: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0785: pop
+			IL_0786: ldstr "console"
+			IL_078b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0790: stloc.s 37
+			IL_0792: ldloc.s 37
+			IL_0794: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0799: stloc.s 37
+			IL_079b: ldloc.s 10
+			IL_079d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07a2: stloc.s 41
+			IL_07a4: ldstr "  git commit -m \"chore(release): cut "
+			IL_07a9: ldloc.s 41
+			IL_07ab: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07b0: stloc.s 41
+			IL_07b2: ldloc.s 41
+			IL_07b4: ldstr "\""
+			IL_07b9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07be: stloc.s 41
+			IL_07c0: ldloc.s 37
+			IL_07c2: ldstr "log"
+			IL_07c7: ldloc.s 41
+			IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_07ce: pop
+			IL_07cf: ldstr "console"
+			IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07d9: stloc.s 37
+			IL_07db: ldloc.s 37
+			IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07e2: stloc.s 37
+			IL_07e4: ldloc.s 10
+			IL_07e6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07eb: stloc.s 41
+			IL_07ed: ldstr "  git tag -a v"
+			IL_07f2: ldloc.s 41
+			IL_07f4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07f9: stloc.s 41
+			IL_07fb: ldloc.s 41
+			IL_07fd: ldstr " -m \"Release "
+			IL_0802: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0807: stloc.s 41
+			IL_0809: ldloc.s 10
+			IL_080b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0810: stloc.s 35
+			IL_0812: ldloc.s 41
+			IL_0814: ldloc.s 35
+			IL_0816: call string [System.Runtime]System.String::Concat(string, string)
+			IL_081b: stloc.s 35
+			IL_081d: ldloc.s 35
+			IL_081f: ldstr "\""
+			IL_0824: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0829: stloc.s 35
+			IL_082b: ldloc.s 37
+			IL_082d: ldstr "log"
+			IL_0832: ldloc.s 35
+			IL_0834: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0839: pop
+			IL_083a: ldstr "console"
+			IL_083f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0844: stloc.s 37
+			IL_0846: ldloc.s 37
+			IL_0848: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_084d: stloc.s 37
+			IL_084f: ldloc.s 37
+			IL_0851: ldstr "log"
+			IL_0856: ldstr "  git push && git push --tags"
+			IL_085b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0860: pop
+			IL_0861: ldnull
+			IL_0862: ret
 		} // end of method perform::__js_call__
 
 	} // end of class perform
@@ -3299,7 +2987,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e27
+				// Method begins at RVA 0x3a8d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3319,7 +3007,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e30
+				// Method begins at RVA 0x3a96
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3357,7 +3045,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3d61
+			// Method begins at RVA 0x39c7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3843,7 +3531,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3e39
+		// Method begins at RVA 0x3a9f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31f1
+				// Method begins at RVA 0x3159
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x320c
+						// Method begins at RVA 0x3174
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3215
+						// Method begins at RVA 0x317d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x321e
+						// Method begins at RVA 0x3186
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3227
+						// Method begins at RVA 0x318f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -124,7 +124,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3203
+					// Method begins at RVA 0x316b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -142,7 +142,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31fa
+				// Method begins at RVA 0x3162
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -468,7 +468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3239
+					// Method begins at RVA 0x31a1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -493,7 +493,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2be0
+				// Method begins at RVA 0x2b48
 				// Header size: 12
 				// Code size: 453 (0x1c5)
 				.maxstack 8
@@ -509,11 +509,11 @@
 					[8] bool,
 					[9] object,
 					[10] object,
-					[11] float64,
-					[12] object,
+					[11] string,
+					[12] float64,
 					[13] object,
-					[14] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-					[15] string,
+					[14] object,
+					[15] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 					[16] string
 				)
 
@@ -538,10 +538,10 @@
 				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0034: stloc.s 7
 				IL_0036: ldloc.s 7
-				IL_0038: ldstr "toLowerCase"
-				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0042: stloc.s 7
-				IL_0044: ldloc.s 7
+				IL_0038: castclass [System.Runtime]System.String
+				IL_003d: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
+				IL_0042: stloc.s 11
+				IL_0044: ldloc.s 11
 				IL_0046: stloc.0
 				IL_0047: ldloc.0
 				IL_0048: stloc.s 7
@@ -596,18 +596,18 @@
 				IL_00dc: ldloc.s 10
 				IL_00de: stelem.ref
 				IL_00df: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::min(object[])
-				IL_00e4: stloc.s 11
-				IL_00e6: ldloc.s 11
+				IL_00e4: stloc.s 12
+				IL_00e6: ldloc.s 12
 				IL_00e8: stloc.s 4
 				IL_00ea: ldstr "#"
 				IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_00f4: stloc.s 7
 				IL_00f6: ldloc.s 4
 				IL_00f8: box [System.Runtime]System.Double
-				IL_00fd: stloc.s 12
+				IL_00fd: stloc.s 13
 				IL_00ff: ldloc.s 7
 				IL_0101: ldstr "repeat"
-				IL_0106: ldloc.s 12
+				IL_0106: ldloc.s 13
 				IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 				IL_010d: stloc.s 7
 				IL_010f: ldloc.s 7
@@ -619,22 +619,22 @@
 				IL_011d: brtrue IL_012e
 
 				IL_0122: ldstr ""
-				IL_0127: stloc.s 13
+				IL_0127: stloc.s 14
 				IL_0129: br IL_0131
 
 				IL_012e: ldarg.1
-				IL_012f: stloc.s 13
+				IL_012f: stloc.s 14
 
-				IL_0131: ldloc.s 13
+				IL_0131: ldloc.s 14
 				IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0138: stloc.s 7
 				IL_013a: ldstr "\\s+"
 				IL_013f: ldstr "g"
 				IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0149: stloc.s 14
+				IL_0149: stloc.s 15
 				IL_014b: ldloc.s 7
 				IL_014d: ldstr "replace"
-				IL_0152: ldloc.s 14
+				IL_0152: ldloc.s 15
 				IL_0154: ldstr " "
 				IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 				IL_015e: stloc.s 7
@@ -649,19 +649,19 @@
 				IL_0179: stloc.s 6
 				IL_017b: ldloc.s 5
 				IL_017d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0182: stloc.s 15
+				IL_0182: stloc.s 11
 				IL_0184: ldstr "\n\n"
-				IL_0189: ldloc.s 15
+				IL_0189: ldloc.s 11
 				IL_018b: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0190: stloc.s 15
-				IL_0192: ldloc.s 15
+				IL_0190: stloc.s 11
+				IL_0192: ldloc.s 11
 				IL_0194: ldstr " "
 				IL_0199: call string [System.Runtime]System.String::Concat(string, string)
-				IL_019e: stloc.s 15
+				IL_019e: stloc.s 11
 				IL_01a0: ldloc.s 6
 				IL_01a2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_01a7: stloc.s 16
-				IL_01a9: ldloc.s 15
+				IL_01a9: ldloc.s 11
 				IL_01ab: ldloc.s 16
 				IL_01ad: call string [System.Runtime]System.String::Concat(string, string)
 				IL_01b2: stloc.s 16
@@ -686,7 +686,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3242
+					// Method begins at RVA 0x31aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -710,7 +710,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2db4
+				// Method begins at RVA 0x2d1c
 				// Header size: 12
 				// Code size: 156 (0x9c)
 				.maxstack 8
@@ -796,7 +796,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x324b
+					// Method begins at RVA 0x31b3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -820,7 +820,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e5c
+				// Method begins at RVA 0x2dc4
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -866,7 +866,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x325d
+						// Method begins at RVA 0x31c5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -890,7 +890,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x30a8
+					// Method begins at RVA 0x3010
 					// Header size: 12
 					// Code size: 221 (0xdd)
 					.maxstack 8
@@ -1013,7 +1013,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3266
+						// Method begins at RVA 0x31ce
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1031,7 +1031,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3254
+					// Method begins at RVA 0x31bc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1057,7 +1057,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e88
+				// Method begins at RVA 0x2df0
 				// Header size: 12
 				// Code size: 530 (0x212)
 				.maxstack 8
@@ -1282,7 +1282,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3230
+				// Method begins at RVA 0x3198
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1311,7 +1311,7 @@
 			)
 			// Method begins at RVA 0x25d4
 			// Header size: 12
-			// Code size: 632 (0x278)
+			// Code size: 620 (0x26c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/Scope,
@@ -1331,215 +1331,211 @@
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::TurndownService
 			IL_000c: stloc.3
-			IL_000d: ldstr "TurndownService"
-			IL_0012: ldloc.3
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.3
-			IL_0019: ldloc.3
-			IL_001a: ldc.i4.1
-			IL_001b: newarr [System.Runtime]System.Object
-			IL_0020: dup
-			IL_0021: ldc.i4.0
-			IL_0022: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0027: dup
-			IL_0028: ldstr "codeBlockStyle"
-			IL_002d: ldstr "fenced"
-			IL_0032: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0037: dup
-			IL_0038: ldstr "emDelimiter"
-			IL_003d: ldstr "_"
-			IL_0042: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0047: dup
-			IL_0048: ldstr "strongDelimiter"
-			IL_004d: ldstr "**"
-			IL_0052: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0057: dup
-			IL_0058: ldstr "bulletListMarker"
-			IL_005d: ldstr "-"
-			IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0067: stelem.ref
-			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_006d: stloc.3
-			IL_006e: ldloc.3
-			IL_006f: stloc.1
-			IL_0070: ldloc.1
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0076: stloc.3
-			IL_0077: ldc.i4.3
-			IL_0078: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_007d: dup
-			IL_007e: ldstr "h1"
-			IL_0083: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0088: dup
-			IL_0089: ldstr "h2"
-			IL_008e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0093: dup
-			IL_0094: ldstr "h3"
-			IL_0099: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_009e: stloc.s 4
-			IL_00a0: ldnull
-			IL_00a1: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15::__js_call__(object, object, object)
-			IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_00ac: ldc.i4.2
-			IL_00ad: conv.r8
-			IL_00ae: ldstr ""
-			IL_00b3: ldc.i4.0
-			IL_00b4: ldc.i4.1
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00ba: stloc.s 5
-			IL_00bc: ldloc.s 5
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_00c3: stloc.s 5
-			IL_00c5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00ca: dup
-			IL_00cb: ldstr "filter"
-			IL_00d0: ldloc.s 4
-			IL_00d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00d7: dup
-			IL_00d8: ldstr "replacement"
-			IL_00dd: ldloc.s 5
-			IL_00df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00e4: stloc.s 6
-			IL_00e6: ldloc.3
-			IL_00e7: ldstr "addRule"
-			IL_00ec: ldstr "ecmaHeadings"
-			IL_00f1: ldloc.s 6
-			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f8: pop
-			IL_00f9: ldloc.1
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ff: stloc.3
-			IL_0100: ldc.i4.3
-			IL_0101: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0106: dup
-			IL_0107: ldstr "emu-val"
-			IL_010c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0111: dup
-			IL_0112: ldstr "emu-const"
-			IL_0117: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_011c: dup
-			IL_011d: ldstr "var"
-			IL_0122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0127: stloc.s 4
-			IL_0129: ldnull
-			IL_012a: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15::__js_call__(object, object)
-			IL_0130: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0135: ldc.i4.1
-			IL_0136: conv.r8
-			IL_0137: ldstr ""
-			IL_013c: ldc.i4.0
-			IL_013d: ldc.i4.1
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0143: stloc.s 5
-			IL_0145: ldloc.s 5
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_014c: stloc.s 5
-			IL_014e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0153: dup
-			IL_0154: ldstr "filter"
-			IL_0159: ldloc.s 4
-			IL_015b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0160: dup
-			IL_0161: ldstr "replacement"
-			IL_0166: ldloc.s 5
-			IL_0168: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_016d: stloc.s 6
-			IL_016f: ldloc.3
-			IL_0170: ldstr "addRule"
-			IL_0175: ldstr "ecmarkupInlineCode"
-			IL_017a: ldloc.s 6
-			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0181: pop
-			IL_0182: ldloc.1
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0188: stloc.3
-			IL_0189: ldnull
-			IL_018a: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10::__js_call__(object, object)
-			IL_0190: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0195: ldc.i4.1
-			IL_0196: conv.r8
-			IL_0197: ldstr ""
-			IL_019c: ldc.i4.0
-			IL_019d: ldc.i4.1
-			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_01a3: stloc.s 5
-			IL_01a5: ldloc.s 5
-			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_01ac: stloc.s 5
-			IL_01ae: ldc.i4.2
-			IL_01af: newarr [System.Runtime]System.Object
-			IL_01b4: dup
-			IL_01b5: ldc.i4.0
-			IL_01b6: ldarg.0
-			IL_01b7: stelem.ref
-			IL_01b8: dup
-			IL_01b9: ldc.i4.1
-			IL_01ba: ldloc.0
-			IL_01bb: stelem.ref
-			IL_01bc: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15::__js_call__(object[], object, object, object)
-			IL_01c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_01c7: ldc.i4.2
-			IL_01c8: conv.r8
-			IL_01c9: ldstr ""
-			IL_01ce: ldc.i4.0
-			IL_01cf: ldc.i4.1
-			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_01d5: stloc.s 7
-			IL_01d7: ldloc.s 7
-			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_01de: stloc.s 7
-			IL_01e0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01e5: dup
-			IL_01e6: ldstr "filter"
-			IL_01eb: ldloc.s 5
-			IL_01ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01f2: dup
-			IL_01f3: ldstr "replacement"
-			IL_01f8: ldloc.s 7
-			IL_01fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01ff: stloc.s 6
-			IL_0201: ldloc.3
-			IL_0202: ldstr "addRule"
-			IL_0207: ldstr "fencedCodeWithLanguage"
-			IL_020c: ldloc.s 6
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0213: pop
-			IL_0214: ldloc.1
-			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_021a: stloc.3
-			IL_021b: ldloc.3
-			IL_021c: ldstr "turndown"
-			IL_0221: ldarg.2
-			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0227: stloc.3
-			IL_0228: ldloc.3
-			IL_0229: stloc.2
-			IL_022a: ldloc.2
-			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0230: stloc.3
-			IL_0231: ldstr "\\n{4,}"
-			IL_0236: ldstr "g"
-			IL_023b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0240: stloc.s 8
-			IL_0242: ldloc.3
-			IL_0243: ldstr "replace"
-			IL_0248: ldloc.s 8
-			IL_024a: ldstr "\n\n\n"
-			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0254: stloc.3
-			IL_0255: ldloc.3
-			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000d: ldloc.3
+			IL_000e: ldc.i4.1
+			IL_000f: newarr [System.Runtime]System.Object
+			IL_0014: dup
+			IL_0015: ldc.i4.0
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "codeBlockStyle"
+			IL_0021: ldstr "fenced"
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_002b: dup
+			IL_002c: ldstr "emDelimiter"
+			IL_0031: ldstr "_"
+			IL_0036: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003b: dup
+			IL_003c: ldstr "strongDelimiter"
+			IL_0041: ldstr "**"
+			IL_0046: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_004b: dup
+			IL_004c: ldstr "bulletListMarker"
+			IL_0051: ldstr "-"
+			IL_0056: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_005b: stelem.ref
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0061: stloc.3
+			IL_0062: ldloc.3
+			IL_0063: stloc.1
+			IL_0064: ldloc.1
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006a: stloc.3
+			IL_006b: ldc.i4.3
+			IL_006c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0071: dup
+			IL_0072: ldstr "h1"
+			IL_0077: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_007c: dup
+			IL_007d: ldstr "h2"
+			IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0087: dup
+			IL_0088: ldstr "h3"
+			IL_008d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0092: stloc.s 4
+			IL_0094: ldnull
+			IL_0095: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15::__js_call__(object, object, object)
+			IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_00a0: ldc.i4.2
+			IL_00a1: conv.r8
+			IL_00a2: ldstr ""
+			IL_00a7: ldc.i4.0
+			IL_00a8: ldc.i4.1
+			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00ae: stloc.s 5
+			IL_00b0: ldloc.s 5
+			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_00b7: stloc.s 5
+			IL_00b9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00be: dup
+			IL_00bf: ldstr "filter"
+			IL_00c4: ldloc.s 4
+			IL_00c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00cb: dup
+			IL_00cc: ldstr "replacement"
+			IL_00d1: ldloc.s 5
+			IL_00d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00d8: stloc.s 6
+			IL_00da: ldloc.3
+			IL_00db: ldstr "addRule"
+			IL_00e0: ldstr "ecmaHeadings"
+			IL_00e5: ldloc.s 6
+			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00ec: pop
+			IL_00ed: ldloc.1
+			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f3: stloc.3
+			IL_00f4: ldc.i4.3
+			IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00fa: dup
+			IL_00fb: ldstr "emu-val"
+			IL_0100: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0105: dup
+			IL_0106: ldstr "emu-const"
+			IL_010b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0110: dup
+			IL_0111: ldstr "var"
+			IL_0116: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_011b: stloc.s 4
+			IL_011d: ldnull
+			IL_011e: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15::__js_call__(object, object)
+			IL_0124: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0129: ldc.i4.1
+			IL_012a: conv.r8
+			IL_012b: ldstr ""
+			IL_0130: ldc.i4.0
+			IL_0131: ldc.i4.1
+			IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0137: stloc.s 5
+			IL_0139: ldloc.s 5
+			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0140: stloc.s 5
+			IL_0142: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0147: dup
+			IL_0148: ldstr "filter"
+			IL_014d: ldloc.s 4
+			IL_014f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0154: dup
+			IL_0155: ldstr "replacement"
+			IL_015a: ldloc.s 5
+			IL_015c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0161: stloc.s 6
+			IL_0163: ldloc.3
+			IL_0164: ldstr "addRule"
+			IL_0169: ldstr "ecmarkupInlineCode"
+			IL_016e: ldloc.s 6
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0175: pop
+			IL_0176: ldloc.1
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_017c: stloc.3
+			IL_017d: ldnull
+			IL_017e: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10::__js_call__(object, object)
+			IL_0184: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0189: ldc.i4.1
+			IL_018a: conv.r8
+			IL_018b: ldstr ""
+			IL_0190: ldc.i4.0
+			IL_0191: ldc.i4.1
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0197: stloc.s 5
+			IL_0199: ldloc.s 5
+			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_01a0: stloc.s 5
+			IL_01a2: ldc.i4.2
+			IL_01a3: newarr [System.Runtime]System.Object
+			IL_01a8: dup
+			IL_01a9: ldc.i4.0
+			IL_01aa: ldarg.0
+			IL_01ab: stelem.ref
+			IL_01ac: dup
+			IL_01ad: ldc.i4.1
+			IL_01ae: ldloc.0
+			IL_01af: stelem.ref
+			IL_01b0: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15::__js_call__(object[], object, object, object)
+			IL_01b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_01bb: ldc.i4.2
+			IL_01bc: conv.r8
+			IL_01bd: ldstr ""
+			IL_01c2: ldc.i4.0
+			IL_01c3: ldc.i4.1
+			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_01c9: stloc.s 7
+			IL_01cb: ldloc.s 7
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_01d2: stloc.s 7
+			IL_01d4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01d9: dup
+			IL_01da: ldstr "filter"
+			IL_01df: ldloc.s 5
+			IL_01e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01e6: dup
+			IL_01e7: ldstr "replacement"
+			IL_01ec: ldloc.s 7
+			IL_01ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01f3: stloc.s 6
+			IL_01f5: ldloc.3
+			IL_01f6: ldstr "addRule"
+			IL_01fb: ldstr "fencedCodeWithLanguage"
+			IL_0200: ldloc.s 6
+			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0207: pop
+			IL_0208: ldloc.1
+			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_020e: stloc.3
+			IL_020f: ldloc.3
+			IL_0210: ldstr "turndown"
+			IL_0215: ldarg.2
+			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_021b: stloc.3
+			IL_021c: ldloc.3
+			IL_021d: stloc.2
+			IL_021e: ldloc.2
+			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0224: stloc.3
+			IL_0225: ldstr "\\n{4,}"
+			IL_022a: ldstr "g"
+			IL_022f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0234: stloc.s 8
+			IL_0236: ldloc.3
+			IL_0237: ldstr "replace"
+			IL_023c: ldloc.s 8
+			IL_023e: ldstr "\n\n\n"
+			IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0248: stloc.3
+			IL_0249: ldloc.3
+			IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_024f: stloc.3
+			IL_0250: ldloc.3
+			IL_0251: ldstr "trim"
+			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_025b: stloc.3
 			IL_025c: ldloc.3
-			IL_025d: ldstr "trim"
-			IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0267: stloc.3
-			IL_0268: ldloc.3
-			IL_0269: ldstr "\n"
-			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0273: stloc.s 9
-			IL_0275: ldloc.s 9
-			IL_0277: ret
+			IL_025d: ldstr "\n"
+			IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0267: stloc.s 9
+			IL_0269: ldloc.s 9
+			IL_026b: ret
 		} // end of method convertHtmlToMarkdown::__js_call__
 
 	} // end of class convertHtmlToMarkdown
@@ -1555,7 +1551,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x326f
+				// Method begins at RVA 0x31d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1581,9 +1577,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2858
+			// Method begins at RVA 0x284c
 			// Header size: 12
-			// Code size: 889 (0x379)
+			// Code size: 749 (0x2ed)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1605,302 +1601,256 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::parseArgs
 			IL_0006: stloc.s 7
-			IL_0008: ldstr "parseArgs"
-			IL_000d: ldloc.s 7
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 7
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.s 8
-			IL_0022: ldstr "process"
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0008: ldc.i4.1
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: stloc.s 8
+			IL_0014: ldstr "process"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_001e: stloc.s 9
+			IL_0020: ldloc.s 9
+			IL_0022: ldstr "argv"
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_002c: stloc.s 9
-			IL_002e: ldloc.s 9
-			IL_0030: ldstr "argv"
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003a: stloc.s 9
-			IL_003c: ldloc.s 7
-			IL_003e: ldloc.s 8
-			IL_0040: ldloc.s 9
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0047: stloc.s 9
-			IL_0049: ldloc.s 9
-			IL_004b: stloc.0
-			IL_004c: ldloc.0
-			IL_004d: ldstr "inFile"
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_005c: ldc.i4.0
-			IL_005d: ceq
-			IL_005f: stloc.s 10
-			IL_0061: ldloc.s 10
-			IL_0063: brfalse IL_0091
+			IL_002e: ldloc.s 7
+			IL_0030: ldloc.s 8
+			IL_0032: ldloc.s 9
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0039: stloc.s 9
+			IL_003b: ldloc.s 9
+			IL_003d: stloc.0
+			IL_003e: ldloc.0
+			IL_003f: ldstr "inFile"
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0049: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_004e: ldc.i4.0
+			IL_004f: ceq
+			IL_0051: stloc.s 10
+			IL_0053: ldloc.s 10
+			IL_0055: brfalse IL_0083
 
-			IL_0068: ldstr "Missing --in <input.html>"
-			IL_006d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0077: stloc.s 9
-			IL_0079: ldloc.s 9
-			IL_007b: stloc.1
-			IL_007c: ldloc.1
-			IL_007d: isinst [System.Runtime]System.Exception
-			IL_0082: dup
-			IL_0083: brtrue IL_0090
+			IL_005a: ldstr "Missing --in <input.html>"
+			IL_005f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0064: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0069: stloc.s 9
+			IL_006b: ldloc.s 9
+			IL_006d: stloc.1
+			IL_006e: ldloc.1
+			IL_006f: isinst [System.Runtime]System.Exception
+			IL_0074: dup
+			IL_0075: brtrue IL_0082
 
-			IL_0088: pop
-			IL_0089: ldloc.1
-			IL_008a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_008f: throw
+			IL_007a: pop
+			IL_007b: ldloc.1
+			IL_007c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0081: throw
 
-			IL_0090: throw
+			IL_0082: throw
 
-			IL_0091: ldloc.0
-			IL_0092: ldstr "outFile"
-			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_009c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00a1: ldc.i4.0
-			IL_00a2: ceq
-			IL_00a4: stloc.s 10
-			IL_00a6: ldloc.s 10
-			IL_00a8: brfalse IL_00d6
+			IL_0083: ldloc.0
+			IL_0084: ldstr "outFile"
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_008e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0093: ldc.i4.0
+			IL_0094: ceq
+			IL_0096: stloc.s 10
+			IL_0098: ldloc.s 10
+			IL_009a: brfalse IL_00c8
 
-			IL_00ad: ldstr "Missing --out <output.md>"
-			IL_00b2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00bc: stloc.s 9
-			IL_00be: ldloc.s 9
-			IL_00c0: stloc.2
-			IL_00c1: ldloc.2
-			IL_00c2: isinst [System.Runtime]System.Exception
-			IL_00c7: dup
-			IL_00c8: brtrue IL_00d5
+			IL_009f: ldstr "Missing --out <output.md>"
+			IL_00a4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00ae: stloc.s 9
+			IL_00b0: ldloc.s 9
+			IL_00b2: stloc.2
+			IL_00b3: ldloc.2
+			IL_00b4: isinst [System.Runtime]System.Exception
+			IL_00b9: dup
+			IL_00ba: brtrue IL_00c7
 
-			IL_00cd: pop
-			IL_00ce: ldloc.2
-			IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00d4: throw
+			IL_00bf: pop
+			IL_00c0: ldloc.2
+			IL_00c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00c6: throw
 
-			IL_00d5: throw
+			IL_00c7: throw
 
-			IL_00d6: ldarg.0
-			IL_00d7: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_00dc: stloc.s 9
-			IL_00de: ldstr "path"
-			IL_00e3: ldloc.s 9
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ea: stloc.s 9
-			IL_00ec: ldloc.s 9
-			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f3: stloc.s 9
-			IL_00f5: ldstr "process"
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ff: stloc.s 7
-			IL_0101: ldloc.s 7
-			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0108: stloc.s 7
-			IL_010a: ldloc.s 7
-			IL_010c: ldstr "cwd"
-			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0116: stloc.s 7
-			IL_0118: ldloc.s 9
-			IL_011a: ldstr "resolve"
-			IL_011f: ldloc.s 7
-			IL_0121: ldloc.0
-			IL_0122: ldstr "inFile"
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0131: stloc.s 7
-			IL_0133: ldloc.s 7
-			IL_0135: stloc.3
-			IL_0136: ldarg.0
-			IL_0137: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_013c: stloc.s 7
-			IL_013e: ldstr "path"
-			IL_0143: ldloc.s 7
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_014a: stloc.s 7
-			IL_014c: ldloc.s 7
-			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0153: stloc.s 7
-			IL_0155: ldstr "process"
-			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c8: ldarg.0
+			IL_00c9: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d3: stloc.s 9
+			IL_00d5: ldstr "process"
+			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00df: stloc.s 7
+			IL_00e1: ldloc.s 7
+			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e8: stloc.s 7
+			IL_00ea: ldloc.s 7
+			IL_00ec: ldstr "cwd"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00f6: stloc.s 7
+			IL_00f8: ldloc.s 9
+			IL_00fa: ldstr "resolve"
+			IL_00ff: ldloc.s 7
+			IL_0101: ldloc.0
+			IL_0102: ldstr "inFile"
+			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0111: stloc.s 7
+			IL_0113: ldloc.s 7
+			IL_0115: stloc.3
+			IL_0116: ldarg.0
+			IL_0117: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0121: stloc.s 7
+			IL_0123: ldstr "process"
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_012d: stloc.s 9
+			IL_012f: ldloc.s 9
+			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0136: stloc.s 9
+			IL_0138: ldloc.s 9
+			IL_013a: ldstr "cwd"
+			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0144: stloc.s 9
+			IL_0146: ldloc.s 7
+			IL_0148: ldstr "resolve"
+			IL_014d: ldloc.s 9
+			IL_014f: ldloc.0
+			IL_0150: ldstr "outFile"
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 			IL_015f: stloc.s 9
 			IL_0161: ldloc.s 9
-			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0168: stloc.s 9
-			IL_016a: ldloc.s 9
-			IL_016c: ldstr "cwd"
-			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0176: stloc.s 9
-			IL_0178: ldloc.s 7
-			IL_017a: ldstr "resolve"
-			IL_017f: ldloc.s 9
-			IL_0181: ldloc.0
-			IL_0182: ldstr "outFile"
-			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0191: stloc.s 9
-			IL_0193: ldloc.s 9
-			IL_0195: stloc.s 4
-			IL_0197: ldarg.0
-			IL_0198: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_019d: stloc.s 9
-			IL_019f: ldstr "fs"
-			IL_01a4: ldloc.s 9
-			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01ab: stloc.s 9
-			IL_01ad: ldloc.s 9
-			IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b4: stloc.s 9
-			IL_01b6: ldloc.s 9
-			IL_01b8: ldstr "readFileSync"
-			IL_01bd: ldloc.3
-			IL_01be: ldstr "utf8"
-			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01c8: stloc.s 9
-			IL_01ca: ldloc.s 9
-			IL_01cc: stloc.s 5
-			IL_01ce: ldarg.0
-			IL_01cf: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::convertHtmlToMarkdown
-			IL_01d4: stloc.s 9
-			IL_01d6: ldstr "convertHtmlToMarkdown"
-			IL_01db: ldloc.s 9
-			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01e2: stloc.s 9
-			IL_01e4: ldloc.s 9
-			IL_01e6: ldc.i4.1
-			IL_01e7: newarr [System.Runtime]System.Object
-			IL_01ec: dup
-			IL_01ed: ldc.i4.0
-			IL_01ee: ldarg.0
-			IL_01ef: stelem.ref
-			IL_01f0: ldloc.s 5
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01f7: stloc.s 9
-			IL_01f9: ldloc.s 9
-			IL_01fb: stloc.s 6
-			IL_01fd: ldarg.0
-			IL_01fe: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_0203: stloc.s 9
-			IL_0205: ldstr "fs"
-			IL_020a: ldloc.s 9
-			IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0211: stloc.s 9
-			IL_0213: ldloc.s 9
-			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_021a: stloc.s 9
-			IL_021c: ldarg.0
-			IL_021d: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_0222: stloc.s 7
-			IL_0224: ldstr "path"
-			IL_0229: ldloc.s 7
-			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0230: stloc.s 7
-			IL_0232: ldloc.s 7
-			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0239: stloc.s 7
-			IL_023b: ldloc.s 7
-			IL_023d: ldstr "dirname"
-			IL_0242: ldloc.s 4
-			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0249: stloc.s 7
-			IL_024b: ldloc.s 9
-			IL_024d: ldstr "mkdirSync"
-			IL_0252: ldloc.s 7
-			IL_0254: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0259: dup
-			IL_025a: ldstr "recursive"
-			IL_025f: ldc.i4.1
-			IL_0260: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_026a: pop
-			IL_026b: ldarg.0
-			IL_026c: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_0271: stloc.s 7
-			IL_0273: ldstr "fs"
-			IL_0278: ldloc.s 7
-			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_027f: stloc.s 7
-			IL_0281: ldloc.s 7
-			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0288: stloc.s 7
-			IL_028a: ldloc.s 7
-			IL_028c: ldstr "writeFileSync"
-			IL_0291: ldloc.s 4
-			IL_0293: ldloc.s 6
-			IL_0295: ldstr "utf8"
-			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_029f: pop
-			IL_02a0: ldstr "console"
-			IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02aa: stloc.s 7
-			IL_02ac: ldloc.s 7
-			IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02b3: stloc.s 7
-			IL_02b5: ldloc.0
-			IL_02b6: ldstr "inFile"
-			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02c5: stloc.s 11
-			IL_02c7: ldstr "Converted "
-			IL_02cc: ldloc.s 11
-			IL_02ce: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02d3: stloc.s 11
-			IL_02d5: ldloc.s 11
-			IL_02d7: ldstr " -> "
-			IL_02dc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02e1: stloc.s 11
-			IL_02e3: ldloc.0
-			IL_02e4: ldstr "outFile"
-			IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ee: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02f3: stloc.s 12
-			IL_02f5: ldloc.s 11
-			IL_02f7: ldloc.s 12
-			IL_02f9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02fe: stloc.s 12
-			IL_0300: ldloc.s 12
-			IL_0302: ldstr " ("
-			IL_0307: call string [System.Runtime]System.String::Concat(string, string)
-			IL_030c: stloc.s 12
-			IL_030e: ldloc.s 6
-			IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0315: stloc.s 9
-			IL_0317: ldstr "\\n"
-			IL_031c: ldstr ""
-			IL_0321: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0326: stloc.s 13
-			IL_0328: ldloc.s 9
-			IL_032a: ldstr "split"
-			IL_032f: ldloc.s 13
-			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0336: stloc.s 9
-			IL_0338: ldloc.s 9
-			IL_033a: ldstr "length"
-			IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0344: stloc.s 9
-			IL_0346: ldloc.s 9
-			IL_0348: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_034d: stloc.s 11
-			IL_034f: ldloc.s 12
-			IL_0351: ldloc.s 11
-			IL_0353: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0358: stloc.s 11
-			IL_035a: ldloc.s 11
-			IL_035c: ldstr " lines)"
-			IL_0361: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0366: stloc.s 11
-			IL_0368: ldloc.s 7
-			IL_036a: ldstr "log"
-			IL_036f: ldloc.s 11
-			IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0376: pop
-			IL_0377: ldnull
-			IL_0378: ret
+			IL_0163: stloc.s 4
+			IL_0165: ldarg.0
+			IL_0166: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0170: stloc.s 9
+			IL_0172: ldloc.s 9
+			IL_0174: ldstr "readFileSync"
+			IL_0179: ldloc.3
+			IL_017a: ldstr "utf8"
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0184: stloc.s 9
+			IL_0186: ldloc.s 9
+			IL_0188: stloc.s 5
+			IL_018a: ldarg.0
+			IL_018b: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::convertHtmlToMarkdown
+			IL_0190: ldc.i4.1
+			IL_0191: newarr [System.Runtime]System.Object
+			IL_0196: dup
+			IL_0197: ldc.i4.0
+			IL_0198: ldarg.0
+			IL_0199: stelem.ref
+			IL_019a: ldloc.s 5
+			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_01a1: stloc.s 9
+			IL_01a3: ldloc.s 9
+			IL_01a5: stloc.s 6
+			IL_01a7: ldarg.0
+			IL_01a8: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01b2: stloc.s 9
+			IL_01b4: ldarg.0
+			IL_01b5: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01bf: stloc.s 7
+			IL_01c1: ldloc.s 7
+			IL_01c3: ldstr "dirname"
+			IL_01c8: ldloc.s 4
+			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01cf: stloc.s 7
+			IL_01d1: ldloc.s 9
+			IL_01d3: ldstr "mkdirSync"
+			IL_01d8: ldloc.s 7
+			IL_01da: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01df: dup
+			IL_01e0: ldstr "recursive"
+			IL_01e5: ldc.i4.1
+			IL_01e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01f0: pop
+			IL_01f1: ldarg.0
+			IL_01f2: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01fc: stloc.s 7
+			IL_01fe: ldloc.s 7
+			IL_0200: ldstr "writeFileSync"
+			IL_0205: ldloc.s 4
+			IL_0207: ldloc.s 6
+			IL_0209: ldstr "utf8"
+			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0213: pop
+			IL_0214: ldstr "console"
+			IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_021e: stloc.s 7
+			IL_0220: ldloc.s 7
+			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0227: stloc.s 7
+			IL_0229: ldloc.0
+			IL_022a: ldstr "inFile"
+			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0234: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0239: stloc.s 11
+			IL_023b: ldstr "Converted "
+			IL_0240: ldloc.s 11
+			IL_0242: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0247: stloc.s 11
+			IL_0249: ldloc.s 11
+			IL_024b: ldstr " -> "
+			IL_0250: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0255: stloc.s 11
+			IL_0257: ldloc.0
+			IL_0258: ldstr "outFile"
+			IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0262: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0267: stloc.s 12
+			IL_0269: ldloc.s 11
+			IL_026b: ldloc.s 12
+			IL_026d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0272: stloc.s 12
+			IL_0274: ldloc.s 12
+			IL_0276: ldstr " ("
+			IL_027b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0280: stloc.s 12
+			IL_0282: ldloc.s 6
+			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0289: stloc.s 9
+			IL_028b: ldstr "\\n"
+			IL_0290: ldstr ""
+			IL_0295: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_029a: stloc.s 13
+			IL_029c: ldloc.s 9
+			IL_029e: ldstr "split"
+			IL_02a3: ldloc.s 13
+			IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02aa: stloc.s 9
+			IL_02ac: ldloc.s 9
+			IL_02ae: ldstr "length"
+			IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02b8: stloc.s 9
+			IL_02ba: ldloc.s 9
+			IL_02bc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02c1: stloc.s 11
+			IL_02c3: ldloc.s 12
+			IL_02c5: ldloc.s 11
+			IL_02c7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02cc: stloc.s 11
+			IL_02ce: ldloc.s 11
+			IL_02d0: ldstr " lines)"
+			IL_02d5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02da: stloc.s 11
+			IL_02dc: ldloc.s 7
+			IL_02de: ldstr "log"
+			IL_02e3: ldloc.s 11
+			IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02ea: pop
+			IL_02eb: ldnull
+			IL_02ec: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1932,7 +1882,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3281
+					// Method begins at RVA 0x31e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1952,7 +1902,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x328a
+					// Method begins at RVA 0x31f2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1970,7 +1920,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3278
+				// Method begins at RVA 0x31e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1996,7 +1946,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x31e8
+			// Method begins at RVA 0x3150
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2251,7 +2201,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x329c
+				// Method begins at RVA 0x3204
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2274,7 +2224,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3191
+			// Method begins at RVA 0x30f9
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2303,7 +2253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32a5
+				// Method begins at RVA 0x320d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2328,7 +2278,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3194
+			// Method begins at RVA 0x30fc
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -2365,7 +2315,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32ae
+				// Method begins at RVA 0x3216
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2389,7 +2339,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31ac
+			// Method begins at RVA 0x3114
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -2443,7 +2393,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3293
+			// Method begins at RVA 0x31fb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2545,7 +2495,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x32b7
+		// Method begins at RVA 0x321f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x343e
+				// Method begins at RVA 0x3250
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3447
+				// Method begins at RVA 0x3259
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			)
 			// Method begins at RVA 0x22e0
 			// Header size: 12
-			// Code size: 217 (0xd9)
+			// Code size: 175 (0xaf)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -173,87 +173,69 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
-			IL_0006: stloc.1
-			IL_0007: ldstr "os"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.1
 			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "tmpdir"
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_000d: ldstr "tmpdir"
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: stloc.0
+			IL_001a: ldarg.0
+			IL_001b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0025: stloc.1
-			IL_0026: ldloc.1
-			IL_0027: stloc.0
-			IL_0028: ldarg.0
-			IL_0029: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_002e: stloc.1
-			IL_002f: ldstr "path"
-			IL_0034: ldloc.1
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003a: stloc.1
-			IL_003b: ldloc.1
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0041: stloc.1
-			IL_0042: ldarg.2
-			IL_0043: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0048: stloc.2
-			IL_0049: ldstr ""
-			IL_004e: ldloc.2
-			IL_004f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0054: stloc.2
-			IL_0055: ldloc.2
-			IL_0056: ldstr ".GeneratorTests"
-			IL_005b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0060: stloc.2
-			IL_0061: ldloc.1
-			IL_0062: ldstr "join"
-			IL_0067: ldloc.0
-			IL_0068: ldstr "Jroc.Tests"
-			IL_006d: ldloc.2
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0073: stloc.1
-			IL_0074: ldarg.0
-			IL_0075: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_007a: stloc.3
-			IL_007b: ldstr "path"
-			IL_0080: ldloc.3
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0086: stloc.3
-			IL_0087: ldloc.3
-			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_008d: stloc.3
-			IL_008e: ldarg.2
-			IL_008f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0094: stloc.2
-			IL_0095: ldstr ""
-			IL_009a: ldloc.2
-			IL_009b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00a0: stloc.2
-			IL_00a1: ldloc.2
-			IL_00a2: ldstr ".ExecutionTests"
-			IL_00a7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00ac: stloc.2
-			IL_00ad: ldloc.3
-			IL_00ae: ldstr "join"
-			IL_00b3: ldloc.0
-			IL_00b4: ldstr "Jroc.Tests"
-			IL_00b9: ldloc.2
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_00bf: stloc.3
-			IL_00c0: ldc.i4.2
-			IL_00c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00c6: dup
-			IL_00c7: ldloc.1
-			IL_00c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00cd: dup
-			IL_00ce: ldloc.3
-			IL_00cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00d4: stloc.s 4
-			IL_00d6: ldloc.s 4
-			IL_00d8: ret
+			IL_0026: ldarg.2
+			IL_0027: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_002c: stloc.2
+			IL_002d: ldstr ""
+			IL_0032: ldloc.2
+			IL_0033: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0038: stloc.2
+			IL_0039: ldloc.2
+			IL_003a: ldstr ".GeneratorTests"
+			IL_003f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0044: stloc.2
+			IL_0045: ldloc.1
+			IL_0046: ldstr "join"
+			IL_004b: ldloc.0
+			IL_004c: ldstr "Jroc.Tests"
+			IL_0051: ldloc.2
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0057: stloc.1
+			IL_0058: ldarg.0
+			IL_0059: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0063: stloc.3
+			IL_0064: ldarg.2
+			IL_0065: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_006a: stloc.2
+			IL_006b: ldstr ""
+			IL_0070: ldloc.2
+			IL_0071: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0076: stloc.2
+			IL_0077: ldloc.2
+			IL_0078: ldstr ".ExecutionTests"
+			IL_007d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0082: stloc.2
+			IL_0083: ldloc.3
+			IL_0084: ldstr "join"
+			IL_0089: ldloc.0
+			IL_008a: ldstr "Jroc.Tests"
+			IL_008f: ldloc.2
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0095: stloc.3
+			IL_0096: ldc.i4.2
+			IL_0097: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_009c: dup
+			IL_009d: ldloc.1
+			IL_009e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00a3: dup
+			IL_00a4: ldloc.3
+			IL_00a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00aa: stloc.s 4
+			IL_00ac: ldloc.s 4
+			IL_00ae: ret
 		} // end of method getCandidateCategoryRoots::__js_call__
 
 	} // end of class getCandidateCategoryRoots
@@ -279,7 +261,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3462
+					// Method begins at RVA 0x3274
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -303,7 +285,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33b0
+				// Method begins at RVA 0x31dc
 				// Header size: 12
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -341,7 +323,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x346b
+					// Method begins at RVA 0x327d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,9 +348,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33d4
+				// Method begins at RVA 0x3200
 				// Header size: 12
-				// Code size: 85 (0x55)
+				// Code size: 59 (0x3b)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -380,34 +362,24 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
 				IL_0008: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_000d: stloc.0
-				IL_000e: ldstr "path"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldarg.0
-				IL_0022: ldc.i4.1
-				IL_0023: ldelem.ref
-				IL_0024: castclass Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope
-				IL_0029: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
-				IL_002e: stloc.1
-				IL_002f: ldstr "categoryRoot"
-				IL_0034: ldloc.1
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003a: stloc.1
-				IL_003b: ldloc.0
-				IL_003c: ldstr "join"
-				IL_0041: ldloc.1
-				IL_0042: ldarg.2
-				IL_0043: ldstr "name"
-				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0052: stloc.1
-				IL_0053: ldloc.1
-				IL_0054: ret
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
+				IL_0013: ldarg.0
+				IL_0014: ldc.i4.1
+				IL_0015: ldelem.ref
+				IL_0016: castclass Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope
+				IL_001b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
+				IL_0020: stloc.1
+				IL_0021: ldloc.0
+				IL_0022: ldstr "join"
+				IL_0027: ldloc.1
+				IL_0028: ldarg.2
+				IL_0029: ldstr "name"
+				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0038: stloc.1
+				IL_0039: ldloc.1
+				IL_003a: ret
 			} // end of method ArrowFunction_L48C10::__js_call__
 
 		} // end of class ArrowFunction_L48C10
@@ -428,7 +400,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3459
+					// Method begins at RVA 0x326b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -449,7 +421,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3450
+				// Method begins at RVA 0x3262
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -477,7 +449,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3486
+						// Method begins at RVA 0x3298
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -495,7 +467,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x347d
+					// Method begins at RVA 0x328f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -513,7 +485,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3474
+				// Method begins at RVA 0x3286
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -541,9 +513,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x23c8
+			// Method begins at RVA 0x239c
 			// Header size: 12
-			// Code size: 706 (0x2c2)
+			// Code size: 616 (0x268)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope,
@@ -573,263 +545,233 @@
 			IL_0008: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
 			IL_000d: ldarg.0
 			IL_000e: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-			IL_0013: stloc.s 13
-			IL_0015: ldstr "fs"
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0018: stloc.s 13
 			IL_001a: ldloc.s 13
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0021: stloc.s 13
-			IL_0023: ldloc.s 13
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002a: stloc.s 13
-			IL_002c: ldloc.s 13
-			IL_002e: ldstr "existsSync"
-			IL_0033: ldloc.0
-			IL_0034: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003e: stloc.s 13
-			IL_0040: ldloc.s 13
-			IL_0042: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_001c: ldstr "existsSync"
+			IL_0021: ldloc.0
+			IL_0022: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_002c: stloc.s 13
+			IL_002e: ldloc.s 13
+			IL_0030: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0035: ldc.i4.0
+			IL_0036: ceq
+			IL_0038: stloc.s 14
+			IL_003a: ldloc.s 14
+			IL_003c: brfalse IL_004e
+
+			IL_0041: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope/Block_L41C36::.ctor()
+			IL_0046: stloc.1
 			IL_0047: ldc.i4.0
-			IL_0048: ceq
-			IL_004a: stloc.s 14
-			IL_004c: ldloc.s 14
-			IL_004e: brfalse IL_0060
+			IL_0048: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_004d: ret
 
-			IL_0053: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope/Block_L41C36::.ctor()
-			IL_0058: stloc.1
-			IL_0059: ldc.i4.0
-			IL_005a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_005f: ret
-
-			IL_0060: ldarg.0
-			IL_0061: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-			IL_0066: stloc.s 13
-			IL_0068: ldstr "fs"
-			IL_006d: ldloc.s 13
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0074: stloc.s 13
-			IL_0076: ldloc.s 13
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007d: stloc.s 13
-			IL_007f: ldloc.0
-			IL_0080: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
-			IL_0085: stloc.s 15
-			IL_0087: ldloc.s 13
-			IL_0089: ldstr "readdirSync"
-			IL_008e: ldloc.s 15
-			IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0095: dup
-			IL_0096: ldstr "withFileTypes"
-			IL_009b: ldc.i4.1
-			IL_009c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00a6: stloc.s 15
-			IL_00a8: ldloc.s 15
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00af: stloc.s 15
-			IL_00b1: ldnull
-			IL_00b2: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L47C13::__js_call__(object, object)
-			IL_00b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00bd: ldc.i4.1
-			IL_00be: newarr [System.Runtime]System.Object
-			IL_00c3: dup
-			IL_00c4: ldc.i4.0
-			IL_00c5: ldarg.0
-			IL_00c6: stelem.ref
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00d1: ldc.i4.1
-			IL_00d2: conv.r8
-			IL_00d3: ldstr ""
-			IL_00d8: ldc.i4.0
-			IL_00d9: ldc.i4.1
-			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_00e4: stloc.s 13
-			IL_00e6: ldloc.s 15
-			IL_00e8: ldstr "filter"
-			IL_00ed: ldloc.s 13
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00f4: stloc.s 13
-			IL_00f6: ldloc.s 13
-			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fd: stloc.s 13
-			IL_00ff: ldnull
-			IL_0100: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L48C10::__js_call__(object[], object, object)
-			IL_0106: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_010b: ldc.i4.2
-			IL_010c: newarr [System.Runtime]System.Object
-			IL_0111: dup
-			IL_0112: ldc.i4.0
-			IL_0113: ldarg.0
-			IL_0114: stelem.ref
-			IL_0115: dup
-			IL_0116: ldc.i4.1
-			IL_0117: ldloc.0
-			IL_0118: stelem.ref
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0123: ldc.i4.1
-			IL_0124: conv.r8
-			IL_0125: ldstr ""
-			IL_012a: ldc.i4.0
-			IL_012b: ldc.i4.1
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0136: stloc.s 15
-			IL_0138: ldloc.s 13
-			IL_013a: ldstr "map"
-			IL_013f: ldloc.s 15
-			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0146: stloc.s 15
-			IL_0148: ldloc.s 15
-			IL_014a: stloc.2
-			IL_014b: ldc.i4.0
-			IL_014c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0151: stloc.3
-			IL_0152: ldc.r8 1
-			IL_015b: neg
-			IL_015c: box [System.Runtime]System.Double
-			IL_0161: stloc.s 4
-			IL_0163: ldloc.2
-			IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_0169: stloc.s 5
-			IL_016b: ldc.i4.0
-			IL_016c: stloc.s 6
-			IL_016e: ldc.i4.0
-			IL_016f: stloc.s 7
+			IL_004e: ldarg.0
+			IL_004f: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0059: stloc.s 13
+			IL_005b: ldloc.0
+			IL_005c: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
+			IL_0061: stloc.s 15
+			IL_0063: ldloc.s 13
+			IL_0065: ldstr "readdirSync"
+			IL_006a: ldloc.s 15
+			IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0071: dup
+			IL_0072: ldstr "withFileTypes"
+			IL_0077: ldc.i4.1
+			IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0082: stloc.s 15
+			IL_0084: ldloc.s 15
+			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008b: stloc.s 15
+			IL_008d: ldnull
+			IL_008e: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L47C13::__js_call__(object, object)
+			IL_0094: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0099: ldc.i4.1
+			IL_009a: newarr [System.Runtime]System.Object
+			IL_009f: dup
+			IL_00a0: ldc.i4.0
+			IL_00a1: ldarg.0
+			IL_00a2: stelem.ref
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00ad: ldc.i4.1
+			IL_00ae: conv.r8
+			IL_00af: ldstr ""
+			IL_00b4: ldc.i4.0
+			IL_00b5: ldc.i4.1
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_00c0: stloc.s 13
+			IL_00c2: ldloc.s 15
+			IL_00c4: ldstr "filter"
+			IL_00c9: ldloc.s 13
+			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00d0: stloc.s 13
+			IL_00d2: ldloc.s 13
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d9: stloc.s 13
+			IL_00db: ldnull
+			IL_00dc: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L48C10::__js_call__(object[], object, object)
+			IL_00e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_00e7: ldc.i4.2
+			IL_00e8: newarr [System.Runtime]System.Object
+			IL_00ed: dup
+			IL_00ee: ldc.i4.0
+			IL_00ef: ldarg.0
+			IL_00f0: stelem.ref
+			IL_00f1: dup
+			IL_00f2: ldc.i4.1
+			IL_00f3: ldloc.0
+			IL_00f4: stelem.ref
+			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00ff: ldc.i4.1
+			IL_0100: conv.r8
+			IL_0101: ldstr ""
+			IL_0106: ldc.i4.0
+			IL_0107: ldc.i4.1
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0112: stloc.s 15
+			IL_0114: ldloc.s 13
+			IL_0116: ldstr "map"
+			IL_011b: ldloc.s 15
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0122: stloc.s 15
+			IL_0124: ldloc.s 15
+			IL_0126: stloc.2
+			IL_0127: ldc.i4.0
+			IL_0128: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_012d: stloc.3
+			IL_012e: ldc.r8 1
+			IL_0137: neg
+			IL_0138: box [System.Runtime]System.Double
+			IL_013d: stloc.s 4
+			IL_013f: ldloc.2
+			IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_0145: stloc.s 5
+			IL_0147: ldc.i4.0
+			IL_0148: stloc.s 6
+			IL_014a: ldc.i4.0
+			IL_014b: stloc.s 7
 			.try
 			{
-				// loop start (head: IL_0171)
-					IL_0171: ldloc.s 5
-					IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_0178: stloc.s 15
-					IL_017a: ldloc.s 15
-					IL_017c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_0181: stloc.s 14
-					IL_0183: ldloc.s 14
-					IL_0185: brtrue IL_02a2
+				// loop start (head: IL_014d)
+					IL_014d: ldloc.s 5
+					IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_0154: stloc.s 15
+					IL_0156: ldloc.s 15
+					IL_0158: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_015d: stloc.s 14
+					IL_015f: ldloc.s 14
+					IL_0161: brtrue IL_0248
 
-					IL_018a: ldloc.s 15
-					IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_0191: stloc.s 15
-					IL_0193: ldloc.s 15
-					IL_0195: stloc.s 8
-					IL_0197: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope_ForOf_L53C7/Block_L53C32::.ctor()
-					IL_019c: stloc.s 9
-					IL_019e: ldarg.0
-					IL_019f: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-					IL_01a4: stloc.s 15
-					IL_01a6: ldstr "path"
-					IL_01ab: ldloc.s 15
-					IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_01b2: stloc.s 15
-					IL_01b4: ldloc.s 15
-					IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01bb: stloc.s 15
-					IL_01bd: ldloc.s 15
-					IL_01bf: ldstr "join"
-					IL_01c4: ldloc.s 8
-					IL_01c6: ldarg.3
-					IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_01cc: stloc.s 15
-					IL_01ce: ldloc.s 15
-					IL_01d0: stloc.s 10
-					IL_01d2: ldarg.0
-					IL_01d3: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-					IL_01d8: stloc.s 15
-					IL_01da: ldstr "fs"
-					IL_01df: ldloc.s 15
-					IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_01e6: stloc.s 15
-					IL_01e8: ldloc.s 15
-					IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01ef: stloc.s 15
-					IL_01f1: ldloc.s 15
-					IL_01f3: ldstr "existsSync"
-					IL_01f8: ldloc.s 10
-					IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_01ff: stloc.s 15
-					IL_0201: ldloc.s 15
-					IL_0203: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0208: ldc.i4.0
-					IL_0209: ceq
-					IL_020b: stloc.s 14
-					IL_020d: ldloc.s 14
-					IL_020f: brfalse IL_0219
+					IL_0166: ldloc.s 15
+					IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_016d: stloc.s 15
+					IL_016f: ldloc.s 15
+					IL_0171: stloc.s 8
+					IL_0173: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope_ForOf_L53C7/Block_L53C32::.ctor()
+					IL_0178: stloc.s 9
+					IL_017a: ldarg.0
+					IL_017b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+					IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0185: stloc.s 15
+					IL_0187: ldloc.s 15
+					IL_0189: ldstr "join"
+					IL_018e: ldloc.s 8
+					IL_0190: ldarg.3
+					IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0196: stloc.s 15
+					IL_0198: ldloc.s 15
+					IL_019a: stloc.s 10
+					IL_019c: ldarg.0
+					IL_019d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+					IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01a7: stloc.s 15
+					IL_01a9: ldloc.s 15
+					IL_01ab: ldstr "existsSync"
+					IL_01b0: ldloc.s 10
+					IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_01b7: stloc.s 15
+					IL_01b9: ldloc.s 15
+					IL_01bb: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_01c0: ldc.i4.0
+					IL_01c1: ceq
+					IL_01c3: stloc.s 14
+					IL_01c5: ldloc.s 14
+					IL_01c7: brfalse IL_01d1
 
-					IL_0214: br IL_028e
+					IL_01cc: br IL_0234
 
-					IL_0219: ldarg.0
-					IL_021a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-					IL_021f: stloc.s 15
-					IL_0221: ldstr "fs"
-					IL_0226: ldloc.s 15
-					IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_022d: stloc.s 15
-					IL_022f: ldloc.s 15
-					IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0236: stloc.s 15
-					IL_0238: ldloc.s 15
-					IL_023a: ldstr "statSync"
-					IL_023f: ldloc.s 10
-					IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0246: stloc.s 15
-					IL_0248: ldloc.s 15
-					IL_024a: stloc.s 11
-					IL_024c: ldloc.s 11
-					IL_024e: ldstr "mtimeMs"
-					IL_0253: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-					IL_0258: stloc.s 16
-					IL_025a: ldloc.s 4
-					IL_025c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0261: stloc.s 17
-					IL_0263: ldloc.s 16
-					IL_0265: ldloc.s 17
-					IL_0267: cgt
-					IL_0269: brfalse IL_028e
+					IL_01d1: ldarg.0
+					IL_01d2: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+					IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01dc: stloc.s 15
+					IL_01de: ldloc.s 15
+					IL_01e0: ldstr "statSync"
+					IL_01e5: ldloc.s 10
+					IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_01ec: stloc.s 15
+					IL_01ee: ldloc.s 15
+					IL_01f0: stloc.s 11
+					IL_01f2: ldloc.s 11
+					IL_01f4: ldstr "mtimeMs"
+					IL_01f9: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+					IL_01fe: stloc.s 16
+					IL_0200: ldloc.s 4
+					IL_0202: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0207: stloc.s 17
+					IL_0209: ldloc.s 16
+					IL_020b: ldloc.s 17
+					IL_020d: cgt
+					IL_020f: brfalse IL_0234
 
-					IL_026e: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope_ForOf_L53C7/Block_L53C32/Block_L57C34::.ctor()
-					IL_0273: stloc.s 12
-					IL_0275: ldloc.s 11
-					IL_0277: ldstr "mtimeMs"
-					IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0281: stloc.s 15
-					IL_0283: ldloc.s 15
-					IL_0285: stloc.s 4
-					IL_0287: ldloc.s 10
-					IL_0289: stloc.s 15
-					IL_028b: ldloc.s 15
-					IL_028d: stloc.3
+					IL_0214: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope_ForOf_L53C7/Block_L53C32/Block_L57C34::.ctor()
+					IL_0219: stloc.s 12
+					IL_021b: ldloc.s 11
+					IL_021d: ldstr "mtimeMs"
+					IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0227: stloc.s 15
+					IL_0229: ldloc.s 15
+					IL_022b: stloc.s 4
+					IL_022d: ldloc.s 10
+					IL_022f: stloc.s 15
+					IL_0231: ldloc.s 15
+					IL_0233: stloc.3
 
-					IL_028e: br IL_0171
+					IL_0234: br IL_014d
 				// end loop
-				IL_0293: ldloc.s 5
-				IL_0295: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_029a: ldc.i4.1
-				IL_029b: stloc.s 7
-				IL_029d: leave IL_02c0
+				IL_0239: ldloc.s 5
+				IL_023b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0240: ldc.i4.1
+				IL_0241: stloc.s 7
+				IL_0243: leave IL_0266
 
-				IL_02a2: ldc.i4.1
-				IL_02a3: stloc.s 6
-				IL_02a5: leave IL_02c0
+				IL_0248: ldc.i4.1
+				IL_0249: stloc.s 6
+				IL_024b: leave IL_0266
 			} // end .try
 			finally
 			{
-				IL_02aa: ldloc.s 6
-				IL_02ac: brtrue IL_02bf
+				IL_0250: ldloc.s 6
+				IL_0252: brtrue IL_0265
 
-				IL_02b1: ldloc.s 7
-				IL_02b3: brtrue IL_02bf
+				IL_0257: ldloc.s 7
+				IL_0259: brtrue IL_0265
 
-				IL_02b8: ldloc.s 5
-				IL_02ba: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_025e: ldloc.s 5
+				IL_0260: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_02bf: endfinally
+				IL_0265: endfinally
 			} // end handler
 
-			IL_02c0: ldloc.3
-			IL_02c1: ret
+			IL_0266: ldloc.3
+			IL_0267: ret
 		} // end of method tryFindLatestGeneratedAssemblyInRoot::__js_call__
 
 	} // end of class tryFindLatestGeneratedAssemblyInRoot
@@ -849,7 +791,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3498
+					// Method begins at RVA 0x32aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -867,7 +809,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x348f
+				// Method begins at RVA 0x32a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -895,9 +837,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x26b4
+			// Method begins at RVA 0x262c
 			// Header size: 12
-			// Code size: 355 (0x163)
+			// Code size: 319 (0x13f)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
@@ -908,177 +850,165 @@
 				[5] string,
 				[6] object,
 				[7] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/Scope/Block_L70C17,
-				[8] object,
-				[9] object[],
+				[8] object[],
+				[9] object,
 				[10] string,
 				[11] bool
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
-			IL_0006: stloc.s 8
-			IL_0008: ldstr "getCandidateCategoryRoots"
-			IL_000d: ldloc.s 8
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 8
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.s 9
-			IL_0022: ldloc.s 8
-			IL_0024: ldloc.s 9
-			IL_0026: ldarg.2
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_002c: stloc.s 8
-			IL_002e: ldloc.s 8
-			IL_0030: brfalse IL_0041
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 8
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
+			IL_0012: ldloc.s 8
+			IL_0014: ldarg.2
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_001a: stloc.s 9
+			IL_001c: ldloc.s 9
+			IL_001e: brfalse IL_002f
 
-			IL_0035: ldloc.s 8
-			IL_0037: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_003c: brfalse IL_0052
+			IL_0023: ldloc.s 9
+			IL_0025: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_002a: brfalse IL_0040
 
-			IL_0041: ldloc.s 8
-			IL_0043: ldstr ""
-			IL_0048: ldstr "0"
-			IL_004d: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_002f: ldloc.s 9
+			IL_0031: ldstr ""
+			IL_0036: ldstr "0"
+			IL_003b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_0052: ldloc.s 8
-			IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_0059: stloc.0
-			IL_005a: ldc.i4.0
-			IL_005b: stloc.1
-			IL_005c: ldc.i4.0
-			IL_005d: stloc.2
+			IL_0040: ldloc.s 9
+			IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_0047: stloc.0
+			IL_0048: ldc.i4.0
+			IL_0049: stloc.1
+			IL_004a: ldc.i4.0
+			IL_004b: stloc.2
 			.try
 			{
-				IL_005e: ldloc.2
-				IL_005f: brtrue IL_0086
+				IL_004c: ldloc.2
+				IL_004d: brtrue IL_0074
 
-				IL_0064: ldloc.0
-				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
-				IL_006a: stloc.s 8
-				IL_006c: ldloc.s 8
-				IL_006e: brfalse IL_0084
+				IL_0052: ldloc.0
+				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
+				IL_0058: stloc.s 9
+				IL_005a: ldloc.s 9
+				IL_005c: brfalse IL_0072
 
-				IL_0073: ldloc.s 8
-				IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
-				IL_007a: stloc.s 8
-				IL_007c: ldloc.s 8
-				IL_007e: stloc.3
-				IL_007f: br IL_0088
+				IL_0061: ldloc.s 9
+				IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
+				IL_0068: stloc.s 9
+				IL_006a: ldloc.s 9
+				IL_006c: stloc.3
+				IL_006d: br IL_0076
 
-				IL_0084: ldc.i4.1
-				IL_0085: stloc.2
+				IL_0072: ldc.i4.1
+				IL_0073: stloc.2
 
-				IL_0086: ldnull
-				IL_0087: stloc.3
+				IL_0074: ldnull
+				IL_0075: stloc.3
 
-				IL_0088: ldloc.2
-				IL_0089: brtrue IL_00b1
+				IL_0076: ldloc.2
+				IL_0077: brtrue IL_009f
 
-				IL_008e: ldloc.0
-				IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
-				IL_0094: stloc.s 8
-				IL_0096: ldloc.s 8
-				IL_0098: brfalse IL_00af
+				IL_007c: ldloc.0
+				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
+				IL_0082: stloc.s 9
+				IL_0084: ldloc.s 9
+				IL_0086: brfalse IL_009d
 
-				IL_009d: ldloc.s 8
-				IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
-				IL_00a4: stloc.s 8
-				IL_00a6: ldloc.s 8
-				IL_00a8: stloc.s 4
-				IL_00aa: br IL_00b4
+				IL_008b: ldloc.s 9
+				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
+				IL_0092: stloc.s 9
+				IL_0094: ldloc.s 9
+				IL_0096: stloc.s 4
+				IL_0098: br IL_00a2
 
-				IL_00af: ldc.i4.1
-				IL_00b0: stloc.2
+				IL_009d: ldc.i4.1
+				IL_009e: stloc.2
 
-				IL_00b1: ldnull
-				IL_00b2: stloc.s 4
+				IL_009f: ldnull
+				IL_00a0: stloc.s 4
 
-				IL_00b4: ldloc.2
-				IL_00b5: brtrue IL_00c2
+				IL_00a2: ldloc.2
+				IL_00a3: brtrue IL_00b0
 
-				IL_00ba: ldc.i4.1
-				IL_00bb: stloc.1
-				IL_00bc: ldloc.0
-				IL_00bd: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_00a8: ldc.i4.1
+				IL_00a9: stloc.1
+				IL_00aa: ldloc.0
+				IL_00ab: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
 
-				IL_00c2: ldc.i4.1
-				IL_00c3: stloc.1
-				IL_00c4: leave IL_00dc
+				IL_00b0: ldc.i4.1
+				IL_00b1: stloc.1
+				IL_00b2: leave IL_00ca
 			} // end .try
 			finally
 			{
-				IL_00c9: ldloc.1
-				IL_00ca: brtrue IL_00db
+				IL_00b7: ldloc.1
+				IL_00b8: brtrue IL_00c9
 
-				IL_00cf: ldloc.2
-				IL_00d0: brtrue IL_00db
+				IL_00bd: ldloc.2
+				IL_00be: brtrue IL_00c9
 
-				IL_00d5: ldloc.0
-				IL_00d6: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_00c3: ldloc.0
+				IL_00c4: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_00db: endfinally
+				IL_00c9: endfinally
 			} // end handler
 
-			IL_00dc: ldarg.3
-			IL_00dd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00e2: stloc.s 10
-			IL_00e4: ldstr ""
-			IL_00e9: ldloc.s 10
-			IL_00eb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00f0: stloc.s 10
-			IL_00f2: ldloc.s 10
-			IL_00f4: ldstr ".dll"
-			IL_00f9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00fe: stloc.s 10
-			IL_0100: ldloc.s 10
-			IL_0102: stloc.s 5
-			IL_0104: ldarg.0
-			IL_0105: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssemblyInRoot
-			IL_010a: stloc.s 8
-			IL_010c: ldstr "tryFindLatestGeneratedAssemblyInRoot"
-			IL_0111: ldloc.s 8
-			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0118: stloc.s 8
-			IL_011a: ldloc.s 8
-			IL_011c: ldc.i4.1
-			IL_011d: newarr [System.Runtime]System.Object
-			IL_0122: dup
-			IL_0123: ldc.i4.0
-			IL_0124: ldarg.0
-			IL_0125: stelem.ref
-			IL_0126: ldloc.3
-			IL_0127: ldloc.s 5
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_012e: stloc.s 8
-			IL_0130: ldloc.s 8
-			IL_0132: stloc.s 6
-			IL_0134: ldloc.s 6
-			IL_0136: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_013b: stloc.s 11
-			IL_013d: ldloc.s 11
-			IL_013f: brfalse IL_014e
+			IL_00ca: ldarg.3
+			IL_00cb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00d0: stloc.s 10
+			IL_00d2: ldstr ""
+			IL_00d7: ldloc.s 10
+			IL_00d9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00de: stloc.s 10
+			IL_00e0: ldloc.s 10
+			IL_00e2: ldstr ".dll"
+			IL_00e7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00ec: stloc.s 10
+			IL_00ee: ldloc.s 10
+			IL_00f0: stloc.s 5
+			IL_00f2: ldarg.0
+			IL_00f3: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssemblyInRoot
+			IL_00f8: ldc.i4.1
+			IL_00f9: newarr [System.Runtime]System.Object
+			IL_00fe: dup
+			IL_00ff: ldc.i4.0
+			IL_0100: ldarg.0
+			IL_0101: stelem.ref
+			IL_0102: ldloc.3
+			IL_0103: ldloc.s 5
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_010a: stloc.s 9
+			IL_010c: ldloc.s 9
+			IL_010e: stloc.s 6
+			IL_0110: ldloc.s 6
+			IL_0112: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0117: stloc.s 11
+			IL_0119: ldloc.s 11
+			IL_011b: brfalse IL_012a
 
-			IL_0144: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/Scope/Block_L70C17::.ctor()
-			IL_0149: stloc.s 7
-			IL_014b: ldloc.s 6
-			IL_014d: ret
+			IL_0120: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/Scope/Block_L70C17::.ctor()
+			IL_0125: stloc.s 7
+			IL_0127: ldloc.s 6
+			IL_0129: ret
 
-			IL_014e: ldarg.0
-			IL_014f: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_0154: ldnull
-			IL_0155: ldloc.s 4
-			IL_0157: ldloc.s 5
-			IL_0159: tail.
-			IL_015b: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-			IL_0160: ret
+			IL_012a: ldarg.0
+			IL_012b: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_0130: ldnull
+			IL_0131: ldloc.s 4
+			IL_0133: ldloc.s 5
+			IL_0135: tail.
+			IL_0137: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+			IL_013c: ret
 
-			IL_0161: ldnull
-			IL_0162: ret
+			IL_013d: ldnull
+			IL_013e: ret
 		} // end of method tryFindLatestGeneratedAssembly::__js_call__
 
 	} // end of class tryFindLatestGeneratedAssembly
@@ -1102,7 +1032,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34b3
+						// Method begins at RVA 0x32c5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1120,7 +1050,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34aa
+					// Method begins at RVA 0x32bc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1138,7 +1068,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34a1
+				// Method begins at RVA 0x32b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1165,9 +1095,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2834
+			// Method begins at RVA 0x2788
 			// Header size: 12
-			// Code size: 494 (0x1ee)
+			// Code size: 404 (0x194)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1192,190 +1122,160 @@
 			IL_0001: stloc.0
 			// loop start (head: IL_0002)
 				IL_0002: ldc.i4.1
-				IL_0003: brfalse IL_01ad
+				IL_0003: brfalse IL_0153
 
 				IL_0008: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/Scope/Block_L80C15::.ctor()
 				IL_000d: stloc.1
 				IL_000e: ldarg.0
 				IL_000f: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_0014: stloc.s 7
-				IL_0016: ldstr "path"
+				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0019: stloc.s 7
 				IL_001b: ldloc.s 7
-				IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0022: stloc.s 7
-				IL_0024: ldloc.s 7
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_002b: stloc.s 7
-				IL_002d: ldloc.s 7
-				IL_002f: ldstr "join"
-				IL_0034: ldloc.0
-				IL_0035: ldstr "jroc.sln"
-				IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_003f: stloc.s 7
-				IL_0041: ldloc.s 7
-				IL_0043: stloc.2
-				IL_0044: ldarg.0
-				IL_0045: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_004a: stloc.s 7
-				IL_004c: ldstr "path"
-				IL_0051: ldloc.s 7
-				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0058: stloc.s 7
-				IL_005a: ldloc.s 7
-				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0061: stloc.s 7
-				IL_0063: ldloc.s 7
-				IL_0065: ldstr "join"
-				IL_006a: ldloc.0
-				IL_006b: ldstr "tests"
-				IL_0070: ldstr "Jroc.Tests"
-				IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_007a: stloc.s 7
-				IL_007c: ldloc.s 7
-				IL_007e: stloc.3
-				IL_007f: ldarg.0
-				IL_0080: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-				IL_0085: stloc.s 7
-				IL_0087: ldstr "fs"
-				IL_008c: ldloc.s 7
-				IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0093: stloc.s 7
-				IL_0095: ldloc.s 7
-				IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_009c: stloc.s 7
-				IL_009e: ldloc.s 7
-				IL_00a0: ldstr "existsSync"
-				IL_00a5: ldloc.2
-				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00ab: stloc.s 7
-				IL_00ad: ldloc.s 7
-				IL_00af: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00b4: stloc.s 8
-				IL_00b6: ldloc.s 8
-				IL_00b8: brfalse IL_00f4
+				IL_001d: ldstr "join"
+				IL_0022: ldloc.0
+				IL_0023: ldstr "jroc.sln"
+				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_002d: stloc.s 7
+				IL_002f: ldloc.s 7
+				IL_0031: stloc.2
+				IL_0032: ldarg.0
+				IL_0033: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003d: stloc.s 7
+				IL_003f: ldloc.s 7
+				IL_0041: ldstr "join"
+				IL_0046: ldloc.0
+				IL_0047: ldstr "tests"
+				IL_004c: ldstr "Jroc.Tests"
+				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0056: stloc.s 7
+				IL_0058: ldloc.s 7
+				IL_005a: stloc.3
+				IL_005b: ldarg.0
+				IL_005c: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+				IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0066: stloc.s 7
+				IL_0068: ldloc.s 7
+				IL_006a: ldstr "existsSync"
+				IL_006f: ldloc.2
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0075: stloc.s 7
+				IL_0077: ldloc.s 7
+				IL_0079: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_007e: stloc.s 8
+				IL_0080: ldloc.s 8
+				IL_0082: brfalse IL_00ac
 
-				IL_00bd: ldarg.0
-				IL_00be: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-				IL_00c3: stloc.s 9
-				IL_00c5: ldstr "fs"
-				IL_00ca: ldloc.s 9
-				IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00d1: stloc.s 9
-				IL_00d3: ldloc.s 9
-				IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00da: stloc.s 9
-				IL_00dc: ldloc.s 9
-				IL_00de: ldstr "existsSync"
-				IL_00e3: ldloc.3
-				IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00e9: stloc.s 9
-				IL_00eb: ldloc.s 9
-				IL_00ed: stloc.s 11
-				IL_00ef: br IL_00f8
+				IL_0087: ldarg.0
+				IL_0088: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0092: stloc.s 9
+				IL_0094: ldloc.s 9
+				IL_0096: ldstr "existsSync"
+				IL_009b: ldloc.3
+				IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00a1: stloc.s 9
+				IL_00a3: ldloc.s 9
+				IL_00a5: stloc.s 11
+				IL_00a7: br IL_00b0
 
-				IL_00f4: ldloc.s 7
-				IL_00f6: stloc.s 11
+				IL_00ac: ldloc.s 7
+				IL_00ae: stloc.s 11
 
-				IL_00f8: ldloc.s 11
-				IL_00fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00ff: stloc.s 8
-				IL_0101: ldloc.s 8
-				IL_0103: brfalse IL_0111
+				IL_00b0: ldloc.s 11
+				IL_00b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00b7: stloc.s 8
+				IL_00b9: ldloc.s 8
+				IL_00bb: brfalse IL_00c9
 
-				IL_0108: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/Scope/Block_L80C15/Block_L83C55::.ctor()
-				IL_010d: stloc.s 4
-				IL_010f: ldloc.0
-				IL_0110: ret
+				IL_00c0: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/Scope/Block_L80C15/Block_L83C55::.ctor()
+				IL_00c5: stloc.s 4
+				IL_00c7: ldloc.0
+				IL_00c8: ret
 
-				IL_0111: ldarg.0
-				IL_0112: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_0117: stloc.s 7
-				IL_0119: ldstr "path"
-				IL_011e: ldloc.s 7
-				IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0125: stloc.s 7
-				IL_0127: ldloc.s 7
-				IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_012e: stloc.s 7
-				IL_0130: ldloc.s 7
-				IL_0132: ldstr "dirname"
-				IL_0137: ldloc.0
-				IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_013d: stloc.s 7
-				IL_013f: ldloc.s 7
-				IL_0141: stloc.s 5
-				IL_0143: ldloc.s 5
-				IL_0145: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_014a: ldc.i4.0
-				IL_014b: ceq
-				IL_014d: stloc.s 8
-				IL_014f: ldloc.s 8
-				IL_0151: box [System.Runtime]System.Boolean
-				IL_0156: stloc.s 12
-				IL_0158: ldloc.s 12
-				IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_015f: stloc.s 8
-				IL_0161: ldloc.s 8
-				IL_0163: brtrue IL_0188
+				IL_00c9: ldarg.0
+				IL_00ca: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+				IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00d4: stloc.s 7
+				IL_00d6: ldloc.s 7
+				IL_00d8: ldstr "dirname"
+				IL_00dd: ldloc.0
+				IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00e3: stloc.s 7
+				IL_00e5: ldloc.s 7
+				IL_00e7: stloc.s 5
+				IL_00e9: ldloc.s 5
+				IL_00eb: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_00f0: ldc.i4.0
+				IL_00f1: ceq
+				IL_00f3: stloc.s 8
+				IL_00f5: ldloc.s 8
+				IL_00f7: box [System.Runtime]System.Boolean
+				IL_00fc: stloc.s 12
+				IL_00fe: ldloc.s 12
+				IL_0100: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0105: stloc.s 8
+				IL_0107: ldloc.s 8
+				IL_0109: brtrue IL_012e
 
-				IL_0168: ldloc.s 5
-				IL_016a: stloc.s 7
-				IL_016c: ldloc.s 7
-				IL_016e: ldloc.0
-				IL_016f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0174: stloc.s 8
-				IL_0176: ldloc.s 8
-				IL_0178: box [System.Runtime]System.Boolean
-				IL_017d: stloc.s 13
-				IL_017f: ldloc.s 13
-				IL_0181: stloc.s 14
-				IL_0183: br IL_018c
+				IL_010e: ldloc.s 5
+				IL_0110: stloc.s 7
+				IL_0112: ldloc.s 7
+				IL_0114: ldloc.0
+				IL_0115: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_011a: stloc.s 8
+				IL_011c: ldloc.s 8
+				IL_011e: box [System.Runtime]System.Boolean
+				IL_0123: stloc.s 13
+				IL_0125: ldloc.s 13
+				IL_0127: stloc.s 14
+				IL_0129: br IL_0132
 
-				IL_0188: ldloc.s 12
-				IL_018a: stloc.s 14
+				IL_012e: ldloc.s 12
+				IL_0130: stloc.s 14
 
-				IL_018c: ldloc.s 14
-				IL_018e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0193: stloc.s 8
-				IL_0195: ldloc.s 8
-				IL_0197: brfalse IL_01a1
+				IL_0132: ldloc.s 14
+				IL_0134: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0139: stloc.s 8
+				IL_013b: ldloc.s 8
+				IL_013d: brfalse IL_0147
 
-				IL_019c: br IL_01ad
+				IL_0142: br IL_0153
 
-				IL_01a1: ldloc.s 5
-				IL_01a3: stloc.s 7
-				IL_01a5: ldloc.s 7
-				IL_01a7: stloc.0
-				IL_01a8: br IL_0002
+				IL_0147: ldloc.s 5
+				IL_0149: stloc.s 7
+				IL_014b: ldloc.s 7
+				IL_014d: stloc.0
+				IL_014e: br IL_0002
 			// end loop
 
-			IL_01ad: ldarg.2
-			IL_01ae: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01b3: stloc.s 15
-			IL_01b5: ldstr "Could not locate jroc repo root starting from: "
-			IL_01ba: ldloc.s 15
-			IL_01bc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01c1: stloc.s 15
-			IL_01c3: ldloc.s 15
-			IL_01c5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01cf: stloc.s 7
-			IL_01d1: ldloc.s 7
-			IL_01d3: stloc.s 6
-			IL_01d5: ldloc.s 6
-			IL_01d7: isinst [System.Runtime]System.Exception
-			IL_01dc: dup
-			IL_01dd: brtrue IL_01eb
+			IL_0153: ldarg.2
+			IL_0154: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0159: stloc.s 15
+			IL_015b: ldstr "Could not locate jroc repo root starting from: "
+			IL_0160: ldloc.s 15
+			IL_0162: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0167: stloc.s 15
+			IL_0169: ldloc.s 15
+			IL_016b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0170: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
+			IL_0179: stloc.s 6
+			IL_017b: ldloc.s 6
+			IL_017d: isinst [System.Runtime]System.Exception
+			IL_0182: dup
+			IL_0183: brtrue IL_0191
 
-			IL_01e2: pop
-			IL_01e3: ldloc.s 6
-			IL_01e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_01ea: throw
+			IL_0188: pop
+			IL_0189: ldloc.s 6
+			IL_018b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0190: throw
 
-			IL_01eb: throw
+			IL_0191: throw
 
-			IL_01ec: ldnull
-			IL_01ed: ret
+			IL_0192: ldnull
+			IL_0193: ret
 		} // end of method findProjectRoot::__js_call__
 
 	} // end of class findProjectRoot
@@ -1391,7 +1291,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34bc
+				// Method begins at RVA 0x32ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1418,9 +1318,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2a30
+			// Method begins at RVA 0x2928
 			// Header size: 12
-			// Code size: 172 (0xac)
+			// Code size: 158 (0x9e)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1432,66 +1332,60 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_0006: stloc.1
-			IL_0007: ldstr "childProcess"
-			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldc.i4.1
-			IL_001b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0020: dup
-			IL_0021: ldarg.2
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0027: stloc.2
-			IL_0028: ldstr "process"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0032: stloc.3
-			IL_0033: ldloc.3
-			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0039: stloc.3
-			IL_003a: ldloc.3
-			IL_003b: ldstr "cwd"
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0045: stloc.3
-			IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_004b: dup
-			IL_004c: ldstr "detached"
-			IL_0051: ldc.i4.1
-			IL_0052: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0057: dup
-			IL_0058: ldstr "stdio"
-			IL_005d: ldstr "ignore"
-			IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0067: dup
-			IL_0068: ldstr "shell"
-			IL_006d: ldc.i4.1
-			IL_006e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0073: dup
-			IL_0074: ldstr "cwd"
-			IL_0079: ldloc.3
-			IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_007f: stloc.s 4
-			IL_0081: ldloc.1
-			IL_0082: ldstr "spawn"
-			IL_0087: ldstr "ilspy"
-			IL_008c: ldloc.2
-			IL_008d: ldloc.s 4
-			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0094: stloc.1
-			IL_0095: ldloc.1
-			IL_0096: stloc.0
-			IL_0097: ldloc.0
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009d: stloc.1
-			IL_009e: ldloc.1
-			IL_009f: ldstr "unref"
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00a9: pop
-			IL_00aa: ldnull
-			IL_00ab: ret
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.1
+			IL_000c: ldc.i4.1
+			IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0012: dup
+			IL_0013: ldarg.2
+			IL_0014: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0019: stloc.2
+			IL_001a: ldstr "process"
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0024: stloc.3
+			IL_0025: ldloc.3
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_002b: stloc.3
+			IL_002c: ldloc.3
+			IL_002d: ldstr "cwd"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0037: stloc.3
+			IL_0038: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_003d: dup
+			IL_003e: ldstr "detached"
+			IL_0043: ldc.i4.1
+			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0049: dup
+			IL_004a: ldstr "stdio"
+			IL_004f: ldstr "ignore"
+			IL_0054: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0059: dup
+			IL_005a: ldstr "shell"
+			IL_005f: ldc.i4.1
+			IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0065: dup
+			IL_0066: ldstr "cwd"
+			IL_006b: ldloc.3
+			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0071: stloc.s 4
+			IL_0073: ldloc.1
+			IL_0074: ldstr "spawn"
+			IL_0079: ldstr "ilspy"
+			IL_007e: ldloc.2
+			IL_007f: ldloc.s 4
+			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0086: stloc.1
+			IL_0087: ldloc.1
+			IL_0088: stloc.0
+			IL_0089: ldloc.0
+			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008f: stloc.1
+			IL_0090: ldloc.1
+			IL_0091: ldstr "unref"
+			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_009b: pop
+			IL_009c: ldnull
+			IL_009d: ret
 		} // end of method openInIlSpy::__js_call__
 
 	} // end of class openInIlSpy
@@ -1511,7 +1405,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34ce
+					// Method begins at RVA 0x32e0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1535,7 +1429,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34e0
+						// Method begins at RVA 0x32f2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1553,7 +1447,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34d7
+					// Method begins at RVA 0x32e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1573,7 +1467,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34e9
+					// Method begins at RVA 0x32fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1597,7 +1491,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34fb
+						// Method begins at RVA 0x330d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1615,7 +1509,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34f2
+					// Method begins at RVA 0x3304
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1635,7 +1529,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3504
+					// Method begins at RVA 0x3316
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1655,7 +1549,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x350d
+					// Method begins at RVA 0x331f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1673,7 +1567,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34c5
+				// Method begins at RVA 0x32d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1699,10 +1593,10 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2ae8
+			// Method begins at RVA 0x29d4
 			// Header size: 12
-			// Code size: 2220 (0x8ac)
-			.maxstack 8
+			// Code size: 2028 (0x7ec)
+			.maxstack 9
 			.locals init (
 				[0] object,
 				[1] class Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L110C23,
@@ -1729,14 +1623,11 @@
 				[22] object,
 				[23] string,
 				[24] string,
-				[25] object,
-				[26] object[],
-				[27] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[28] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[29] bool,
-				[30] object,
-				[31] object,
-				[32] float64
+				[25] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[26] bool,
+				[27] object,
+				[28] object,
+				[29] float64
 			)
 
 			IL_0000: ldstr "process"
@@ -1865,592 +1756,526 @@
 			IL_01b4: stloc.s 4
 			IL_01b6: ldarg.0
 			IL_01b7: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_01bc: stloc.s 22
-			IL_01be: ldstr "path"
+			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c1: stloc.s 22
 			IL_01c3: ldloc.s 22
-			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01ca: stloc.s 22
-			IL_01cc: ldloc.s 22
-			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01d3: stloc.s 22
-			IL_01d5: ldarg.0
-			IL_01d6: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_01db: stloc.s 25
-			IL_01dd: ldstr "projectRoot"
-			IL_01e2: ldloc.s 25
-			IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01e9: stloc.s 25
-			IL_01eb: ldc.i4.4
-			IL_01ec: newarr [System.Runtime]System.Object
-			IL_01f1: dup
-			IL_01f2: ldc.i4.0
-			IL_01f3: ldloc.s 25
-			IL_01f5: stelem.ref
-			IL_01f6: dup
-			IL_01f7: ldc.i4.1
-			IL_01f8: ldstr "tests"
-			IL_01fd: stelem.ref
-			IL_01fe: dup
-			IL_01ff: ldc.i4.2
-			IL_0200: ldstr "Jroc.Tests"
-			IL_0205: stelem.ref
-			IL_0206: dup
-			IL_0207: ldc.i4.3
-			IL_0208: ldstr "Jroc.Tests.csproj"
-			IL_020d: stelem.ref
-			IL_020e: stloc.s 26
-			IL_0210: ldloc.s 22
-			IL_0212: ldstr "join"
-			IL_0217: ldloc.s 26
-			IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_021e: stloc.s 22
-			IL_0220: ldloc.s 22
-			IL_0222: stloc.s 5
-			IL_0224: ldstr "console"
-			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_022e: stloc.s 22
-			IL_0230: ldloc.s 22
-			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0237: stloc.s 22
-			IL_0239: ldloc.s 4
-			IL_023b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0240: stloc.s 24
-			IL_0242: ldstr "Running test: "
-			IL_0247: ldloc.s 24
-			IL_0249: call string [System.Runtime]System.String::Concat(string, string)
-			IL_024e: stloc.s 24
-			IL_0250: ldloc.s 22
-			IL_0252: ldstr "log"
-			IL_0257: ldloc.s 24
-			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_025e: pop
-			IL_025f: ldarg.0
-			IL_0260: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_0265: stloc.s 22
-			IL_0267: ldstr "childProcess"
-			IL_026c: ldloc.s 22
-			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0273: stloc.s 22
-			IL_0275: ldloc.s 22
-			IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027c: stloc.s 22
-			IL_027e: ldloc.s 4
-			IL_0280: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0285: stloc.s 24
-			IL_0287: ldstr "FullyQualifiedName="
-			IL_028c: ldloc.s 24
-			IL_028e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0293: stloc.s 24
-			IL_0295: ldc.i4.5
-			IL_0296: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_029b: dup
-			IL_029c: ldstr "test"
-			IL_02a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02a6: dup
-			IL_02a7: ldloc.s 5
-			IL_02a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02ae: dup
-			IL_02af: ldstr "--filter"
-			IL_02b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02b9: dup
-			IL_02ba: ldloc.s 24
-			IL_02bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02c1: dup
-			IL_02c2: ldstr "--no-build"
-			IL_02c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02cc: stloc.s 27
-			IL_02ce: ldarg.0
-			IL_02cf: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_02d4: stloc.s 25
-			IL_02d6: ldstr "projectRoot"
-			IL_02db: ldloc.s 25
-			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02e2: stloc.s 25
-			IL_02e4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02e9: dup
-			IL_02ea: ldstr "stdio"
-			IL_02ef: ldstr "inherit"
-			IL_02f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_02f9: dup
-			IL_02fa: ldstr "shell"
-			IL_02ff: ldc.i4.1
-			IL_0300: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0305: dup
-			IL_0306: ldstr "cwd"
-			IL_030b: ldloc.s 25
-			IL_030d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0312: stloc.s 28
-			IL_0314: ldloc.s 22
-			IL_0316: ldstr "spawnSync"
-			IL_031b: ldstr "dotnet"
-			IL_0320: ldloc.s 27
-			IL_0322: ldloc.s 28
-			IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0329: stloc.s 22
-			IL_032b: ldloc.s 22
-			IL_032d: stloc.s 6
-			IL_032f: ldloc.s 6
-			IL_0331: ldstr "status"
-			IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_033b: stloc.s 22
-			IL_033d: ldloc.s 22
-			IL_033f: ldc.r8 0.0
-			IL_0348: box [System.Runtime]System.Double
-			IL_034d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0352: stloc.s 29
-			IL_0354: ldloc.s 29
-			IL_0356: brfalse IL_04fa
+			IL_01c5: ldstr "join"
+			IL_01ca: ldc.i4.4
+			IL_01cb: newarr [System.Runtime]System.Object
+			IL_01d0: dup
+			IL_01d1: ldc.i4.0
+			IL_01d2: ldarg.0
+			IL_01d3: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_01d8: stelem.ref
+			IL_01d9: dup
+			IL_01da: ldc.i4.1
+			IL_01db: ldstr "tests"
+			IL_01e0: stelem.ref
+			IL_01e1: dup
+			IL_01e2: ldc.i4.2
+			IL_01e3: ldstr "Jroc.Tests"
+			IL_01e8: stelem.ref
+			IL_01e9: dup
+			IL_01ea: ldc.i4.3
+			IL_01eb: ldstr "Jroc.Tests.csproj"
+			IL_01f0: stelem.ref
+			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_01f6: stloc.s 22
+			IL_01f8: ldloc.s 22
+			IL_01fa: stloc.s 5
+			IL_01fc: ldstr "console"
+			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0206: stloc.s 22
+			IL_0208: ldloc.s 22
+			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_020f: stloc.s 22
+			IL_0211: ldloc.s 4
+			IL_0213: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0218: stloc.s 24
+			IL_021a: ldstr "Running test: "
+			IL_021f: ldloc.s 24
+			IL_0221: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0226: stloc.s 24
+			IL_0228: ldloc.s 22
+			IL_022a: ldstr "log"
+			IL_022f: ldloc.s 24
+			IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0236: pop
+			IL_0237: ldarg.0
+			IL_0238: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0242: stloc.s 22
+			IL_0244: ldloc.s 4
+			IL_0246: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_024b: stloc.s 24
+			IL_024d: ldstr "FullyQualifiedName="
+			IL_0252: ldloc.s 24
+			IL_0254: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0259: stloc.s 24
+			IL_025b: ldc.i4.5
+			IL_025c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0261: dup
+			IL_0262: ldstr "test"
+			IL_0267: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_026c: dup
+			IL_026d: ldloc.s 5
+			IL_026f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0274: dup
+			IL_0275: ldstr "--filter"
+			IL_027a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_027f: dup
+			IL_0280: ldloc.s 24
+			IL_0282: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0287: dup
+			IL_0288: ldstr "--no-build"
+			IL_028d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0292: stloc.s 25
+			IL_0294: ldloc.s 22
+			IL_0296: ldstr "spawnSync"
+			IL_029b: ldstr "dotnet"
+			IL_02a0: ldloc.s 25
+			IL_02a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02a7: dup
+			IL_02a8: ldstr "stdio"
+			IL_02ad: ldstr "inherit"
+			IL_02b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_02b7: dup
+			IL_02b8: ldstr "shell"
+			IL_02bd: ldc.i4.1
+			IL_02be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02c3: dup
+			IL_02c4: ldstr "cwd"
+			IL_02c9: ldarg.0
+			IL_02ca: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_02cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_02d9: stloc.s 22
+			IL_02db: ldloc.s 22
+			IL_02dd: stloc.s 6
+			IL_02df: ldloc.s 6
+			IL_02e1: ldstr "status"
+			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02eb: stloc.s 22
+			IL_02ed: ldloc.s 22
+			IL_02ef: ldc.r8 0.0
+			IL_02f8: box [System.Runtime]System.Double
+			IL_02fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0302: stloc.s 26
+			IL_0304: ldloc.s 26
+			IL_0306: brfalse IL_0482
 
-			IL_035b: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L137C31::.ctor()
-			IL_0360: stloc.s 7
-			IL_0362: ldstr "console"
-			IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_036c: stloc.s 22
-			IL_036e: ldloc.s 22
-			IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0375: stloc.s 22
-			IL_0377: ldloc.s 22
-			IL_0379: ldstr "log"
-			IL_037e: ldstr "Test failed or not found, retrying with build..."
-			IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0388: pop
-			IL_0389: ldarg.0
-			IL_038a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_038f: stloc.s 22
-			IL_0391: ldstr "childProcess"
-			IL_0396: ldloc.s 22
-			IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_039d: stloc.s 22
-			IL_039f: ldloc.s 22
-			IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03a6: stloc.s 22
-			IL_03a8: ldloc.s 4
-			IL_03aa: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03af: stloc.s 24
-			IL_03b1: ldstr "FullyQualifiedName="
-			IL_03b6: ldloc.s 24
-			IL_03b8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03bd: stloc.s 24
-			IL_03bf: ldc.i4.4
-			IL_03c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_03c5: dup
-			IL_03c6: ldstr "test"
-			IL_03cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03d0: dup
-			IL_03d1: ldloc.s 5
-			IL_03d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03d8: dup
-			IL_03d9: ldstr "--filter"
-			IL_03de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03e3: dup
-			IL_03e4: ldloc.s 24
-			IL_03e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03eb: stloc.s 27
-			IL_03ed: ldarg.0
-			IL_03ee: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_03f3: stloc.s 25
-			IL_03f5: ldstr "projectRoot"
-			IL_03fa: ldloc.s 25
-			IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0401: stloc.s 25
-			IL_0403: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0408: dup
-			IL_0409: ldstr "stdio"
-			IL_040e: ldstr "inherit"
-			IL_0413: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0418: dup
-			IL_0419: ldstr "shell"
-			IL_041e: ldc.i4.1
-			IL_041f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0424: dup
-			IL_0425: ldstr "cwd"
-			IL_042a: ldloc.s 25
-			IL_042c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0431: stloc.s 28
-			IL_0433: ldloc.s 22
-			IL_0435: ldstr "spawnSync"
-			IL_043a: ldstr "dotnet"
-			IL_043f: ldloc.s 27
-			IL_0441: ldloc.s 28
-			IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0448: stloc.s 22
-			IL_044a: ldloc.s 22
-			IL_044c: stloc.s 8
-			IL_044e: ldloc.s 8
-			IL_0450: ldstr "status"
-			IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_045a: stloc.s 22
-			IL_045c: ldloc.s 22
-			IL_045e: ldc.r8 0.0
-			IL_0467: box [System.Runtime]System.Double
-			IL_046c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0471: stloc.s 29
-			IL_0473: ldloc.s 29
-			IL_0475: brfalse IL_04fa
+			IL_030b: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L137C31::.ctor()
+			IL_0310: stloc.s 7
+			IL_0312: ldstr "console"
+			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_031c: stloc.s 22
+			IL_031e: ldloc.s 22
+			IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0325: stloc.s 22
+			IL_0327: ldloc.s 22
+			IL_0329: ldstr "log"
+			IL_032e: ldstr "Test failed or not found, retrying with build..."
+			IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0338: pop
+			IL_0339: ldarg.0
+			IL_033a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0344: stloc.s 22
+			IL_0346: ldloc.s 4
+			IL_0348: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_034d: stloc.s 24
+			IL_034f: ldstr "FullyQualifiedName="
+			IL_0354: ldloc.s 24
+			IL_0356: call string [System.Runtime]System.String::Concat(string, string)
+			IL_035b: stloc.s 24
+			IL_035d: ldc.i4.4
+			IL_035e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0363: dup
+			IL_0364: ldstr "test"
+			IL_0369: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_036e: dup
+			IL_036f: ldloc.s 5
+			IL_0371: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0376: dup
+			IL_0377: ldstr "--filter"
+			IL_037c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0381: dup
+			IL_0382: ldloc.s 24
+			IL_0384: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0389: stloc.s 25
+			IL_038b: ldloc.s 22
+			IL_038d: ldstr "spawnSync"
+			IL_0392: ldstr "dotnet"
+			IL_0397: ldloc.s 25
+			IL_0399: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_039e: dup
+			IL_039f: ldstr "stdio"
+			IL_03a4: ldstr "inherit"
+			IL_03a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03ae: dup
+			IL_03af: ldstr "shell"
+			IL_03b4: ldc.i4.1
+			IL_03b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_03ba: dup
+			IL_03bb: ldstr "cwd"
+			IL_03c0: ldarg.0
+			IL_03c1: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_03c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_03d0: stloc.s 22
+			IL_03d2: ldloc.s 22
+			IL_03d4: stloc.s 8
+			IL_03d6: ldloc.s 8
+			IL_03d8: ldstr "status"
+			IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e2: stloc.s 22
+			IL_03e4: ldloc.s 22
+			IL_03e6: ldc.r8 0.0
+			IL_03ef: box [System.Runtime]System.Double
+			IL_03f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_03f9: stloc.s 26
+			IL_03fb: ldloc.s 26
+			IL_03fd: brfalse IL_0482
 
-			IL_047a: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L137C31/Block_L150C34::.ctor()
-			IL_047f: stloc.s 9
-			IL_0481: ldstr "console"
-			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_048b: stloc.s 22
-			IL_048d: ldloc.s 22
-			IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0494: stloc.s 22
-			IL_0496: ldloc.s 4
-			IL_0498: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_049d: stloc.s 24
-			IL_049f: ldstr "Test "
-			IL_04a4: ldloc.s 24
-			IL_04a6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04ab: stloc.s 24
-			IL_04ad: ldloc.s 24
-			IL_04af: ldstr " failed or not found."
-			IL_04b4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04b9: stloc.s 24
-			IL_04bb: ldloc.s 22
-			IL_04bd: ldstr "error"
-			IL_04c2: ldloc.s 24
-			IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_04c9: pop
-			IL_04ca: ldstr "process"
-			IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04d4: stloc.s 22
-			IL_04d6: ldloc.s 22
-			IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04dd: stloc.s 22
-			IL_04df: ldloc.s 22
-			IL_04e1: ldstr "exit"
-			IL_04e6: ldc.r8 1
-			IL_04ef: box [System.Runtime]System.Double
-			IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_04f9: pop
+			IL_0402: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L137C31/Block_L150C34::.ctor()
+			IL_0407: stloc.s 9
+			IL_0409: ldstr "console"
+			IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0413: stloc.s 22
+			IL_0415: ldloc.s 22
+			IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_041c: stloc.s 22
+			IL_041e: ldloc.s 4
+			IL_0420: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0425: stloc.s 24
+			IL_0427: ldstr "Test "
+			IL_042c: ldloc.s 24
+			IL_042e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0433: stloc.s 24
+			IL_0435: ldloc.s 24
+			IL_0437: ldstr " failed or not found."
+			IL_043c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0441: stloc.s 24
+			IL_0443: ldloc.s 22
+			IL_0445: ldstr "error"
+			IL_044a: ldloc.s 24
+			IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0451: pop
+			IL_0452: ldstr "process"
+			IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_045c: stloc.s 22
+			IL_045e: ldloc.s 22
+			IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0465: stloc.s 22
+			IL_0467: ldloc.s 22
+			IL_0469: ldstr "exit"
+			IL_046e: ldc.r8 1
+			IL_0477: box [System.Runtime]System.Double
+			IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0481: pop
 
-			IL_04fa: ldarg.0
-			IL_04fb: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
-			IL_0500: stloc.s 22
-			IL_0502: ldstr "getAssemblyFileBaseName"
-			IL_0507: ldloc.s 22
-			IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_050e: stloc.s 22
-			IL_0510: ldloc.s 22
-			IL_0512: ldc.i4.1
-			IL_0513: newarr [System.Runtime]System.Object
-			IL_0518: dup
-			IL_0519: ldc.i4.0
-			IL_051a: ldarg.0
-			IL_051b: stelem.ref
-			IL_051c: ldloc.3
-			IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0522: stloc.s 22
-			IL_0524: ldloc.s 22
-			IL_0526: stloc.s 10
-			IL_0528: ldarg.0
-			IL_0529: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_052e: stloc.s 22
-			IL_0530: ldstr "tryFindLatestGeneratedAssembly"
-			IL_0535: ldloc.s 22
-			IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_053c: stloc.s 22
-			IL_053e: ldloc.s 22
-			IL_0540: ldc.i4.1
-			IL_0541: newarr [System.Runtime]System.Object
-			IL_0546: dup
-			IL_0547: ldc.i4.0
-			IL_0548: ldarg.0
-			IL_0549: stelem.ref
-			IL_054a: ldloc.2
-			IL_054b: ldloc.s 10
-			IL_054d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0552: stloc.s 22
+			IL_0482: ldarg.0
+			IL_0483: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
+			IL_0488: ldc.i4.1
+			IL_0489: newarr [System.Runtime]System.Object
+			IL_048e: dup
+			IL_048f: ldc.i4.0
+			IL_0490: ldarg.0
+			IL_0491: stelem.ref
+			IL_0492: ldloc.3
+			IL_0493: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0498: stloc.s 22
+			IL_049a: ldloc.s 22
+			IL_049c: stloc.s 10
+			IL_049e: ldarg.0
+			IL_049f: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_04a4: ldc.i4.1
+			IL_04a5: newarr [System.Runtime]System.Object
+			IL_04aa: dup
+			IL_04ab: ldc.i4.0
+			IL_04ac: ldarg.0
+			IL_04ad: stelem.ref
+			IL_04ae: ldloc.2
+			IL_04af: ldloc.s 10
+			IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04b6: stloc.s 22
+			IL_04b8: ldloc.s 22
+			IL_04ba: brfalse IL_04d4
+
+			IL_04bf: ldloc.s 22
+			IL_04c1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04c6: brtrue IL_04d4
+
+			IL_04cb: ldloc.s 22
+			IL_04cd: stloc.s 28
+			IL_04cf: br IL_04dc
+
+			IL_04d4: ldc.i4.0
+			IL_04d5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04da: stloc.s 28
+
+			IL_04dc: ldloc.s 28
+			IL_04de: stloc.s 11
+			IL_04e0: ldloc.s 11
+			IL_04e2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04e7: ldc.i4.0
+			IL_04e8: ceq
+			IL_04ea: stloc.s 26
+			IL_04ec: ldloc.s 26
+			IL_04ee: brfalse IL_067c
+
+			IL_04f3: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21::.ctor()
+			IL_04f8: stloc.s 12
+			IL_04fa: ldstr "console"
+			IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0504: stloc.s 22
+			IL_0506: ldloc.s 22
+			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_050d: stloc.s 22
+			IL_050f: ldloc.2
+			IL_0510: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0515: stloc.s 24
+			IL_0517: ldstr "Assembly not found for category '"
+			IL_051c: ldloc.s 24
+			IL_051e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0523: stloc.s 24
+			IL_0525: ldloc.s 24
+			IL_0527: ldstr "' and test '"
+			IL_052c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0531: stloc.s 24
+			IL_0533: ldloc.3
+			IL_0534: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0539: stloc.s 23
+			IL_053b: ldloc.s 24
+			IL_053d: ldloc.s 23
+			IL_053f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0544: stloc.s 23
+			IL_0546: ldloc.s 23
+			IL_0548: ldstr "'."
+			IL_054d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0552: stloc.s 23
 			IL_0554: ldloc.s 22
-			IL_0556: brfalse IL_0570
-
-			IL_055b: ldloc.s 22
-			IL_055d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0562: brtrue IL_0570
-
-			IL_0567: ldloc.s 22
-			IL_0569: stloc.s 31
-			IL_056b: br IL_0578
-
-			IL_0570: ldc.i4.0
-			IL_0571: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0576: stloc.s 31
-
-			IL_0578: ldloc.s 31
-			IL_057a: stloc.s 11
-			IL_057c: ldloc.s 11
-			IL_057e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0583: ldc.i4.0
-			IL_0584: ceq
-			IL_0586: stloc.s 29
-			IL_0588: ldloc.s 29
-			IL_058a: brfalse IL_072a
-
-			IL_058f: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21::.ctor()
-			IL_0594: stloc.s 12
-			IL_0596: ldstr "console"
-			IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0556: ldstr "error"
+			IL_055b: ldloc.s 23
+			IL_055d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0562: pop
+			IL_0563: ldstr "console"
+			IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_056d: stloc.s 22
+			IL_056f: ldloc.s 22
+			IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0576: stloc.s 22
+			IL_0578: ldloc.s 22
+			IL_057a: ldstr "error"
+			IL_057f: ldstr "Looked under:"
+			IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0589: pop
+			IL_058a: ldarg.0
+			IL_058b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
+			IL_0590: ldc.i4.1
+			IL_0591: newarr [System.Runtime]System.Object
+			IL_0596: dup
+			IL_0597: ldc.i4.0
+			IL_0598: ldarg.0
+			IL_0599: stelem.ref
+			IL_059a: ldloc.2
+			IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 			IL_05a0: stloc.s 22
 			IL_05a2: ldloc.s 22
-			IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05a9: stloc.s 22
-			IL_05ab: ldloc.2
-			IL_05ac: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05b1: stloc.s 24
-			IL_05b3: ldstr "Assembly not found for category '"
-			IL_05b8: ldloc.s 24
-			IL_05ba: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05bf: stloc.s 24
-			IL_05c1: ldloc.s 24
-			IL_05c3: ldstr "' and test '"
-			IL_05c8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05cd: stloc.s 24
-			IL_05cf: ldloc.3
-			IL_05d0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05d5: stloc.s 23
-			IL_05d7: ldloc.s 24
-			IL_05d9: ldloc.s 23
-			IL_05db: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05e0: stloc.s 23
-			IL_05e2: ldloc.s 23
-			IL_05e4: ldstr "'."
-			IL_05e9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05ee: stloc.s 23
-			IL_05f0: ldloc.s 22
-			IL_05f2: ldstr "error"
-			IL_05f7: ldloc.s 23
-			IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05fe: pop
-			IL_05ff: ldstr "console"
-			IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0609: stloc.s 22
-			IL_060b: ldloc.s 22
-			IL_060d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0612: stloc.s 22
-			IL_0614: ldloc.s 22
-			IL_0616: ldstr "error"
-			IL_061b: ldstr "Looked under:"
-			IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0625: pop
-			IL_0626: ldarg.0
-			IL_0627: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
-			IL_062c: stloc.s 22
-			IL_062e: ldstr "getCandidateCategoryRoots"
-			IL_0633: ldloc.s 22
-			IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_063a: stloc.s 22
-			IL_063c: ldloc.s 22
-			IL_063e: ldc.i4.1
-			IL_063f: newarr [System.Runtime]System.Object
-			IL_0644: dup
-			IL_0645: ldc.i4.0
-			IL_0646: ldarg.0
-			IL_0647: stelem.ref
-			IL_0648: ldloc.2
-			IL_0649: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_064e: stloc.s 22
-			IL_0650: ldloc.s 22
-			IL_0652: stloc.s 13
-			IL_0654: ldc.r8 0.0
-			IL_065d: stloc.s 14
-			// loop start (head: IL_065f)
-				IL_065f: ldloc.s 14
-				IL_0661: stloc.s 32
-				IL_0663: ldloc.s 32
-				IL_0665: ldloc.s 13
-				IL_0667: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_066c: clt
-				IL_066e: brfalse IL_06d3
+			IL_05a4: stloc.s 13
+			IL_05a6: ldc.r8 0.0
+			IL_05af: stloc.s 14
+			// loop start (head: IL_05b1)
+				IL_05b1: ldloc.s 14
+				IL_05b3: stloc.s 29
+				IL_05b5: ldloc.s 29
+				IL_05b7: ldloc.s 13
+				IL_05b9: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+				IL_05be: clt
+				IL_05c0: brfalse IL_0625
 
-				IL_0673: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Scope_For_L170C9/Block_L170C54::.ctor()
-				IL_0678: stloc.s 15
-				IL_067a: ldstr "console"
-				IL_067f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0684: stloc.s 22
-				IL_0686: ldloc.s 22
-				IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_068d: stloc.s 22
-				IL_068f: ldloc.s 13
-				IL_0691: ldloc.s 14
-				IL_0693: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0698: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_069d: stloc.s 23
-				IL_069f: ldstr "  - "
-				IL_06a4: ldloc.s 23
-				IL_06a6: call string [System.Runtime]System.String::Concat(string, string)
-				IL_06ab: stloc.s 23
-				IL_06ad: ldloc.s 22
-				IL_06af: ldstr "error"
-				IL_06b4: ldloc.s 23
-				IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_06bb: pop
-				IL_06bc: ldloc.s 14
-				IL_06be: ldc.r8 1
-				IL_06c7: add
-				IL_06c8: stloc.s 32
-				IL_06ca: ldloc.s 32
-				IL_06cc: stloc.s 14
-				IL_06ce: br IL_065f
+				IL_05c5: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Scope_For_L170C9/Block_L170C54::.ctor()
+				IL_05ca: stloc.s 15
+				IL_05cc: ldstr "console"
+				IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_05d6: stloc.s 22
+				IL_05d8: ldloc.s 22
+				IL_05da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_05df: stloc.s 22
+				IL_05e1: ldloc.s 13
+				IL_05e3: ldloc.s 14
+				IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_05ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_05ef: stloc.s 23
+				IL_05f1: ldstr "  - "
+				IL_05f6: ldloc.s 23
+				IL_05f8: call string [System.Runtime]System.String::Concat(string, string)
+				IL_05fd: stloc.s 23
+				IL_05ff: ldloc.s 22
+				IL_0601: ldstr "error"
+				IL_0606: ldloc.s 23
+				IL_0608: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_060d: pop
+				IL_060e: ldloc.s 14
+				IL_0610: ldc.r8 1
+				IL_0619: add
+				IL_061a: stloc.s 29
+				IL_061c: ldloc.s 29
+				IL_061e: stloc.s 14
+				IL_0620: br IL_05b1
 			// end loop
 
-			IL_06d3: ldstr "console"
-			IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06dd: stloc.s 22
-			IL_06df: ldloc.s 22
-			IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06e6: stloc.s 22
-			IL_06e8: ldloc.s 22
-			IL_06ea: ldstr "error"
-			IL_06ef: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_06f9: pop
-			IL_06fa: ldstr "process"
-			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0704: stloc.s 22
-			IL_0706: ldloc.s 22
-			IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_070d: stloc.s 22
-			IL_070f: ldloc.s 22
-			IL_0711: ldstr "exit"
-			IL_0716: ldc.r8 1
-			IL_071f: box [System.Runtime]System.Double
-			IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0729: pop
+			IL_0625: ldstr "console"
+			IL_062a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_062f: stloc.s 22
+			IL_0631: ldloc.s 22
+			IL_0633: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0638: stloc.s 22
+			IL_063a: ldloc.s 22
+			IL_063c: ldstr "error"
+			IL_0641: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_0646: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_064b: pop
+			IL_064c: ldstr "process"
+			IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0656: stloc.s 22
+			IL_0658: ldloc.s 22
+			IL_065a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_065f: stloc.s 22
+			IL_0661: ldloc.s 22
+			IL_0663: ldstr "exit"
+			IL_0668: ldc.r8 1
+			IL_0671: box [System.Runtime]System.Double
+			IL_0676: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_067b: pop
 
-			IL_072a: ldstr "console"
-			IL_072f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0734: stloc.s 22
-			IL_0736: ldloc.s 22
-			IL_0738: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_073d: stloc.s 22
-			IL_073f: ldloc.s 11
-			IL_0741: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0746: stloc.s 23
-			IL_0748: ldstr "Found assembly: "
-			IL_074d: ldloc.s 23
-			IL_074f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0754: stloc.s 23
-			IL_0756: ldloc.s 22
-			IL_0758: ldstr "log"
-			IL_075d: ldloc.s 23
-			IL_075f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0764: pop
+			IL_067c: ldstr "console"
+			IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0686: stloc.s 22
+			IL_0688: ldloc.s 22
+			IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_068f: stloc.s 22
+			IL_0691: ldloc.s 11
+			IL_0693: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0698: stloc.s 23
+			IL_069a: ldstr "Found assembly: "
+			IL_069f: ldloc.s 23
+			IL_06a1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06a6: stloc.s 23
+			IL_06a8: ldloc.s 22
+			IL_06aa: ldstr "log"
+			IL_06af: ldloc.s 23
+			IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_06b6: pop
 			.try
 			{
-				IL_0765: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L180C6::.ctor()
-				IL_076a: stloc.s 16
-				IL_076c: ldstr "console"
-				IL_0771: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0776: stloc.s 22
-				IL_0778: ldloc.s 22
-				IL_077a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_077f: stloc.s 22
-				IL_0781: ldloc.s 22
-				IL_0783: ldstr "log"
-				IL_0788: ldstr "Opening in ILSpy..."
-				IL_078d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0792: pop
-				IL_0793: ldarg.0
-				IL_0794: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
-				IL_0799: stloc.s 22
-				IL_079b: ldstr "openInIlSpy"
-				IL_07a0: ldloc.s 22
-				IL_07a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_07a7: stloc.s 22
-				IL_07a9: ldloc.s 22
-				IL_07ab: ldc.i4.1
-				IL_07ac: newarr [System.Runtime]System.Object
-				IL_07b1: dup
-				IL_07b2: ldc.i4.0
-				IL_07b3: ldarg.0
-				IL_07b4: stelem.ref
-				IL_07b5: ldloc.s 11
-				IL_07b7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_07bc: pop
-				IL_07bd: leave IL_087f
+				IL_06b7: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L180C6::.ctor()
+				IL_06bc: stloc.s 16
+				IL_06be: ldstr "console"
+				IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_06c8: stloc.s 22
+				IL_06ca: ldloc.s 22
+				IL_06cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_06d1: stloc.s 22
+				IL_06d3: ldloc.s 22
+				IL_06d5: ldstr "log"
+				IL_06da: ldstr "Opening in ILSpy..."
+				IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_06e4: pop
+				IL_06e5: ldarg.0
+				IL_06e6: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
+				IL_06eb: ldc.i4.1
+				IL_06ec: newarr [System.Runtime]System.Object
+				IL_06f1: dup
+				IL_06f2: ldc.i4.0
+				IL_06f3: ldarg.0
+				IL_06f4: stelem.ref
+				IL_06f5: ldloc.s 11
+				IL_06f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_06fc: pop
+				IL_06fd: leave IL_07bf
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_07c2: stloc.s 17
-				IL_07c4: ldloc.s 17
-				IL_07c6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_07cb: dup
-				IL_07cc: brtrue IL_07e2
+				IL_0702: stloc.s 17
+				IL_0704: ldloc.s 17
+				IL_0706: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_070b: dup
+				IL_070c: brtrue IL_0722
 
-				IL_07d1: pop
-				IL_07d2: ldloc.s 17
-				IL_07d4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_07d9: dup
-				IL_07da: brtrue IL_07ee
+				IL_0711: pop
+				IL_0712: ldloc.s 17
+				IL_0714: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0719: dup
+				IL_071a: brtrue IL_072e
 
-				IL_07df: pop
-				IL_07e0: rethrow
+				IL_071f: pop
+				IL_0720: rethrow
 
-				IL_07e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_07e7: stloc.s 18
-				IL_07e9: br IL_07f0
+				IL_0722: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0727: stloc.s 18
+				IL_0729: br IL_0730
 
-				IL_07ee: stloc.s 18
+				IL_072e: stloc.s 18
 
-				IL_07f0: ldloc.s 18
-				IL_07f2: stloc.s 22
-				IL_07f4: ldloc.s 22
-				IL_07f6: stloc.s 19
-				IL_07f8: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L183C16::.ctor()
-				IL_07fd: stloc.s 20
-				IL_07ff: ldstr "console"
-				IL_0804: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0809: stloc.s 22
-				IL_080b: ldloc.s 22
-				IL_080d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0812: stloc.s 22
-				IL_0814: ldloc.s 22
-				IL_0816: ldstr "error"
-				IL_081b: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_0820: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0825: pop
-				IL_0826: ldstr "console"
-				IL_082b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0830: stloc.s 22
-				IL_0832: ldloc.s 22
-				IL_0834: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0839: stloc.s 22
-				IL_083b: ldloc.s 22
-				IL_083d: ldstr "error"
-				IL_0842: ldloc.s 19
-				IL_0844: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0849: pop
-				IL_084a: ldstr "process"
-				IL_084f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0854: stloc.s 22
-				IL_0856: ldloc.s 22
-				IL_0858: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_085d: stloc.s 22
-				IL_085f: ldloc.s 22
-				IL_0861: ldstr "exit"
-				IL_0866: ldc.r8 1
-				IL_086f: box [System.Runtime]System.Double
-				IL_0874: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0879: pop
-				IL_087a: leave IL_087f
+				IL_0730: ldloc.s 18
+				IL_0732: stloc.s 22
+				IL_0734: ldloc.s 22
+				IL_0736: stloc.s 19
+				IL_0738: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L183C16::.ctor()
+				IL_073d: stloc.s 20
+				IL_073f: ldstr "console"
+				IL_0744: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0749: stloc.s 22
+				IL_074b: ldloc.s 22
+				IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0752: stloc.s 22
+				IL_0754: ldloc.s 22
+				IL_0756: ldstr "error"
+				IL_075b: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0765: pop
+				IL_0766: ldstr "console"
+				IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0770: stloc.s 22
+				IL_0772: ldloc.s 22
+				IL_0774: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0779: stloc.s 22
+				IL_077b: ldloc.s 22
+				IL_077d: ldstr "error"
+				IL_0782: ldloc.s 19
+				IL_0784: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0789: pop
+				IL_078a: ldstr "process"
+				IL_078f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0794: stloc.s 22
+				IL_0796: ldloc.s 22
+				IL_0798: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_079d: stloc.s 22
+				IL_079f: ldloc.s 22
+				IL_07a1: ldstr "exit"
+				IL_07a6: ldc.r8 1
+				IL_07af: box [System.Runtime]System.Double
+				IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_07b9: pop
+				IL_07ba: leave IL_07bf
 			} // end handler
 
-			IL_087f: ldstr "console"
-			IL_0884: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0889: stloc.s 22
-			IL_088b: ldloc.s 22
-			IL_088d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0892: stloc.s 22
-			IL_0894: ldloc.s 22
-			IL_0896: ldstr "log"
-			IL_089b: ldstr "Done!"
-			IL_08a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_08a5: pop
-			IL_08a6: ldnull
-			IL_08a7: stloc.s 21
-			IL_08a9: ldloc.s 21
-			IL_08ab: ret
+			IL_07bf: ldstr "console"
+			IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07c9: stloc.s 22
+			IL_07cb: ldloc.s 22
+			IL_07cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07d2: stloc.s 22
+			IL_07d4: ldloc.s 22
+			IL_07d6: ldstr "log"
+			IL_07db: ldstr "Done!"
+			IL_07e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_07e5: pop
+			IL_07e6: ldnull
+			IL_07e7: stloc.s 21
+			IL_07e9: ldloc.s 21
+			IL_07eb: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -2499,7 +2324,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3435
+			// Method begins at RVA 0x3247
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2728,7 +2553,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3516
+		// Method begins at RVA 0x3328
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4abf
+				// Method begins at RVA 0x483b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,14 +54,12 @@
 			)
 			// Method begins at RVA 0x2320
 			// Header size: 12
-			// Code size: 331 (0x14b)
+			// Code size: 273 (0x111)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope,
 				[1] object,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate,
-				[3] object,
-				[4] object[]
+				[2] object
 			)
 
 			IL_0000: ldarg.0
@@ -94,14 +92,14 @@
 			IL_0042: brtrue IL_0053
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.4
+			IL_0048: ldc.i4.2
 			IL_0049: newarr [System.Runtime]System.Object
 			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0053: ldloc.0
 			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0059: ldc.i4.0
-			IL_005a: ble IL_0081
+			IL_005a: ble IL_006e
 
 			IL_005f: ldloc.0
 			IL_0060: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -112,108 +110,74 @@
 			IL_0069: dup
 			IL_006a: ldc.i4.1
 			IL_006b: ldelem.ref
-			IL_006c: castclass [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate
-			IL_0071: stloc.2
-			IL_0072: dup
-			IL_0073: ldc.i4.2
-			IL_0074: ldelem.ref
-			IL_0075: stloc.3
-			IL_0076: dup
-			IL_0077: ldc.i4.3
-			IL_0078: ldelem.ref
-			IL_0079: castclass object[]
-			IL_007e: stloc.s 4
-			IL_0080: pop
+			IL_006c: stloc.2
+			IL_006d: pop
 
-			IL_0081: ldloc.0
-			IL_0082: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0087: switch (IL_0094, IL_0119)
+			IL_006e: ldloc.0
+			IL_006f: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0074: switch (IL_0081, IL_00df)
 
-			IL_0094: ldarg.0
-			IL_0095: ldc.i4.1
-			IL_0096: ldelem.ref
-			IL_0097: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope
-			IL_009c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::require
+			IL_0081: ldarg.0
+			IL_0082: ldc.i4.1
+			IL_0083: ldelem.ref
+			IL_0084: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope
+			IL_0089: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope::require
+			IL_008e: ldstr "./Compile_Scripts_ExtractEcma262SectionHtml_TestHarness"
+			IL_0093: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0098: stloc.2
+			IL_0099: ldloc.2
+			IL_009a: stloc.1
+			IL_009b: ldloc.1
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00a1: stloc.2
-			IL_00a2: ldstr "require"
-			IL_00a7: ldloc.2
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ad: stloc.3
-			IL_00ae: ldc.i4.1
-			IL_00af: newarr [System.Runtime]System.Object
-			IL_00b4: dup
-			IL_00b5: ldc.i4.0
-			IL_00b6: ldarg.0
-			IL_00b7: ldc.i4.1
-			IL_00b8: ldelem.ref
-			IL_00b9: stelem.ref
-			IL_00ba: stloc.s 4
-			IL_00bc: ldloc.3
-			IL_00bd: ldloc.s 4
-			IL_00bf: ldstr "./Compile_Scripts_ExtractEcma262SectionHtml_TestHarness"
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00c9: stloc.3
-			IL_00ca: ldloc.3
-			IL_00cb: stloc.1
+			IL_00a2: ldloc.2
+			IL_00a3: ldstr "runHarnessCli"
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00ad: stloc.2
+			IL_00ae: ldloc.0
+			IL_00af: ldc.i4.1
+			IL_00b0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00b5: ldloc.0
+			IL_00b6: ldloc.2
+			IL_00b7: ldarg.0
+			IL_00b8: ldc.i4.1
+			IL_00b9: ldloc.0
+			IL_00ba: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00c4: ldloc.0
+			IL_00c5: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00ca: dup
+			IL_00cb: ldc.i4.0
 			IL_00cc: ldloc.1
-			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d2: stloc.3
-			IL_00d3: ldloc.3
-			IL_00d4: ldstr "runHarnessCli"
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00de: stloc.3
-			IL_00df: ldloc.0
-			IL_00e0: ldc.i4.1
-			IL_00e1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00e6: ldloc.0
-			IL_00e7: ldloc.3
-			IL_00e8: ldarg.0
-			IL_00e9: ldc.i4.1
-			IL_00ea: ldloc.0
-			IL_00eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_00f5: ldloc.0
-			IL_00f6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00fb: dup
-			IL_00fc: ldc.i4.0
-			IL_00fd: ldloc.1
-			IL_00fe: stelem.ref
-			IL_00ff: dup
-			IL_0100: ldc.i4.1
-			IL_0101: ldloc.2
-			IL_0102: stelem.ref
-			IL_0103: dup
-			IL_0104: ldc.i4.2
-			IL_0105: ldloc.3
-			IL_0106: stelem.ref
-			IL_0107: dup
-			IL_0108: ldc.i4.3
-			IL_0109: ldloc.s 4
-			IL_010b: stelem.ref
-			IL_010c: pop
-			IL_010d: ldloc.0
-			IL_010e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0113: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0118: ret
+			IL_00cd: stelem.ref
+			IL_00ce: dup
+			IL_00cf: ldc.i4.1
+			IL_00d0: ldloc.2
+			IL_00d1: stelem.ref
+			IL_00d2: pop
+			IL_00d3: ldloc.0
+			IL_00d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00d9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_00de: ret
 
-			IL_0119: ldloc.0
-			IL_011a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::_awaited1
-			IL_011f: pop
-			IL_0120: ldloc.0
-			IL_0121: ldc.i4.m1
-			IL_0122: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0127: ldloc.0
-			IL_0128: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_012d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0132: ldarg.0
-			IL_0133: ldc.i4.1
-			IL_0134: newarr [System.Runtime]System.Object
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_013e: pop
-			IL_013f: ldloc.0
-			IL_0140: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0145: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_014a: ret
+			IL_00df: ldloc.0
+			IL_00e0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/Scope::_awaited1
+			IL_00e5: pop
+			IL_00e6: ldloc.0
+			IL_00e7: ldc.i4.m1
+			IL_00e8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00ed: ldloc.0
+			IL_00ee: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_00f8: ldarg.0
+			IL_00f9: ldc.i4.1
+			IL_00fa: newarr [System.Runtime]System.Object
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0104: pop
+			IL_0105: ldloc.0
+			IL_0106: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_010b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0110: ret
 		} // end of method run::__js_call__
 
 	} // end of class run
@@ -236,7 +200,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ac8
+				// Method begins at RVA 0x4844
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -260,7 +224,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2478
+			// Method begins at RVA 0x2440
 			// Header size: 12
 			// Code size: 200 (0xc8)
 			.maxstack 8
@@ -376,7 +340,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4ab6
+			// Method begins at RVA 0x4832
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -489,7 +453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ae3
+					// Method begins at RVA 0x485f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -507,7 +471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ada
+				// Method begins at RVA 0x4856
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -532,7 +496,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x254c
+			// Method begins at RVA 0x2514
 			// Header size: 12
 			// Code size: 306 (0x132)
 			.maxstack 8
@@ -659,7 +623,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4aec
+				// Method begins at RVA 0x4868
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -687,7 +651,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b07
+						// Method begins at RVA 0x4883
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -707,7 +671,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b10
+						// Method begins at RVA 0x488c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -727,7 +691,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b19
+						// Method begins at RVA 0x4895
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -747,7 +711,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b22
+						// Method begins at RVA 0x489e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -767,7 +731,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b2b
+						// Method begins at RVA 0x48a7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -787,7 +751,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b34
+						// Method begins at RVA 0x48b0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -805,7 +769,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4afe
+					// Method begins at RVA 0x487a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -823,7 +787,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4af5
+				// Method begins at RVA 0x4871
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -850,7 +814,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x268c
+			// Method begins at RVA 0x2654
 			// Header size: 12
 			// Code size: 824 (0x338)
 			.maxstack 8
@@ -1212,7 +1176,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4b8e
+							// Method begins at RVA 0x490a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1237,13 +1201,12 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4a0c
+						// Method begins at RVA 0x47b4
 						// Header size: 12
-						// Code size: 50 (0x32)
+						// Code size: 36 (0x24)
 						.maxstack 8
 						.locals init (
-							[0] object,
-							[1] object
+							[0] object
 						)
 
 						IL_0000: ldarg.0
@@ -1251,23 +1214,17 @@
 						IL_0002: ldelem.ref
 						IL_0003: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
 						IL_0008: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-						IL_000d: stloc.0
-						IL_000e: ldstr "data"
-						IL_0013: ldloc.0
-						IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-						IL_0019: stloc.0
-						IL_001a: ldloc.0
-						IL_001b: ldarg.2
-						IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-						IL_0021: stloc.1
-						IL_0022: ldarg.0
-						IL_0023: ldc.i4.3
-						IL_0024: ldelem.ref
-						IL_0025: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
-						IL_002a: ldloc.1
-						IL_002b: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-						IL_0030: ldnull
-						IL_0031: ret
+						IL_000d: ldarg.2
+						IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+						IL_0013: stloc.0
+						IL_0014: ldarg.0
+						IL_0015: ldc.i4.3
+						IL_0016: ldelem.ref
+						IL_0017: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+						IL_001c: ldloc.0
+						IL_001d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+						IL_0022: ldnull
+						IL_0023: ret
 					} // end of method ArrowFunction_L116C24::__js_call__
 
 				} // end of class ArrowFunction_L116C24
@@ -1283,7 +1240,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4b97
+							// Method begins at RVA 0x4913
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1307,70 +1264,56 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4a4c
+						// Method begins at RVA 0x47e4
 						// Header size: 12
-						// Code size: 94 (0x5e)
+						// Code size: 66 (0x42)
 						.maxstack 8
 						.locals init (
-							[0] object,
-							[1] object[],
-							[2] object
+							[0] object[]
 						)
 
-						IL_0000: ldarg.0
-						IL_0001: ldc.i4.2
-						IL_0002: ldelem.ref
-						IL_0003: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-						IL_0008: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-						IL_000d: stloc.0
-						IL_000e: ldstr "resolve"
-						IL_0013: ldloc.0
-						IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-						IL_0019: stloc.0
-						IL_001a: ldc.i4.4
-						IL_001b: newarr [System.Runtime]System.Object
-						IL_0020: dup
-						IL_0021: ldc.i4.0
-						IL_0022: ldarg.0
-						IL_0023: ldc.i4.0
-						IL_0024: ldelem.ref
-						IL_0025: stelem.ref
-						IL_0026: dup
-						IL_0027: ldc.i4.1
-						IL_0028: ldarg.0
-						IL_0029: ldc.i4.1
-						IL_002a: ldelem.ref
-						IL_002b: stelem.ref
-						IL_002c: dup
-						IL_002d: ldc.i4.2
-						IL_002e: ldarg.0
-						IL_002f: ldc.i4.2
-						IL_0030: ldelem.ref
-						IL_0031: stelem.ref
-						IL_0032: dup
-						IL_0033: ldc.i4.3
-						IL_0034: ldarg.0
-						IL_0035: ldc.i4.3
-						IL_0036: ldelem.ref
-						IL_0037: stelem.ref
-						IL_0038: stloc.1
-						IL_0039: ldarg.0
-						IL_003a: ldc.i4.3
-						IL_003b: ldelem.ref
-						IL_003c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
-						IL_0041: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-						IL_0046: stloc.2
-						IL_0047: ldstr "data"
-						IL_004c: ldloc.2
-						IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-						IL_0052: stloc.2
-						IL_0053: ldloc.0
-						IL_0054: ldloc.1
-						IL_0055: ldloc.2
-						IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-						IL_005b: pop
-						IL_005c: ldnull
-						IL_005d: ret
+						IL_0000: ldc.i4.4
+						IL_0001: newarr [System.Runtime]System.Object
+						IL_0006: dup
+						IL_0007: ldc.i4.0
+						IL_0008: ldarg.0
+						IL_0009: ldc.i4.0
+						IL_000a: ldelem.ref
+						IL_000b: stelem.ref
+						IL_000c: dup
+						IL_000d: ldc.i4.1
+						IL_000e: ldarg.0
+						IL_000f: ldc.i4.1
+						IL_0010: ldelem.ref
+						IL_0011: stelem.ref
+						IL_0012: dup
+						IL_0013: ldc.i4.2
+						IL_0014: ldarg.0
+						IL_0015: ldc.i4.2
+						IL_0016: ldelem.ref
+						IL_0017: stelem.ref
+						IL_0018: dup
+						IL_0019: ldc.i4.3
+						IL_001a: ldarg.0
+						IL_001b: ldc.i4.3
+						IL_001c: ldelem.ref
+						IL_001d: stelem.ref
+						IL_001e: stloc.0
+						IL_001f: ldarg.0
+						IL_0020: ldc.i4.2
+						IL_0021: ldelem.ref
+						IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+						IL_0027: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+						IL_002c: ldloc.0
+						IL_002d: ldarg.0
+						IL_002e: ldc.i4.3
+						IL_002f: ldelem.ref
+						IL_0030: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+						IL_0035: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+						IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+						IL_003f: pop
+						IL_0040: ldnull
+						IL_0041: ret
 					} // end of method ArrowFunction_L119C23::__js_call__
 
 				} // end of class ArrowFunction_L119C23
@@ -1394,7 +1337,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x4b7c
+								// Method begins at RVA 0x48f8
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1412,7 +1355,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4b73
+							// Method begins at RVA 0x48ef
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1432,7 +1375,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4b85
+							// Method begins at RVA 0x4901
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1454,7 +1397,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b6a
+						// Method begins at RVA 0x48e6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1479,9 +1422,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x44ac
+					// Method begins at RVA 0x4318
 					// Header size: 12
-					// Code size: 1361 (0x551)
+					// Code size: 1167 (0x48f)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -1501,12 +1444,10 @@
 						[14] object,
 						[15] object,
 						[16] object[],
-						[17] object,
-						[18] string,
+						[17] string,
+						[18] object,
 						[19] object,
-						[20] object,
-						[21] object,
-						[22] string
+						[20] string
 					)
 
 					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::.ctor()
@@ -1590,7 +1531,7 @@
 					IL_00d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00dc: stloc.s 8
 					IL_00de: ldloc.s 8
-					IL_00e0: brfalse IL_0328
+					IL_00e0: brfalse IL_0286
 
 					IL_00e5: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55::.ctor()
 					IL_00ea: stloc.3
@@ -1599,460 +1540,396 @@
 					IL_00ed: ldelem.ref
 					IL_00ee: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
 					IL_00f3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_00f8: stloc.s 7
-					IL_00fa: ldstr "maxRedirects"
-					IL_00ff: ldloc.s 7
-					IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0106: stloc.s 7
-					IL_0108: ldloc.s 7
-					IL_010a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_010f: stloc.s 11
-					IL_0111: ldloc.s 11
-					IL_0113: ldc.r8 0.0
-					IL_011c: cgt
-					IL_011e: ldc.i4.0
-					IL_011f: ceq
-					IL_0121: brfalse IL_01c9
+					IL_00f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_00fd: ldc.r8 0.0
+					IL_0106: cgt
+					IL_0108: ldc.i4.0
+					IL_0109: ceq
+					IL_010b: brfalse IL_0193
 
-					IL_0126: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55/Block_L96C33::.ctor()
-					IL_012b: stloc.s 4
-					IL_012d: ldarg.2
-					IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0133: stloc.s 7
-					IL_0135: ldloc.s 7
-					IL_0137: ldstr "resume"
-					IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_0141: pop
-					IL_0142: ldarg.0
-					IL_0143: ldc.i4.2
-					IL_0144: ldelem.ref
-					IL_0145: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_014a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_014f: stloc.s 7
-					IL_0151: ldstr "reject"
-					IL_0156: ldloc.s 7
-					IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_015d: stloc.s 7
-					IL_015f: ldc.i4.3
-					IL_0160: newarr [System.Runtime]System.Object
-					IL_0165: dup
-					IL_0166: ldc.i4.0
-					IL_0167: ldarg.0
-					IL_0168: ldc.i4.0
-					IL_0169: ldelem.ref
-					IL_016a: stelem.ref
-					IL_016b: dup
-					IL_016c: ldc.i4.1
-					IL_016d: ldarg.0
-					IL_016e: ldc.i4.1
-					IL_016f: ldelem.ref
-					IL_0170: stelem.ref
-					IL_0171: dup
-					IL_0172: ldc.i4.2
-					IL_0173: ldarg.0
-					IL_0174: ldc.i4.2
-					IL_0175: ldelem.ref
-					IL_0176: stelem.ref
-					IL_0177: stloc.s 16
-					IL_0179: ldarg.0
-					IL_017a: ldc.i4.1
-					IL_017b: ldelem.ref
-					IL_017c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0181: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0186: stloc.s 17
-					IL_0188: ldstr "urlString"
-					IL_018d: ldloc.s 17
-					IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0194: stloc.s 17
-					IL_0196: ldloc.s 17
-					IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_019d: stloc.s 18
-					IL_019f: ldstr "Too many redirects fetching "
-					IL_01a4: ldloc.s 18
-					IL_01a6: call string [System.Runtime]System.String::Concat(string, string)
-					IL_01ab: stloc.s 18
-					IL_01ad: ldloc.s 18
-					IL_01af: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_01b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_01b9: stloc.s 17
-					IL_01bb: ldloc.s 7
-					IL_01bd: ldloc.s 16
-					IL_01bf: ldloc.s 17
-					IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_01c6: pop
-					IL_01c7: ldnull
-					IL_01c8: ret
+					IL_0110: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55/Block_L96C33::.ctor()
+					IL_0115: stloc.s 4
+					IL_0117: ldarg.2
+					IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_011d: stloc.s 7
+					IL_011f: ldloc.s 7
+					IL_0121: ldstr "resume"
+					IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_012b: pop
+					IL_012c: ldarg.0
+					IL_012d: ldc.i4.2
+					IL_012e: ldelem.ref
+					IL_012f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0134: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0139: stloc.s 7
+					IL_013b: ldc.i4.3
+					IL_013c: newarr [System.Runtime]System.Object
+					IL_0141: dup
+					IL_0142: ldc.i4.0
+					IL_0143: ldarg.0
+					IL_0144: ldc.i4.0
+					IL_0145: ldelem.ref
+					IL_0146: stelem.ref
+					IL_0147: dup
+					IL_0148: ldc.i4.1
+					IL_0149: ldarg.0
+					IL_014a: ldc.i4.1
+					IL_014b: ldelem.ref
+					IL_014c: stelem.ref
+					IL_014d: dup
+					IL_014e: ldc.i4.2
+					IL_014f: ldarg.0
+					IL_0150: ldc.i4.2
+					IL_0151: ldelem.ref
+					IL_0152: stelem.ref
+					IL_0153: stloc.s 16
+					IL_0155: ldarg.0
+					IL_0156: ldc.i4.1
+					IL_0157: ldelem.ref
+					IL_0158: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_015d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0162: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0167: stloc.s 17
+					IL_0169: ldstr "Too many redirects fetching "
+					IL_016e: ldloc.s 17
+					IL_0170: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0175: stloc.s 17
+					IL_0177: ldloc.s 17
+					IL_0179: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_017e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0183: stloc.s 18
+					IL_0185: ldloc.s 7
+					IL_0187: ldloc.s 16
+					IL_0189: ldloc.s 18
+					IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0190: pop
+					IL_0191: ldnull
+					IL_0192: ret
 
-					IL_01c9: ldarg.0
-					IL_01ca: ldc.i4.0
-					IL_01cb: ldelem.ref
-					IL_01cc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_01d1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-					IL_01d6: stloc.s 17
-					IL_01d8: ldstr "NodeUrl"
-					IL_01dd: ldloc.s 17
-					IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_01e4: stloc.s 17
-					IL_01e6: ldarg.0
-					IL_01e7: ldc.i4.2
-					IL_01e8: ldelem.ref
-					IL_01e9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_01ee: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_01f3: stloc.s 7
-					IL_01f5: ldstr "urlObj"
-					IL_01fa: ldloc.s 7
-					IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0201: stloc.s 7
-					IL_0203: ldc.i4.2
-					IL_0204: newarr [System.Runtime]System.Object
-					IL_0209: dup
-					IL_020a: ldc.i4.0
-					IL_020b: ldloc.2
-					IL_020c: stelem.ref
-					IL_020d: dup
-					IL_020e: ldc.i4.1
-					IL_020f: ldloc.s 7
-					IL_0211: stelem.ref
-					IL_0212: stloc.s 16
-					IL_0214: ldloc.s 17
-					IL_0216: ldloc.s 16
-					IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_021d: stloc.s 17
-					IL_021f: ldloc.s 17
-					IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0226: stloc.s 17
-					IL_0228: ldloc.s 17
-					IL_022a: ldstr "toString"
-					IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_0234: stloc.s 17
-					IL_0236: ldloc.s 17
-					IL_0238: stloc.s 5
-					IL_023a: ldarg.2
-					IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0240: stloc.s 17
-					IL_0242: ldloc.s 17
-					IL_0244: ldstr "resume"
-					IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_024e: pop
-					IL_024f: ldarg.0
-					IL_0250: ldc.i4.0
-					IL_0251: ldelem.ref
-					IL_0252: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0257: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-					IL_025c: stloc.s 17
-					IL_025e: ldstr "fetchText"
-					IL_0263: ldloc.s 17
-					IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_026a: stloc.s 17
-					IL_026c: ldc.i4.3
-					IL_026d: newarr [System.Runtime]System.Object
-					IL_0272: dup
-					IL_0273: ldc.i4.0
-					IL_0274: ldarg.0
-					IL_0275: ldc.i4.0
-					IL_0276: ldelem.ref
-					IL_0277: stelem.ref
-					IL_0278: dup
-					IL_0279: ldc.i4.1
-					IL_027a: ldarg.0
-					IL_027b: ldc.i4.1
-					IL_027c: ldelem.ref
-					IL_027d: stelem.ref
-					IL_027e: dup
-					IL_027f: ldc.i4.2
-					IL_0280: ldarg.0
-					IL_0281: ldc.i4.2
-					IL_0282: ldelem.ref
-					IL_0283: stelem.ref
-					IL_0284: stloc.s 16
-					IL_0286: ldarg.0
-					IL_0287: ldc.i4.1
-					IL_0288: ldelem.ref
-					IL_0289: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_028e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_0293: stloc.s 7
-					IL_0295: ldstr "maxRedirects"
-					IL_029a: ldloc.s 7
-					IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_02a1: stloc.s 7
-					IL_02a3: ldloc.s 7
-					IL_02a5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_02aa: stloc.s 11
-					IL_02ac: ldloc.s 11
-					IL_02ae: ldc.r8 1
-					IL_02b7: sub
-					IL_02b8: stloc.s 11
-					IL_02ba: ldloc.s 11
-					IL_02bc: box [System.Runtime]System.Double
-					IL_02c1: stloc.s 19
-					IL_02c3: ldloc.s 17
-					IL_02c5: ldloc.s 16
-					IL_02c7: ldloc.s 5
-					IL_02c9: ldloc.s 19
-					IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-					IL_02d0: stloc.s 17
-					IL_02d2: ldloc.s 17
-					IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02d9: stloc.s 17
-					IL_02db: ldarg.0
-					IL_02dc: ldc.i4.2
-					IL_02dd: ldelem.ref
-					IL_02de: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_02e3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_02e8: stloc.s 7
-					IL_02ea: ldstr "resolve"
-					IL_02ef: ldloc.s 7
-					IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_02f6: stloc.s 7
-					IL_02f8: ldarg.0
-					IL_02f9: ldc.i4.2
-					IL_02fa: ldelem.ref
-					IL_02fb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0300: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0305: stloc.s 20
-					IL_0307: ldstr "reject"
-					IL_030c: ldloc.s 20
-					IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0313: stloc.s 20
-					IL_0315: ldloc.s 17
-					IL_0317: ldstr "then"
-					IL_031c: ldloc.s 7
-					IL_031e: ldloc.s 20
-					IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0325: pop
-					IL_0326: ldnull
-					IL_0327: ret
+					IL_0193: ldarg.0
+					IL_0194: ldc.i4.0
+					IL_0195: ldelem.ref
+					IL_0196: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_019b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+					IL_01a0: stloc.s 18
+					IL_01a2: ldc.i4.2
+					IL_01a3: newarr [System.Runtime]System.Object
+					IL_01a8: dup
+					IL_01a9: ldc.i4.0
+					IL_01aa: ldloc.2
+					IL_01ab: stelem.ref
+					IL_01ac: dup
+					IL_01ad: ldc.i4.1
+					IL_01ae: ldarg.0
+					IL_01af: ldc.i4.2
+					IL_01b0: ldelem.ref
+					IL_01b1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_01b6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_01bb: stelem.ref
+					IL_01bc: stloc.s 16
+					IL_01be: ldloc.s 18
+					IL_01c0: ldloc.s 16
+					IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_01c7: stloc.s 18
+					IL_01c9: ldloc.s 18
+					IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01d0: stloc.s 18
+					IL_01d2: ldloc.s 18
+					IL_01d4: ldstr "toString"
+					IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01de: stloc.s 18
+					IL_01e0: ldloc.s 18
+					IL_01e2: stloc.s 5
+					IL_01e4: ldarg.2
+					IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01ea: stloc.s 18
+					IL_01ec: ldloc.s 18
+					IL_01ee: ldstr "resume"
+					IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01f8: pop
+					IL_01f9: ldarg.0
+					IL_01fa: ldc.i4.0
+					IL_01fb: ldelem.ref
+					IL_01fc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_0201: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+					IL_0206: stloc.s 18
+					IL_0208: ldc.i4.3
+					IL_0209: newarr [System.Runtime]System.Object
+					IL_020e: dup
+					IL_020f: ldc.i4.0
+					IL_0210: ldarg.0
+					IL_0211: ldc.i4.0
+					IL_0212: ldelem.ref
+					IL_0213: stelem.ref
+					IL_0214: dup
+					IL_0215: ldc.i4.1
+					IL_0216: ldarg.0
+					IL_0217: ldc.i4.1
+					IL_0218: ldelem.ref
+					IL_0219: stelem.ref
+					IL_021a: dup
+					IL_021b: ldc.i4.2
+					IL_021c: ldarg.0
+					IL_021d: ldc.i4.2
+					IL_021e: ldelem.ref
+					IL_021f: stelem.ref
+					IL_0220: stloc.s 16
+					IL_0222: ldloc.s 18
+					IL_0224: ldloc.s 16
+					IL_0226: ldloc.s 5
+					IL_0228: ldarg.0
+					IL_0229: ldc.i4.1
+					IL_022a: ldelem.ref
+					IL_022b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0230: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_0235: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_023a: ldc.r8 1
+					IL_0243: sub
+					IL_0244: box [System.Runtime]System.Double
+					IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+					IL_024e: stloc.s 18
+					IL_0250: ldloc.s 18
+					IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0257: stloc.s 18
+					IL_0259: ldarg.0
+					IL_025a: ldc.i4.2
+					IL_025b: ldelem.ref
+					IL_025c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0261: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_0266: stloc.s 7
+					IL_0268: ldloc.s 18
+					IL_026a: ldstr "then"
+					IL_026f: ldloc.s 7
+					IL_0271: ldarg.0
+					IL_0272: ldc.i4.2
+					IL_0273: ldelem.ref
+					IL_0274: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0279: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0283: pop
+					IL_0284: ldnull
+					IL_0285: ret
 
-					IL_0328: ldloc.1
-					IL_0329: stloc.s 14
-					IL_032b: ldloc.s 14
-					IL_032d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0332: stloc.s 11
-					IL_0334: ldloc.s 11
-					IL_0336: ldc.r8 200
-					IL_033f: clt
-					IL_0341: stloc.s 8
-					IL_0343: ldloc.s 8
-					IL_0345: box [System.Runtime]System.Boolean
-					IL_034a: stloc.s 12
-					IL_034c: ldloc.s 12
-					IL_034e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0353: stloc.s 8
-					IL_0355: ldloc.s 8
-					IL_0357: brtrue IL_038c
+					IL_0286: ldloc.1
+					IL_0287: stloc.s 14
+					IL_0289: ldloc.s 14
+					IL_028b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0290: stloc.s 11
+					IL_0292: ldloc.s 11
+					IL_0294: ldc.r8 200
+					IL_029d: clt
+					IL_029f: stloc.s 8
+					IL_02a1: ldloc.s 8
+					IL_02a3: box [System.Runtime]System.Boolean
+					IL_02a8: stloc.s 12
+					IL_02aa: ldloc.s 12
+					IL_02ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02b1: stloc.s 8
+					IL_02b3: ldloc.s 8
+					IL_02b5: brtrue IL_02ea
 
-					IL_035c: ldloc.1
-					IL_035d: stloc.s 14
-					IL_035f: ldloc.s 14
-					IL_0361: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0366: stloc.s 11
-					IL_0368: ldloc.s 11
-					IL_036a: ldc.r8 300
-					IL_0373: clt
-					IL_0375: ldc.i4.0
-					IL_0376: ceq
-					IL_0378: stloc.s 8
-					IL_037a: ldloc.s 8
-					IL_037c: box [System.Runtime]System.Boolean
-					IL_0381: stloc.s 13
-					IL_0383: ldloc.s 13
-					IL_0385: stloc.s 21
-					IL_0387: br IL_0390
+					IL_02ba: ldloc.1
+					IL_02bb: stloc.s 14
+					IL_02bd: ldloc.s 14
+					IL_02bf: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_02c4: stloc.s 11
+					IL_02c6: ldloc.s 11
+					IL_02c8: ldc.r8 300
+					IL_02d1: clt
+					IL_02d3: ldc.i4.0
+					IL_02d4: ceq
+					IL_02d6: stloc.s 8
+					IL_02d8: ldloc.s 8
+					IL_02da: box [System.Runtime]System.Boolean
+					IL_02df: stloc.s 13
+					IL_02e1: ldloc.s 13
+					IL_02e3: stloc.s 19
+					IL_02e5: br IL_02ee
 
-					IL_038c: ldloc.s 12
-					IL_038e: stloc.s 21
+					IL_02ea: ldloc.s 12
+					IL_02ec: stloc.s 19
 
-					IL_0390: ldloc.s 21
-					IL_0392: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0397: stloc.s 8
-					IL_0399: ldloc.s 8
-					IL_039b: brfalse IL_0464
+					IL_02ee: ldloc.s 19
+					IL_02f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02f5: stloc.s 8
+					IL_02f7: ldloc.s 8
+					IL_02f9: brfalse IL_03a2
 
-					IL_03a0: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
-					IL_03a5: stloc.s 6
-					IL_03a7: ldarg.2
-					IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_03ad: stloc.s 20
-					IL_03af: ldloc.s 20
-					IL_03b1: ldstr "resume"
-					IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02fe: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
+					IL_0303: stloc.s 6
+					IL_0305: ldarg.2
+					IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_030b: stloc.s 7
+					IL_030d: ldloc.s 7
+					IL_030f: ldstr "resume"
+					IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_0319: pop
+					IL_031a: ldarg.0
+					IL_031b: ldc.i4.2
+					IL_031c: ldelem.ref
+					IL_031d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0322: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0327: stloc.s 7
+					IL_0329: ldc.i4.3
+					IL_032a: newarr [System.Runtime]System.Object
+					IL_032f: dup
+					IL_0330: ldc.i4.0
+					IL_0331: ldarg.0
+					IL_0332: ldc.i4.0
+					IL_0333: ldelem.ref
+					IL_0334: stelem.ref
+					IL_0335: dup
+					IL_0336: ldc.i4.1
+					IL_0337: ldarg.0
+					IL_0338: ldc.i4.1
+					IL_0339: ldelem.ref
+					IL_033a: stelem.ref
+					IL_033b: dup
+					IL_033c: ldc.i4.2
+					IL_033d: ldarg.0
+					IL_033e: ldc.i4.2
+					IL_033f: ldelem.ref
+					IL_0340: stelem.ref
+					IL_0341: stloc.s 16
+					IL_0343: ldloc.1
+					IL_0344: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0349: stloc.s 17
+					IL_034b: ldstr "HTTP "
+					IL_0350: ldloc.s 17
+					IL_0352: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0357: stloc.s 17
+					IL_0359: ldloc.s 17
+					IL_035b: ldstr " fetching "
+					IL_0360: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0365: stloc.s 17
+					IL_0367: ldarg.0
+					IL_0368: ldc.i4.1
+					IL_0369: ldelem.ref
+					IL_036a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_036f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0374: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0379: stloc.s 20
+					IL_037b: ldloc.s 17
+					IL_037d: ldloc.s 20
+					IL_037f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0384: stloc.s 20
+					IL_0386: ldloc.s 20
+					IL_0388: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_038d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0392: stloc.s 18
+					IL_0394: ldloc.s 7
+					IL_0396: ldloc.s 16
+					IL_0398: ldloc.s 18
+					IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_039f: pop
+					IL_03a0: ldnull
+					IL_03a1: ret
+
+					IL_03a2: ldarg.2
+					IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_03a8: stloc.s 18
+					IL_03aa: ldloc.s 18
+					IL_03ac: ldstr "setEncoding"
+					IL_03b1: ldstr "utf8"
+					IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 					IL_03bb: pop
-					IL_03bc: ldarg.0
-					IL_03bd: ldc.i4.2
-					IL_03be: ldelem.ref
-					IL_03bf: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_03c4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_03c9: stloc.s 20
-					IL_03cb: ldstr "reject"
-					IL_03d0: ldloc.s 20
-					IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_03d7: stloc.s 20
-					IL_03d9: ldc.i4.3
-					IL_03da: newarr [System.Runtime]System.Object
-					IL_03df: dup
-					IL_03e0: ldc.i4.0
-					IL_03e1: ldarg.0
+					IL_03bc: ldloc.0
+					IL_03bd: ldstr ""
+					IL_03c2: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_03c7: ldarg.2
+					IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_03cd: stloc.s 18
+					IL_03cf: ldnull
+					IL_03d0: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_03d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_03db: ldc.i4.4
+					IL_03dc: newarr [System.Runtime]System.Object
+					IL_03e1: dup
 					IL_03e2: ldc.i4.0
-					IL_03e3: ldelem.ref
-					IL_03e4: stelem.ref
-					IL_03e5: dup
-					IL_03e6: ldc.i4.1
-					IL_03e7: ldarg.0
+					IL_03e3: ldarg.0
+					IL_03e4: ldc.i4.0
+					IL_03e5: ldelem.ref
+					IL_03e6: stelem.ref
+					IL_03e7: dup
 					IL_03e8: ldc.i4.1
-					IL_03e9: ldelem.ref
-					IL_03ea: stelem.ref
-					IL_03eb: dup
-					IL_03ec: ldc.i4.2
-					IL_03ed: ldarg.0
+					IL_03e9: ldarg.0
+					IL_03ea: ldc.i4.1
+					IL_03eb: ldelem.ref
+					IL_03ec: stelem.ref
+					IL_03ed: dup
 					IL_03ee: ldc.i4.2
-					IL_03ef: ldelem.ref
-					IL_03f0: stelem.ref
-					IL_03f1: stloc.s 16
-					IL_03f3: ldloc.1
-					IL_03f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_03f9: stloc.s 18
-					IL_03fb: ldstr "HTTP "
-					IL_0400: ldloc.s 18
-					IL_0402: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0407: stloc.s 18
-					IL_0409: ldloc.s 18
-					IL_040b: ldstr " fetching "
-					IL_0410: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0415: stloc.s 18
-					IL_0417: ldarg.0
-					IL_0418: ldc.i4.1
-					IL_0419: ldelem.ref
-					IL_041a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_041f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0424: stloc.s 7
-					IL_0426: ldstr "urlString"
-					IL_042b: ldloc.s 7
-					IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0432: stloc.s 7
-					IL_0434: ldloc.s 7
-					IL_0436: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_043b: stloc.s 22
-					IL_043d: ldloc.s 18
-					IL_043f: ldloc.s 22
-					IL_0441: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0446: stloc.s 22
-					IL_0448: ldloc.s 22
-					IL_044a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_044f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0454: stloc.s 7
-					IL_0456: ldloc.s 20
-					IL_0458: ldloc.s 16
-					IL_045a: ldloc.s 7
-					IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0461: pop
-					IL_0462: ldnull
-					IL_0463: ret
-
-					IL_0464: ldarg.2
-					IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_046a: stloc.s 7
-					IL_046c: ldloc.s 7
-					IL_046e: ldstr "setEncoding"
-					IL_0473: ldstr "utf8"
-					IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_047d: pop
-					IL_047e: ldloc.0
-					IL_047f: ldstr ""
-					IL_0484: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_0489: ldarg.2
-					IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_048f: stloc.s 7
-					IL_0491: ldnull
-					IL_0492: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
-					IL_0498: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_049d: ldc.i4.4
-					IL_049e: newarr [System.Runtime]System.Object
-					IL_04a3: dup
-					IL_04a4: ldc.i4.0
-					IL_04a5: ldarg.0
-					IL_04a6: ldc.i4.0
-					IL_04a7: ldelem.ref
-					IL_04a8: stelem.ref
-					IL_04a9: dup
-					IL_04aa: ldc.i4.1
-					IL_04ab: ldarg.0
-					IL_04ac: ldc.i4.1
-					IL_04ad: ldelem.ref
-					IL_04ae: stelem.ref
-					IL_04af: dup
-					IL_04b0: ldc.i4.2
-					IL_04b1: ldarg.0
-					IL_04b2: ldc.i4.2
-					IL_04b3: ldelem.ref
-					IL_04b4: stelem.ref
-					IL_04b5: dup
-					IL_04b6: ldc.i4.3
-					IL_04b7: ldloc.0
-					IL_04b8: stelem.ref
-					IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_04c3: ldc.i4.1
-					IL_04c4: conv.r8
-					IL_04c5: ldstr ""
-					IL_04ca: ldc.i4.0
-					IL_04cb: ldc.i4.1
-					IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_04d6: stloc.s 20
-					IL_04d8: ldloc.s 7
-					IL_04da: ldstr "on"
-					IL_04df: ldstr "data"
-					IL_04e4: ldloc.s 20
-					IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_04eb: pop
-					IL_04ec: ldarg.2
-					IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_04f2: stloc.s 20
-					IL_04f4: ldnull
-					IL_04f5: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
-					IL_04fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_0500: ldc.i4.4
-					IL_0501: newarr [System.Runtime]System.Object
-					IL_0506: dup
-					IL_0507: ldc.i4.0
-					IL_0508: ldarg.0
-					IL_0509: ldc.i4.0
-					IL_050a: ldelem.ref
-					IL_050b: stelem.ref
-					IL_050c: dup
-					IL_050d: ldc.i4.1
-					IL_050e: ldarg.0
-					IL_050f: ldc.i4.1
-					IL_0510: ldelem.ref
-					IL_0511: stelem.ref
-					IL_0512: dup
-					IL_0513: ldc.i4.2
-					IL_0514: ldarg.0
-					IL_0515: ldc.i4.2
-					IL_0516: ldelem.ref
-					IL_0517: stelem.ref
-					IL_0518: dup
-					IL_0519: ldc.i4.3
-					IL_051a: ldloc.0
-					IL_051b: stelem.ref
-					IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_0526: ldc.i4.0
-					IL_0527: conv.r8
-					IL_0528: ldstr ""
-					IL_052d: ldc.i4.0
-					IL_052e: ldc.i4.1
-					IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_0539: stloc.s 7
-					IL_053b: ldloc.s 20
-					IL_053d: ldstr "on"
-					IL_0542: ldstr "end"
-					IL_0547: ldloc.s 7
-					IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_054e: pop
-					IL_054f: ldnull
-					IL_0550: ret
+					IL_03ef: ldarg.0
+					IL_03f0: ldc.i4.2
+					IL_03f1: ldelem.ref
+					IL_03f2: stelem.ref
+					IL_03f3: dup
+					IL_03f4: ldc.i4.3
+					IL_03f5: ldloc.0
+					IL_03f6: stelem.ref
+					IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0401: ldc.i4.1
+					IL_0402: conv.r8
+					IL_0403: ldstr ""
+					IL_0408: ldc.i4.0
+					IL_0409: ldc.i4.1
+					IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0414: stloc.s 7
+					IL_0416: ldloc.s 18
+					IL_0418: ldstr "on"
+					IL_041d: ldstr "data"
+					IL_0422: ldloc.s 7
+					IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0429: pop
+					IL_042a: ldarg.2
+					IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0430: stloc.s 7
+					IL_0432: ldnull
+					IL_0433: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_0439: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_043e: ldc.i4.4
+					IL_043f: newarr [System.Runtime]System.Object
+					IL_0444: dup
+					IL_0445: ldc.i4.0
+					IL_0446: ldarg.0
+					IL_0447: ldc.i4.0
+					IL_0448: ldelem.ref
+					IL_0449: stelem.ref
+					IL_044a: dup
+					IL_044b: ldc.i4.1
+					IL_044c: ldarg.0
+					IL_044d: ldc.i4.1
+					IL_044e: ldelem.ref
+					IL_044f: stelem.ref
+					IL_0450: dup
+					IL_0451: ldc.i4.2
+					IL_0452: ldarg.0
+					IL_0453: ldc.i4.2
+					IL_0454: ldelem.ref
+					IL_0455: stelem.ref
+					IL_0456: dup
+					IL_0457: ldc.i4.3
+					IL_0458: ldloc.0
+					IL_0459: stelem.ref
+					IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0464: ldc.i4.0
+					IL_0465: conv.r8
+					IL_0466: ldstr ""
+					IL_046b: ldc.i4.0
+					IL_046c: ldc.i4.1
+					IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0477: stloc.s 18
+					IL_0479: ldloc.s 7
+					IL_047b: ldstr "on"
+					IL_0480: ldstr "end"
+					IL_0485: ldloc.s 18
+					IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_048c: pop
+					IL_048d: ldnull
+					IL_048e: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -2074,7 +1951,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b58
+						// Method begins at RVA 0x48d4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2094,7 +1971,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b61
+						// Method begins at RVA 0x48dd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2117,7 +1994,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b4f
+					// Method begins at RVA 0x48cb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2143,9 +2020,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4234
+				// Method begins at RVA 0x40fc
 				// Header size: 12
-				// Code size: 602 (0x25a)
+				// Code size: 512 (0x200)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope,
@@ -2157,9 +2034,9 @@
 					[6] object,
 					[7] object,
 					[8] object,
-					[9] object,
-					[10] object[],
-					[11] string,
+					[9] object[],
+					[10] string,
+					[11] object,
 					[12] bool,
 					[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 					[14] object
@@ -2186,217 +2063,187 @@
 					IL_0024: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
 					IL_0029: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
 					IL_002e: stloc.s 8
-					IL_0030: ldstr "NodeUrl"
-					IL_0035: ldloc.s 8
-					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_003c: stloc.s 8
-					IL_003e: ldarg.0
-					IL_003f: ldc.i4.1
-					IL_0040: ldelem.ref
-					IL_0041: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0046: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_004b: stloc.s 9
-					IL_004d: ldstr "urlString"
-					IL_0052: ldloc.s 9
-					IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0059: stloc.s 9
-					IL_005b: ldc.i4.1
-					IL_005c: newarr [System.Runtime]System.Object
-					IL_0061: dup
-					IL_0062: ldc.i4.0
-					IL_0063: ldloc.s 9
-					IL_0065: stelem.ref
-					IL_0066: stloc.s 10
-					IL_0068: ldloc.s 8
-					IL_006a: ldloc.s 10
-					IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_0071: stloc.s 8
-					IL_0073: ldloc.0
-					IL_0074: ldloc.s 8
-					IL_0076: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_007b: leave IL_0101
+					IL_0030: ldloc.s 8
+					IL_0032: ldc.i4.1
+					IL_0033: newarr [System.Runtime]System.Object
+					IL_0038: dup
+					IL_0039: ldc.i4.0
+					IL_003a: ldarg.0
+					IL_003b: ldc.i4.1
+					IL_003c: ldelem.ref
+					IL_003d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0042: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0047: stelem.ref
+					IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_004d: stloc.s 8
+					IL_004f: ldloc.0
+					IL_0050: ldloc.s 8
+					IL_0052: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_0057: leave IL_00cb
 				} // end .try
 				catch [System.Runtime]System.Exception
 				{
-					IL_0080: stloc.2
-					IL_0081: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope/Block_L76C12::.ctor()
-					IL_0086: stloc.3
-					IL_0087: ldloc.0
-					IL_0088: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_008d: stloc.s 8
-					IL_008f: ldc.i4.2
-					IL_0090: newarr [System.Runtime]System.Object
-					IL_0095: dup
-					IL_0096: ldc.i4.0
-					IL_0097: ldarg.0
-					IL_0098: ldc.i4.0
-					IL_0099: ldelem.ref
-					IL_009a: stelem.ref
-					IL_009b: dup
-					IL_009c: ldc.i4.1
-					IL_009d: ldarg.0
-					IL_009e: ldc.i4.1
-					IL_009f: ldelem.ref
-					IL_00a0: stelem.ref
-					IL_00a1: stloc.s 10
-					IL_00a3: ldarg.0
-					IL_00a4: ldc.i4.1
-					IL_00a5: ldelem.ref
-					IL_00a6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_00ab: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_00b0: stloc.s 9
-					IL_00b2: ldstr "urlString"
-					IL_00b7: ldloc.s 9
-					IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_00be: stloc.s 9
-					IL_00c0: ldloc.s 9
-					IL_00c2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_00c7: stloc.s 11
-					IL_00c9: ldstr "Invalid URL: "
-					IL_00ce: ldloc.s 11
-					IL_00d0: call string [System.Runtime]System.String::Concat(string, string)
-					IL_00d5: stloc.s 11
-					IL_00d7: ldloc.s 11
-					IL_00d9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_00de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_00e3: stloc.s 9
-					IL_00e5: ldloc.s 8
-					IL_00e7: ldloc.s 10
-					IL_00e9: ldloc.s 9
-					IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_00f0: pop
-					IL_00f1: ldnull
-					IL_00f2: stloc.s 4
-					IL_00f4: ldnull
-					IL_00f5: stloc.s 4
-					IL_00f7: leave IL_0257
+					IL_005c: stloc.2
+					IL_005d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope/Block_L76C12::.ctor()
+					IL_0062: stloc.3
+					IL_0063: ldloc.0
+					IL_0064: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0069: stloc.s 8
+					IL_006b: ldc.i4.2
+					IL_006c: newarr [System.Runtime]System.Object
+					IL_0071: dup
+					IL_0072: ldc.i4.0
+					IL_0073: ldarg.0
+					IL_0074: ldc.i4.0
+					IL_0075: ldelem.ref
+					IL_0076: stelem.ref
+					IL_0077: dup
+					IL_0078: ldc.i4.1
+					IL_0079: ldarg.0
+					IL_007a: ldc.i4.1
+					IL_007b: ldelem.ref
+					IL_007c: stelem.ref
+					IL_007d: stloc.s 9
+					IL_007f: ldarg.0
+					IL_0080: ldc.i4.1
+					IL_0081: ldelem.ref
+					IL_0082: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0087: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_008c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0091: stloc.s 10
+					IL_0093: ldstr "Invalid URL: "
+					IL_0098: ldloc.s 10
+					IL_009a: call string [System.Runtime]System.String::Concat(string, string)
+					IL_009f: stloc.s 10
+					IL_00a1: ldloc.s 10
+					IL_00a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_00a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_00ad: stloc.s 11
+					IL_00af: ldloc.s 8
+					IL_00b1: ldloc.s 9
+					IL_00b3: ldloc.s 11
+					IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_00ba: pop
+					IL_00bb: ldnull
+					IL_00bc: stloc.s 4
+					IL_00be: ldnull
+					IL_00bf: stloc.s 4
+					IL_00c1: leave IL_01fd
 
-					IL_00fc: leave IL_0101
+					IL_00c6: leave IL_00cb
 				} // end handler
 
-				IL_0101: ldloc.0
-				IL_0102: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_0107: ldstr "protocol"
-				IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0111: ldstr "https:"
-				IL_0116: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_011b: stloc.s 12
-				IL_011d: ldloc.s 12
-				IL_011f: brfalse IL_014a
+				IL_00cb: ldloc.0
+				IL_00cc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_00d1: ldstr "protocol"
+				IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00db: ldstr "https:"
+				IL_00e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00e5: stloc.s 12
+				IL_00e7: ldloc.s 12
+				IL_00e9: brfalse IL_0102
 
-				IL_0124: ldarg.0
-				IL_0125: ldc.i4.0
-				IL_0126: ldelem.ref
-				IL_0127: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_012c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
-				IL_0131: stloc.s 9
-				IL_0133: ldstr "https"
-				IL_0138: ldloc.s 9
-				IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_013f: stloc.s 9
-				IL_0141: ldloc.s 9
-				IL_0143: stloc.s 5
-				IL_0145: br IL_016b
+				IL_00ee: ldarg.0
+				IL_00ef: ldc.i4.0
+				IL_00f0: ldelem.ref
+				IL_00f1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_00f6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+				IL_00fb: stloc.s 5
+				IL_00fd: br IL_0111
 
-				IL_014a: ldarg.0
-				IL_014b: ldc.i4.0
-				IL_014c: ldelem.ref
-				IL_014d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_0152: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
-				IL_0157: stloc.s 9
-				IL_0159: ldstr "http"
-				IL_015e: ldloc.s 9
-				IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0165: stloc.s 9
-				IL_0167: ldloc.s 9
-				IL_0169: stloc.s 5
+				IL_0102: ldarg.0
+				IL_0103: ldc.i4.0
+				IL_0104: ldelem.ref
+				IL_0105: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_010a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+				IL_010f: stloc.s 5
 
-				IL_016b: ldloc.s 5
-				IL_016d: stloc.s 6
-				IL_016f: ldloc.s 6
-				IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0176: stloc.s 9
-				IL_0178: ldloc.0
-				IL_0179: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_017e: stloc.s 8
-				IL_0180: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0111: ldloc.s 5
+				IL_0113: stloc.s 6
+				IL_0115: ldloc.s 6
+				IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_011c: stloc.s 11
+				IL_011e: ldloc.0
+				IL_011f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_0124: stloc.s 8
+				IL_0126: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_012b: dup
+				IL_012c: ldstr "method"
+				IL_0131: ldstr "GET"
+				IL_0136: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_013b: dup
+				IL_013c: ldstr "headers"
+				IL_0141: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0146: dup
+				IL_0147: ldstr "Accept-Encoding"
+				IL_014c: ldstr "identity"
+				IL_0151: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0156: dup
+				IL_0157: ldstr "User-Agent"
+				IL_015c: ldstr "jroc-docs-script"
+				IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0166: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_016b: stloc.s 13
+				IL_016d: ldnull
+				IL_016e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
+				IL_0174: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_0179: ldc.i4.3
+				IL_017a: newarr [System.Runtime]System.Object
+				IL_017f: dup
+				IL_0180: ldc.i4.0
+				IL_0181: ldarg.0
+				IL_0182: ldc.i4.0
+				IL_0183: ldelem.ref
+				IL_0184: stelem.ref
 				IL_0185: dup
-				IL_0186: ldstr "method"
-				IL_018b: ldstr "GET"
-				IL_0190: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0195: dup
-				IL_0196: ldstr "headers"
-				IL_019b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_01a0: dup
-				IL_01a1: ldstr "Accept-Encoding"
-				IL_01a6: ldstr "identity"
-				IL_01ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_01b0: dup
-				IL_01b1: ldstr "User-Agent"
-				IL_01b6: ldstr "jroc-docs-script"
-				IL_01bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_01c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_01c5: stloc.s 13
-				IL_01c7: ldnull
-				IL_01c8: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
-				IL_01ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_01d3: ldc.i4.3
-				IL_01d4: newarr [System.Runtime]System.Object
-				IL_01d9: dup
-				IL_01da: ldc.i4.0
-				IL_01db: ldarg.0
-				IL_01dc: ldc.i4.0
-				IL_01dd: ldelem.ref
-				IL_01de: stelem.ref
-				IL_01df: dup
-				IL_01e0: ldc.i4.1
-				IL_01e1: ldarg.0
-				IL_01e2: ldc.i4.1
-				IL_01e3: ldelem.ref
-				IL_01e4: stelem.ref
-				IL_01e5: dup
-				IL_01e6: ldc.i4.2
-				IL_01e7: ldloc.0
-				IL_01e8: stelem.ref
-				IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_01f3: ldc.i4.1
-				IL_01f4: conv.r8
-				IL_01f5: ldstr ""
-				IL_01fa: ldc.i4.0
-				IL_01fb: ldc.i4.1
-				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-				IL_0206: stloc.s 14
-				IL_0208: ldloc.s 9
-				IL_020a: ldstr "request"
-				IL_020f: ldloc.s 8
-				IL_0211: ldloc.s 13
-				IL_0213: ldloc.s 14
-				IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_021a: stloc.s 14
-				IL_021c: ldloc.s 14
-				IL_021e: stloc.s 7
-				IL_0220: ldloc.s 7
-				IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0227: stloc.s 14
-				IL_0229: ldloc.s 14
-				IL_022b: ldstr "on"
-				IL_0230: ldstr "error"
-				IL_0235: ldloc.0
-				IL_0236: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-				IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0240: pop
-				IL_0241: ldloc.s 7
-				IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0248: stloc.s 14
-				IL_024a: ldloc.s 14
-				IL_024c: ldstr "end"
-				IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0256: pop
+				IL_0186: ldc.i4.1
+				IL_0187: ldarg.0
+				IL_0188: ldc.i4.1
+				IL_0189: ldelem.ref
+				IL_018a: stelem.ref
+				IL_018b: dup
+				IL_018c: ldc.i4.2
+				IL_018d: ldloc.0
+				IL_018e: stelem.ref
+				IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_0199: ldc.i4.1
+				IL_019a: conv.r8
+				IL_019b: ldstr ""
+				IL_01a0: ldc.i4.0
+				IL_01a1: ldc.i4.1
+				IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+				IL_01ac: stloc.s 14
+				IL_01ae: ldloc.s 11
+				IL_01b0: ldstr "request"
+				IL_01b5: ldloc.s 8
+				IL_01b7: ldloc.s 13
+				IL_01b9: ldloc.s 14
+				IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_01c0: stloc.s 14
+				IL_01c2: ldloc.s 14
+				IL_01c4: stloc.s 7
+				IL_01c6: ldloc.s 7
+				IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01cd: stloc.s 14
+				IL_01cf: ldloc.s 14
+				IL_01d1: ldstr "on"
+				IL_01d6: ldstr "error"
+				IL_01db: ldloc.0
+				IL_01dc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+				IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_01e6: pop
+				IL_01e7: ldloc.s 7
+				IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01ee: stloc.s 14
+				IL_01f0: ldloc.s 14
+				IL_01f2: ldstr "end"
+				IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_01fc: pop
 
-				IL_0257: ldloc.s 4
-				IL_0259: ret
+				IL_01fd: ldloc.s 4
+				IL_01ff: ret
 			} // end of method ArrowFunction_L72C22::__js_call__
 
 		} // end of class ArrowFunction_L72C22
@@ -2418,7 +2265,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b46
+					// Method begins at RVA 0x48c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2440,7 +2287,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b3d
+				// Method begins at RVA 0x48b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2468,7 +2315,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x29d0
+			// Method begins at RVA 0x2998
 			// Header size: 12
 			// Code size: 113 (0x71)
 			.maxstack 8
@@ -2539,7 +2386,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ba0
+				// Method begins at RVA 0x491c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2563,7 +2410,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a50
+			// Method begins at RVA 0x2a18
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -2606,7 +2453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bb2
+					// Method begins at RVA 0x492e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2630,7 +2477,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4bc4
+						// Method begins at RVA 0x4940
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2648,7 +2495,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bbb
+					// Method begins at RVA 0x4937
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2666,7 +2513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ba9
+				// Method begins at RVA 0x4925
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2694,7 +2541,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2a88
+			// Method begins at RVA 0x2a50
 			// Header size: 12
 			// Code size: 586 (0x24a)
 			.maxstack 8
@@ -2954,7 +2801,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bd6
+					// Method begins at RVA 0x4952
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2974,7 +2821,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bdf
+					// Method begins at RVA 0x495b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2994,7 +2841,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4be8
+					// Method begins at RVA 0x4964
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3014,7 +2861,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bf1
+					// Method begins at RVA 0x496d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3038,7 +2885,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c03
+						// Method begins at RVA 0x497f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3058,7 +2905,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c0c
+						// Method begins at RVA 0x4988
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3082,7 +2929,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4c1e
+							// Method begins at RVA 0x499a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -3100,7 +2947,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c15
+						// Method begins at RVA 0x4991
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3120,7 +2967,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c27
+						// Method begins at RVA 0x49a3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3138,7 +2985,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bfa
+					// Method begins at RVA 0x4976
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3156,7 +3003,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bcd
+				// Method begins at RVA 0x4949
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3184,9 +3031,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2ce0
+			// Method begins at RVA 0x2ca8
 			// Header size: 12
-			// Code size: 1180 (0x49c)
+			// Code size: 1144 (0x478)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -3376,271 +3223,259 @@
 
 			IL_01aa: throw
 
-			IL_01ab: ldarg.0
-			IL_01ac: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
-			IL_01b1: stloc.s 25
-			IL_01b3: ldstr "findTagNameAt"
-			IL_01b8: ldloc.s 25
-			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01bf: stloc.s 25
-			IL_01c1: ldc.i4.1
-			IL_01c2: newarr [System.Runtime]System.Object
-			IL_01c7: dup
-			IL_01c8: ldc.i4.0
-			IL_01c9: ldarg.0
-			IL_01ca: stelem.ref
-			IL_01cb: stloc.s 27
-			IL_01cd: ldloc.s 25
-			IL_01cf: ldloc.s 27
-			IL_01d1: ldarg.2
-			IL_01d2: ldloc.s 6
-			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01d9: stloc.s 25
-			IL_01db: ldloc.s 25
-			IL_01dd: stloc.s 9
-			IL_01df: ldloc.s 9
-			IL_01e1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01e6: ldc.i4.0
-			IL_01e7: ceq
-			IL_01e9: stloc.s 28
-			IL_01eb: ldloc.s 28
-			IL_01ed: brfalse IL_0246
+			IL_01ab: ldc.i4.1
+			IL_01ac: newarr [System.Runtime]System.Object
+			IL_01b1: dup
+			IL_01b2: ldc.i4.0
+			IL_01b3: ldarg.0
+			IL_01b4: stelem.ref
+			IL_01b5: stloc.s 27
+			IL_01b7: ldarg.0
+			IL_01b8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
+			IL_01bd: ldloc.s 27
+			IL_01bf: ldarg.2
+			IL_01c0: ldloc.s 6
+			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01c7: stloc.s 25
+			IL_01c9: ldloc.s 25
+			IL_01cb: stloc.s 9
+			IL_01cd: ldloc.s 9
+			IL_01cf: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01d4: ldc.i4.0
+			IL_01d5: ceq
+			IL_01d7: stloc.s 28
+			IL_01d9: ldloc.s 28
+			IL_01db: brfalse IL_0234
 
-			IL_01f2: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L170C16::.ctor()
-			IL_01f7: stloc.s 10
-			IL_01f9: ldarg.3
-			IL_01fa: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ff: stloc.s 24
-			IL_0201: ldstr "Could not determine tag name for id '"
-			IL_0206: ldloc.s 24
-			IL_0208: call string [System.Runtime]System.String::Concat(string, string)
-			IL_020d: stloc.s 24
-			IL_020f: ldloc.s 24
-			IL_0211: ldstr "'."
-			IL_0216: call string [System.Runtime]System.String::Concat(string, string)
-			IL_021b: stloc.s 24
-			IL_021d: ldloc.s 24
-			IL_021f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0224: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0229: stloc.s 25
-			IL_022b: ldloc.s 25
-			IL_022d: stloc.s 11
-			IL_022f: ldloc.s 11
-			IL_0231: isinst [System.Runtime]System.Exception
-			IL_0236: dup
-			IL_0237: brtrue IL_0245
+			IL_01e0: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L170C16::.ctor()
+			IL_01e5: stloc.s 10
+			IL_01e7: ldarg.3
+			IL_01e8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ed: stloc.s 24
+			IL_01ef: ldstr "Could not determine tag name for id '"
+			IL_01f4: ldloc.s 24
+			IL_01f6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01fb: stloc.s 24
+			IL_01fd: ldloc.s 24
+			IL_01ff: ldstr "'."
+			IL_0204: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0209: stloc.s 24
+			IL_020b: ldloc.s 24
+			IL_020d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0212: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0217: stloc.s 25
+			IL_0219: ldloc.s 25
+			IL_021b: stloc.s 11
+			IL_021d: ldloc.s 11
+			IL_021f: isinst [System.Runtime]System.Exception
+			IL_0224: dup
+			IL_0225: brtrue IL_0233
 
-			IL_023c: pop
-			IL_023d: ldloc.s 11
-			IL_023f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0244: throw
+			IL_022a: pop
+			IL_022b: ldloc.s 11
+			IL_022d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0232: throw
 
-			IL_0245: throw
+			IL_0233: throw
 
-			IL_0246: ldarg.0
-			IL_0247: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_024c: stloc.s 25
-			IL_024e: ldstr "escapeRegExp"
-			IL_0253: ldloc.s 25
-			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_025a: stloc.s 25
-			IL_025c: ldloc.s 25
-			IL_025e: ldc.i4.1
-			IL_025f: newarr [System.Runtime]System.Object
-			IL_0264: dup
-			IL_0265: ldc.i4.0
-			IL_0266: ldarg.0
-			IL_0267: stelem.ref
-			IL_0268: ldloc.s 9
-			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_026f: stloc.s 25
-			IL_0271: ldloc.s 25
-			IL_0273: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0278: stloc.s 24
-			IL_027a: ldstr "<\\/?"
-			IL_027f: ldloc.s 24
-			IL_0281: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0286: stloc.s 24
-			IL_0288: ldloc.s 24
-			IL_028a: ldstr "\\b[^>]*>"
-			IL_028f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0294: stloc.s 24
-			IL_0296: ldloc.s 24
-			IL_0298: ldstr "gi"
-			IL_029d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_02a2: stloc.s 29
-			IL_02a4: ldloc.s 29
-			IL_02a6: stloc.s 12
-			IL_02a8: ldloc.s 12
-			IL_02aa: ldstr "lastIndex"
-			IL_02af: ldloc.s 6
-			IL_02b1: ldc.i4.1
-			IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_02b7: pop
-			IL_02b8: ldc.r8 0.0
-			IL_02c1: stloc.s 13
-			IL_02c3: ldc.r8 1
-			IL_02cc: neg
-			IL_02cd: box [System.Runtime]System.Double
-			IL_02d2: stloc.s 14
-			// loop start (head: IL_02d4)
-				IL_02d4: ldc.i4.1
-				IL_02d5: brfalse IL_042b
+			IL_0234: ldarg.0
+			IL_0235: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_023a: ldc.i4.1
+			IL_023b: newarr [System.Runtime]System.Object
+			IL_0240: dup
+			IL_0241: ldc.i4.0
+			IL_0242: ldarg.0
+			IL_0243: stelem.ref
+			IL_0244: ldloc.s 9
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_024b: stloc.s 25
+			IL_024d: ldloc.s 25
+			IL_024f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0254: stloc.s 24
+			IL_0256: ldstr "<\\/?"
+			IL_025b: ldloc.s 24
+			IL_025d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0262: stloc.s 24
+			IL_0264: ldloc.s 24
+			IL_0266: ldstr "\\b[^>]*>"
+			IL_026b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0270: stloc.s 24
+			IL_0272: ldloc.s 24
+			IL_0274: ldstr "gi"
+			IL_0279: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_027e: stloc.s 29
+			IL_0280: ldloc.s 29
+			IL_0282: stloc.s 12
+			IL_0284: ldloc.s 12
+			IL_0286: ldstr "lastIndex"
+			IL_028b: ldloc.s 6
+			IL_028d: ldc.i4.1
+			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0293: pop
+			IL_0294: ldc.r8 0.0
+			IL_029d: stloc.s 13
+			IL_029f: ldc.r8 1
+			IL_02a8: neg
+			IL_02a9: box [System.Runtime]System.Double
+			IL_02ae: stloc.s 14
+			// loop start (head: IL_02b0)
+				IL_02b0: ldc.i4.1
+				IL_02b1: brfalse IL_0407
 
-				IL_02da: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
-				IL_02df: stloc.s 15
-				IL_02e1: ldloc.s 12
-				IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02e8: stloc.s 25
-				IL_02ea: ldloc.s 25
-				IL_02ec: ldstr "exec"
-				IL_02f1: ldarg.2
-				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02f7: stloc.s 25
-				IL_02f9: ldloc.s 25
-				IL_02fb: stloc.s 16
-				IL_02fd: ldloc.s 16
-				IL_02ff: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0304: ldc.i4.0
-				IL_0305: ceq
-				IL_0307: stloc.s 28
-				IL_0309: ldloc.s 28
-				IL_030b: brfalse IL_031c
+				IL_02b6: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
+				IL_02bb: stloc.s 15
+				IL_02bd: ldloc.s 12
+				IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02c4: stloc.s 25
+				IL_02c6: ldloc.s 25
+				IL_02c8: ldstr "exec"
+				IL_02cd: ldarg.2
+				IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02d3: stloc.s 25
+				IL_02d5: ldloc.s 25
+				IL_02d7: stloc.s 16
+				IL_02d9: ldloc.s 16
+				IL_02db: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_02e0: ldc.i4.0
+				IL_02e1: ceq
+				IL_02e3: stloc.s 28
+				IL_02e5: ldloc.s 28
+				IL_02e7: brfalse IL_02f8
 
-				IL_0310: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L182C16::.ctor()
-				IL_0315: stloc.s 17
-				IL_0317: br IL_042b
+				IL_02ec: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L182C16::.ctor()
+				IL_02f1: stloc.s 17
+				IL_02f3: br IL_0407
 
-				IL_031c: ldloc.s 16
-				IL_031e: ldc.r8 0.0
-				IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_032c: stloc.s 18
-				IL_032e: ldloc.s 14
-				IL_0330: stloc.s 30
-				IL_0332: ldloc.s 30
-				IL_0334: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0339: stloc.s 26
-				IL_033b: ldloc.s 26
-				IL_033d: ldc.r8 0.0
-				IL_0346: clt
-				IL_0348: brfalse IL_0366
+				IL_02f8: ldloc.s 16
+				IL_02fa: ldc.r8 0.0
+				IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0308: stloc.s 18
+				IL_030a: ldloc.s 14
+				IL_030c: stloc.s 30
+				IL_030e: ldloc.s 30
+				IL_0310: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0315: stloc.s 26
+				IL_0317: ldloc.s 26
+				IL_0319: ldc.r8 0.0
+				IL_0322: clt
+				IL_0324: brfalse IL_0342
 
-				IL_034d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L187C24::.ctor()
-				IL_0352: stloc.s 19
-				IL_0354: ldloc.s 16
-				IL_0356: ldstr "index"
-				IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0360: stloc.s 25
-				IL_0362: ldloc.s 25
-				IL_0364: stloc.s 14
+				IL_0329: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L187C24::.ctor()
+				IL_032e: stloc.s 19
+				IL_0330: ldloc.s 16
+				IL_0332: ldstr "index"
+				IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_033c: stloc.s 25
+				IL_033e: ldloc.s 25
+				IL_0340: stloc.s 14
 
-				IL_0366: ldloc.s 18
-				IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_036d: stloc.s 25
-				IL_036f: ldloc.s 25
-				IL_0371: ldstr "startsWith"
-				IL_0376: ldstr "</"
-				IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0380: stloc.s 25
-				IL_0382: ldloc.s 25
-				IL_0384: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0389: stloc.s 28
-				IL_038b: ldloc.s 28
-				IL_038d: brfalse IL_0411
+				IL_0342: ldloc.s 18
+				IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0349: stloc.s 25
+				IL_034b: ldloc.s 25
+				IL_034d: ldstr "startsWith"
+				IL_0352: ldstr "</"
+				IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_035c: stloc.s 25
+				IL_035e: ldloc.s 25
+				IL_0360: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0365: stloc.s 28
+				IL_0367: ldloc.s 28
+				IL_0369: brfalse IL_03ed
 
-				IL_0392: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32::.ctor()
-				IL_0397: stloc.s 20
-				IL_0399: ldloc.s 13
-				IL_039b: ldc.r8 1
-				IL_03a4: sub
-				IL_03a5: stloc.s 13
-				IL_03a7: ldloc.s 13
-				IL_03a9: stloc.s 26
-				IL_03ab: ldloc.s 26
-				IL_03ad: ldc.r8 0.0
-				IL_03b6: ceq
-				IL_03b8: brfalse IL_040c
+				IL_036e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32::.ctor()
+				IL_0373: stloc.s 20
+				IL_0375: ldloc.s 13
+				IL_0377: ldc.r8 1
+				IL_0380: sub
+				IL_0381: stloc.s 13
+				IL_0383: ldloc.s 13
+				IL_0385: stloc.s 26
+				IL_0387: ldloc.s 26
+				IL_0389: ldc.r8 0.0
+				IL_0392: ceq
+				IL_0394: brfalse IL_03e8
 
-				IL_03bd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32/Block_L193C23::.ctor()
-				IL_03c2: stloc.s 21
-				IL_03c4: ldarg.2
-				IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03ca: stloc.s 25
-				IL_03cc: ldloc.s 25
-				IL_03ce: ldstr "substring"
-				IL_03d3: ldloc.s 14
-				IL_03d5: ldloc.s 12
-				IL_03d7: ldstr "lastIndex"
-				IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_03e6: stloc.s 25
-				IL_03e8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_03ed: dup
-				IL_03ee: ldstr "tagName"
-				IL_03f3: ldloc.s 9
-				IL_03f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_03fa: dup
-				IL_03fb: ldstr "html"
-				IL_0400: ldloc.s 25
-				IL_0402: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0407: stloc.s 31
-				IL_0409: ldloc.s 31
-				IL_040b: ret
+				IL_0399: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32/Block_L193C23::.ctor()
+				IL_039e: stloc.s 21
+				IL_03a0: ldarg.2
+				IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03a6: stloc.s 25
+				IL_03a8: ldloc.s 25
+				IL_03aa: ldstr "substring"
+				IL_03af: ldloc.s 14
+				IL_03b1: ldloc.s 12
+				IL_03b3: ldstr "lastIndex"
+				IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_03c2: stloc.s 25
+				IL_03c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_03c9: dup
+				IL_03ca: ldstr "tagName"
+				IL_03cf: ldloc.s 9
+				IL_03d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03d6: dup
+				IL_03d7: ldstr "html"
+				IL_03dc: ldloc.s 25
+				IL_03de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03e3: stloc.s 31
+				IL_03e5: ldloc.s 31
+				IL_03e7: ret
 
-				IL_040c: br IL_0426
+				IL_03e8: br IL_0402
 
-				IL_0411: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L199C11::.ctor()
-				IL_0416: stloc.s 22
-				IL_0418: ldloc.s 13
-				IL_041a: ldc.r8 1
-				IL_0423: add
-				IL_0424: stloc.s 13
+				IL_03ed: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L199C11::.ctor()
+				IL_03f2: stloc.s 22
+				IL_03f4: ldloc.s 13
+				IL_03f6: ldc.r8 1
+				IL_03ff: add
+				IL_0400: stloc.s 13
 
-				IL_0426: br IL_02d4
+				IL_0402: br IL_02b0
 			// end loop
 
-			IL_042b: ldloc.s 9
+			IL_0407: ldloc.s 9
+			IL_0409: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_040e: stloc.s 24
+			IL_0410: ldstr "Could not find a matching closing </"
+			IL_0415: ldloc.s 24
+			IL_0417: call string [System.Runtime]System.String::Concat(string, string)
+			IL_041c: stloc.s 24
+			IL_041e: ldloc.s 24
+			IL_0420: ldstr "> for id '"
+			IL_0425: call string [System.Runtime]System.String::Concat(string, string)
+			IL_042a: stloc.s 24
+			IL_042c: ldarg.3
 			IL_042d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0432: stloc.s 24
-			IL_0434: ldstr "Could not find a matching closing </"
-			IL_0439: ldloc.s 24
-			IL_043b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0440: stloc.s 24
-			IL_0442: ldloc.s 24
-			IL_0444: ldstr "> for id '"
-			IL_0449: call string [System.Runtime]System.String::Concat(string, string)
-			IL_044e: stloc.s 24
-			IL_0450: ldarg.3
-			IL_0451: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0456: stloc.s 32
-			IL_0458: ldloc.s 24
-			IL_045a: ldloc.s 32
-			IL_045c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0461: stloc.s 32
-			IL_0463: ldloc.s 32
-			IL_0465: ldstr "'."
-			IL_046a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_046f: stloc.s 32
-			IL_0471: ldloc.s 32
-			IL_0473: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0478: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_047d: stloc.s 25
-			IL_047f: ldloc.s 25
-			IL_0481: stloc.s 23
-			IL_0483: ldloc.s 23
-			IL_0485: isinst [System.Runtime]System.Exception
-			IL_048a: dup
-			IL_048b: brtrue IL_0499
+			IL_0432: stloc.s 32
+			IL_0434: ldloc.s 24
+			IL_0436: ldloc.s 32
+			IL_0438: call string [System.Runtime]System.String::Concat(string, string)
+			IL_043d: stloc.s 32
+			IL_043f: ldloc.s 32
+			IL_0441: ldstr "'."
+			IL_0446: call string [System.Runtime]System.String::Concat(string, string)
+			IL_044b: stloc.s 32
+			IL_044d: ldloc.s 32
+			IL_044f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0454: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0459: stloc.s 25
+			IL_045b: ldloc.s 25
+			IL_045d: stloc.s 23
+			IL_045f: ldloc.s 23
+			IL_0461: isinst [System.Runtime]System.Exception
+			IL_0466: dup
+			IL_0467: brtrue IL_0475
 
-			IL_0490: pop
-			IL_0491: ldloc.s 23
-			IL_0493: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0498: throw
+			IL_046c: pop
+			IL_046d: ldloc.s 23
+			IL_046f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0474: throw
 
-			IL_0499: throw
+			IL_0475: throw
 
-			IL_049a: ldnull
-			IL_049b: ret
+			IL_0476: ldnull
+			IL_0477: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3660,7 +3495,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c39
+					// Method begins at RVA 0x49b5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3678,7 +3513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c30
+				// Method begins at RVA 0x49ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3706,9 +3541,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x3188
+			// Method begins at RVA 0x312c
 			// Header size: 12
-			// Code size: 536 (0x218)
+			// Code size: 523 (0x20b)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3719,8 +3554,8 @@
 				[5] object,
 				[6] object,
 				[7] object,
-				[8] object,
-				[9] object[],
+				[8] object[],
+				[9] object,
 				[10] string,
 				[11] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[12] bool,
@@ -3733,200 +3568,195 @@
 				[19] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_0006: stloc.s 8
-			IL_0008: ldstr "escapeRegExp"
-			IL_000d: ldloc.s 8
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 8
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.s 9
-			IL_0022: ldloc.s 8
-			IL_0024: ldloc.s 9
-			IL_0026: ldarg.3
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_002c: stloc.s 8
-			IL_002e: ldloc.s 8
-			IL_0030: stloc.0
-			IL_0031: ldloc.0
-			IL_0032: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0037: stloc.s 10
-			IL_0039: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
-			IL_003e: ldloc.s 10
-			IL_0040: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0045: stloc.s 10
-			IL_0047: ldloc.s 10
-			IL_0049: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
-			IL_004e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0053: stloc.s 10
-			IL_0055: ldloc.s 10
-			IL_0057: ldstr "i"
-			IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0061: stloc.s 11
-			IL_0063: ldloc.s 11
-			IL_0065: stloc.1
-			IL_0066: ldloc.1
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006c: stloc.s 8
-			IL_006e: ldloc.s 8
-			IL_0070: ldstr "exec"
-			IL_0075: ldarg.2
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_007b: stloc.s 8
-			IL_007d: ldloc.s 8
-			IL_007f: stloc.2
-			IL_0080: ldloc.2
-			IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0086: stloc.s 12
-			IL_0088: ldloc.s 12
-			IL_008a: brfalse IL_00d3
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 8
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_0012: ldloc.s 8
+			IL_0014: ldarg.3
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_001a: stloc.s 9
+			IL_001c: ldloc.s 9
+			IL_001e: stloc.0
+			IL_001f: ldloc.0
+			IL_0020: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0025: stloc.s 10
+			IL_0027: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_002c: ldloc.s 10
+			IL_002e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0033: stloc.s 10
+			IL_0035: ldloc.s 10
+			IL_0037: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
+			IL_003c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0041: stloc.s 10
+			IL_0043: ldloc.s 10
+			IL_0045: ldstr "i"
+			IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_004f: stloc.s 11
+			IL_0051: ldloc.s 11
+			IL_0053: stloc.1
+			IL_0054: ldloc.1
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005a: stloc.s 9
+			IL_005c: ldloc.s 9
+			IL_005e: ldstr "exec"
+			IL_0063: ldarg.2
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0069: stloc.s 9
+			IL_006b: ldloc.s 9
+			IL_006d: stloc.2
+			IL_006e: ldloc.2
+			IL_006f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0074: stloc.s 12
+			IL_0076: ldloc.s 12
+			IL_0078: brfalse IL_00c1
 
-			IL_008f: ldloc.2
-			IL_0090: ldc.r8 1
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_009e: stloc.s 8
-			IL_00a0: ldloc.s 8
-			IL_00a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00a7: stloc.s 12
-			IL_00a9: ldloc.s 12
-			IL_00ab: brtrue IL_00c6
+			IL_007d: ldloc.2
+			IL_007e: ldc.r8 1
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_008c: stloc.s 9
+			IL_008e: ldloc.s 9
+			IL_0090: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0095: stloc.s 12
+			IL_0097: ldloc.s 12
+			IL_0099: brtrue IL_00b4
 
-			IL_00b0: ldloc.2
-			IL_00b1: ldc.r8 2
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00bf: stloc.s 14
-			IL_00c1: br IL_00ca
+			IL_009e: ldloc.2
+			IL_009f: ldc.r8 2
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00ad: stloc.s 14
+			IL_00af: br IL_00b8
 
-			IL_00c6: ldloc.s 8
-			IL_00c8: stloc.s 14
+			IL_00b4: ldloc.s 9
+			IL_00b6: stloc.s 14
 
-			IL_00ca: ldloc.s 14
-			IL_00cc: stloc.s 15
-			IL_00ce: br IL_00d6
+			IL_00b8: ldloc.s 14
+			IL_00ba: stloc.s 15
+			IL_00bc: br IL_00c4
 
-			IL_00d3: ldloc.2
-			IL_00d4: stloc.s 15
+			IL_00c1: ldloc.2
+			IL_00c2: stloc.s 15
 
-			IL_00d6: ldloc.s 15
-			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00dd: stloc.s 12
-			IL_00df: ldloc.s 12
-			IL_00e1: brtrue IL_00f2
+			IL_00c4: ldloc.s 15
+			IL_00c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00cb: stloc.s 12
+			IL_00cd: ldloc.s 12
+			IL_00cf: brtrue IL_00e0
 
-			IL_00e6: ldstr ""
-			IL_00eb: stloc.s 15
-			IL_00ed: br IL_00f2
+			IL_00d4: ldstr ""
+			IL_00d9: stloc.s 15
+			IL_00db: br IL_00e0
 
-			IL_00f2: ldloc.s 15
-			IL_00f4: stloc.3
-			IL_00f5: ldloc.3
-			IL_00f6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00fb: ldc.i4.0
-			IL_00fc: ceq
-			IL_00fe: stloc.s 12
-			IL_0100: ldloc.s 12
-			IL_0102: brfalse IL_0115
+			IL_00e0: ldloc.s 15
+			IL_00e2: stloc.3
+			IL_00e3: ldloc.3
+			IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00e9: ldc.i4.0
+			IL_00ea: ceq
+			IL_00ec: stloc.s 12
+			IL_00ee: ldloc.s 12
+			IL_00f0: brfalse IL_0103
 
-			IL_0107: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/Scope/Block_L215C13::.ctor()
-			IL_010c: stloc.s 4
-			IL_010e: ldc.i4.0
-			IL_010f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0114: ret
+			IL_00f5: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/Scope/Block_L215C13::.ctor()
+			IL_00fa: stloc.s 4
+			IL_00fc: ldc.i4.0
+			IL_00fd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0102: ret
 
-			IL_0115: ldloc.3
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011b: stloc.s 8
-			IL_011d: ldloc.s 8
-			IL_011f: ldstr "indexOf"
-			IL_0124: ldstr "#"
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_012e: stloc.s 8
-			IL_0130: ldloc.s 8
-			IL_0132: stloc.s 5
-			IL_0134: ldloc.s 5
-			IL_0136: stloc.s 8
-			IL_0138: ldloc.s 8
-			IL_013a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_013f: stloc.s 17
-			IL_0141: ldloc.s 17
-			IL_0143: ldc.r8 0.0
-			IL_014c: clt
-			IL_014e: ldc.i4.0
-			IL_014f: ceq
-			IL_0151: brfalse IL_0185
+			IL_0103: ldloc.3
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0109: stloc.s 9
+			IL_010b: ldloc.s 9
+			IL_010d: castclass [System.Runtime]System.String
+			IL_0112: ldstr "#"
+			IL_0117: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_011c: stloc.s 17
+			IL_011e: ldloc.s 17
+			IL_0120: box [System.Runtime]System.Double
+			IL_0125: stloc.s 5
+			IL_0127: ldloc.s 5
+			IL_0129: stloc.s 9
+			IL_012b: ldloc.s 9
+			IL_012d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0132: stloc.s 17
+			IL_0134: ldloc.s 17
+			IL_0136: ldc.r8 0.0
+			IL_013f: clt
+			IL_0141: ldc.i4.0
+			IL_0142: ceq
+			IL_0144: brfalse IL_0178
 
-			IL_0156: ldloc.3
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_015c: stloc.s 8
-			IL_015e: ldloc.s 8
-			IL_0160: ldstr "substring"
-			IL_0165: ldc.r8 0.0
-			IL_016e: box [System.Runtime]System.Double
-			IL_0173: ldloc.s 5
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_017a: stloc.s 8
-			IL_017c: ldloc.s 8
-			IL_017e: stloc.s 6
-			IL_0180: br IL_0188
+			IL_0149: ldloc.3
+			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014f: stloc.s 9
+			IL_0151: ldloc.s 9
+			IL_0153: castclass [System.Runtime]System.String
+			IL_0158: ldc.r8 0.0
+			IL_0161: box [System.Runtime]System.Double
+			IL_0166: ldloc.s 5
+			IL_0168: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_016d: stloc.s 10
+			IL_016f: ldloc.s 10
+			IL_0171: stloc.s 6
+			IL_0173: br IL_017b
 
-			IL_0185: ldloc.3
-			IL_0186: stloc.s 6
+			IL_0178: ldloc.3
+			IL_0179: stloc.s 6
 
-			IL_0188: ldloc.s 5
-			IL_018a: stloc.s 8
-			IL_018c: ldloc.s 8
-			IL_018e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0193: stloc.s 17
-			IL_0195: ldloc.s 17
-			IL_0197: ldc.r8 0.0
-			IL_01a0: clt
-			IL_01a2: ldc.i4.0
-			IL_01a3: ceq
-			IL_01a5: brfalse IL_01e1
+			IL_017b: ldloc.s 5
+			IL_017d: stloc.s 9
+			IL_017f: ldloc.s 9
+			IL_0181: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0186: stloc.s 17
+			IL_0188: ldloc.s 17
+			IL_018a: ldc.r8 0.0
+			IL_0193: clt
+			IL_0195: ldc.i4.0
+			IL_0196: ceq
+			IL_0198: brfalse IL_01d4
 
-			IL_01aa: ldloc.3
-			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b0: stloc.s 8
-			IL_01b2: ldloc.s 5
-			IL_01b4: stloc.s 18
-			IL_01b6: ldloc.s 18
-			IL_01b8: ldc.r8 1
-			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_01c6: stloc.s 15
-			IL_01c8: ldloc.s 8
-			IL_01ca: ldstr "substring"
-			IL_01cf: ldloc.s 15
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01d6: stloc.s 8
-			IL_01d8: ldloc.s 8
-			IL_01da: stloc.s 7
-			IL_01dc: br IL_01e8
+			IL_019d: ldloc.3
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a3: stloc.s 9
+			IL_01a5: ldloc.s 5
+			IL_01a7: stloc.s 18
+			IL_01a9: ldloc.s 18
+			IL_01ab: ldc.r8 1
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01b9: stloc.s 15
+			IL_01bb: ldloc.s 9
+			IL_01bd: castclass [System.Runtime]System.String
+			IL_01c2: ldloc.s 15
+			IL_01c4: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_01c9: stloc.s 10
+			IL_01cb: ldloc.s 10
+			IL_01cd: stloc.s 7
+			IL_01cf: br IL_01db
 
-			IL_01e1: ldstr ""
-			IL_01e6: stloc.s 7
+			IL_01d4: ldstr ""
+			IL_01d9: stloc.s 7
 
-			IL_01e8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01ed: dup
-			IL_01ee: ldstr "href"
-			IL_01f3: ldloc.3
+			IL_01db: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01e0: dup
+			IL_01e1: ldstr "href"
+			IL_01e6: ldloc.3
+			IL_01e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01ec: dup
+			IL_01ed: ldstr "filePart"
+			IL_01f2: ldloc.s 6
 			IL_01f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_01f9: dup
-			IL_01fa: ldstr "filePart"
-			IL_01ff: ldloc.s 6
+			IL_01fa: ldstr "fragment"
+			IL_01ff: ldloc.s 7
 			IL_0201: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0206: dup
-			IL_0207: ldstr "fragment"
-			IL_020c: ldloc.s 7
-			IL_020e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0213: stloc.s 19
-			IL_0215: ldloc.s 19
-			IL_0217: ret
+			IL_0206: stloc.s 19
+			IL_0208: ldloc.s 19
+			IL_020a: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -3942,7 +3772,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c42
+				// Method begins at RVA 0x49be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3968,7 +3798,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x33ac
+			// Method begins at RVA 0x3344
 			// Header size: 12
 			// Code size: 152 (0x98)
 			.maxstack 8
@@ -4075,7 +3905,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c54
+					// Method begins at RVA 0x49d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4095,7 +3925,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c5d
+					// Method begins at RVA 0x49d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4115,7 +3945,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c66
+					// Method begins at RVA 0x49e2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4139,7 +3969,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c78
+						// Method begins at RVA 0x49f4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4159,7 +3989,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c81
+						// Method begins at RVA 0x49fd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4177,7 +4007,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c6f
+					// Method begins at RVA 0x49eb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4197,7 +4027,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c8a
+					// Method begins at RVA 0x4a06
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4217,7 +4047,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c93
+					// Method begins at RVA 0x4a0f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4257,7 +4087,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c4b
+				// Method begins at RVA 0x49c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4281,9 +4111,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3450
+			// Method begins at RVA 0x33e8
 			// Header size: 12
-			// Code size: 3543 (0xdd7)
+			// Code size: 3333 (0xd05)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -4542,7 +4372,7 @@
 
 			IL_0186: ldloc.0
 			IL_0187: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_018c: switch (IL_01a1, IL_0597, IL_086a, IL_0a3b)
+			IL_018c: switch (IL_01a1, IL_0577, IL_081c, IL_09db)
 
 			IL_01a1: ldarg.0
 			IL_01a2: ldc.i4.1
@@ -4550,1363 +4380,1297 @@
 			IL_01a4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
 			IL_01a9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::parseArgs
 			IL_01ae: stloc.s 29
-			IL_01b0: ldstr "parseArgs"
-			IL_01b5: ldloc.s 29
-			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01bc: stloc.s 29
-			IL_01be: ldc.i4.1
-			IL_01bf: newarr [System.Runtime]System.Object
-			IL_01c4: dup
-			IL_01c5: ldc.i4.0
-			IL_01c6: ldarg.0
-			IL_01c7: ldc.i4.1
-			IL_01c8: ldelem.ref
-			IL_01c9: stelem.ref
-			IL_01ca: stloc.s 30
-			IL_01cc: ldstr "process"
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01b0: ldc.i4.1
+			IL_01b1: newarr [System.Runtime]System.Object
+			IL_01b6: dup
+			IL_01b7: ldc.i4.0
+			IL_01b8: ldarg.0
+			IL_01b9: ldc.i4.1
+			IL_01ba: ldelem.ref
+			IL_01bb: stelem.ref
+			IL_01bc: stloc.s 30
+			IL_01be: ldstr "process"
+			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01c8: stloc.s 31
+			IL_01ca: ldloc.s 31
+			IL_01cc: ldstr "argv"
+			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_01d6: stloc.s 31
-			IL_01d8: ldloc.s 31
-			IL_01da: ldstr "argv"
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01e4: stloc.s 31
-			IL_01e6: ldloc.s 29
-			IL_01e8: ldloc.s 30
-			IL_01ea: ldloc.s 31
-			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01f1: stloc.s 31
-			IL_01f3: ldloc.s 31
-			IL_01f5: stloc.1
-			IL_01f6: ldloc.1
-			IL_01f7: ldstr "section"
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0201: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0206: ldc.i4.0
-			IL_0207: ceq
-			IL_0209: stloc.s 32
-			IL_020b: ldloc.s 32
-			IL_020d: brfalse IL_025b
+			IL_01d8: ldloc.s 29
+			IL_01da: ldloc.s 30
+			IL_01dc: ldloc.s 31
+			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_01e3: stloc.s 31
+			IL_01e5: ldloc.s 31
+			IL_01e7: stloc.1
+			IL_01e8: ldloc.1
+			IL_01e9: ldstr "section"
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01f8: ldc.i4.0
+			IL_01f9: ceq
+			IL_01fb: stloc.s 32
+			IL_01fd: ldloc.s 32
+			IL_01ff: brfalse IL_024d
 
-			IL_0212: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L254C21::.ctor()
-			IL_0217: stloc.2
-			IL_0218: ldstr "Missing required --section (e.g. 27.3)."
-			IL_021d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0222: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0227: stloc.s 31
-			IL_0229: ldloc.s 31
-			IL_022b: stloc.3
-			IL_022c: ldloc.0
-			IL_022d: ldc.i4.m1
-			IL_022e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0233: ldloc.0
-			IL_0234: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0239: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_023e: ldarg.0
-			IL_023f: ldc.i4.1
-			IL_0240: newarr [System.Runtime]System.Object
-			IL_0245: dup
-			IL_0246: ldc.i4.0
-			IL_0247: ldloc.3
-			IL_0248: stelem.ref
-			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_024e: pop
-			IL_024f: ldloc.0
-			IL_0250: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0255: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_025a: ret
+			IL_0204: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L254C21::.ctor()
+			IL_0209: stloc.2
+			IL_020a: ldstr "Missing required --section (e.g. 27.3)."
+			IL_020f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0214: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0219: stloc.s 31
+			IL_021b: ldloc.s 31
+			IL_021d: stloc.3
+			IL_021e: ldloc.0
+			IL_021f: ldc.i4.m1
+			IL_0220: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0225: ldloc.0
+			IL_0226: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_022b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0230: ldarg.0
+			IL_0231: ldc.i4.1
+			IL_0232: newarr [System.Runtime]System.Object
+			IL_0237: dup
+			IL_0238: ldc.i4.0
+			IL_0239: ldloc.3
+			IL_023a: stelem.ref
+			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0240: pop
+			IL_0241: ldloc.0
+			IL_0242: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0247: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_024c: ret
 
-			IL_025b: ldloc.1
-			IL_025c: ldstr "outFile"
-			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0266: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_026b: ldc.i4.0
-			IL_026c: ceq
-			IL_026e: stloc.s 32
-			IL_0270: ldloc.s 32
-			IL_0272: brfalse IL_02c3
+			IL_024d: ldloc.1
+			IL_024e: ldstr "outFile"
+			IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0258: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_025d: ldc.i4.0
+			IL_025e: ceq
+			IL_0260: stloc.s 32
+			IL_0262: ldloc.s 32
+			IL_0264: brfalse IL_02b5
 
-			IL_0277: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L258C21::.ctor()
-			IL_027c: stloc.s 4
-			IL_027e: ldstr "Missing required --out <output.html>."
-			IL_0283: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0288: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_028d: stloc.s 31
-			IL_028f: ldloc.s 31
-			IL_0291: stloc.s 5
-			IL_0293: ldloc.0
-			IL_0294: ldc.i4.m1
-			IL_0295: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_029a: ldloc.0
-			IL_029b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_02a5: ldarg.0
-			IL_02a6: ldc.i4.1
-			IL_02a7: newarr [System.Runtime]System.Object
-			IL_02ac: dup
-			IL_02ad: ldc.i4.0
-			IL_02ae: ldloc.s 5
-			IL_02b0: stelem.ref
-			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02b6: pop
-			IL_02b7: ldloc.0
-			IL_02b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02bd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02c2: ret
+			IL_0269: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L258C21::.ctor()
+			IL_026e: stloc.s 4
+			IL_0270: ldstr "Missing required --out <output.html>."
+			IL_0275: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_027a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_027f: stloc.s 31
+			IL_0281: ldloc.s 31
+			IL_0283: stloc.s 5
+			IL_0285: ldloc.0
+			IL_0286: ldc.i4.m1
+			IL_0287: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_028c: ldloc.0
+			IL_028d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0292: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0297: ldarg.0
+			IL_0298: ldc.i4.1
+			IL_0299: newarr [System.Runtime]System.Object
+			IL_029e: dup
+			IL_029f: ldc.i4.0
+			IL_02a0: ldloc.s 5
+			IL_02a2: stelem.ref
+			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02a8: pop
+			IL_02a9: ldloc.0
+			IL_02aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02af: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02b4: ret
 
-			IL_02c3: ldloc.1
-			IL_02c4: ldstr "url"
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02d3: stloc.s 32
-			IL_02d5: ldloc.s 32
-			IL_02d7: brfalse IL_02f1
+			IL_02b5: ldloc.1
+			IL_02b6: ldstr "url"
+			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02c5: stloc.s 32
+			IL_02c7: ldloc.s 32
+			IL_02c9: brfalse IL_02e3
 
-			IL_02dc: ldc.r8 1
-			IL_02e5: box [System.Runtime]System.Double
-			IL_02ea: stloc.s 6
-			IL_02ec: br IL_0301
+			IL_02ce: ldc.r8 1
+			IL_02d7: box [System.Runtime]System.Double
+			IL_02dc: stloc.s 6
+			IL_02de: br IL_02f3
 
-			IL_02f1: ldc.r8 0.0
-			IL_02fa: box [System.Runtime]System.Double
-			IL_02ff: stloc.s 6
+			IL_02e3: ldc.r8 0.0
+			IL_02ec: box [System.Runtime]System.Double
+			IL_02f1: stloc.s 6
 
-			IL_0301: ldloc.s 6
-			IL_0303: stloc.s 33
-			IL_0305: ldloc.1
-			IL_0306: ldstr "auto"
-			IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0310: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0315: stloc.s 32
-			IL_0317: ldloc.s 32
-			IL_0319: brfalse IL_0333
+			IL_02f3: ldloc.s 6
+			IL_02f5: stloc.s 33
+			IL_02f7: ldloc.1
+			IL_02f8: ldstr "auto"
+			IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0302: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0307: stloc.s 32
+			IL_0309: ldloc.s 32
+			IL_030b: brfalse IL_0325
 
-			IL_031e: ldc.r8 1
-			IL_0327: box [System.Runtime]System.Double
-			IL_032c: stloc.s 7
-			IL_032e: br IL_0343
+			IL_0310: ldc.r8 1
+			IL_0319: box [System.Runtime]System.Double
+			IL_031e: stloc.s 7
+			IL_0320: br IL_0335
 
-			IL_0333: ldc.r8 0.0
-			IL_033c: box [System.Runtime]System.Double
-			IL_0341: stloc.s 7
+			IL_0325: ldc.r8 0.0
+			IL_032e: box [System.Runtime]System.Double
+			IL_0333: stloc.s 7
 
-			IL_0343: ldloc.s 33
-			IL_0345: ldloc.s 7
-			IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_034c: stloc.s 33
-			IL_034e: ldloc.s 33
-			IL_0350: stloc.s 8
-			IL_0352: ldloc.s 8
-			IL_0354: stloc.s 33
-			IL_0356: ldloc.s 33
-			IL_0358: ldc.r8 1
-			IL_0361: box [System.Runtime]System.Double
-			IL_0366: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_036b: stloc.s 32
-			IL_036d: ldloc.s 32
-			IL_036f: brfalse IL_03c0
+			IL_0335: ldloc.s 33
+			IL_0337: ldloc.s 7
+			IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_033e: stloc.s 33
+			IL_0340: ldloc.s 33
+			IL_0342: stloc.s 8
+			IL_0344: ldloc.s 8
+			IL_0346: stloc.s 33
+			IL_0348: ldloc.s 33
+			IL_034a: ldc.r8 1
+			IL_0353: box [System.Runtime]System.Double
+			IL_0358: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_035d: stloc.s 32
+			IL_035f: ldloc.s 32
+			IL_0361: brfalse IL_03b2
 
-			IL_0374: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L263C28::.ctor()
-			IL_0379: stloc.s 9
-			IL_037b: ldstr "Provide exactly one input mode: --url or --auto."
-			IL_0380: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0385: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_038a: stloc.s 31
-			IL_038c: ldloc.s 31
-			IL_038e: stloc.s 10
-			IL_0390: ldloc.0
-			IL_0391: ldc.i4.m1
-			IL_0392: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0397: ldloc.0
-			IL_0398: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_039d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_03a2: ldarg.0
-			IL_03a3: ldc.i4.1
-			IL_03a4: newarr [System.Runtime]System.Object
-			IL_03a9: dup
-			IL_03aa: ldc.i4.0
-			IL_03ab: ldloc.s 10
-			IL_03ad: stelem.ref
-			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03b3: pop
-			IL_03b4: ldloc.0
-			IL_03b5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03ba: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03bf: ret
+			IL_0366: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L263C28::.ctor()
+			IL_036b: stloc.s 9
+			IL_036d: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_0372: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0377: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_037c: stloc.s 31
+			IL_037e: ldloc.s 31
+			IL_0380: stloc.s 10
+			IL_0382: ldloc.0
+			IL_0383: ldc.i4.m1
+			IL_0384: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0389: ldloc.0
+			IL_038a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_038f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0394: ldarg.0
+			IL_0395: ldc.i4.1
+			IL_0396: newarr [System.Runtime]System.Object
+			IL_039b: dup
+			IL_039c: ldc.i4.0
+			IL_039d: ldloc.s 10
+			IL_039f: stelem.ref
+			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03a5: pop
+			IL_03a6: ldloc.0
+			IL_03a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03ac: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03b1: ret
 
-			IL_03c0: ldnull
-			IL_03c1: stloc.s 11
-			IL_03c3: ldloc.1
-			IL_03c4: ldstr "id"
-			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ce: stloc.s 31
-			IL_03d0: ldloc.s 31
-			IL_03d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03d7: stloc.s 32
-			IL_03d9: ldloc.s 32
-			IL_03db: brtrue IL_03ec
+			IL_03b2: ldnull
+			IL_03b3: stloc.s 11
+			IL_03b5: ldloc.1
+			IL_03b6: ldstr "id"
+			IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c0: stloc.s 31
+			IL_03c2: ldloc.s 31
+			IL_03c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03c9: stloc.s 32
+			IL_03cb: ldloc.s 32
+			IL_03cd: brtrue IL_03de
 
-			IL_03e0: ldstr ""
-			IL_03e5: stloc.s 34
-			IL_03e7: br IL_03f0
+			IL_03d2: ldstr ""
+			IL_03d7: stloc.s 34
+			IL_03d9: br IL_03e2
 
-			IL_03ec: ldloc.s 31
-			IL_03ee: stloc.s 34
+			IL_03de: ldloc.s 31
+			IL_03e0: stloc.s 34
 
-			IL_03f0: ldloc.s 34
-			IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03f7: stloc.s 31
-			IL_03f9: ldloc.s 31
-			IL_03fb: ldstr "trim"
-			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0405: stloc.s 31
-			IL_0407: ldloc.s 31
-			IL_0409: stloc.s 12
-			IL_040b: ldstr ""
-			IL_0410: stloc.s 13
-			IL_0412: ldloc.1
-			IL_0413: ldstr "auto"
-			IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_041d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0422: stloc.s 32
-			IL_0424: ldloc.s 32
-			IL_0426: brfalse IL_08cf
+			IL_03e2: ldloc.s 34
+			IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03e9: stloc.s 31
+			IL_03eb: ldloc.s 31
+			IL_03ed: castclass [System.Runtime]System.String
+			IL_03f2: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_03f7: stloc.s 35
+			IL_03f9: ldloc.s 35
+			IL_03fb: stloc.s 12
+			IL_03fd: ldstr ""
+			IL_0402: stloc.s 13
+			IL_0404: ldloc.1
+			IL_0405: ldstr "auto"
+			IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_040f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0414: stloc.s 32
+			IL_0416: ldloc.s 32
+			IL_0418: brfalse IL_0881
 
-			IL_042b: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
-			IL_0430: stloc.s 14
-			IL_0432: ldloc.1
-			IL_0433: ldstr "indexUrl"
-			IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_041d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
+			IL_0422: stloc.s 14
+			IL_0424: ldloc.1
+			IL_0425: ldstr "indexUrl"
+			IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0434: stloc.s 31
+			IL_0436: ldloc.s 31
+			IL_0438: ldstr "trim"
+			IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0442: stloc.s 31
 			IL_0444: ldloc.s 31
-			IL_0446: ldstr "trim"
-			IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0450: stloc.s 31
-			IL_0452: ldloc.s 31
-			IL_0454: stloc.s 15
-			IL_0456: ldarg.0
-			IL_0457: ldc.i4.1
-			IL_0458: ldelem.ref
-			IL_0459: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_045e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0463: stloc.s 31
-			IL_0465: ldstr "fetchText"
-			IL_046a: ldloc.s 31
-			IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0471: stloc.s 31
-			IL_0473: ldloc.s 31
+			IL_0446: stloc.s 15
+			IL_0448: ldarg.0
+			IL_0449: ldc.i4.1
+			IL_044a: ldelem.ref
+			IL_044b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0450: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_0455: ldc.i4.1
+			IL_0456: newarr [System.Runtime]System.Object
+			IL_045b: dup
+			IL_045c: ldc.i4.0
+			IL_045d: ldarg.0
+			IL_045e: ldc.i4.1
+			IL_045f: ldelem.ref
+			IL_0460: stelem.ref
+			IL_0461: ldloc.s 15
+			IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0468: stloc.s 31
+			IL_046a: ldloc.0
+			IL_046b: ldc.i4.1
+			IL_046c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0471: ldloc.0
+			IL_0472: ldloc.s 31
+			IL_0474: ldarg.0
 			IL_0475: ldc.i4.1
-			IL_0476: newarr [System.Runtime]System.Object
-			IL_047b: dup
-			IL_047c: ldc.i4.0
-			IL_047d: ldarg.0
-			IL_047e: ldc.i4.1
-			IL_047f: ldelem.ref
-			IL_0480: stelem.ref
-			IL_0481: ldloc.s 15
-			IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0488: stloc.s 31
-			IL_048a: ldloc.0
-			IL_048b: ldc.i4.1
-			IL_048c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0491: ldloc.0
-			IL_0492: ldloc.s 31
-			IL_0494: ldarg.0
-			IL_0495: ldc.i4.1
-			IL_0496: ldloc.0
-			IL_0497: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_049c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_04a1: ldloc.0
-			IL_04a2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0476: ldloc.0
+			IL_0477: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_047c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0481: ldloc.0
+			IL_0482: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0487: dup
+			IL_0488: ldc.i4.0
+			IL_0489: ldloc.1
+			IL_048a: stelem.ref
+			IL_048b: dup
+			IL_048c: ldc.i4.1
+			IL_048d: ldloc.2
+			IL_048e: stelem.ref
+			IL_048f: dup
+			IL_0490: ldc.i4.2
+			IL_0491: ldloc.3
+			IL_0492: stelem.ref
+			IL_0493: dup
+			IL_0494: ldc.i4.3
+			IL_0495: ldloc.s 4
+			IL_0497: stelem.ref
+			IL_0498: dup
+			IL_0499: ldc.i4.4
+			IL_049a: ldloc.s 5
+			IL_049c: stelem.ref
+			IL_049d: dup
+			IL_049e: ldc.i4.5
+			IL_049f: ldloc.s 6
+			IL_04a1: stelem.ref
+			IL_04a2: dup
+			IL_04a3: ldc.i4.6
+			IL_04a4: ldloc.s 7
+			IL_04a6: stelem.ref
 			IL_04a7: dup
-			IL_04a8: ldc.i4.0
-			IL_04a9: ldloc.1
-			IL_04aa: stelem.ref
-			IL_04ab: dup
-			IL_04ac: ldc.i4.1
-			IL_04ad: ldloc.2
-			IL_04ae: stelem.ref
-			IL_04af: dup
-			IL_04b0: ldc.i4.2
-			IL_04b1: ldloc.3
-			IL_04b2: stelem.ref
-			IL_04b3: dup
-			IL_04b4: ldc.i4.3
-			IL_04b5: ldloc.s 4
-			IL_04b7: stelem.ref
-			IL_04b8: dup
-			IL_04b9: ldc.i4.4
-			IL_04ba: ldloc.s 5
+			IL_04a8: ldc.i4.7
+			IL_04a9: ldloc.s 8
+			IL_04ab: stelem.ref
+			IL_04ac: dup
+			IL_04ad: ldc.i4.8
+			IL_04ae: ldloc.s 9
+			IL_04b0: stelem.ref
+			IL_04b1: dup
+			IL_04b2: ldc.i4.s 9
+			IL_04b4: ldloc.s 10
+			IL_04b6: stelem.ref
+			IL_04b7: dup
+			IL_04b8: ldc.i4.s 10
+			IL_04ba: ldloc.s 11
 			IL_04bc: stelem.ref
 			IL_04bd: dup
-			IL_04be: ldc.i4.5
-			IL_04bf: ldloc.s 6
-			IL_04c1: stelem.ref
-			IL_04c2: dup
-			IL_04c3: ldc.i4.6
-			IL_04c4: ldloc.s 7
-			IL_04c6: stelem.ref
-			IL_04c7: dup
-			IL_04c8: ldc.i4.7
-			IL_04c9: ldloc.s 8
-			IL_04cb: stelem.ref
-			IL_04cc: dup
-			IL_04cd: ldc.i4.8
-			IL_04ce: ldloc.s 9
-			IL_04d0: stelem.ref
-			IL_04d1: dup
-			IL_04d2: ldc.i4.s 9
-			IL_04d4: ldloc.s 10
-			IL_04d6: stelem.ref
-			IL_04d7: dup
-			IL_04d8: ldc.i4.s 10
-			IL_04da: ldloc.s 11
-			IL_04dc: stelem.ref
-			IL_04dd: dup
-			IL_04de: ldc.i4.s 11
-			IL_04e0: ldloc.s 12
-			IL_04e2: stelem.ref
-			IL_04e3: dup
-			IL_04e4: ldc.i4.s 12
-			IL_04e6: ldloc.s 13
-			IL_04e8: stelem.ref
-			IL_04e9: dup
-			IL_04ea: ldc.i4.s 13
-			IL_04ec: ldloc.s 14
-			IL_04ee: stelem.ref
-			IL_04ef: dup
-			IL_04f0: ldc.i4.s 14
-			IL_04f2: ldloc.s 15
-			IL_04f4: stelem.ref
-			IL_04f5: dup
-			IL_04f6: ldc.i4.s 15
-			IL_04f8: ldloc.s 16
-			IL_04fa: stelem.ref
-			IL_04fb: dup
-			IL_04fc: ldc.i4.s 16
-			IL_04fe: ldloc.s 17
-			IL_0500: stelem.ref
-			IL_0501: dup
-			IL_0502: ldc.i4.s 17
-			IL_0504: ldloc.s 18
-			IL_0506: stelem.ref
-			IL_0507: dup
-			IL_0508: ldc.i4.s 18
-			IL_050a: ldloc.s 19
-			IL_050c: stelem.ref
-			IL_050d: dup
-			IL_050e: ldc.i4.s 19
-			IL_0510: ldloc.s 20
-			IL_0512: stelem.ref
-			IL_0513: dup
-			IL_0514: ldc.i4.s 20
-			IL_0516: ldloc.s 21
-			IL_0518: stelem.ref
-			IL_0519: dup
-			IL_051a: ldc.i4.s 21
-			IL_051c: ldloc.s 22
-			IL_051e: stelem.ref
-			IL_051f: dup
-			IL_0520: ldc.i4.s 22
-			IL_0522: ldloc.s 23
-			IL_0524: stelem.ref
-			IL_0525: dup
-			IL_0526: ldc.i4.s 23
-			IL_0528: ldloc.s 24
-			IL_052a: stelem.ref
-			IL_052b: dup
-			IL_052c: ldc.i4.s 24
-			IL_052e: ldloc.s 25
-			IL_0530: stelem.ref
-			IL_0531: dup
-			IL_0532: ldc.i4.s 25
-			IL_0534: ldloc.s 26
-			IL_0536: stelem.ref
-			IL_0537: dup
-			IL_0538: ldc.i4.s 26
-			IL_053a: ldloc.s 27
-			IL_053c: stelem.ref
-			IL_053d: dup
-			IL_053e: ldc.i4.s 27
-			IL_0540: ldloc.s 28
-			IL_0542: stelem.ref
-			IL_0543: dup
-			IL_0544: ldc.i4.s 28
-			IL_0546: ldloc.s 29
-			IL_0548: stelem.ref
-			IL_0549: dup
-			IL_054a: ldc.i4.s 29
-			IL_054c: ldloc.s 30
-			IL_054e: stelem.ref
-			IL_054f: dup
-			IL_0550: ldc.i4.s 30
-			IL_0552: ldloc.s 31
-			IL_0554: stelem.ref
-			IL_0555: dup
-			IL_0556: ldc.i4.s 31
-			IL_0558: ldloc.s 32
-			IL_055a: box [System.Runtime]System.Boolean
-			IL_055f: stelem.ref
-			IL_0560: dup
-			IL_0561: ldc.i4.s 32
-			IL_0563: ldloc.s 33
-			IL_0565: stelem.ref
-			IL_0566: dup
-			IL_0567: ldc.i4.s 33
-			IL_0569: ldloc.s 34
-			IL_056b: stelem.ref
-			IL_056c: dup
-			IL_056d: ldc.i4.s 34
-			IL_056f: ldloc.s 35
-			IL_0571: stelem.ref
-			IL_0572: dup
-			IL_0573: ldc.i4.s 35
-			IL_0575: ldloc.s 36
-			IL_0577: stelem.ref
-			IL_0578: dup
-			IL_0579: ldc.i4.s 36
-			IL_057b: ldloc.s 37
-			IL_057d: stelem.ref
-			IL_057e: dup
-			IL_057f: ldc.i4.s 37
-			IL_0581: ldloc.s 38
-			IL_0583: stelem.ref
-			IL_0584: dup
-			IL_0585: ldc.i4.s 38
-			IL_0587: ldloc.s 39
-			IL_0589: stelem.ref
-			IL_058a: pop
-			IL_058b: ldloc.0
-			IL_058c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0591: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0596: ret
+			IL_04be: ldc.i4.s 11
+			IL_04c0: ldloc.s 12
+			IL_04c2: stelem.ref
+			IL_04c3: dup
+			IL_04c4: ldc.i4.s 12
+			IL_04c6: ldloc.s 13
+			IL_04c8: stelem.ref
+			IL_04c9: dup
+			IL_04ca: ldc.i4.s 13
+			IL_04cc: ldloc.s 14
+			IL_04ce: stelem.ref
+			IL_04cf: dup
+			IL_04d0: ldc.i4.s 14
+			IL_04d2: ldloc.s 15
+			IL_04d4: stelem.ref
+			IL_04d5: dup
+			IL_04d6: ldc.i4.s 15
+			IL_04d8: ldloc.s 16
+			IL_04da: stelem.ref
+			IL_04db: dup
+			IL_04dc: ldc.i4.s 16
+			IL_04de: ldloc.s 17
+			IL_04e0: stelem.ref
+			IL_04e1: dup
+			IL_04e2: ldc.i4.s 17
+			IL_04e4: ldloc.s 18
+			IL_04e6: stelem.ref
+			IL_04e7: dup
+			IL_04e8: ldc.i4.s 18
+			IL_04ea: ldloc.s 19
+			IL_04ec: stelem.ref
+			IL_04ed: dup
+			IL_04ee: ldc.i4.s 19
+			IL_04f0: ldloc.s 20
+			IL_04f2: stelem.ref
+			IL_04f3: dup
+			IL_04f4: ldc.i4.s 20
+			IL_04f6: ldloc.s 21
+			IL_04f8: stelem.ref
+			IL_04f9: dup
+			IL_04fa: ldc.i4.s 21
+			IL_04fc: ldloc.s 22
+			IL_04fe: stelem.ref
+			IL_04ff: dup
+			IL_0500: ldc.i4.s 22
+			IL_0502: ldloc.s 23
+			IL_0504: stelem.ref
+			IL_0505: dup
+			IL_0506: ldc.i4.s 23
+			IL_0508: ldloc.s 24
+			IL_050a: stelem.ref
+			IL_050b: dup
+			IL_050c: ldc.i4.s 24
+			IL_050e: ldloc.s 25
+			IL_0510: stelem.ref
+			IL_0511: dup
+			IL_0512: ldc.i4.s 25
+			IL_0514: ldloc.s 26
+			IL_0516: stelem.ref
+			IL_0517: dup
+			IL_0518: ldc.i4.s 26
+			IL_051a: ldloc.s 27
+			IL_051c: stelem.ref
+			IL_051d: dup
+			IL_051e: ldc.i4.s 27
+			IL_0520: ldloc.s 28
+			IL_0522: stelem.ref
+			IL_0523: dup
+			IL_0524: ldc.i4.s 28
+			IL_0526: ldloc.s 29
+			IL_0528: stelem.ref
+			IL_0529: dup
+			IL_052a: ldc.i4.s 29
+			IL_052c: ldloc.s 30
+			IL_052e: stelem.ref
+			IL_052f: dup
+			IL_0530: ldc.i4.s 30
+			IL_0532: ldloc.s 31
+			IL_0534: stelem.ref
+			IL_0535: dup
+			IL_0536: ldc.i4.s 31
+			IL_0538: ldloc.s 32
+			IL_053a: box [System.Runtime]System.Boolean
+			IL_053f: stelem.ref
+			IL_0540: dup
+			IL_0541: ldc.i4.s 32
+			IL_0543: ldloc.s 33
+			IL_0545: stelem.ref
+			IL_0546: dup
+			IL_0547: ldc.i4.s 33
+			IL_0549: ldloc.s 34
+			IL_054b: stelem.ref
+			IL_054c: dup
+			IL_054d: ldc.i4.s 34
+			IL_054f: ldloc.s 35
+			IL_0551: stelem.ref
+			IL_0552: dup
+			IL_0553: ldc.i4.s 35
+			IL_0555: ldloc.s 36
+			IL_0557: stelem.ref
+			IL_0558: dup
+			IL_0559: ldc.i4.s 36
+			IL_055b: ldloc.s 37
+			IL_055d: stelem.ref
+			IL_055e: dup
+			IL_055f: ldc.i4.s 37
+			IL_0561: ldloc.s 38
+			IL_0563: stelem.ref
+			IL_0564: dup
+			IL_0565: ldc.i4.s 38
+			IL_0567: ldloc.s 39
+			IL_0569: stelem.ref
+			IL_056a: pop
+			IL_056b: ldloc.0
+			IL_056c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0571: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0576: ret
 
-			IL_0597: ldloc.0
-			IL_0598: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_059d: stloc.s 31
-			IL_059f: ldloc.s 31
-			IL_05a1: stloc.s 16
-			IL_05a3: ldarg.0
-			IL_05a4: ldc.i4.1
-			IL_05a5: ldelem.ref
-			IL_05a6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_05ab: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
-			IL_05b0: stloc.s 31
-			IL_05b2: ldstr "resolveSectionLinkFromMultipageIndexHtml"
-			IL_05b7: ldloc.s 31
-			IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_05be: stloc.s 31
-			IL_05c0: ldc.i4.1
-			IL_05c1: newarr [System.Runtime]System.Object
-			IL_05c6: dup
-			IL_05c7: ldc.i4.0
-			IL_05c8: ldarg.0
-			IL_05c9: ldc.i4.1
-			IL_05ca: ldelem.ref
-			IL_05cb: stelem.ref
-			IL_05cc: stloc.s 30
-			IL_05ce: ldloc.1
-			IL_05cf: ldstr "section"
-			IL_05d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05de: stloc.s 29
-			IL_05e0: ldloc.s 29
-			IL_05e2: ldstr "trim"
-			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_05ec: stloc.s 29
-			IL_05ee: ldloc.s 31
-			IL_05f0: ldloc.s 30
-			IL_05f2: ldloc.s 16
-			IL_05f4: ldloc.s 29
-			IL_05f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05fb: stloc.s 29
-			IL_05fd: ldloc.s 29
-			IL_05ff: stloc.s 17
-			IL_0601: ldloc.s 17
-			IL_0603: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0608: ldc.i4.0
-			IL_0609: ceq
-			IL_060b: stloc.s 32
-			IL_060d: ldloc.s 32
-			IL_060f: brfalse IL_069f
+			IL_0577: ldloc.0
+			IL_0578: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_057d: stloc.s 31
+			IL_057f: ldloc.s 31
+			IL_0581: stloc.s 16
+			IL_0583: ldarg.0
+			IL_0584: ldc.i4.1
+			IL_0585: ldelem.ref
+			IL_0586: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_058b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+			IL_0590: stloc.s 31
+			IL_0592: ldc.i4.1
+			IL_0593: newarr [System.Runtime]System.Object
+			IL_0598: dup
+			IL_0599: ldc.i4.0
+			IL_059a: ldarg.0
+			IL_059b: ldc.i4.1
+			IL_059c: ldelem.ref
+			IL_059d: stelem.ref
+			IL_059e: stloc.s 30
+			IL_05a0: ldloc.1
+			IL_05a1: ldstr "section"
+			IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05b0: stloc.s 29
+			IL_05b2: ldloc.s 29
+			IL_05b4: ldstr "trim"
+			IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_05be: stloc.s 29
+			IL_05c0: ldloc.s 31
+			IL_05c2: ldloc.s 30
+			IL_05c4: ldloc.s 16
+			IL_05c6: ldloc.s 29
+			IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05cd: stloc.s 29
+			IL_05cf: ldloc.s 29
+			IL_05d1: stloc.s 17
+			IL_05d3: ldloc.s 17
+			IL_05d5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05da: ldc.i4.0
+			IL_05db: ceq
+			IL_05dd: stloc.s 32
+			IL_05df: ldloc.s 32
+			IL_05e1: brfalse IL_0671
 
-			IL_0614: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L275C15::.ctor()
-			IL_0619: stloc.s 18
-			IL_061b: ldloc.1
-			IL_061c: ldstr "section"
-			IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0626: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_062b: stloc.s 35
-			IL_062d: ldstr "Could not find section '"
-			IL_0632: ldloc.s 35
-			IL_0634: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0639: stloc.s 35
-			IL_063b: ldloc.s 35
-			IL_063d: ldstr "' in multipage index: "
-			IL_0642: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0647: stloc.s 35
-			IL_0649: ldloc.s 15
-			IL_064b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0650: stloc.s 36
-			IL_0652: ldloc.s 35
-			IL_0654: ldloc.s 36
-			IL_0656: call string [System.Runtime]System.String::Concat(string, string)
-			IL_065b: stloc.s 36
-			IL_065d: ldloc.s 36
-			IL_065f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0664: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0669: stloc.s 29
-			IL_066b: ldloc.s 29
-			IL_066d: stloc.s 19
-			IL_066f: ldloc.0
-			IL_0670: ldc.i4.m1
-			IL_0671: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0676: ldloc.0
-			IL_0677: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_067c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0681: ldarg.0
-			IL_0682: ldc.i4.1
-			IL_0683: newarr [System.Runtime]System.Object
-			IL_0688: dup
-			IL_0689: ldc.i4.0
-			IL_068a: ldloc.s 19
-			IL_068c: stelem.ref
-			IL_068d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0692: pop
-			IL_0693: ldloc.0
-			IL_0694: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0699: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_069e: ret
+			IL_05e6: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L275C15::.ctor()
+			IL_05eb: stloc.s 18
+			IL_05ed: ldloc.1
+			IL_05ee: ldstr "section"
+			IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05f8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05fd: stloc.s 35
+			IL_05ff: ldstr "Could not find section '"
+			IL_0604: ldloc.s 35
+			IL_0606: call string [System.Runtime]System.String::Concat(string, string)
+			IL_060b: stloc.s 35
+			IL_060d: ldloc.s 35
+			IL_060f: ldstr "' in multipage index: "
+			IL_0614: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0619: stloc.s 35
+			IL_061b: ldloc.s 15
+			IL_061d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0622: stloc.s 36
+			IL_0624: ldloc.s 35
+			IL_0626: ldloc.s 36
+			IL_0628: call string [System.Runtime]System.String::Concat(string, string)
+			IL_062d: stloc.s 36
+			IL_062f: ldloc.s 36
+			IL_0631: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0636: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_063b: stloc.s 29
+			IL_063d: ldloc.s 29
+			IL_063f: stloc.s 19
+			IL_0641: ldloc.0
+			IL_0642: ldc.i4.m1
+			IL_0643: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0648: ldloc.0
+			IL_0649: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_064e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0653: ldarg.0
+			IL_0654: ldc.i4.1
+			IL_0655: newarr [System.Runtime]System.Object
+			IL_065a: dup
+			IL_065b: ldc.i4.0
+			IL_065c: ldloc.s 19
+			IL_065e: stelem.ref
+			IL_065f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0664: pop
+			IL_0665: ldloc.0
+			IL_0666: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_066b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0670: ret
 
-			IL_069f: ldarg.0
-			IL_06a0: ldc.i4.1
-			IL_06a1: ldelem.ref
-			IL_06a2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_06a7: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_06ac: stloc.s 29
-			IL_06ae: ldstr "NodeUrl"
-			IL_06b3: ldloc.s 29
-			IL_06b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06ba: stloc.s 29
-			IL_06bc: ldloc.s 17
-			IL_06be: ldstr "filePart"
-			IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06c8: stloc.s 31
-			IL_06ca: ldloc.s 31
-			IL_06cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_06d1: stloc.s 32
-			IL_06d3: ldloc.s 32
-			IL_06d5: brtrue IL_06ed
+			IL_0671: ldarg.0
+			IL_0672: ldc.i4.1
+			IL_0673: ldelem.ref
+			IL_0674: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0679: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_067e: stloc.s 29
+			IL_0680: ldloc.s 17
+			IL_0682: ldstr "filePart"
+			IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_068c: stloc.s 31
+			IL_068e: ldloc.s 31
+			IL_0690: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0695: stloc.s 32
+			IL_0697: ldloc.s 32
+			IL_0699: brtrue IL_06b1
 
-			IL_06da: ldloc.s 17
-			IL_06dc: ldstr "href"
-			IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06e6: stloc.s 37
-			IL_06e8: br IL_06f1
+			IL_069e: ldloc.s 17
+			IL_06a0: ldstr "href"
+			IL_06a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06aa: stloc.s 37
+			IL_06ac: br IL_06b5
 
-			IL_06ed: ldloc.s 31
-			IL_06ef: stloc.s 37
+			IL_06b1: ldloc.s 31
+			IL_06b3: stloc.s 37
 
-			IL_06f1: ldc.i4.2
-			IL_06f2: newarr [System.Runtime]System.Object
-			IL_06f7: dup
-			IL_06f8: ldc.i4.0
-			IL_06f9: ldloc.s 37
-			IL_06fb: stelem.ref
-			IL_06fc: dup
-			IL_06fd: ldc.i4.1
-			IL_06fe: ldloc.s 15
-			IL_0700: stelem.ref
-			IL_0701: stloc.s 30
-			IL_0703: ldloc.s 29
-			IL_0705: ldloc.s 30
-			IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_070c: stloc.s 29
-			IL_070e: ldloc.s 29
-			IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0715: stloc.s 29
+			IL_06b5: ldc.i4.2
+			IL_06b6: newarr [System.Runtime]System.Object
+			IL_06bb: dup
+			IL_06bc: ldc.i4.0
+			IL_06bd: ldloc.s 37
+			IL_06bf: stelem.ref
+			IL_06c0: dup
+			IL_06c1: ldc.i4.1
+			IL_06c2: ldloc.s 15
+			IL_06c4: stelem.ref
+			IL_06c5: stloc.s 30
+			IL_06c7: ldloc.s 29
+			IL_06c9: ldloc.s 30
+			IL_06cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_06d0: stloc.s 29
+			IL_06d2: ldloc.s 29
+			IL_06d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06d9: stloc.s 29
+			IL_06db: ldloc.s 29
+			IL_06dd: ldstr "toString"
+			IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_06e7: stloc.s 29
+			IL_06e9: ldloc.s 29
+			IL_06eb: stloc.s 20
+			IL_06ed: ldarg.0
+			IL_06ee: ldc.i4.1
+			IL_06ef: ldelem.ref
+			IL_06f0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_06f5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_06fa: ldc.i4.1
+			IL_06fb: newarr [System.Runtime]System.Object
+			IL_0700: dup
+			IL_0701: ldc.i4.0
+			IL_0702: ldarg.0
+			IL_0703: ldc.i4.1
+			IL_0704: ldelem.ref
+			IL_0705: stelem.ref
+			IL_0706: ldloc.s 20
+			IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_070d: stloc.s 29
+			IL_070f: ldloc.0
+			IL_0710: ldc.i4.2
+			IL_0711: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0716: ldloc.0
 			IL_0717: ldloc.s 29
-			IL_0719: ldstr "toString"
-			IL_071e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0723: stloc.s 29
-			IL_0725: ldloc.s 29
-			IL_0727: stloc.s 20
-			IL_0729: ldarg.0
-			IL_072a: ldc.i4.1
-			IL_072b: ldelem.ref
-			IL_072c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0731: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0736: stloc.s 29
-			IL_0738: ldstr "fetchText"
-			IL_073d: ldloc.s 29
-			IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0744: stloc.s 29
-			IL_0746: ldloc.s 29
-			IL_0748: ldc.i4.1
-			IL_0749: newarr [System.Runtime]System.Object
-			IL_074e: dup
-			IL_074f: ldc.i4.0
-			IL_0750: ldarg.0
-			IL_0751: ldc.i4.1
-			IL_0752: ldelem.ref
-			IL_0753: stelem.ref
-			IL_0754: ldloc.s 20
-			IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_075b: stloc.s 29
-			IL_075d: ldloc.0
-			IL_075e: ldc.i4.2
-			IL_075f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0764: ldloc.0
-			IL_0765: ldloc.s 29
-			IL_0767: ldarg.0
-			IL_0768: ldc.i4.2
-			IL_0769: ldloc.0
-			IL_076a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_076f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0774: ldloc.0
-			IL_0775: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0719: ldarg.0
+			IL_071a: ldc.i4.2
+			IL_071b: ldloc.0
+			IL_071c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0721: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0726: ldloc.0
+			IL_0727: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_072c: dup
+			IL_072d: ldc.i4.0
+			IL_072e: ldloc.1
+			IL_072f: stelem.ref
+			IL_0730: dup
+			IL_0731: ldc.i4.1
+			IL_0732: ldloc.2
+			IL_0733: stelem.ref
+			IL_0734: dup
+			IL_0735: ldc.i4.2
+			IL_0736: ldloc.3
+			IL_0737: stelem.ref
+			IL_0738: dup
+			IL_0739: ldc.i4.3
+			IL_073a: ldloc.s 4
+			IL_073c: stelem.ref
+			IL_073d: dup
+			IL_073e: ldc.i4.4
+			IL_073f: ldloc.s 5
+			IL_0741: stelem.ref
+			IL_0742: dup
+			IL_0743: ldc.i4.5
+			IL_0744: ldloc.s 6
+			IL_0746: stelem.ref
+			IL_0747: dup
+			IL_0748: ldc.i4.6
+			IL_0749: ldloc.s 7
+			IL_074b: stelem.ref
+			IL_074c: dup
+			IL_074d: ldc.i4.7
+			IL_074e: ldloc.s 8
+			IL_0750: stelem.ref
+			IL_0751: dup
+			IL_0752: ldc.i4.8
+			IL_0753: ldloc.s 9
+			IL_0755: stelem.ref
+			IL_0756: dup
+			IL_0757: ldc.i4.s 9
+			IL_0759: ldloc.s 10
+			IL_075b: stelem.ref
+			IL_075c: dup
+			IL_075d: ldc.i4.s 10
+			IL_075f: ldloc.s 11
+			IL_0761: stelem.ref
+			IL_0762: dup
+			IL_0763: ldc.i4.s 11
+			IL_0765: ldloc.s 12
+			IL_0767: stelem.ref
+			IL_0768: dup
+			IL_0769: ldc.i4.s 12
+			IL_076b: ldloc.s 13
+			IL_076d: stelem.ref
+			IL_076e: dup
+			IL_076f: ldc.i4.s 13
+			IL_0771: ldloc.s 14
+			IL_0773: stelem.ref
+			IL_0774: dup
+			IL_0775: ldc.i4.s 14
+			IL_0777: ldloc.s 15
+			IL_0779: stelem.ref
 			IL_077a: dup
-			IL_077b: ldc.i4.0
-			IL_077c: ldloc.1
-			IL_077d: stelem.ref
-			IL_077e: dup
-			IL_077f: ldc.i4.1
-			IL_0780: ldloc.2
-			IL_0781: stelem.ref
-			IL_0782: dup
-			IL_0783: ldc.i4.2
-			IL_0784: ldloc.3
+			IL_077b: ldc.i4.s 15
+			IL_077d: ldloc.s 16
+			IL_077f: stelem.ref
+			IL_0780: dup
+			IL_0781: ldc.i4.s 16
+			IL_0783: ldloc.s 17
 			IL_0785: stelem.ref
 			IL_0786: dup
-			IL_0787: ldc.i4.3
-			IL_0788: ldloc.s 4
-			IL_078a: stelem.ref
-			IL_078b: dup
-			IL_078c: ldc.i4.4
-			IL_078d: ldloc.s 5
-			IL_078f: stelem.ref
-			IL_0790: dup
-			IL_0791: ldc.i4.5
-			IL_0792: ldloc.s 6
-			IL_0794: stelem.ref
-			IL_0795: dup
-			IL_0796: ldc.i4.6
-			IL_0797: ldloc.s 7
-			IL_0799: stelem.ref
-			IL_079a: dup
-			IL_079b: ldc.i4.7
-			IL_079c: ldloc.s 8
-			IL_079e: stelem.ref
-			IL_079f: dup
-			IL_07a0: ldc.i4.8
-			IL_07a1: ldloc.s 9
+			IL_0787: ldc.i4.s 17
+			IL_0789: ldloc.s 18
+			IL_078b: stelem.ref
+			IL_078c: dup
+			IL_078d: ldc.i4.s 18
+			IL_078f: ldloc.s 19
+			IL_0791: stelem.ref
+			IL_0792: dup
+			IL_0793: ldc.i4.s 19
+			IL_0795: ldloc.s 20
+			IL_0797: stelem.ref
+			IL_0798: dup
+			IL_0799: ldc.i4.s 20
+			IL_079b: ldloc.s 21
+			IL_079d: stelem.ref
+			IL_079e: dup
+			IL_079f: ldc.i4.s 21
+			IL_07a1: ldloc.s 22
 			IL_07a3: stelem.ref
 			IL_07a4: dup
-			IL_07a5: ldc.i4.s 9
-			IL_07a7: ldloc.s 10
+			IL_07a5: ldc.i4.s 22
+			IL_07a7: ldloc.s 23
 			IL_07a9: stelem.ref
 			IL_07aa: dup
-			IL_07ab: ldc.i4.s 10
-			IL_07ad: ldloc.s 11
+			IL_07ab: ldc.i4.s 23
+			IL_07ad: ldloc.s 24
 			IL_07af: stelem.ref
 			IL_07b0: dup
-			IL_07b1: ldc.i4.s 11
-			IL_07b3: ldloc.s 12
+			IL_07b1: ldc.i4.s 24
+			IL_07b3: ldloc.s 25
 			IL_07b5: stelem.ref
 			IL_07b6: dup
-			IL_07b7: ldc.i4.s 12
-			IL_07b9: ldloc.s 13
+			IL_07b7: ldc.i4.s 25
+			IL_07b9: ldloc.s 26
 			IL_07bb: stelem.ref
 			IL_07bc: dup
-			IL_07bd: ldc.i4.s 13
-			IL_07bf: ldloc.s 14
+			IL_07bd: ldc.i4.s 26
+			IL_07bf: ldloc.s 27
 			IL_07c1: stelem.ref
 			IL_07c2: dup
-			IL_07c3: ldc.i4.s 14
-			IL_07c5: ldloc.s 15
+			IL_07c3: ldc.i4.s 27
+			IL_07c5: ldloc.s 28
 			IL_07c7: stelem.ref
 			IL_07c8: dup
-			IL_07c9: ldc.i4.s 15
-			IL_07cb: ldloc.s 16
+			IL_07c9: ldc.i4.s 28
+			IL_07cb: ldloc.s 29
 			IL_07cd: stelem.ref
 			IL_07ce: dup
-			IL_07cf: ldc.i4.s 16
-			IL_07d1: ldloc.s 17
+			IL_07cf: ldc.i4.s 29
+			IL_07d1: ldloc.s 30
 			IL_07d3: stelem.ref
 			IL_07d4: dup
-			IL_07d5: ldc.i4.s 17
-			IL_07d7: ldloc.s 18
+			IL_07d5: ldc.i4.s 30
+			IL_07d7: ldloc.s 31
 			IL_07d9: stelem.ref
 			IL_07da: dup
-			IL_07db: ldc.i4.s 18
-			IL_07dd: ldloc.s 19
-			IL_07df: stelem.ref
-			IL_07e0: dup
-			IL_07e1: ldc.i4.s 19
-			IL_07e3: ldloc.s 20
-			IL_07e5: stelem.ref
-			IL_07e6: dup
-			IL_07e7: ldc.i4.s 20
-			IL_07e9: ldloc.s 21
-			IL_07eb: stelem.ref
-			IL_07ec: dup
-			IL_07ed: ldc.i4.s 21
-			IL_07ef: ldloc.s 22
-			IL_07f1: stelem.ref
-			IL_07f2: dup
-			IL_07f3: ldc.i4.s 22
-			IL_07f5: ldloc.s 23
-			IL_07f7: stelem.ref
-			IL_07f8: dup
-			IL_07f9: ldc.i4.s 23
-			IL_07fb: ldloc.s 24
-			IL_07fd: stelem.ref
-			IL_07fe: dup
-			IL_07ff: ldc.i4.s 24
-			IL_0801: ldloc.s 25
-			IL_0803: stelem.ref
-			IL_0804: dup
-			IL_0805: ldc.i4.s 25
-			IL_0807: ldloc.s 26
-			IL_0809: stelem.ref
-			IL_080a: dup
-			IL_080b: ldc.i4.s 26
-			IL_080d: ldloc.s 27
-			IL_080f: stelem.ref
-			IL_0810: dup
-			IL_0811: ldc.i4.s 27
-			IL_0813: ldloc.s 28
-			IL_0815: stelem.ref
-			IL_0816: dup
-			IL_0817: ldc.i4.s 28
-			IL_0819: ldloc.s 29
-			IL_081b: stelem.ref
-			IL_081c: dup
-			IL_081d: ldc.i4.s 29
-			IL_081f: ldloc.s 30
-			IL_0821: stelem.ref
-			IL_0822: dup
-			IL_0823: ldc.i4.s 30
-			IL_0825: ldloc.s 31
-			IL_0827: stelem.ref
-			IL_0828: dup
-			IL_0829: ldc.i4.s 31
-			IL_082b: ldloc.s 32
-			IL_082d: box [System.Runtime]System.Boolean
-			IL_0832: stelem.ref
-			IL_0833: dup
-			IL_0834: ldc.i4.s 32
-			IL_0836: ldloc.s 33
-			IL_0838: stelem.ref
-			IL_0839: dup
-			IL_083a: ldc.i4.s 33
-			IL_083c: ldloc.s 34
-			IL_083e: stelem.ref
-			IL_083f: dup
-			IL_0840: ldc.i4.s 34
-			IL_0842: ldloc.s 35
-			IL_0844: stelem.ref
-			IL_0845: dup
-			IL_0846: ldc.i4.s 35
-			IL_0848: ldloc.s 36
-			IL_084a: stelem.ref
-			IL_084b: dup
-			IL_084c: ldc.i4.s 36
-			IL_084e: ldloc.s 37
-			IL_0850: stelem.ref
-			IL_0851: dup
-			IL_0852: ldc.i4.s 37
-			IL_0854: ldloc.s 38
-			IL_0856: stelem.ref
-			IL_0857: dup
-			IL_0858: ldc.i4.s 38
-			IL_085a: ldloc.s 39
-			IL_085c: stelem.ref
-			IL_085d: pop
-			IL_085e: ldloc.0
-			IL_085f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0864: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0869: ret
+			IL_07db: ldc.i4.s 31
+			IL_07dd: ldloc.s 32
+			IL_07df: box [System.Runtime]System.Boolean
+			IL_07e4: stelem.ref
+			IL_07e5: dup
+			IL_07e6: ldc.i4.s 32
+			IL_07e8: ldloc.s 33
+			IL_07ea: stelem.ref
+			IL_07eb: dup
+			IL_07ec: ldc.i4.s 33
+			IL_07ee: ldloc.s 34
+			IL_07f0: stelem.ref
+			IL_07f1: dup
+			IL_07f2: ldc.i4.s 34
+			IL_07f4: ldloc.s 35
+			IL_07f6: stelem.ref
+			IL_07f7: dup
+			IL_07f8: ldc.i4.s 35
+			IL_07fa: ldloc.s 36
+			IL_07fc: stelem.ref
+			IL_07fd: dup
+			IL_07fe: ldc.i4.s 36
+			IL_0800: ldloc.s 37
+			IL_0802: stelem.ref
+			IL_0803: dup
+			IL_0804: ldc.i4.s 37
+			IL_0806: ldloc.s 38
+			IL_0808: stelem.ref
+			IL_0809: dup
+			IL_080a: ldc.i4.s 38
+			IL_080c: ldloc.s 39
+			IL_080e: stelem.ref
+			IL_080f: pop
+			IL_0810: ldloc.0
+			IL_0811: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0816: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_081b: ret
 
-			IL_086a: ldloc.0
-			IL_086b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_0870: stloc.s 29
-			IL_0872: ldloc.s 29
-			IL_0874: stloc.s 11
-			IL_0876: ldloc.s 20
-			IL_0878: stloc.s 29
-			IL_087a: ldloc.s 29
-			IL_087c: stloc.s 13
-			IL_087e: ldloc.s 12
-			IL_0880: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0885: ldc.i4.0
-			IL_0886: ceq
-			IL_0888: stloc.s 32
-			IL_088a: ldloc.s 32
-			IL_088c: brfalse IL_08ca
+			IL_081c: ldloc.0
+			IL_081d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_0822: stloc.s 29
+			IL_0824: ldloc.s 29
+			IL_0826: stloc.s 11
+			IL_0828: ldloc.s 20
+			IL_082a: stloc.s 29
+			IL_082c: ldloc.s 29
+			IL_082e: stloc.s 13
+			IL_0830: ldloc.s 12
+			IL_0832: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0837: ldc.i4.0
+			IL_0838: ceq
+			IL_083a: stloc.s 32
+			IL_083c: ldloc.s 32
+			IL_083e: brfalse IL_087c
 
-			IL_0891: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
-			IL_0896: stloc.s 21
-			IL_0898: ldloc.s 17
-			IL_089a: ldstr "fragment"
-			IL_089f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08a4: stloc.s 29
-			IL_08a6: ldloc.s 29
-			IL_08a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_08ad: stloc.s 32
-			IL_08af: ldloc.s 32
-			IL_08b1: brtrue IL_08c2
+			IL_0843: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
+			IL_0848: stloc.s 21
+			IL_084a: ldloc.s 17
+			IL_084c: ldstr "fragment"
+			IL_0851: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0856: stloc.s 29
+			IL_0858: ldloc.s 29
+			IL_085a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_085f: stloc.s 32
+			IL_0861: ldloc.s 32
+			IL_0863: brtrue IL_0874
 
-			IL_08b6: ldstr ""
-			IL_08bb: stloc.s 38
-			IL_08bd: br IL_08c6
+			IL_0868: ldstr ""
+			IL_086d: stloc.s 38
+			IL_086f: br IL_0878
 
-			IL_08c2: ldloc.s 29
-			IL_08c4: stloc.s 38
+			IL_0874: ldloc.s 29
+			IL_0876: stloc.s 38
 
-			IL_08c6: ldloc.s 38
-			IL_08c8: stloc.s 12
+			IL_0878: ldloc.s 38
+			IL_087a: stloc.s 12
 
-			IL_08ca: br IL_0a4f
+			IL_087c: br IL_09ef
 
-			IL_08cf: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
-			IL_08d4: stloc.s 22
-			IL_08d6: ldloc.1
-			IL_08d7: ldstr "url"
-			IL_08dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_08e6: stloc.s 29
-			IL_08e8: ldloc.s 29
-			IL_08ea: ldstr "trim"
-			IL_08ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_08f4: stloc.s 29
-			IL_08f6: ldloc.s 29
-			IL_08f8: stloc.s 23
-			IL_08fa: ldarg.0
-			IL_08fb: ldc.i4.1
-			IL_08fc: ldelem.ref
-			IL_08fd: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0902: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0907: stloc.s 29
-			IL_0909: ldstr "fetchText"
-			IL_090e: ldloc.s 29
-			IL_0910: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0915: stloc.s 29
-			IL_0917: ldloc.s 29
-			IL_0919: ldc.i4.1
-			IL_091a: newarr [System.Runtime]System.Object
-			IL_091f: dup
-			IL_0920: ldc.i4.0
-			IL_0921: ldarg.0
-			IL_0922: ldc.i4.1
-			IL_0923: ldelem.ref
-			IL_0924: stelem.ref
-			IL_0925: ldloc.s 23
-			IL_0927: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_092c: stloc.s 29
-			IL_092e: ldloc.0
-			IL_092f: ldc.i4.3
-			IL_0930: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0935: ldloc.0
-			IL_0936: ldloc.s 29
-			IL_0938: ldarg.0
-			IL_0939: ldc.i4.3
-			IL_093a: ldloc.0
-			IL_093b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0940: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0945: ldloc.0
-			IL_0946: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0881: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
+			IL_0886: stloc.s 22
+			IL_0888: ldloc.1
+			IL_0889: ldstr "url"
+			IL_088e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0893: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0898: stloc.s 29
+			IL_089a: ldloc.s 29
+			IL_089c: ldstr "trim"
+			IL_08a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_08a6: stloc.s 29
+			IL_08a8: ldloc.s 29
+			IL_08aa: stloc.s 23
+			IL_08ac: ldarg.0
+			IL_08ad: ldc.i4.1
+			IL_08ae: ldelem.ref
+			IL_08af: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_08b4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_08b9: ldc.i4.1
+			IL_08ba: newarr [System.Runtime]System.Object
+			IL_08bf: dup
+			IL_08c0: ldc.i4.0
+			IL_08c1: ldarg.0
+			IL_08c2: ldc.i4.1
+			IL_08c3: ldelem.ref
+			IL_08c4: stelem.ref
+			IL_08c5: ldloc.s 23
+			IL_08c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_08cc: stloc.s 29
+			IL_08ce: ldloc.0
+			IL_08cf: ldc.i4.3
+			IL_08d0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08d5: ldloc.0
+			IL_08d6: ldloc.s 29
+			IL_08d8: ldarg.0
+			IL_08d9: ldc.i4.3
+			IL_08da: ldloc.0
+			IL_08db: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_08e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_08e5: ldloc.0
+			IL_08e6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08eb: dup
+			IL_08ec: ldc.i4.0
+			IL_08ed: ldloc.1
+			IL_08ee: stelem.ref
+			IL_08ef: dup
+			IL_08f0: ldc.i4.1
+			IL_08f1: ldloc.2
+			IL_08f2: stelem.ref
+			IL_08f3: dup
+			IL_08f4: ldc.i4.2
+			IL_08f5: ldloc.3
+			IL_08f6: stelem.ref
+			IL_08f7: dup
+			IL_08f8: ldc.i4.3
+			IL_08f9: ldloc.s 4
+			IL_08fb: stelem.ref
+			IL_08fc: dup
+			IL_08fd: ldc.i4.4
+			IL_08fe: ldloc.s 5
+			IL_0900: stelem.ref
+			IL_0901: dup
+			IL_0902: ldc.i4.5
+			IL_0903: ldloc.s 6
+			IL_0905: stelem.ref
+			IL_0906: dup
+			IL_0907: ldc.i4.6
+			IL_0908: ldloc.s 7
+			IL_090a: stelem.ref
+			IL_090b: dup
+			IL_090c: ldc.i4.7
+			IL_090d: ldloc.s 8
+			IL_090f: stelem.ref
+			IL_0910: dup
+			IL_0911: ldc.i4.8
+			IL_0912: ldloc.s 9
+			IL_0914: stelem.ref
+			IL_0915: dup
+			IL_0916: ldc.i4.s 9
+			IL_0918: ldloc.s 10
+			IL_091a: stelem.ref
+			IL_091b: dup
+			IL_091c: ldc.i4.s 10
+			IL_091e: ldloc.s 11
+			IL_0920: stelem.ref
+			IL_0921: dup
+			IL_0922: ldc.i4.s 11
+			IL_0924: ldloc.s 12
+			IL_0926: stelem.ref
+			IL_0927: dup
+			IL_0928: ldc.i4.s 12
+			IL_092a: ldloc.s 13
+			IL_092c: stelem.ref
+			IL_092d: dup
+			IL_092e: ldc.i4.s 13
+			IL_0930: ldloc.s 14
+			IL_0932: stelem.ref
+			IL_0933: dup
+			IL_0934: ldc.i4.s 14
+			IL_0936: ldloc.s 15
+			IL_0938: stelem.ref
+			IL_0939: dup
+			IL_093a: ldc.i4.s 15
+			IL_093c: ldloc.s 16
+			IL_093e: stelem.ref
+			IL_093f: dup
+			IL_0940: ldc.i4.s 16
+			IL_0942: ldloc.s 17
+			IL_0944: stelem.ref
+			IL_0945: dup
+			IL_0946: ldc.i4.s 17
+			IL_0948: ldloc.s 18
+			IL_094a: stelem.ref
 			IL_094b: dup
-			IL_094c: ldc.i4.0
-			IL_094d: ldloc.1
-			IL_094e: stelem.ref
-			IL_094f: dup
-			IL_0950: ldc.i4.1
-			IL_0951: ldloc.2
-			IL_0952: stelem.ref
-			IL_0953: dup
-			IL_0954: ldc.i4.2
-			IL_0955: ldloc.3
+			IL_094c: ldc.i4.s 18
+			IL_094e: ldloc.s 19
+			IL_0950: stelem.ref
+			IL_0951: dup
+			IL_0952: ldc.i4.s 19
+			IL_0954: ldloc.s 20
 			IL_0956: stelem.ref
 			IL_0957: dup
-			IL_0958: ldc.i4.3
-			IL_0959: ldloc.s 4
-			IL_095b: stelem.ref
-			IL_095c: dup
-			IL_095d: ldc.i4.4
-			IL_095e: ldloc.s 5
-			IL_0960: stelem.ref
-			IL_0961: dup
-			IL_0962: ldc.i4.5
-			IL_0963: ldloc.s 6
-			IL_0965: stelem.ref
-			IL_0966: dup
-			IL_0967: ldc.i4.6
-			IL_0968: ldloc.s 7
-			IL_096a: stelem.ref
-			IL_096b: dup
-			IL_096c: ldc.i4.7
-			IL_096d: ldloc.s 8
-			IL_096f: stelem.ref
-			IL_0970: dup
-			IL_0971: ldc.i4.8
-			IL_0972: ldloc.s 9
+			IL_0958: ldc.i4.s 20
+			IL_095a: ldloc.s 21
+			IL_095c: stelem.ref
+			IL_095d: dup
+			IL_095e: ldc.i4.s 21
+			IL_0960: ldloc.s 22
+			IL_0962: stelem.ref
+			IL_0963: dup
+			IL_0964: ldc.i4.s 22
+			IL_0966: ldloc.s 23
+			IL_0968: stelem.ref
+			IL_0969: dup
+			IL_096a: ldc.i4.s 23
+			IL_096c: ldloc.s 24
+			IL_096e: stelem.ref
+			IL_096f: dup
+			IL_0970: ldc.i4.s 24
+			IL_0972: ldloc.s 25
 			IL_0974: stelem.ref
 			IL_0975: dup
-			IL_0976: ldc.i4.s 9
-			IL_0978: ldloc.s 10
+			IL_0976: ldc.i4.s 25
+			IL_0978: ldloc.s 26
 			IL_097a: stelem.ref
 			IL_097b: dup
-			IL_097c: ldc.i4.s 10
-			IL_097e: ldloc.s 11
+			IL_097c: ldc.i4.s 26
+			IL_097e: ldloc.s 27
 			IL_0980: stelem.ref
 			IL_0981: dup
-			IL_0982: ldc.i4.s 11
-			IL_0984: ldloc.s 12
+			IL_0982: ldc.i4.s 27
+			IL_0984: ldloc.s 28
 			IL_0986: stelem.ref
 			IL_0987: dup
-			IL_0988: ldc.i4.s 12
-			IL_098a: ldloc.s 13
+			IL_0988: ldc.i4.s 28
+			IL_098a: ldloc.s 29
 			IL_098c: stelem.ref
 			IL_098d: dup
-			IL_098e: ldc.i4.s 13
-			IL_0990: ldloc.s 14
+			IL_098e: ldc.i4.s 29
+			IL_0990: ldloc.s 30
 			IL_0992: stelem.ref
 			IL_0993: dup
-			IL_0994: ldc.i4.s 14
-			IL_0996: ldloc.s 15
+			IL_0994: ldc.i4.s 30
+			IL_0996: ldloc.s 31
 			IL_0998: stelem.ref
 			IL_0999: dup
-			IL_099a: ldc.i4.s 15
-			IL_099c: ldloc.s 16
-			IL_099e: stelem.ref
-			IL_099f: dup
-			IL_09a0: ldc.i4.s 16
-			IL_09a2: ldloc.s 17
-			IL_09a4: stelem.ref
-			IL_09a5: dup
-			IL_09a6: ldc.i4.s 17
-			IL_09a8: ldloc.s 18
-			IL_09aa: stelem.ref
-			IL_09ab: dup
-			IL_09ac: ldc.i4.s 18
-			IL_09ae: ldloc.s 19
-			IL_09b0: stelem.ref
-			IL_09b1: dup
-			IL_09b2: ldc.i4.s 19
-			IL_09b4: ldloc.s 20
-			IL_09b6: stelem.ref
-			IL_09b7: dup
-			IL_09b8: ldc.i4.s 20
-			IL_09ba: ldloc.s 21
-			IL_09bc: stelem.ref
-			IL_09bd: dup
-			IL_09be: ldc.i4.s 21
-			IL_09c0: ldloc.s 22
-			IL_09c2: stelem.ref
-			IL_09c3: dup
-			IL_09c4: ldc.i4.s 22
-			IL_09c6: ldloc.s 23
-			IL_09c8: stelem.ref
-			IL_09c9: dup
-			IL_09ca: ldc.i4.s 23
-			IL_09cc: ldloc.s 24
-			IL_09ce: stelem.ref
-			IL_09cf: dup
-			IL_09d0: ldc.i4.s 24
-			IL_09d2: ldloc.s 25
-			IL_09d4: stelem.ref
-			IL_09d5: dup
-			IL_09d6: ldc.i4.s 25
-			IL_09d8: ldloc.s 26
-			IL_09da: stelem.ref
-			IL_09db: dup
-			IL_09dc: ldc.i4.s 26
-			IL_09de: ldloc.s 27
-			IL_09e0: stelem.ref
-			IL_09e1: dup
-			IL_09e2: ldc.i4.s 27
-			IL_09e4: ldloc.s 28
-			IL_09e6: stelem.ref
-			IL_09e7: dup
-			IL_09e8: ldc.i4.s 28
-			IL_09ea: ldloc.s 29
-			IL_09ec: stelem.ref
-			IL_09ed: dup
-			IL_09ee: ldc.i4.s 29
-			IL_09f0: ldloc.s 30
-			IL_09f2: stelem.ref
-			IL_09f3: dup
-			IL_09f4: ldc.i4.s 30
-			IL_09f6: ldloc.s 31
-			IL_09f8: stelem.ref
-			IL_09f9: dup
-			IL_09fa: ldc.i4.s 31
-			IL_09fc: ldloc.s 32
-			IL_09fe: box [System.Runtime]System.Boolean
-			IL_0a03: stelem.ref
-			IL_0a04: dup
-			IL_0a05: ldc.i4.s 32
-			IL_0a07: ldloc.s 33
-			IL_0a09: stelem.ref
-			IL_0a0a: dup
-			IL_0a0b: ldc.i4.s 33
-			IL_0a0d: ldloc.s 34
-			IL_0a0f: stelem.ref
-			IL_0a10: dup
-			IL_0a11: ldc.i4.s 34
-			IL_0a13: ldloc.s 35
-			IL_0a15: stelem.ref
-			IL_0a16: dup
-			IL_0a17: ldc.i4.s 35
-			IL_0a19: ldloc.s 36
-			IL_0a1b: stelem.ref
-			IL_0a1c: dup
-			IL_0a1d: ldc.i4.s 36
-			IL_0a1f: ldloc.s 37
-			IL_0a21: stelem.ref
-			IL_0a22: dup
-			IL_0a23: ldc.i4.s 37
-			IL_0a25: ldloc.s 38
-			IL_0a27: stelem.ref
-			IL_0a28: dup
-			IL_0a29: ldc.i4.s 38
-			IL_0a2b: ldloc.s 39
-			IL_0a2d: stelem.ref
-			IL_0a2e: pop
-			IL_0a2f: ldloc.0
-			IL_0a30: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a35: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a3a: ret
+			IL_099a: ldc.i4.s 31
+			IL_099c: ldloc.s 32
+			IL_099e: box [System.Runtime]System.Boolean
+			IL_09a3: stelem.ref
+			IL_09a4: dup
+			IL_09a5: ldc.i4.s 32
+			IL_09a7: ldloc.s 33
+			IL_09a9: stelem.ref
+			IL_09aa: dup
+			IL_09ab: ldc.i4.s 33
+			IL_09ad: ldloc.s 34
+			IL_09af: stelem.ref
+			IL_09b0: dup
+			IL_09b1: ldc.i4.s 34
+			IL_09b3: ldloc.s 35
+			IL_09b5: stelem.ref
+			IL_09b6: dup
+			IL_09b7: ldc.i4.s 35
+			IL_09b9: ldloc.s 36
+			IL_09bb: stelem.ref
+			IL_09bc: dup
+			IL_09bd: ldc.i4.s 36
+			IL_09bf: ldloc.s 37
+			IL_09c1: stelem.ref
+			IL_09c2: dup
+			IL_09c3: ldc.i4.s 37
+			IL_09c5: ldloc.s 38
+			IL_09c7: stelem.ref
+			IL_09c8: dup
+			IL_09c9: ldc.i4.s 38
+			IL_09cb: ldloc.s 39
+			IL_09cd: stelem.ref
+			IL_09ce: pop
+			IL_09cf: ldloc.0
+			IL_09d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09d5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09da: ret
 
-			IL_0a3b: ldloc.0
-			IL_0a3c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_0a41: stloc.s 29
-			IL_0a43: ldloc.s 29
-			IL_0a45: stloc.s 11
-			IL_0a47: ldloc.s 23
-			IL_0a49: stloc.s 29
-			IL_0a4b: ldloc.s 29
-			IL_0a4d: stloc.s 13
+			IL_09db: ldloc.0
+			IL_09dc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_09e1: stloc.s 29
+			IL_09e3: ldloc.s 29
+			IL_09e5: stloc.s 11
+			IL_09e7: ldloc.s 23
+			IL_09e9: stloc.s 29
+			IL_09eb: ldloc.s 29
+			IL_09ed: stloc.s 13
 
-			IL_0a4f: ldloc.s 12
-			IL_0a51: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0a56: ldc.i4.0
-			IL_0a57: ceq
-			IL_0a59: stloc.s 32
-			IL_0a5b: ldloc.s 32
-			IL_0a5d: brfalse IL_0ad9
+			IL_09ef: ldloc.s 12
+			IL_09f1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_09f6: ldc.i4.0
+			IL_09f7: ceq
+			IL_09f9: stloc.s 32
+			IL_09fb: ldloc.s 32
+			IL_09fd: brfalse IL_0a79
 
-			IL_0a62: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
-			IL_0a67: stloc.s 24
-			IL_0a69: ldloc.1
-			IL_0a6a: ldstr "section"
-			IL_0a6f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a74: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a79: stloc.s 36
-			IL_0a7b: ldstr "Could not infer an element id for section '"
-			IL_0a80: ldloc.s 36
-			IL_0a82: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a87: stloc.s 36
-			IL_0a89: ldloc.s 36
-			IL_0a8b: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0a90: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a95: stloc.s 36
-			IL_0a97: ldloc.s 36
-			IL_0a99: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a9e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0aa3: stloc.s 29
-			IL_0aa5: ldloc.s 29
-			IL_0aa7: stloc.s 25
-			IL_0aa9: ldloc.0
-			IL_0aaa: ldc.i4.m1
-			IL_0aab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0ab0: ldloc.0
-			IL_0ab1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ab6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0abb: ldarg.0
-			IL_0abc: ldc.i4.1
-			IL_0abd: newarr [System.Runtime]System.Object
-			IL_0ac2: dup
-			IL_0ac3: ldc.i4.0
-			IL_0ac4: ldloc.s 25
-			IL_0ac6: stelem.ref
-			IL_0ac7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0acc: pop
-			IL_0acd: ldloc.0
-			IL_0ace: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ad3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0ad8: ret
+			IL_0a02: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
+			IL_0a07: stloc.s 24
+			IL_0a09: ldloc.1
+			IL_0a0a: ldstr "section"
+			IL_0a0f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a14: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a19: stloc.s 36
+			IL_0a1b: ldstr "Could not infer an element id for section '"
+			IL_0a20: ldloc.s 36
+			IL_0a22: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a27: stloc.s 36
+			IL_0a29: ldloc.s 36
+			IL_0a2b: ldstr "'. Try passing --id sec-... explicitly."
+			IL_0a30: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a35: stloc.s 36
+			IL_0a37: ldloc.s 36
+			IL_0a39: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a3e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0a43: stloc.s 29
+			IL_0a45: ldloc.s 29
+			IL_0a47: stloc.s 25
+			IL_0a49: ldloc.0
+			IL_0a4a: ldc.i4.m1
+			IL_0a4b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0a50: ldloc.0
+			IL_0a51: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a56: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0a5b: ldarg.0
+			IL_0a5c: ldc.i4.1
+			IL_0a5d: newarr [System.Runtime]System.Object
+			IL_0a62: dup
+			IL_0a63: ldc.i4.0
+			IL_0a64: ldloc.s 25
+			IL_0a66: stelem.ref
+			IL_0a67: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0a6c: pop
+			IL_0a6d: ldloc.0
+			IL_0a6e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a73: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0a78: ret
 
-			IL_0ad9: ldarg.0
-			IL_0ada: ldc.i4.1
-			IL_0adb: ldelem.ref
-			IL_0adc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0ae1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
-			IL_0ae6: stloc.s 29
-			IL_0ae8: ldstr "extractElementById"
-			IL_0aed: ldloc.s 29
-			IL_0aef: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0af4: stloc.s 29
-			IL_0af6: ldloc.s 29
+			IL_0a79: ldarg.0
+			IL_0a7a: ldc.i4.1
+			IL_0a7b: ldelem.ref
+			IL_0a7c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a81: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+			IL_0a86: ldc.i4.1
+			IL_0a87: newarr [System.Runtime]System.Object
+			IL_0a8c: dup
+			IL_0a8d: ldc.i4.0
+			IL_0a8e: ldarg.0
+			IL_0a8f: ldc.i4.1
+			IL_0a90: ldelem.ref
+			IL_0a91: stelem.ref
+			IL_0a92: ldloc.s 11
+			IL_0a94: ldloc.s 12
+			IL_0a96: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0a9b: stloc.s 29
+			IL_0a9d: ldloc.s 29
+			IL_0a9f: stloc.s 26
+			IL_0aa1: ldarg.0
+			IL_0aa2: ldc.i4.1
+			IL_0aa3: ldelem.ref
+			IL_0aa4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0aa9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0aae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ab3: stloc.s 29
+			IL_0ab5: ldstr "process"
+			IL_0aba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0abf: stloc.s 31
+			IL_0ac1: ldloc.s 31
+			IL_0ac3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ac8: stloc.s 31
+			IL_0aca: ldloc.s 31
+			IL_0acc: ldstr "cwd"
+			IL_0ad1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0ad6: stloc.s 31
+			IL_0ad8: ldloc.s 29
+			IL_0ada: ldstr "join"
+			IL_0adf: ldloc.s 31
+			IL_0ae1: ldloc.1
+			IL_0ae2: ldstr "outFile"
+			IL_0ae7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0aec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0af1: stloc.s 31
+			IL_0af3: ldloc.s 31
+			IL_0af5: stloc.s 27
+			IL_0af7: ldarg.0
 			IL_0af8: ldc.i4.1
-			IL_0af9: newarr [System.Runtime]System.Object
-			IL_0afe: dup
-			IL_0aff: ldc.i4.0
-			IL_0b00: ldarg.0
-			IL_0b01: ldc.i4.1
-			IL_0b02: ldelem.ref
-			IL_0b03: stelem.ref
-			IL_0b04: ldloc.s 11
-			IL_0b06: ldloc.s 12
-			IL_0b08: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b0d: stloc.s 29
-			IL_0b0f: ldloc.s 29
-			IL_0b11: stloc.s 26
-			IL_0b13: ldarg.0
-			IL_0b14: ldc.i4.1
-			IL_0b15: ldelem.ref
-			IL_0b16: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b1b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0af9: ldelem.ref
+			IL_0afa: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0aff: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_0b04: stloc.s 31
+			IL_0b06: ldc.i4.1
+			IL_0b07: newarr [System.Runtime]System.Object
+			IL_0b0c: dup
+			IL_0b0d: ldc.i4.0
+			IL_0b0e: ldarg.0
+			IL_0b0f: ldc.i4.1
+			IL_0b10: ldelem.ref
+			IL_0b11: stelem.ref
+			IL_0b12: stloc.s 30
+			IL_0b14: ldloc.s 26
+			IL_0b16: ldstr "html"
+			IL_0b1b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0b20: stloc.s 29
-			IL_0b22: ldstr "path"
-			IL_0b27: ldloc.s 29
-			IL_0b29: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0b2e: stloc.s 29
-			IL_0b30: ldloc.s 29
-			IL_0b32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b37: stloc.s 29
-			IL_0b39: ldstr "process"
-			IL_0b3e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b43: stloc.s 31
-			IL_0b45: ldloc.s 31
-			IL_0b47: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b4c: stloc.s 31
-			IL_0b4e: ldloc.s 31
-			IL_0b50: ldstr "cwd"
-			IL_0b55: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0b5a: stloc.s 31
-			IL_0b5c: ldloc.s 29
-			IL_0b5e: ldstr "join"
-			IL_0b63: ldloc.s 31
-			IL_0b65: ldloc.1
-			IL_0b66: ldstr "outFile"
-			IL_0b6b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b70: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0b75: stloc.s 31
-			IL_0b77: ldloc.s 31
-			IL_0b79: stloc.s 27
-			IL_0b7b: ldarg.0
-			IL_0b7c: ldc.i4.1
-			IL_0b7d: ldelem.ref
-			IL_0b7e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b83: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_0b88: stloc.s 31
-			IL_0b8a: ldstr "wrapAsStandaloneHtml"
-			IL_0b8f: ldloc.s 31
-			IL_0b91: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0b96: stloc.s 31
-			IL_0b98: ldc.i4.1
-			IL_0b99: newarr [System.Runtime]System.Object
-			IL_0b9e: dup
-			IL_0b9f: ldc.i4.0
-			IL_0ba0: ldarg.0
-			IL_0ba1: ldc.i4.1
-			IL_0ba2: ldelem.ref
-			IL_0ba3: stelem.ref
-			IL_0ba4: stloc.s 30
-			IL_0ba6: ldloc.s 26
-			IL_0ba8: ldstr "html"
-			IL_0bad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bb2: stloc.s 29
-			IL_0bb4: ldloc.1
-			IL_0bb5: ldstr "section"
-			IL_0bba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bbf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0bc4: stloc.s 36
-			IL_0bc6: ldstr "ECMA-262 "
-			IL_0bcb: ldloc.s 36
-			IL_0bcd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0bd2: stloc.s 36
-			IL_0bd4: ldloc.s 31
-			IL_0bd6: ldloc.s 30
-			IL_0bd8: ldloc.s 29
-			IL_0bda: ldloc.s 36
-			IL_0bdc: ldloc.s 13
-			IL_0bde: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0be3: stloc.s 29
-			IL_0be5: ldloc.s 29
-			IL_0be7: stloc.s 28
-			IL_0be9: ldarg.0
-			IL_0bea: ldc.i4.1
-			IL_0beb: ldelem.ref
-			IL_0bec: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0bf1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0bf6: stloc.s 29
-			IL_0bf8: ldstr "fs"
-			IL_0bfd: ldloc.s 29
-			IL_0bff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0c04: stloc.s 29
-			IL_0c06: ldloc.s 29
-			IL_0c08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0c0d: stloc.s 29
-			IL_0c0f: ldloc.s 29
-			IL_0c11: ldstr "writeFileSync"
-			IL_0c16: ldloc.s 27
-			IL_0c18: ldloc.s 28
-			IL_0c1a: ldstr "utf8"
-			IL_0c1f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0c24: pop
-			IL_0c25: ldstr "console"
-			IL_0c2a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0c2f: stloc.s 29
-			IL_0c31: ldloc.s 29
-			IL_0c33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0c38: stloc.s 29
-			IL_0c3a: ldarg.0
-			IL_0c3b: ldc.i4.1
-			IL_0c3c: ldelem.ref
-			IL_0c3d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0c42: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0c47: stloc.s 31
-			IL_0c49: ldstr "normalize"
-			IL_0c4e: ldloc.s 31
-			IL_0c50: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0c55: stloc.s 31
-			IL_0c57: ldc.i4.1
-			IL_0c58: newarr [System.Runtime]System.Object
-			IL_0c5d: dup
-			IL_0c5e: ldc.i4.0
-			IL_0c5f: ldarg.0
-			IL_0c60: ldc.i4.1
-			IL_0c61: ldelem.ref
-			IL_0c62: stelem.ref
-			IL_0c63: stloc.s 30
-			IL_0c65: ldloc.1
-			IL_0c66: ldstr "section"
-			IL_0c6b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c70: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0c75: stloc.s 36
-			IL_0c77: ldstr "Extracted section "
-			IL_0c7c: ldloc.s 36
-			IL_0c7e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0c83: stloc.s 36
-			IL_0c85: ldloc.s 36
-			IL_0c87: ldstr " (id="
-			IL_0c8c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0c91: stloc.s 36
-			IL_0c93: ldloc.s 12
-			IL_0c95: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0c9a: stloc.s 35
-			IL_0c9c: ldloc.s 36
-			IL_0c9e: ldloc.s 35
-			IL_0ca0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ca5: stloc.s 35
-			IL_0ca7: ldloc.s 35
-			IL_0ca9: ldstr ", tag="
-			IL_0cae: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0cb3: stloc.s 35
-			IL_0cb5: ldloc.s 26
-			IL_0cb7: ldstr "tagName"
-			IL_0cbc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cc1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0cc6: stloc.s 36
-			IL_0cc8: ldloc.s 35
-			IL_0cca: ldloc.s 36
-			IL_0ccc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0cd1: stloc.s 36
-			IL_0cd3: ldloc.s 36
-			IL_0cd5: ldstr ") -> "
-			IL_0cda: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0cdf: stloc.s 36
-			IL_0ce1: ldloc.s 27
-			IL_0ce3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ce8: stloc.s 35
-			IL_0cea: ldloc.s 36
-			IL_0cec: ldloc.s 35
-			IL_0cee: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0cf3: stloc.s 35
-			IL_0cf5: ldloc.s 31
-			IL_0cf7: ldloc.s 30
-			IL_0cf9: ldloc.s 35
-			IL_0cfb: ldloc.s 27
-			IL_0cfd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0d02: stloc.s 31
-			IL_0d04: ldloc.s 29
-			IL_0d06: ldstr "log"
-			IL_0d0b: ldloc.s 31
-			IL_0d0d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0d12: pop
-			IL_0d13: ldstr "console"
-			IL_0d18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0d1d: stloc.s 31
-			IL_0d1f: ldloc.s 31
-			IL_0d21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0d26: stloc.s 31
-			IL_0d28: ldarg.0
-			IL_0d29: ldc.i4.1
-			IL_0d2a: ldelem.ref
-			IL_0d2b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0d30: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0d35: stloc.s 29
-			IL_0d37: ldstr "normalize"
-			IL_0d3c: ldloc.s 29
-			IL_0d3e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0d43: stloc.s 29
-			IL_0d45: ldc.i4.1
-			IL_0d46: newarr [System.Runtime]System.Object
-			IL_0d4b: dup
-			IL_0d4c: ldc.i4.0
-			IL_0d4d: ldarg.0
-			IL_0d4e: ldc.i4.1
-			IL_0d4f: ldelem.ref
-			IL_0d50: stelem.ref
-			IL_0d51: stloc.s 30
-			IL_0d53: ldarg.0
-			IL_0d54: ldc.i4.1
-			IL_0d55: ldelem.ref
-			IL_0d56: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0d5b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0d60: stloc.s 39
-			IL_0d62: ldstr "fs"
-			IL_0d67: ldloc.s 39
-			IL_0d69: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0d6e: stloc.s 39
-			IL_0d70: ldloc.s 39
-			IL_0d72: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0d77: stloc.s 39
-			IL_0d79: ldloc.s 39
-			IL_0d7b: ldstr "readFileSync"
-			IL_0d80: ldloc.s 27
-			IL_0d82: ldstr "utf8"
-			IL_0d87: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0d8c: stloc.s 39
-			IL_0d8e: ldloc.s 29
-			IL_0d90: ldloc.s 30
-			IL_0d92: ldloc.s 39
-			IL_0d94: ldloc.s 27
-			IL_0d96: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0d9b: stloc.s 39
-			IL_0d9d: ldloc.s 31
-			IL_0d9f: ldstr "log"
-			IL_0da4: ldloc.s 39
-			IL_0da6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0dab: pop
-			IL_0dac: ldloc.0
-			IL_0dad: ldc.i4.m1
-			IL_0dae: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0db3: ldloc.0
-			IL_0db4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0db9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0dbe: ldarg.0
-			IL_0dbf: ldc.i4.1
-			IL_0dc0: newarr [System.Runtime]System.Object
-			IL_0dc5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0dca: pop
-			IL_0dcb: ldloc.0
-			IL_0dcc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0dd1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0dd6: ret
+			IL_0b22: ldloc.1
+			IL_0b23: ldstr "section"
+			IL_0b28: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b2d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b32: stloc.s 36
+			IL_0b34: ldstr "ECMA-262 "
+			IL_0b39: ldloc.s 36
+			IL_0b3b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b40: stloc.s 36
+			IL_0b42: ldloc.s 31
+			IL_0b44: ldloc.s 30
+			IL_0b46: ldloc.s 29
+			IL_0b48: ldloc.s 36
+			IL_0b4a: ldloc.s 13
+			IL_0b4c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0b51: stloc.s 29
+			IL_0b53: ldloc.s 29
+			IL_0b55: stloc.s 28
+			IL_0b57: ldarg.0
+			IL_0b58: ldc.i4.1
+			IL_0b59: ldelem.ref
+			IL_0b5a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b5f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0b64: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b69: stloc.s 29
+			IL_0b6b: ldloc.s 29
+			IL_0b6d: ldstr "writeFileSync"
+			IL_0b72: ldloc.s 27
+			IL_0b74: ldloc.s 28
+			IL_0b76: ldstr "utf8"
+			IL_0b7b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0b80: pop
+			IL_0b81: ldstr "console"
+			IL_0b86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b8b: stloc.s 29
+			IL_0b8d: ldloc.s 29
+			IL_0b8f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b94: stloc.s 29
+			IL_0b96: ldarg.0
+			IL_0b97: ldc.i4.1
+			IL_0b98: ldelem.ref
+			IL_0b99: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b9e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0ba3: stloc.s 31
+			IL_0ba5: ldc.i4.1
+			IL_0ba6: newarr [System.Runtime]System.Object
+			IL_0bab: dup
+			IL_0bac: ldc.i4.0
+			IL_0bad: ldarg.0
+			IL_0bae: ldc.i4.1
+			IL_0baf: ldelem.ref
+			IL_0bb0: stelem.ref
+			IL_0bb1: stloc.s 30
+			IL_0bb3: ldloc.1
+			IL_0bb4: ldstr "section"
+			IL_0bb9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bbe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0bc3: stloc.s 36
+			IL_0bc5: ldstr "Extracted section "
+			IL_0bca: ldloc.s 36
+			IL_0bcc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bd1: stloc.s 36
+			IL_0bd3: ldloc.s 36
+			IL_0bd5: ldstr " (id="
+			IL_0bda: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bdf: stloc.s 36
+			IL_0be1: ldloc.s 12
+			IL_0be3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0be8: stloc.s 35
+			IL_0bea: ldloc.s 36
+			IL_0bec: ldloc.s 35
+			IL_0bee: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bf3: stloc.s 35
+			IL_0bf5: ldloc.s 35
+			IL_0bf7: ldstr ", tag="
+			IL_0bfc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c01: stloc.s 35
+			IL_0c03: ldloc.s 26
+			IL_0c05: ldstr "tagName"
+			IL_0c0a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c0f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0c14: stloc.s 36
+			IL_0c16: ldloc.s 35
+			IL_0c18: ldloc.s 36
+			IL_0c1a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c1f: stloc.s 36
+			IL_0c21: ldloc.s 36
+			IL_0c23: ldstr ") -> "
+			IL_0c28: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c2d: stloc.s 36
+			IL_0c2f: ldloc.s 27
+			IL_0c31: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0c36: stloc.s 35
+			IL_0c38: ldloc.s 36
+			IL_0c3a: ldloc.s 35
+			IL_0c3c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c41: stloc.s 35
+			IL_0c43: ldloc.s 31
+			IL_0c45: ldloc.s 30
+			IL_0c47: ldloc.s 35
+			IL_0c49: ldloc.s 27
+			IL_0c4b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0c50: stloc.s 31
+			IL_0c52: ldloc.s 29
+			IL_0c54: ldstr "log"
+			IL_0c59: ldloc.s 31
+			IL_0c5b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0c60: pop
+			IL_0c61: ldstr "console"
+			IL_0c66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0c6b: stloc.s 31
+			IL_0c6d: ldloc.s 31
+			IL_0c6f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0c74: stloc.s 31
+			IL_0c76: ldarg.0
+			IL_0c77: ldc.i4.1
+			IL_0c78: ldelem.ref
+			IL_0c79: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0c7e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0c83: stloc.s 29
+			IL_0c85: ldc.i4.1
+			IL_0c86: newarr [System.Runtime]System.Object
+			IL_0c8b: dup
+			IL_0c8c: ldc.i4.0
+			IL_0c8d: ldarg.0
+			IL_0c8e: ldc.i4.1
+			IL_0c8f: ldelem.ref
+			IL_0c90: stelem.ref
+			IL_0c91: stloc.s 30
+			IL_0c93: ldarg.0
+			IL_0c94: ldc.i4.1
+			IL_0c95: ldelem.ref
+			IL_0c96: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0c9b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0ca0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ca5: stloc.s 39
+			IL_0ca7: ldloc.s 39
+			IL_0ca9: ldstr "readFileSync"
+			IL_0cae: ldloc.s 27
+			IL_0cb0: ldstr "utf8"
+			IL_0cb5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0cba: stloc.s 39
+			IL_0cbc: ldloc.s 29
+			IL_0cbe: ldloc.s 30
+			IL_0cc0: ldloc.s 39
+			IL_0cc2: ldloc.s 27
+			IL_0cc4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0cc9: stloc.s 39
+			IL_0ccb: ldloc.s 31
+			IL_0ccd: ldstr "log"
+			IL_0cd2: ldloc.s 39
+			IL_0cd4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0cd9: pop
+			IL_0cda: ldloc.0
+			IL_0cdb: ldc.i4.m1
+			IL_0cdc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0ce1: ldloc.0
+			IL_0ce2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0ce7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0cec: ldarg.0
+			IL_0ced: ldc.i4.1
+			IL_0cee: newarr [System.Runtime]System.Object
+			IL_0cf3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0cf8: pop
+			IL_0cf9: ldloc.0
+			IL_0cfa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0cff: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0d04: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5946,7 +5710,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4ad1
+			// Method begins at RVA 0x484d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -6212,7 +5976,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4c9c
+		// Method begins at RVA 0x4a18
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4abf
+				// Method begins at RVA 0x483b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,14 +54,12 @@
 			)
 			// Method begins at RVA 0x2320
 			// Header size: 12
-			// Code size: 331 (0x14b)
+			// Code size: 273 (0x111)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope,
 				[1] object,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate,
-				[3] object,
-				[4] object[]
+				[2] object
 			)
 
 			IL_0000: ldarg.0
@@ -94,14 +92,14 @@
 			IL_0042: brtrue IL_0053
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.4
+			IL_0048: ldc.i4.2
 			IL_0049: newarr [System.Runtime]System.Object
 			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0053: ldloc.0
 			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0059: ldc.i4.0
-			IL_005a: ble IL_0081
+			IL_005a: ble IL_006e
 
 			IL_005f: ldloc.0
 			IL_0060: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -112,108 +110,74 @@
 			IL_0069: dup
 			IL_006a: ldc.i4.1
 			IL_006b: ldelem.ref
-			IL_006c: castclass [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate
-			IL_0071: stloc.2
-			IL_0072: dup
-			IL_0073: ldc.i4.2
-			IL_0074: ldelem.ref
-			IL_0075: stloc.3
-			IL_0076: dup
-			IL_0077: ldc.i4.3
-			IL_0078: ldelem.ref
-			IL_0079: castclass object[]
-			IL_007e: stloc.s 4
-			IL_0080: pop
+			IL_006c: stloc.2
+			IL_006d: pop
 
-			IL_0081: ldloc.0
-			IL_0082: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0087: switch (IL_0094, IL_0119)
+			IL_006e: ldloc.0
+			IL_006f: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0074: switch (IL_0081, IL_00df)
 
-			IL_0094: ldarg.0
-			IL_0095: ldc.i4.1
-			IL_0096: ldelem.ref
-			IL_0097: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope
-			IL_009c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::require
+			IL_0081: ldarg.0
+			IL_0082: ldc.i4.1
+			IL_0083: ldelem.ref
+			IL_0084: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope
+			IL_0089: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope::require
+			IL_008e: ldstr "./Compile_Scripts_ExtractEcma262SectionHtml_TestHarness"
+			IL_0093: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0098: stloc.2
+			IL_0099: ldloc.2
+			IL_009a: stloc.1
+			IL_009b: ldloc.1
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00a1: stloc.2
-			IL_00a2: ldstr "require"
-			IL_00a7: ldloc.2
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ad: stloc.3
-			IL_00ae: ldc.i4.1
-			IL_00af: newarr [System.Runtime]System.Object
-			IL_00b4: dup
-			IL_00b5: ldc.i4.0
-			IL_00b6: ldarg.0
-			IL_00b7: ldc.i4.1
-			IL_00b8: ldelem.ref
-			IL_00b9: stelem.ref
-			IL_00ba: stloc.s 4
-			IL_00bc: ldloc.3
-			IL_00bd: ldloc.s 4
-			IL_00bf: ldstr "./Compile_Scripts_ExtractEcma262SectionHtml_TestHarness"
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00c9: stloc.3
-			IL_00ca: ldloc.3
-			IL_00cb: stloc.1
+			IL_00a2: ldloc.2
+			IL_00a3: ldstr "runHarnessCli"
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00ad: stloc.2
+			IL_00ae: ldloc.0
+			IL_00af: ldc.i4.1
+			IL_00b0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00b5: ldloc.0
+			IL_00b6: ldloc.2
+			IL_00b7: ldarg.0
+			IL_00b8: ldc.i4.1
+			IL_00b9: ldloc.0
+			IL_00ba: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00c4: ldloc.0
+			IL_00c5: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00ca: dup
+			IL_00cb: ldc.i4.0
 			IL_00cc: ldloc.1
-			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d2: stloc.3
-			IL_00d3: ldloc.3
-			IL_00d4: ldstr "runHarnessCli"
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00de: stloc.3
-			IL_00df: ldloc.0
-			IL_00e0: ldc.i4.1
-			IL_00e1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00e6: ldloc.0
-			IL_00e7: ldloc.3
-			IL_00e8: ldarg.0
-			IL_00e9: ldc.i4.1
-			IL_00ea: ldloc.0
-			IL_00eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_00f5: ldloc.0
-			IL_00f6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00fb: dup
-			IL_00fc: ldc.i4.0
-			IL_00fd: ldloc.1
-			IL_00fe: stelem.ref
-			IL_00ff: dup
-			IL_0100: ldc.i4.1
-			IL_0101: ldloc.2
-			IL_0102: stelem.ref
-			IL_0103: dup
-			IL_0104: ldc.i4.2
-			IL_0105: ldloc.3
-			IL_0106: stelem.ref
-			IL_0107: dup
-			IL_0108: ldc.i4.3
-			IL_0109: ldloc.s 4
-			IL_010b: stelem.ref
-			IL_010c: pop
-			IL_010d: ldloc.0
-			IL_010e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0113: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0118: ret
+			IL_00cd: stelem.ref
+			IL_00ce: dup
+			IL_00cf: ldc.i4.1
+			IL_00d0: ldloc.2
+			IL_00d1: stelem.ref
+			IL_00d2: pop
+			IL_00d3: ldloc.0
+			IL_00d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00d9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_00de: ret
 
-			IL_0119: ldloc.0
-			IL_011a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::_awaited1
-			IL_011f: pop
-			IL_0120: ldloc.0
-			IL_0121: ldc.i4.m1
-			IL_0122: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0127: ldloc.0
-			IL_0128: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_012d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0132: ldarg.0
-			IL_0133: ldc.i4.1
-			IL_0134: newarr [System.Runtime]System.Object
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_013e: pop
-			IL_013f: ldloc.0
-			IL_0140: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0145: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_014a: ret
+			IL_00df: ldloc.0
+			IL_00e0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/Scope::_awaited1
+			IL_00e5: pop
+			IL_00e6: ldloc.0
+			IL_00e7: ldc.i4.m1
+			IL_00e8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00ed: ldloc.0
+			IL_00ee: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_00f8: ldarg.0
+			IL_00f9: ldc.i4.1
+			IL_00fa: newarr [System.Runtime]System.Object
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0104: pop
+			IL_0105: ldloc.0
+			IL_0106: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_010b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0110: ret
 		} // end of method run::__js_call__
 
 	} // end of class run
@@ -236,7 +200,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ac8
+				// Method begins at RVA 0x4844
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -260,7 +224,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2478
+			// Method begins at RVA 0x2440
 			// Header size: 12
 			// Code size: 200 (0xc8)
 			.maxstack 8
@@ -376,7 +340,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4ab6
+			// Method begins at RVA 0x4832
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -489,7 +453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ae3
+					// Method begins at RVA 0x485f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -507,7 +471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ada
+				// Method begins at RVA 0x4856
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -532,7 +496,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x254c
+			// Method begins at RVA 0x2514
 			// Header size: 12
 			// Code size: 306 (0x132)
 			.maxstack 8
@@ -659,7 +623,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4aec
+				// Method begins at RVA 0x4868
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -687,7 +651,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b07
+						// Method begins at RVA 0x4883
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -707,7 +671,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b10
+						// Method begins at RVA 0x488c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -727,7 +691,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b19
+						// Method begins at RVA 0x4895
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -747,7 +711,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b22
+						// Method begins at RVA 0x489e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -767,7 +731,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b2b
+						// Method begins at RVA 0x48a7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -787,7 +751,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b34
+						// Method begins at RVA 0x48b0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -805,7 +769,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4afe
+					// Method begins at RVA 0x487a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -823,7 +787,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4af5
+				// Method begins at RVA 0x4871
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -850,7 +814,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x268c
+			// Method begins at RVA 0x2654
 			// Header size: 12
 			// Code size: 824 (0x338)
 			.maxstack 8
@@ -1212,7 +1176,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4b8e
+							// Method begins at RVA 0x490a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1237,13 +1201,12 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4a0c
+						// Method begins at RVA 0x47b4
 						// Header size: 12
-						// Code size: 50 (0x32)
+						// Code size: 36 (0x24)
 						.maxstack 8
 						.locals init (
-							[0] object,
-							[1] object
+							[0] object
 						)
 
 						IL_0000: ldarg.0
@@ -1251,23 +1214,17 @@
 						IL_0002: ldelem.ref
 						IL_0003: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
 						IL_0008: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-						IL_000d: stloc.0
-						IL_000e: ldstr "data"
-						IL_0013: ldloc.0
-						IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-						IL_0019: stloc.0
-						IL_001a: ldloc.0
-						IL_001b: ldarg.2
-						IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-						IL_0021: stloc.1
-						IL_0022: ldarg.0
-						IL_0023: ldc.i4.3
-						IL_0024: ldelem.ref
-						IL_0025: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
-						IL_002a: ldloc.1
-						IL_002b: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-						IL_0030: ldnull
-						IL_0031: ret
+						IL_000d: ldarg.2
+						IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+						IL_0013: stloc.0
+						IL_0014: ldarg.0
+						IL_0015: ldc.i4.3
+						IL_0016: ldelem.ref
+						IL_0017: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+						IL_001c: ldloc.0
+						IL_001d: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+						IL_0022: ldnull
+						IL_0023: ret
 					} // end of method ArrowFunction_L116C24::__js_call__
 
 				} // end of class ArrowFunction_L116C24
@@ -1283,7 +1240,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4b97
+							// Method begins at RVA 0x4913
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1307,70 +1264,56 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4a4c
+						// Method begins at RVA 0x47e4
 						// Header size: 12
-						// Code size: 94 (0x5e)
+						// Code size: 66 (0x42)
 						.maxstack 8
 						.locals init (
-							[0] object,
-							[1] object[],
-							[2] object
+							[0] object[]
 						)
 
-						IL_0000: ldarg.0
-						IL_0001: ldc.i4.2
-						IL_0002: ldelem.ref
-						IL_0003: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-						IL_0008: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-						IL_000d: stloc.0
-						IL_000e: ldstr "resolve"
-						IL_0013: ldloc.0
-						IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-						IL_0019: stloc.0
-						IL_001a: ldc.i4.4
-						IL_001b: newarr [System.Runtime]System.Object
-						IL_0020: dup
-						IL_0021: ldc.i4.0
-						IL_0022: ldarg.0
-						IL_0023: ldc.i4.0
-						IL_0024: ldelem.ref
-						IL_0025: stelem.ref
-						IL_0026: dup
-						IL_0027: ldc.i4.1
-						IL_0028: ldarg.0
-						IL_0029: ldc.i4.1
-						IL_002a: ldelem.ref
-						IL_002b: stelem.ref
-						IL_002c: dup
-						IL_002d: ldc.i4.2
-						IL_002e: ldarg.0
-						IL_002f: ldc.i4.2
-						IL_0030: ldelem.ref
-						IL_0031: stelem.ref
-						IL_0032: dup
-						IL_0033: ldc.i4.3
-						IL_0034: ldarg.0
-						IL_0035: ldc.i4.3
-						IL_0036: ldelem.ref
-						IL_0037: stelem.ref
-						IL_0038: stloc.1
-						IL_0039: ldarg.0
-						IL_003a: ldc.i4.3
-						IL_003b: ldelem.ref
-						IL_003c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
-						IL_0041: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-						IL_0046: stloc.2
-						IL_0047: ldstr "data"
-						IL_004c: ldloc.2
-						IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-						IL_0052: stloc.2
-						IL_0053: ldloc.0
-						IL_0054: ldloc.1
-						IL_0055: ldloc.2
-						IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-						IL_005b: pop
-						IL_005c: ldnull
-						IL_005d: ret
+						IL_0000: ldc.i4.4
+						IL_0001: newarr [System.Runtime]System.Object
+						IL_0006: dup
+						IL_0007: ldc.i4.0
+						IL_0008: ldarg.0
+						IL_0009: ldc.i4.0
+						IL_000a: ldelem.ref
+						IL_000b: stelem.ref
+						IL_000c: dup
+						IL_000d: ldc.i4.1
+						IL_000e: ldarg.0
+						IL_000f: ldc.i4.1
+						IL_0010: ldelem.ref
+						IL_0011: stelem.ref
+						IL_0012: dup
+						IL_0013: ldc.i4.2
+						IL_0014: ldarg.0
+						IL_0015: ldc.i4.2
+						IL_0016: ldelem.ref
+						IL_0017: stelem.ref
+						IL_0018: dup
+						IL_0019: ldc.i4.3
+						IL_001a: ldarg.0
+						IL_001b: ldc.i4.3
+						IL_001c: ldelem.ref
+						IL_001d: stelem.ref
+						IL_001e: stloc.0
+						IL_001f: ldarg.0
+						IL_0020: ldc.i4.2
+						IL_0021: ldelem.ref
+						IL_0022: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+						IL_0027: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+						IL_002c: ldloc.0
+						IL_002d: ldarg.0
+						IL_002e: ldc.i4.3
+						IL_002f: ldelem.ref
+						IL_0030: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+						IL_0035: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+						IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+						IL_003f: pop
+						IL_0040: ldnull
+						IL_0041: ret
 					} // end of method ArrowFunction_L119C23::__js_call__
 
 				} // end of class ArrowFunction_L119C23
@@ -1394,7 +1337,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x4b7c
+								// Method begins at RVA 0x48f8
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1412,7 +1355,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4b73
+							// Method begins at RVA 0x48ef
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1432,7 +1375,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4b85
+							// Method begins at RVA 0x4901
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1454,7 +1397,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b6a
+						// Method begins at RVA 0x48e6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1479,9 +1422,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x44ac
+					// Method begins at RVA 0x4318
 					// Header size: 12
-					// Code size: 1361 (0x551)
+					// Code size: 1167 (0x48f)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -1501,12 +1444,10 @@
 						[14] object,
 						[15] object,
 						[16] object[],
-						[17] object,
-						[18] string,
+						[17] string,
+						[18] object,
 						[19] object,
-						[20] object,
-						[21] object,
-						[22] string
+						[20] string
 					)
 
 					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::.ctor()
@@ -1590,7 +1531,7 @@
 					IL_00d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00dc: stloc.s 8
 					IL_00de: ldloc.s 8
-					IL_00e0: brfalse IL_0328
+					IL_00e0: brfalse IL_0286
 
 					IL_00e5: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55::.ctor()
 					IL_00ea: stloc.3
@@ -1599,460 +1540,396 @@
 					IL_00ed: ldelem.ref
 					IL_00ee: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
 					IL_00f3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_00f8: stloc.s 7
-					IL_00fa: ldstr "maxRedirects"
-					IL_00ff: ldloc.s 7
-					IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0106: stloc.s 7
-					IL_0108: ldloc.s 7
-					IL_010a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_010f: stloc.s 11
-					IL_0111: ldloc.s 11
-					IL_0113: ldc.r8 0.0
-					IL_011c: cgt
-					IL_011e: ldc.i4.0
-					IL_011f: ceq
-					IL_0121: brfalse IL_01c9
+					IL_00f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_00fd: ldc.r8 0.0
+					IL_0106: cgt
+					IL_0108: ldc.i4.0
+					IL_0109: ceq
+					IL_010b: brfalse IL_0193
 
-					IL_0126: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55/Block_L96C33::.ctor()
-					IL_012b: stloc.s 4
-					IL_012d: ldarg.2
-					IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0133: stloc.s 7
-					IL_0135: ldloc.s 7
-					IL_0137: ldstr "resume"
-					IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_0141: pop
-					IL_0142: ldarg.0
-					IL_0143: ldc.i4.2
-					IL_0144: ldelem.ref
-					IL_0145: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_014a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_014f: stloc.s 7
-					IL_0151: ldstr "reject"
-					IL_0156: ldloc.s 7
-					IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_015d: stloc.s 7
-					IL_015f: ldc.i4.3
-					IL_0160: newarr [System.Runtime]System.Object
-					IL_0165: dup
-					IL_0166: ldc.i4.0
-					IL_0167: ldarg.0
-					IL_0168: ldc.i4.0
-					IL_0169: ldelem.ref
-					IL_016a: stelem.ref
-					IL_016b: dup
-					IL_016c: ldc.i4.1
-					IL_016d: ldarg.0
-					IL_016e: ldc.i4.1
-					IL_016f: ldelem.ref
-					IL_0170: stelem.ref
-					IL_0171: dup
-					IL_0172: ldc.i4.2
-					IL_0173: ldarg.0
-					IL_0174: ldc.i4.2
-					IL_0175: ldelem.ref
-					IL_0176: stelem.ref
-					IL_0177: stloc.s 16
-					IL_0179: ldarg.0
-					IL_017a: ldc.i4.1
-					IL_017b: ldelem.ref
-					IL_017c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0181: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0186: stloc.s 17
-					IL_0188: ldstr "urlString"
-					IL_018d: ldloc.s 17
-					IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0194: stloc.s 17
-					IL_0196: ldloc.s 17
-					IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_019d: stloc.s 18
-					IL_019f: ldstr "Too many redirects fetching "
-					IL_01a4: ldloc.s 18
-					IL_01a6: call string [System.Runtime]System.String::Concat(string, string)
-					IL_01ab: stloc.s 18
-					IL_01ad: ldloc.s 18
-					IL_01af: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_01b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_01b9: stloc.s 17
-					IL_01bb: ldloc.s 7
-					IL_01bd: ldloc.s 16
-					IL_01bf: ldloc.s 17
-					IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_01c6: pop
-					IL_01c7: ldnull
-					IL_01c8: ret
+					IL_0110: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55/Block_L96C33::.ctor()
+					IL_0115: stloc.s 4
+					IL_0117: ldarg.2
+					IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_011d: stloc.s 7
+					IL_011f: ldloc.s 7
+					IL_0121: ldstr "resume"
+					IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_012b: pop
+					IL_012c: ldarg.0
+					IL_012d: ldc.i4.2
+					IL_012e: ldelem.ref
+					IL_012f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0134: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0139: stloc.s 7
+					IL_013b: ldc.i4.3
+					IL_013c: newarr [System.Runtime]System.Object
+					IL_0141: dup
+					IL_0142: ldc.i4.0
+					IL_0143: ldarg.0
+					IL_0144: ldc.i4.0
+					IL_0145: ldelem.ref
+					IL_0146: stelem.ref
+					IL_0147: dup
+					IL_0148: ldc.i4.1
+					IL_0149: ldarg.0
+					IL_014a: ldc.i4.1
+					IL_014b: ldelem.ref
+					IL_014c: stelem.ref
+					IL_014d: dup
+					IL_014e: ldc.i4.2
+					IL_014f: ldarg.0
+					IL_0150: ldc.i4.2
+					IL_0151: ldelem.ref
+					IL_0152: stelem.ref
+					IL_0153: stloc.s 16
+					IL_0155: ldarg.0
+					IL_0156: ldc.i4.1
+					IL_0157: ldelem.ref
+					IL_0158: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_015d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0162: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0167: stloc.s 17
+					IL_0169: ldstr "Too many redirects fetching "
+					IL_016e: ldloc.s 17
+					IL_0170: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0175: stloc.s 17
+					IL_0177: ldloc.s 17
+					IL_0179: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_017e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0183: stloc.s 18
+					IL_0185: ldloc.s 7
+					IL_0187: ldloc.s 16
+					IL_0189: ldloc.s 18
+					IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0190: pop
+					IL_0191: ldnull
+					IL_0192: ret
 
-					IL_01c9: ldarg.0
-					IL_01ca: ldc.i4.0
-					IL_01cb: ldelem.ref
-					IL_01cc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_01d1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-					IL_01d6: stloc.s 17
-					IL_01d8: ldstr "NodeUrl"
-					IL_01dd: ldloc.s 17
-					IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_01e4: stloc.s 17
-					IL_01e6: ldarg.0
-					IL_01e7: ldc.i4.2
-					IL_01e8: ldelem.ref
-					IL_01e9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_01ee: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_01f3: stloc.s 7
-					IL_01f5: ldstr "urlObj"
-					IL_01fa: ldloc.s 7
-					IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0201: stloc.s 7
-					IL_0203: ldc.i4.2
-					IL_0204: newarr [System.Runtime]System.Object
-					IL_0209: dup
-					IL_020a: ldc.i4.0
-					IL_020b: ldloc.2
-					IL_020c: stelem.ref
-					IL_020d: dup
-					IL_020e: ldc.i4.1
-					IL_020f: ldloc.s 7
-					IL_0211: stelem.ref
-					IL_0212: stloc.s 16
-					IL_0214: ldloc.s 17
-					IL_0216: ldloc.s 16
-					IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_021d: stloc.s 17
-					IL_021f: ldloc.s 17
-					IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0226: stloc.s 17
-					IL_0228: ldloc.s 17
-					IL_022a: ldstr "toString"
-					IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_0234: stloc.s 17
-					IL_0236: ldloc.s 17
-					IL_0238: stloc.s 5
-					IL_023a: ldarg.2
-					IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0240: stloc.s 17
-					IL_0242: ldloc.s 17
-					IL_0244: ldstr "resume"
-					IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_024e: pop
-					IL_024f: ldarg.0
-					IL_0250: ldc.i4.0
-					IL_0251: ldelem.ref
-					IL_0252: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0257: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-					IL_025c: stloc.s 17
-					IL_025e: ldstr "fetchText"
-					IL_0263: ldloc.s 17
-					IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_026a: stloc.s 17
-					IL_026c: ldc.i4.3
-					IL_026d: newarr [System.Runtime]System.Object
-					IL_0272: dup
-					IL_0273: ldc.i4.0
-					IL_0274: ldarg.0
-					IL_0275: ldc.i4.0
-					IL_0276: ldelem.ref
-					IL_0277: stelem.ref
-					IL_0278: dup
-					IL_0279: ldc.i4.1
-					IL_027a: ldarg.0
-					IL_027b: ldc.i4.1
-					IL_027c: ldelem.ref
-					IL_027d: stelem.ref
-					IL_027e: dup
-					IL_027f: ldc.i4.2
-					IL_0280: ldarg.0
-					IL_0281: ldc.i4.2
-					IL_0282: ldelem.ref
-					IL_0283: stelem.ref
-					IL_0284: stloc.s 16
-					IL_0286: ldarg.0
-					IL_0287: ldc.i4.1
-					IL_0288: ldelem.ref
-					IL_0289: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_028e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_0293: stloc.s 7
-					IL_0295: ldstr "maxRedirects"
-					IL_029a: ldloc.s 7
-					IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_02a1: stloc.s 7
-					IL_02a3: ldloc.s 7
-					IL_02a5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_02aa: stloc.s 11
-					IL_02ac: ldloc.s 11
-					IL_02ae: ldc.r8 1
-					IL_02b7: sub
-					IL_02b8: stloc.s 11
-					IL_02ba: ldloc.s 11
-					IL_02bc: box [System.Runtime]System.Double
-					IL_02c1: stloc.s 19
-					IL_02c3: ldloc.s 17
-					IL_02c5: ldloc.s 16
-					IL_02c7: ldloc.s 5
-					IL_02c9: ldloc.s 19
-					IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-					IL_02d0: stloc.s 17
-					IL_02d2: ldloc.s 17
-					IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02d9: stloc.s 17
-					IL_02db: ldarg.0
-					IL_02dc: ldc.i4.2
-					IL_02dd: ldelem.ref
-					IL_02de: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_02e3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_02e8: stloc.s 7
-					IL_02ea: ldstr "resolve"
-					IL_02ef: ldloc.s 7
-					IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_02f6: stloc.s 7
-					IL_02f8: ldarg.0
-					IL_02f9: ldc.i4.2
-					IL_02fa: ldelem.ref
-					IL_02fb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0300: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0305: stloc.s 20
-					IL_0307: ldstr "reject"
-					IL_030c: ldloc.s 20
-					IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0313: stloc.s 20
-					IL_0315: ldloc.s 17
-					IL_0317: ldstr "then"
-					IL_031c: ldloc.s 7
-					IL_031e: ldloc.s 20
-					IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0325: pop
-					IL_0326: ldnull
-					IL_0327: ret
+					IL_0193: ldarg.0
+					IL_0194: ldc.i4.0
+					IL_0195: ldelem.ref
+					IL_0196: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_019b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+					IL_01a0: stloc.s 18
+					IL_01a2: ldc.i4.2
+					IL_01a3: newarr [System.Runtime]System.Object
+					IL_01a8: dup
+					IL_01a9: ldc.i4.0
+					IL_01aa: ldloc.2
+					IL_01ab: stelem.ref
+					IL_01ac: dup
+					IL_01ad: ldc.i4.1
+					IL_01ae: ldarg.0
+					IL_01af: ldc.i4.2
+					IL_01b0: ldelem.ref
+					IL_01b1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_01b6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_01bb: stelem.ref
+					IL_01bc: stloc.s 16
+					IL_01be: ldloc.s 18
+					IL_01c0: ldloc.s 16
+					IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_01c7: stloc.s 18
+					IL_01c9: ldloc.s 18
+					IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01d0: stloc.s 18
+					IL_01d2: ldloc.s 18
+					IL_01d4: ldstr "toString"
+					IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01de: stloc.s 18
+					IL_01e0: ldloc.s 18
+					IL_01e2: stloc.s 5
+					IL_01e4: ldarg.2
+					IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01ea: stloc.s 18
+					IL_01ec: ldloc.s 18
+					IL_01ee: ldstr "resume"
+					IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01f8: pop
+					IL_01f9: ldarg.0
+					IL_01fa: ldc.i4.0
+					IL_01fb: ldelem.ref
+					IL_01fc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_0201: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+					IL_0206: stloc.s 18
+					IL_0208: ldc.i4.3
+					IL_0209: newarr [System.Runtime]System.Object
+					IL_020e: dup
+					IL_020f: ldc.i4.0
+					IL_0210: ldarg.0
+					IL_0211: ldc.i4.0
+					IL_0212: ldelem.ref
+					IL_0213: stelem.ref
+					IL_0214: dup
+					IL_0215: ldc.i4.1
+					IL_0216: ldarg.0
+					IL_0217: ldc.i4.1
+					IL_0218: ldelem.ref
+					IL_0219: stelem.ref
+					IL_021a: dup
+					IL_021b: ldc.i4.2
+					IL_021c: ldarg.0
+					IL_021d: ldc.i4.2
+					IL_021e: ldelem.ref
+					IL_021f: stelem.ref
+					IL_0220: stloc.s 16
+					IL_0222: ldloc.s 18
+					IL_0224: ldloc.s 16
+					IL_0226: ldloc.s 5
+					IL_0228: ldarg.0
+					IL_0229: ldc.i4.1
+					IL_022a: ldelem.ref
+					IL_022b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0230: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_0235: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_023a: ldc.r8 1
+					IL_0243: sub
+					IL_0244: box [System.Runtime]System.Double
+					IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+					IL_024e: stloc.s 18
+					IL_0250: ldloc.s 18
+					IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0257: stloc.s 18
+					IL_0259: ldarg.0
+					IL_025a: ldc.i4.2
+					IL_025b: ldelem.ref
+					IL_025c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0261: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_0266: stloc.s 7
+					IL_0268: ldloc.s 18
+					IL_026a: ldstr "then"
+					IL_026f: ldloc.s 7
+					IL_0271: ldarg.0
+					IL_0272: ldc.i4.2
+					IL_0273: ldelem.ref
+					IL_0274: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0279: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0283: pop
+					IL_0284: ldnull
+					IL_0285: ret
 
-					IL_0328: ldloc.1
-					IL_0329: stloc.s 14
-					IL_032b: ldloc.s 14
-					IL_032d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0332: stloc.s 11
-					IL_0334: ldloc.s 11
-					IL_0336: ldc.r8 200
-					IL_033f: clt
-					IL_0341: stloc.s 8
-					IL_0343: ldloc.s 8
-					IL_0345: box [System.Runtime]System.Boolean
-					IL_034a: stloc.s 12
-					IL_034c: ldloc.s 12
-					IL_034e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0353: stloc.s 8
-					IL_0355: ldloc.s 8
-					IL_0357: brtrue IL_038c
+					IL_0286: ldloc.1
+					IL_0287: stloc.s 14
+					IL_0289: ldloc.s 14
+					IL_028b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0290: stloc.s 11
+					IL_0292: ldloc.s 11
+					IL_0294: ldc.r8 200
+					IL_029d: clt
+					IL_029f: stloc.s 8
+					IL_02a1: ldloc.s 8
+					IL_02a3: box [System.Runtime]System.Boolean
+					IL_02a8: stloc.s 12
+					IL_02aa: ldloc.s 12
+					IL_02ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02b1: stloc.s 8
+					IL_02b3: ldloc.s 8
+					IL_02b5: brtrue IL_02ea
 
-					IL_035c: ldloc.1
-					IL_035d: stloc.s 14
-					IL_035f: ldloc.s 14
-					IL_0361: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0366: stloc.s 11
-					IL_0368: ldloc.s 11
-					IL_036a: ldc.r8 300
-					IL_0373: clt
-					IL_0375: ldc.i4.0
-					IL_0376: ceq
-					IL_0378: stloc.s 8
-					IL_037a: ldloc.s 8
-					IL_037c: box [System.Runtime]System.Boolean
-					IL_0381: stloc.s 13
-					IL_0383: ldloc.s 13
-					IL_0385: stloc.s 21
-					IL_0387: br IL_0390
+					IL_02ba: ldloc.1
+					IL_02bb: stloc.s 14
+					IL_02bd: ldloc.s 14
+					IL_02bf: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_02c4: stloc.s 11
+					IL_02c6: ldloc.s 11
+					IL_02c8: ldc.r8 300
+					IL_02d1: clt
+					IL_02d3: ldc.i4.0
+					IL_02d4: ceq
+					IL_02d6: stloc.s 8
+					IL_02d8: ldloc.s 8
+					IL_02da: box [System.Runtime]System.Boolean
+					IL_02df: stloc.s 13
+					IL_02e1: ldloc.s 13
+					IL_02e3: stloc.s 19
+					IL_02e5: br IL_02ee
 
-					IL_038c: ldloc.s 12
-					IL_038e: stloc.s 21
+					IL_02ea: ldloc.s 12
+					IL_02ec: stloc.s 19
 
-					IL_0390: ldloc.s 21
-					IL_0392: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0397: stloc.s 8
-					IL_0399: ldloc.s 8
-					IL_039b: brfalse IL_0464
+					IL_02ee: ldloc.s 19
+					IL_02f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02f5: stloc.s 8
+					IL_02f7: ldloc.s 8
+					IL_02f9: brfalse IL_03a2
 
-					IL_03a0: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
-					IL_03a5: stloc.s 6
-					IL_03a7: ldarg.2
-					IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_03ad: stloc.s 20
-					IL_03af: ldloc.s 20
-					IL_03b1: ldstr "resume"
-					IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02fe: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
+					IL_0303: stloc.s 6
+					IL_0305: ldarg.2
+					IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_030b: stloc.s 7
+					IL_030d: ldloc.s 7
+					IL_030f: ldstr "resume"
+					IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_0319: pop
+					IL_031a: ldarg.0
+					IL_031b: ldc.i4.2
+					IL_031c: ldelem.ref
+					IL_031d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0322: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0327: stloc.s 7
+					IL_0329: ldc.i4.3
+					IL_032a: newarr [System.Runtime]System.Object
+					IL_032f: dup
+					IL_0330: ldc.i4.0
+					IL_0331: ldarg.0
+					IL_0332: ldc.i4.0
+					IL_0333: ldelem.ref
+					IL_0334: stelem.ref
+					IL_0335: dup
+					IL_0336: ldc.i4.1
+					IL_0337: ldarg.0
+					IL_0338: ldc.i4.1
+					IL_0339: ldelem.ref
+					IL_033a: stelem.ref
+					IL_033b: dup
+					IL_033c: ldc.i4.2
+					IL_033d: ldarg.0
+					IL_033e: ldc.i4.2
+					IL_033f: ldelem.ref
+					IL_0340: stelem.ref
+					IL_0341: stloc.s 16
+					IL_0343: ldloc.1
+					IL_0344: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0349: stloc.s 17
+					IL_034b: ldstr "HTTP "
+					IL_0350: ldloc.s 17
+					IL_0352: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0357: stloc.s 17
+					IL_0359: ldloc.s 17
+					IL_035b: ldstr " fetching "
+					IL_0360: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0365: stloc.s 17
+					IL_0367: ldarg.0
+					IL_0368: ldc.i4.1
+					IL_0369: ldelem.ref
+					IL_036a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_036f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0374: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0379: stloc.s 20
+					IL_037b: ldloc.s 17
+					IL_037d: ldloc.s 20
+					IL_037f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0384: stloc.s 20
+					IL_0386: ldloc.s 20
+					IL_0388: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_038d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0392: stloc.s 18
+					IL_0394: ldloc.s 7
+					IL_0396: ldloc.s 16
+					IL_0398: ldloc.s 18
+					IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_039f: pop
+					IL_03a0: ldnull
+					IL_03a1: ret
+
+					IL_03a2: ldarg.2
+					IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_03a8: stloc.s 18
+					IL_03aa: ldloc.s 18
+					IL_03ac: ldstr "setEncoding"
+					IL_03b1: ldstr "utf8"
+					IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 					IL_03bb: pop
-					IL_03bc: ldarg.0
-					IL_03bd: ldc.i4.2
-					IL_03be: ldelem.ref
-					IL_03bf: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_03c4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_03c9: stloc.s 20
-					IL_03cb: ldstr "reject"
-					IL_03d0: ldloc.s 20
-					IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_03d7: stloc.s 20
-					IL_03d9: ldc.i4.3
-					IL_03da: newarr [System.Runtime]System.Object
-					IL_03df: dup
-					IL_03e0: ldc.i4.0
-					IL_03e1: ldarg.0
+					IL_03bc: ldloc.0
+					IL_03bd: ldstr ""
+					IL_03c2: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_03c7: ldarg.2
+					IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_03cd: stloc.s 18
+					IL_03cf: ldnull
+					IL_03d0: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_03d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_03db: ldc.i4.4
+					IL_03dc: newarr [System.Runtime]System.Object
+					IL_03e1: dup
 					IL_03e2: ldc.i4.0
-					IL_03e3: ldelem.ref
-					IL_03e4: stelem.ref
-					IL_03e5: dup
-					IL_03e6: ldc.i4.1
-					IL_03e7: ldarg.0
+					IL_03e3: ldarg.0
+					IL_03e4: ldc.i4.0
+					IL_03e5: ldelem.ref
+					IL_03e6: stelem.ref
+					IL_03e7: dup
 					IL_03e8: ldc.i4.1
-					IL_03e9: ldelem.ref
-					IL_03ea: stelem.ref
-					IL_03eb: dup
-					IL_03ec: ldc.i4.2
-					IL_03ed: ldarg.0
+					IL_03e9: ldarg.0
+					IL_03ea: ldc.i4.1
+					IL_03eb: ldelem.ref
+					IL_03ec: stelem.ref
+					IL_03ed: dup
 					IL_03ee: ldc.i4.2
-					IL_03ef: ldelem.ref
-					IL_03f0: stelem.ref
-					IL_03f1: stloc.s 16
-					IL_03f3: ldloc.1
-					IL_03f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_03f9: stloc.s 18
-					IL_03fb: ldstr "HTTP "
-					IL_0400: ldloc.s 18
-					IL_0402: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0407: stloc.s 18
-					IL_0409: ldloc.s 18
-					IL_040b: ldstr " fetching "
-					IL_0410: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0415: stloc.s 18
-					IL_0417: ldarg.0
-					IL_0418: ldc.i4.1
-					IL_0419: ldelem.ref
-					IL_041a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_041f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0424: stloc.s 7
-					IL_0426: ldstr "urlString"
-					IL_042b: ldloc.s 7
-					IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0432: stloc.s 7
-					IL_0434: ldloc.s 7
-					IL_0436: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_043b: stloc.s 22
-					IL_043d: ldloc.s 18
-					IL_043f: ldloc.s 22
-					IL_0441: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0446: stloc.s 22
-					IL_0448: ldloc.s 22
-					IL_044a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_044f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0454: stloc.s 7
-					IL_0456: ldloc.s 20
-					IL_0458: ldloc.s 16
-					IL_045a: ldloc.s 7
-					IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0461: pop
-					IL_0462: ldnull
-					IL_0463: ret
-
-					IL_0464: ldarg.2
-					IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_046a: stloc.s 7
-					IL_046c: ldloc.s 7
-					IL_046e: ldstr "setEncoding"
-					IL_0473: ldstr "utf8"
-					IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_047d: pop
-					IL_047e: ldloc.0
-					IL_047f: ldstr ""
-					IL_0484: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_0489: ldarg.2
-					IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_048f: stloc.s 7
-					IL_0491: ldnull
-					IL_0492: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
-					IL_0498: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_049d: ldc.i4.4
-					IL_049e: newarr [System.Runtime]System.Object
-					IL_04a3: dup
-					IL_04a4: ldc.i4.0
-					IL_04a5: ldarg.0
-					IL_04a6: ldc.i4.0
-					IL_04a7: ldelem.ref
-					IL_04a8: stelem.ref
-					IL_04a9: dup
-					IL_04aa: ldc.i4.1
-					IL_04ab: ldarg.0
-					IL_04ac: ldc.i4.1
-					IL_04ad: ldelem.ref
-					IL_04ae: stelem.ref
-					IL_04af: dup
-					IL_04b0: ldc.i4.2
-					IL_04b1: ldarg.0
-					IL_04b2: ldc.i4.2
-					IL_04b3: ldelem.ref
-					IL_04b4: stelem.ref
-					IL_04b5: dup
-					IL_04b6: ldc.i4.3
-					IL_04b7: ldloc.0
-					IL_04b8: stelem.ref
-					IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_04c3: ldc.i4.1
-					IL_04c4: conv.r8
-					IL_04c5: ldstr ""
-					IL_04ca: ldc.i4.0
-					IL_04cb: ldc.i4.1
-					IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_04d6: stloc.s 20
-					IL_04d8: ldloc.s 7
-					IL_04da: ldstr "on"
-					IL_04df: ldstr "data"
-					IL_04e4: ldloc.s 20
-					IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_04eb: pop
-					IL_04ec: ldarg.2
-					IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_04f2: stloc.s 20
-					IL_04f4: ldnull
-					IL_04f5: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
-					IL_04fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_0500: ldc.i4.4
-					IL_0501: newarr [System.Runtime]System.Object
-					IL_0506: dup
-					IL_0507: ldc.i4.0
-					IL_0508: ldarg.0
-					IL_0509: ldc.i4.0
-					IL_050a: ldelem.ref
-					IL_050b: stelem.ref
-					IL_050c: dup
-					IL_050d: ldc.i4.1
-					IL_050e: ldarg.0
-					IL_050f: ldc.i4.1
-					IL_0510: ldelem.ref
-					IL_0511: stelem.ref
-					IL_0512: dup
-					IL_0513: ldc.i4.2
-					IL_0514: ldarg.0
-					IL_0515: ldc.i4.2
-					IL_0516: ldelem.ref
-					IL_0517: stelem.ref
-					IL_0518: dup
-					IL_0519: ldc.i4.3
-					IL_051a: ldloc.0
-					IL_051b: stelem.ref
-					IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_0526: ldc.i4.0
-					IL_0527: conv.r8
-					IL_0528: ldstr ""
-					IL_052d: ldc.i4.0
-					IL_052e: ldc.i4.1
-					IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_0539: stloc.s 7
-					IL_053b: ldloc.s 20
-					IL_053d: ldstr "on"
-					IL_0542: ldstr "end"
-					IL_0547: ldloc.s 7
-					IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_054e: pop
-					IL_054f: ldnull
-					IL_0550: ret
+					IL_03ef: ldarg.0
+					IL_03f0: ldc.i4.2
+					IL_03f1: ldelem.ref
+					IL_03f2: stelem.ref
+					IL_03f3: dup
+					IL_03f4: ldc.i4.3
+					IL_03f5: ldloc.0
+					IL_03f6: stelem.ref
+					IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0401: ldc.i4.1
+					IL_0402: conv.r8
+					IL_0403: ldstr ""
+					IL_0408: ldc.i4.0
+					IL_0409: ldc.i4.1
+					IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0414: stloc.s 7
+					IL_0416: ldloc.s 18
+					IL_0418: ldstr "on"
+					IL_041d: ldstr "data"
+					IL_0422: ldloc.s 7
+					IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0429: pop
+					IL_042a: ldarg.2
+					IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0430: stloc.s 7
+					IL_0432: ldnull
+					IL_0433: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_0439: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_043e: ldc.i4.4
+					IL_043f: newarr [System.Runtime]System.Object
+					IL_0444: dup
+					IL_0445: ldc.i4.0
+					IL_0446: ldarg.0
+					IL_0447: ldc.i4.0
+					IL_0448: ldelem.ref
+					IL_0449: stelem.ref
+					IL_044a: dup
+					IL_044b: ldc.i4.1
+					IL_044c: ldarg.0
+					IL_044d: ldc.i4.1
+					IL_044e: ldelem.ref
+					IL_044f: stelem.ref
+					IL_0450: dup
+					IL_0451: ldc.i4.2
+					IL_0452: ldarg.0
+					IL_0453: ldc.i4.2
+					IL_0454: ldelem.ref
+					IL_0455: stelem.ref
+					IL_0456: dup
+					IL_0457: ldc.i4.3
+					IL_0458: ldloc.0
+					IL_0459: stelem.ref
+					IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0464: ldc.i4.0
+					IL_0465: conv.r8
+					IL_0466: ldstr ""
+					IL_046b: ldc.i4.0
+					IL_046c: ldc.i4.1
+					IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0477: stloc.s 18
+					IL_0479: ldloc.s 7
+					IL_047b: ldstr "on"
+					IL_0480: ldstr "end"
+					IL_0485: ldloc.s 18
+					IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_048c: pop
+					IL_048d: ldnull
+					IL_048e: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -2074,7 +1951,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b58
+						// Method begins at RVA 0x48d4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2094,7 +1971,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b61
+						// Method begins at RVA 0x48dd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2117,7 +1994,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b4f
+					// Method begins at RVA 0x48cb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2143,9 +2020,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4234
+				// Method begins at RVA 0x40fc
 				// Header size: 12
-				// Code size: 602 (0x25a)
+				// Code size: 512 (0x200)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope,
@@ -2157,9 +2034,9 @@
 					[6] object,
 					[7] object,
 					[8] object,
-					[9] object,
-					[10] object[],
-					[11] string,
+					[9] object[],
+					[10] string,
+					[11] object,
 					[12] bool,
 					[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 					[14] object
@@ -2186,217 +2063,187 @@
 					IL_0024: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
 					IL_0029: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
 					IL_002e: stloc.s 8
-					IL_0030: ldstr "NodeUrl"
-					IL_0035: ldloc.s 8
-					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_003c: stloc.s 8
-					IL_003e: ldarg.0
-					IL_003f: ldc.i4.1
-					IL_0040: ldelem.ref
-					IL_0041: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0046: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_004b: stloc.s 9
-					IL_004d: ldstr "urlString"
-					IL_0052: ldloc.s 9
-					IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0059: stloc.s 9
-					IL_005b: ldc.i4.1
-					IL_005c: newarr [System.Runtime]System.Object
-					IL_0061: dup
-					IL_0062: ldc.i4.0
-					IL_0063: ldloc.s 9
-					IL_0065: stelem.ref
-					IL_0066: stloc.s 10
-					IL_0068: ldloc.s 8
-					IL_006a: ldloc.s 10
-					IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_0071: stloc.s 8
-					IL_0073: ldloc.0
-					IL_0074: ldloc.s 8
-					IL_0076: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_007b: leave IL_0101
+					IL_0030: ldloc.s 8
+					IL_0032: ldc.i4.1
+					IL_0033: newarr [System.Runtime]System.Object
+					IL_0038: dup
+					IL_0039: ldc.i4.0
+					IL_003a: ldarg.0
+					IL_003b: ldc.i4.1
+					IL_003c: ldelem.ref
+					IL_003d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0042: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0047: stelem.ref
+					IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_004d: stloc.s 8
+					IL_004f: ldloc.0
+					IL_0050: ldloc.s 8
+					IL_0052: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_0057: leave IL_00cb
 				} // end .try
 				catch [System.Runtime]System.Exception
 				{
-					IL_0080: stloc.2
-					IL_0081: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope/Block_L76C12::.ctor()
-					IL_0086: stloc.3
-					IL_0087: ldloc.0
-					IL_0088: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_008d: stloc.s 8
-					IL_008f: ldc.i4.2
-					IL_0090: newarr [System.Runtime]System.Object
-					IL_0095: dup
-					IL_0096: ldc.i4.0
-					IL_0097: ldarg.0
-					IL_0098: ldc.i4.0
-					IL_0099: ldelem.ref
-					IL_009a: stelem.ref
-					IL_009b: dup
-					IL_009c: ldc.i4.1
-					IL_009d: ldarg.0
-					IL_009e: ldc.i4.1
-					IL_009f: ldelem.ref
-					IL_00a0: stelem.ref
-					IL_00a1: stloc.s 10
-					IL_00a3: ldarg.0
-					IL_00a4: ldc.i4.1
-					IL_00a5: ldelem.ref
-					IL_00a6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_00ab: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_00b0: stloc.s 9
-					IL_00b2: ldstr "urlString"
-					IL_00b7: ldloc.s 9
-					IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_00be: stloc.s 9
-					IL_00c0: ldloc.s 9
-					IL_00c2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_00c7: stloc.s 11
-					IL_00c9: ldstr "Invalid URL: "
-					IL_00ce: ldloc.s 11
-					IL_00d0: call string [System.Runtime]System.String::Concat(string, string)
-					IL_00d5: stloc.s 11
-					IL_00d7: ldloc.s 11
-					IL_00d9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_00de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_00e3: stloc.s 9
-					IL_00e5: ldloc.s 8
-					IL_00e7: ldloc.s 10
-					IL_00e9: ldloc.s 9
-					IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_00f0: pop
-					IL_00f1: ldnull
-					IL_00f2: stloc.s 4
-					IL_00f4: ldnull
-					IL_00f5: stloc.s 4
-					IL_00f7: leave IL_0257
+					IL_005c: stloc.2
+					IL_005d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope/Block_L76C12::.ctor()
+					IL_0062: stloc.3
+					IL_0063: ldloc.0
+					IL_0064: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0069: stloc.s 8
+					IL_006b: ldc.i4.2
+					IL_006c: newarr [System.Runtime]System.Object
+					IL_0071: dup
+					IL_0072: ldc.i4.0
+					IL_0073: ldarg.0
+					IL_0074: ldc.i4.0
+					IL_0075: ldelem.ref
+					IL_0076: stelem.ref
+					IL_0077: dup
+					IL_0078: ldc.i4.1
+					IL_0079: ldarg.0
+					IL_007a: ldc.i4.1
+					IL_007b: ldelem.ref
+					IL_007c: stelem.ref
+					IL_007d: stloc.s 9
+					IL_007f: ldarg.0
+					IL_0080: ldc.i4.1
+					IL_0081: ldelem.ref
+					IL_0082: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0087: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_008c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0091: stloc.s 10
+					IL_0093: ldstr "Invalid URL: "
+					IL_0098: ldloc.s 10
+					IL_009a: call string [System.Runtime]System.String::Concat(string, string)
+					IL_009f: stloc.s 10
+					IL_00a1: ldloc.s 10
+					IL_00a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_00a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_00ad: stloc.s 11
+					IL_00af: ldloc.s 8
+					IL_00b1: ldloc.s 9
+					IL_00b3: ldloc.s 11
+					IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_00ba: pop
+					IL_00bb: ldnull
+					IL_00bc: stloc.s 4
+					IL_00be: ldnull
+					IL_00bf: stloc.s 4
+					IL_00c1: leave IL_01fd
 
-					IL_00fc: leave IL_0101
+					IL_00c6: leave IL_00cb
 				} // end handler
 
-				IL_0101: ldloc.0
-				IL_0102: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_0107: ldstr "protocol"
-				IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0111: ldstr "https:"
-				IL_0116: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_011b: stloc.s 12
-				IL_011d: ldloc.s 12
-				IL_011f: brfalse IL_014a
+				IL_00cb: ldloc.0
+				IL_00cc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_00d1: ldstr "protocol"
+				IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00db: ldstr "https:"
+				IL_00e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00e5: stloc.s 12
+				IL_00e7: ldloc.s 12
+				IL_00e9: brfalse IL_0102
 
-				IL_0124: ldarg.0
-				IL_0125: ldc.i4.0
-				IL_0126: ldelem.ref
-				IL_0127: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_012c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
-				IL_0131: stloc.s 9
-				IL_0133: ldstr "https"
-				IL_0138: ldloc.s 9
-				IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_013f: stloc.s 9
-				IL_0141: ldloc.s 9
-				IL_0143: stloc.s 5
-				IL_0145: br IL_016b
+				IL_00ee: ldarg.0
+				IL_00ef: ldc.i4.0
+				IL_00f0: ldelem.ref
+				IL_00f1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_00f6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+				IL_00fb: stloc.s 5
+				IL_00fd: br IL_0111
 
-				IL_014a: ldarg.0
-				IL_014b: ldc.i4.0
-				IL_014c: ldelem.ref
-				IL_014d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_0152: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
-				IL_0157: stloc.s 9
-				IL_0159: ldstr "http"
-				IL_015e: ldloc.s 9
-				IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0165: stloc.s 9
-				IL_0167: ldloc.s 9
-				IL_0169: stloc.s 5
+				IL_0102: ldarg.0
+				IL_0103: ldc.i4.0
+				IL_0104: ldelem.ref
+				IL_0105: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_010a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+				IL_010f: stloc.s 5
 
-				IL_016b: ldloc.s 5
-				IL_016d: stloc.s 6
-				IL_016f: ldloc.s 6
-				IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0176: stloc.s 9
-				IL_0178: ldloc.0
-				IL_0179: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_017e: stloc.s 8
-				IL_0180: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0111: ldloc.s 5
+				IL_0113: stloc.s 6
+				IL_0115: ldloc.s 6
+				IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_011c: stloc.s 11
+				IL_011e: ldloc.0
+				IL_011f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_0124: stloc.s 8
+				IL_0126: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_012b: dup
+				IL_012c: ldstr "method"
+				IL_0131: ldstr "GET"
+				IL_0136: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_013b: dup
+				IL_013c: ldstr "headers"
+				IL_0141: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0146: dup
+				IL_0147: ldstr "Accept-Encoding"
+				IL_014c: ldstr "identity"
+				IL_0151: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0156: dup
+				IL_0157: ldstr "User-Agent"
+				IL_015c: ldstr "jroc-docs-script"
+				IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0166: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_016b: stloc.s 13
+				IL_016d: ldnull
+				IL_016e: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
+				IL_0174: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_0179: ldc.i4.3
+				IL_017a: newarr [System.Runtime]System.Object
+				IL_017f: dup
+				IL_0180: ldc.i4.0
+				IL_0181: ldarg.0
+				IL_0182: ldc.i4.0
+				IL_0183: ldelem.ref
+				IL_0184: stelem.ref
 				IL_0185: dup
-				IL_0186: ldstr "method"
-				IL_018b: ldstr "GET"
-				IL_0190: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0195: dup
-				IL_0196: ldstr "headers"
-				IL_019b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_01a0: dup
-				IL_01a1: ldstr "Accept-Encoding"
-				IL_01a6: ldstr "identity"
-				IL_01ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_01b0: dup
-				IL_01b1: ldstr "User-Agent"
-				IL_01b6: ldstr "jroc-docs-script"
-				IL_01bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_01c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_01c5: stloc.s 13
-				IL_01c7: ldnull
-				IL_01c8: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
-				IL_01ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_01d3: ldc.i4.3
-				IL_01d4: newarr [System.Runtime]System.Object
-				IL_01d9: dup
-				IL_01da: ldc.i4.0
-				IL_01db: ldarg.0
-				IL_01dc: ldc.i4.0
-				IL_01dd: ldelem.ref
-				IL_01de: stelem.ref
-				IL_01df: dup
-				IL_01e0: ldc.i4.1
-				IL_01e1: ldarg.0
-				IL_01e2: ldc.i4.1
-				IL_01e3: ldelem.ref
-				IL_01e4: stelem.ref
-				IL_01e5: dup
-				IL_01e6: ldc.i4.2
-				IL_01e7: ldloc.0
-				IL_01e8: stelem.ref
-				IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_01f3: ldc.i4.1
-				IL_01f4: conv.r8
-				IL_01f5: ldstr ""
-				IL_01fa: ldc.i4.0
-				IL_01fb: ldc.i4.1
-				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-				IL_0206: stloc.s 14
-				IL_0208: ldloc.s 9
-				IL_020a: ldstr "request"
-				IL_020f: ldloc.s 8
-				IL_0211: ldloc.s 13
-				IL_0213: ldloc.s 14
-				IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_021a: stloc.s 14
-				IL_021c: ldloc.s 14
-				IL_021e: stloc.s 7
-				IL_0220: ldloc.s 7
-				IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0227: stloc.s 14
-				IL_0229: ldloc.s 14
-				IL_022b: ldstr "on"
-				IL_0230: ldstr "error"
-				IL_0235: ldloc.0
-				IL_0236: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-				IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0240: pop
-				IL_0241: ldloc.s 7
-				IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0248: stloc.s 14
-				IL_024a: ldloc.s 14
-				IL_024c: ldstr "end"
-				IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0256: pop
+				IL_0186: ldc.i4.1
+				IL_0187: ldarg.0
+				IL_0188: ldc.i4.1
+				IL_0189: ldelem.ref
+				IL_018a: stelem.ref
+				IL_018b: dup
+				IL_018c: ldc.i4.2
+				IL_018d: ldloc.0
+				IL_018e: stelem.ref
+				IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_0199: ldc.i4.1
+				IL_019a: conv.r8
+				IL_019b: ldstr ""
+				IL_01a0: ldc.i4.0
+				IL_01a1: ldc.i4.1
+				IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+				IL_01ac: stloc.s 14
+				IL_01ae: ldloc.s 11
+				IL_01b0: ldstr "request"
+				IL_01b5: ldloc.s 8
+				IL_01b7: ldloc.s 13
+				IL_01b9: ldloc.s 14
+				IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_01c0: stloc.s 14
+				IL_01c2: ldloc.s 14
+				IL_01c4: stloc.s 7
+				IL_01c6: ldloc.s 7
+				IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01cd: stloc.s 14
+				IL_01cf: ldloc.s 14
+				IL_01d1: ldstr "on"
+				IL_01d6: ldstr "error"
+				IL_01db: ldloc.0
+				IL_01dc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+				IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_01e6: pop
+				IL_01e7: ldloc.s 7
+				IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01ee: stloc.s 14
+				IL_01f0: ldloc.s 14
+				IL_01f2: ldstr "end"
+				IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_01fc: pop
 
-				IL_0257: ldloc.s 4
-				IL_0259: ret
+				IL_01fd: ldloc.s 4
+				IL_01ff: ret
 			} // end of method ArrowFunction_L72C22::__js_call__
 
 		} // end of class ArrowFunction_L72C22
@@ -2418,7 +2265,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b46
+					// Method begins at RVA 0x48c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2440,7 +2287,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b3d
+				// Method begins at RVA 0x48b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2468,7 +2315,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x29d0
+			// Method begins at RVA 0x2998
 			// Header size: 12
 			// Code size: 113 (0x71)
 			.maxstack 8
@@ -2539,7 +2386,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ba0
+				// Method begins at RVA 0x491c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2563,7 +2410,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a50
+			// Method begins at RVA 0x2a18
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -2606,7 +2453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bb2
+					// Method begins at RVA 0x492e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2630,7 +2477,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4bc4
+						// Method begins at RVA 0x4940
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2648,7 +2495,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bbb
+					// Method begins at RVA 0x4937
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2666,7 +2513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ba9
+				// Method begins at RVA 0x4925
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2694,7 +2541,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2a88
+			// Method begins at RVA 0x2a50
 			// Header size: 12
 			// Code size: 586 (0x24a)
 			.maxstack 8
@@ -2954,7 +2801,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bd6
+					// Method begins at RVA 0x4952
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2974,7 +2821,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bdf
+					// Method begins at RVA 0x495b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2994,7 +2841,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4be8
+					// Method begins at RVA 0x4964
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3014,7 +2861,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bf1
+					// Method begins at RVA 0x496d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3038,7 +2885,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c03
+						// Method begins at RVA 0x497f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3058,7 +2905,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c0c
+						// Method begins at RVA 0x4988
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3082,7 +2929,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4c1e
+							// Method begins at RVA 0x499a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -3100,7 +2947,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c15
+						// Method begins at RVA 0x4991
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3120,7 +2967,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c27
+						// Method begins at RVA 0x49a3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3138,7 +2985,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bfa
+					// Method begins at RVA 0x4976
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3156,7 +3003,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bcd
+				// Method begins at RVA 0x4949
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3184,9 +3031,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2ce0
+			// Method begins at RVA 0x2ca8
 			// Header size: 12
-			// Code size: 1180 (0x49c)
+			// Code size: 1144 (0x478)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -3376,271 +3223,259 @@
 
 			IL_01aa: throw
 
-			IL_01ab: ldarg.0
-			IL_01ac: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
-			IL_01b1: stloc.s 25
-			IL_01b3: ldstr "findTagNameAt"
-			IL_01b8: ldloc.s 25
-			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01bf: stloc.s 25
-			IL_01c1: ldc.i4.1
-			IL_01c2: newarr [System.Runtime]System.Object
-			IL_01c7: dup
-			IL_01c8: ldc.i4.0
-			IL_01c9: ldarg.0
-			IL_01ca: stelem.ref
-			IL_01cb: stloc.s 27
-			IL_01cd: ldloc.s 25
-			IL_01cf: ldloc.s 27
-			IL_01d1: ldarg.2
-			IL_01d2: ldloc.s 6
-			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01d9: stloc.s 25
-			IL_01db: ldloc.s 25
-			IL_01dd: stloc.s 9
-			IL_01df: ldloc.s 9
-			IL_01e1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01e6: ldc.i4.0
-			IL_01e7: ceq
-			IL_01e9: stloc.s 28
-			IL_01eb: ldloc.s 28
-			IL_01ed: brfalse IL_0246
+			IL_01ab: ldc.i4.1
+			IL_01ac: newarr [System.Runtime]System.Object
+			IL_01b1: dup
+			IL_01b2: ldc.i4.0
+			IL_01b3: ldarg.0
+			IL_01b4: stelem.ref
+			IL_01b5: stloc.s 27
+			IL_01b7: ldarg.0
+			IL_01b8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
+			IL_01bd: ldloc.s 27
+			IL_01bf: ldarg.2
+			IL_01c0: ldloc.s 6
+			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01c7: stloc.s 25
+			IL_01c9: ldloc.s 25
+			IL_01cb: stloc.s 9
+			IL_01cd: ldloc.s 9
+			IL_01cf: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01d4: ldc.i4.0
+			IL_01d5: ceq
+			IL_01d7: stloc.s 28
+			IL_01d9: ldloc.s 28
+			IL_01db: brfalse IL_0234
 
-			IL_01f2: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L170C16::.ctor()
-			IL_01f7: stloc.s 10
-			IL_01f9: ldarg.3
-			IL_01fa: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ff: stloc.s 24
-			IL_0201: ldstr "Could not determine tag name for id '"
-			IL_0206: ldloc.s 24
-			IL_0208: call string [System.Runtime]System.String::Concat(string, string)
-			IL_020d: stloc.s 24
-			IL_020f: ldloc.s 24
-			IL_0211: ldstr "'."
-			IL_0216: call string [System.Runtime]System.String::Concat(string, string)
-			IL_021b: stloc.s 24
-			IL_021d: ldloc.s 24
-			IL_021f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0224: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0229: stloc.s 25
-			IL_022b: ldloc.s 25
-			IL_022d: stloc.s 11
-			IL_022f: ldloc.s 11
-			IL_0231: isinst [System.Runtime]System.Exception
-			IL_0236: dup
-			IL_0237: brtrue IL_0245
+			IL_01e0: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L170C16::.ctor()
+			IL_01e5: stloc.s 10
+			IL_01e7: ldarg.3
+			IL_01e8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ed: stloc.s 24
+			IL_01ef: ldstr "Could not determine tag name for id '"
+			IL_01f4: ldloc.s 24
+			IL_01f6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01fb: stloc.s 24
+			IL_01fd: ldloc.s 24
+			IL_01ff: ldstr "'."
+			IL_0204: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0209: stloc.s 24
+			IL_020b: ldloc.s 24
+			IL_020d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0212: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0217: stloc.s 25
+			IL_0219: ldloc.s 25
+			IL_021b: stloc.s 11
+			IL_021d: ldloc.s 11
+			IL_021f: isinst [System.Runtime]System.Exception
+			IL_0224: dup
+			IL_0225: brtrue IL_0233
 
-			IL_023c: pop
-			IL_023d: ldloc.s 11
-			IL_023f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0244: throw
+			IL_022a: pop
+			IL_022b: ldloc.s 11
+			IL_022d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0232: throw
 
-			IL_0245: throw
+			IL_0233: throw
 
-			IL_0246: ldarg.0
-			IL_0247: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_024c: stloc.s 25
-			IL_024e: ldstr "escapeRegExp"
-			IL_0253: ldloc.s 25
-			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_025a: stloc.s 25
-			IL_025c: ldloc.s 25
-			IL_025e: ldc.i4.1
-			IL_025f: newarr [System.Runtime]System.Object
-			IL_0264: dup
-			IL_0265: ldc.i4.0
-			IL_0266: ldarg.0
-			IL_0267: stelem.ref
-			IL_0268: ldloc.s 9
-			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_026f: stloc.s 25
-			IL_0271: ldloc.s 25
-			IL_0273: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0278: stloc.s 24
-			IL_027a: ldstr "<\\/?"
-			IL_027f: ldloc.s 24
-			IL_0281: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0286: stloc.s 24
-			IL_0288: ldloc.s 24
-			IL_028a: ldstr "\\b[^>]*>"
-			IL_028f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0294: stloc.s 24
-			IL_0296: ldloc.s 24
-			IL_0298: ldstr "gi"
-			IL_029d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_02a2: stloc.s 29
-			IL_02a4: ldloc.s 29
-			IL_02a6: stloc.s 12
-			IL_02a8: ldloc.s 12
-			IL_02aa: ldstr "lastIndex"
-			IL_02af: ldloc.s 6
-			IL_02b1: ldc.i4.1
-			IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_02b7: pop
-			IL_02b8: ldc.r8 0.0
-			IL_02c1: stloc.s 13
-			IL_02c3: ldc.r8 1
-			IL_02cc: neg
-			IL_02cd: box [System.Runtime]System.Double
-			IL_02d2: stloc.s 14
-			// loop start (head: IL_02d4)
-				IL_02d4: ldc.i4.1
-				IL_02d5: brfalse IL_042b
+			IL_0234: ldarg.0
+			IL_0235: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_023a: ldc.i4.1
+			IL_023b: newarr [System.Runtime]System.Object
+			IL_0240: dup
+			IL_0241: ldc.i4.0
+			IL_0242: ldarg.0
+			IL_0243: stelem.ref
+			IL_0244: ldloc.s 9
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_024b: stloc.s 25
+			IL_024d: ldloc.s 25
+			IL_024f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0254: stloc.s 24
+			IL_0256: ldstr "<\\/?"
+			IL_025b: ldloc.s 24
+			IL_025d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0262: stloc.s 24
+			IL_0264: ldloc.s 24
+			IL_0266: ldstr "\\b[^>]*>"
+			IL_026b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0270: stloc.s 24
+			IL_0272: ldloc.s 24
+			IL_0274: ldstr "gi"
+			IL_0279: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_027e: stloc.s 29
+			IL_0280: ldloc.s 29
+			IL_0282: stloc.s 12
+			IL_0284: ldloc.s 12
+			IL_0286: ldstr "lastIndex"
+			IL_028b: ldloc.s 6
+			IL_028d: ldc.i4.1
+			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0293: pop
+			IL_0294: ldc.r8 0.0
+			IL_029d: stloc.s 13
+			IL_029f: ldc.r8 1
+			IL_02a8: neg
+			IL_02a9: box [System.Runtime]System.Double
+			IL_02ae: stloc.s 14
+			// loop start (head: IL_02b0)
+				IL_02b0: ldc.i4.1
+				IL_02b1: brfalse IL_0407
 
-				IL_02da: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
-				IL_02df: stloc.s 15
-				IL_02e1: ldloc.s 12
-				IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02e8: stloc.s 25
-				IL_02ea: ldloc.s 25
-				IL_02ec: ldstr "exec"
-				IL_02f1: ldarg.2
-				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02f7: stloc.s 25
-				IL_02f9: ldloc.s 25
-				IL_02fb: stloc.s 16
-				IL_02fd: ldloc.s 16
-				IL_02ff: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0304: ldc.i4.0
-				IL_0305: ceq
-				IL_0307: stloc.s 28
-				IL_0309: ldloc.s 28
-				IL_030b: brfalse IL_031c
+				IL_02b6: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
+				IL_02bb: stloc.s 15
+				IL_02bd: ldloc.s 12
+				IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02c4: stloc.s 25
+				IL_02c6: ldloc.s 25
+				IL_02c8: ldstr "exec"
+				IL_02cd: ldarg.2
+				IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02d3: stloc.s 25
+				IL_02d5: ldloc.s 25
+				IL_02d7: stloc.s 16
+				IL_02d9: ldloc.s 16
+				IL_02db: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_02e0: ldc.i4.0
+				IL_02e1: ceq
+				IL_02e3: stloc.s 28
+				IL_02e5: ldloc.s 28
+				IL_02e7: brfalse IL_02f8
 
-				IL_0310: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L182C16::.ctor()
-				IL_0315: stloc.s 17
-				IL_0317: br IL_042b
+				IL_02ec: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L182C16::.ctor()
+				IL_02f1: stloc.s 17
+				IL_02f3: br IL_0407
 
-				IL_031c: ldloc.s 16
-				IL_031e: ldc.r8 0.0
-				IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_032c: stloc.s 18
-				IL_032e: ldloc.s 14
-				IL_0330: stloc.s 30
-				IL_0332: ldloc.s 30
-				IL_0334: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0339: stloc.s 26
-				IL_033b: ldloc.s 26
-				IL_033d: ldc.r8 0.0
-				IL_0346: clt
-				IL_0348: brfalse IL_0366
+				IL_02f8: ldloc.s 16
+				IL_02fa: ldc.r8 0.0
+				IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0308: stloc.s 18
+				IL_030a: ldloc.s 14
+				IL_030c: stloc.s 30
+				IL_030e: ldloc.s 30
+				IL_0310: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0315: stloc.s 26
+				IL_0317: ldloc.s 26
+				IL_0319: ldc.r8 0.0
+				IL_0322: clt
+				IL_0324: brfalse IL_0342
 
-				IL_034d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L187C24::.ctor()
-				IL_0352: stloc.s 19
-				IL_0354: ldloc.s 16
-				IL_0356: ldstr "index"
-				IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0360: stloc.s 25
-				IL_0362: ldloc.s 25
-				IL_0364: stloc.s 14
+				IL_0329: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L187C24::.ctor()
+				IL_032e: stloc.s 19
+				IL_0330: ldloc.s 16
+				IL_0332: ldstr "index"
+				IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_033c: stloc.s 25
+				IL_033e: ldloc.s 25
+				IL_0340: stloc.s 14
 
-				IL_0366: ldloc.s 18
-				IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_036d: stloc.s 25
-				IL_036f: ldloc.s 25
-				IL_0371: ldstr "startsWith"
-				IL_0376: ldstr "</"
-				IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0380: stloc.s 25
-				IL_0382: ldloc.s 25
-				IL_0384: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0389: stloc.s 28
-				IL_038b: ldloc.s 28
-				IL_038d: brfalse IL_0411
+				IL_0342: ldloc.s 18
+				IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0349: stloc.s 25
+				IL_034b: ldloc.s 25
+				IL_034d: ldstr "startsWith"
+				IL_0352: ldstr "</"
+				IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_035c: stloc.s 25
+				IL_035e: ldloc.s 25
+				IL_0360: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0365: stloc.s 28
+				IL_0367: ldloc.s 28
+				IL_0369: brfalse IL_03ed
 
-				IL_0392: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32::.ctor()
-				IL_0397: stloc.s 20
-				IL_0399: ldloc.s 13
-				IL_039b: ldc.r8 1
-				IL_03a4: sub
-				IL_03a5: stloc.s 13
-				IL_03a7: ldloc.s 13
-				IL_03a9: stloc.s 26
-				IL_03ab: ldloc.s 26
-				IL_03ad: ldc.r8 0.0
-				IL_03b6: ceq
-				IL_03b8: brfalse IL_040c
+				IL_036e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32::.ctor()
+				IL_0373: stloc.s 20
+				IL_0375: ldloc.s 13
+				IL_0377: ldc.r8 1
+				IL_0380: sub
+				IL_0381: stloc.s 13
+				IL_0383: ldloc.s 13
+				IL_0385: stloc.s 26
+				IL_0387: ldloc.s 26
+				IL_0389: ldc.r8 0.0
+				IL_0392: ceq
+				IL_0394: brfalse IL_03e8
 
-				IL_03bd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32/Block_L193C23::.ctor()
-				IL_03c2: stloc.s 21
-				IL_03c4: ldarg.2
-				IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03ca: stloc.s 25
-				IL_03cc: ldloc.s 25
-				IL_03ce: ldstr "substring"
-				IL_03d3: ldloc.s 14
-				IL_03d5: ldloc.s 12
-				IL_03d7: ldstr "lastIndex"
-				IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_03e6: stloc.s 25
-				IL_03e8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_03ed: dup
-				IL_03ee: ldstr "tagName"
-				IL_03f3: ldloc.s 9
-				IL_03f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_03fa: dup
-				IL_03fb: ldstr "html"
-				IL_0400: ldloc.s 25
-				IL_0402: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0407: stloc.s 31
-				IL_0409: ldloc.s 31
-				IL_040b: ret
+				IL_0399: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32/Block_L193C23::.ctor()
+				IL_039e: stloc.s 21
+				IL_03a0: ldarg.2
+				IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03a6: stloc.s 25
+				IL_03a8: ldloc.s 25
+				IL_03aa: ldstr "substring"
+				IL_03af: ldloc.s 14
+				IL_03b1: ldloc.s 12
+				IL_03b3: ldstr "lastIndex"
+				IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_03c2: stloc.s 25
+				IL_03c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_03c9: dup
+				IL_03ca: ldstr "tagName"
+				IL_03cf: ldloc.s 9
+				IL_03d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03d6: dup
+				IL_03d7: ldstr "html"
+				IL_03dc: ldloc.s 25
+				IL_03de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03e3: stloc.s 31
+				IL_03e5: ldloc.s 31
+				IL_03e7: ret
 
-				IL_040c: br IL_0426
+				IL_03e8: br IL_0402
 
-				IL_0411: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L199C11::.ctor()
-				IL_0416: stloc.s 22
-				IL_0418: ldloc.s 13
-				IL_041a: ldc.r8 1
-				IL_0423: add
-				IL_0424: stloc.s 13
+				IL_03ed: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L199C11::.ctor()
+				IL_03f2: stloc.s 22
+				IL_03f4: ldloc.s 13
+				IL_03f6: ldc.r8 1
+				IL_03ff: add
+				IL_0400: stloc.s 13
 
-				IL_0426: br IL_02d4
+				IL_0402: br IL_02b0
 			// end loop
 
-			IL_042b: ldloc.s 9
+			IL_0407: ldloc.s 9
+			IL_0409: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_040e: stloc.s 24
+			IL_0410: ldstr "Could not find a matching closing </"
+			IL_0415: ldloc.s 24
+			IL_0417: call string [System.Runtime]System.String::Concat(string, string)
+			IL_041c: stloc.s 24
+			IL_041e: ldloc.s 24
+			IL_0420: ldstr "> for id '"
+			IL_0425: call string [System.Runtime]System.String::Concat(string, string)
+			IL_042a: stloc.s 24
+			IL_042c: ldarg.3
 			IL_042d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0432: stloc.s 24
-			IL_0434: ldstr "Could not find a matching closing </"
-			IL_0439: ldloc.s 24
-			IL_043b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0440: stloc.s 24
-			IL_0442: ldloc.s 24
-			IL_0444: ldstr "> for id '"
-			IL_0449: call string [System.Runtime]System.String::Concat(string, string)
-			IL_044e: stloc.s 24
-			IL_0450: ldarg.3
-			IL_0451: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0456: stloc.s 32
-			IL_0458: ldloc.s 24
-			IL_045a: ldloc.s 32
-			IL_045c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0461: stloc.s 32
-			IL_0463: ldloc.s 32
-			IL_0465: ldstr "'."
-			IL_046a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_046f: stloc.s 32
-			IL_0471: ldloc.s 32
-			IL_0473: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0478: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_047d: stloc.s 25
-			IL_047f: ldloc.s 25
-			IL_0481: stloc.s 23
-			IL_0483: ldloc.s 23
-			IL_0485: isinst [System.Runtime]System.Exception
-			IL_048a: dup
-			IL_048b: brtrue IL_0499
+			IL_0432: stloc.s 32
+			IL_0434: ldloc.s 24
+			IL_0436: ldloc.s 32
+			IL_0438: call string [System.Runtime]System.String::Concat(string, string)
+			IL_043d: stloc.s 32
+			IL_043f: ldloc.s 32
+			IL_0441: ldstr "'."
+			IL_0446: call string [System.Runtime]System.String::Concat(string, string)
+			IL_044b: stloc.s 32
+			IL_044d: ldloc.s 32
+			IL_044f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0454: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0459: stloc.s 25
+			IL_045b: ldloc.s 25
+			IL_045d: stloc.s 23
+			IL_045f: ldloc.s 23
+			IL_0461: isinst [System.Runtime]System.Exception
+			IL_0466: dup
+			IL_0467: brtrue IL_0475
 
-			IL_0490: pop
-			IL_0491: ldloc.s 23
-			IL_0493: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0498: throw
+			IL_046c: pop
+			IL_046d: ldloc.s 23
+			IL_046f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0474: throw
 
-			IL_0499: throw
+			IL_0475: throw
 
-			IL_049a: ldnull
-			IL_049b: ret
+			IL_0476: ldnull
+			IL_0477: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3660,7 +3495,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c39
+					// Method begins at RVA 0x49b5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3678,7 +3513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c30
+				// Method begins at RVA 0x49ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3706,9 +3541,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x3188
+			// Method begins at RVA 0x312c
 			// Header size: 12
-			// Code size: 536 (0x218)
+			// Code size: 523 (0x20b)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3719,8 +3554,8 @@
 				[5] object,
 				[6] object,
 				[7] object,
-				[8] object,
-				[9] object[],
+				[8] object[],
+				[9] object,
 				[10] string,
 				[11] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[12] bool,
@@ -3733,200 +3568,195 @@
 				[19] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_0006: stloc.s 8
-			IL_0008: ldstr "escapeRegExp"
-			IL_000d: ldloc.s 8
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 8
-			IL_0016: ldc.i4.1
-			IL_0017: newarr [System.Runtime]System.Object
-			IL_001c: dup
-			IL_001d: ldc.i4.0
-			IL_001e: ldarg.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.s 9
-			IL_0022: ldloc.s 8
-			IL_0024: ldloc.s 9
-			IL_0026: ldarg.3
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_002c: stloc.s 8
-			IL_002e: ldloc.s 8
-			IL_0030: stloc.0
-			IL_0031: ldloc.0
-			IL_0032: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0037: stloc.s 10
-			IL_0039: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
-			IL_003e: ldloc.s 10
-			IL_0040: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0045: stloc.s 10
-			IL_0047: ldloc.s 10
-			IL_0049: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
-			IL_004e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0053: stloc.s 10
-			IL_0055: ldloc.s 10
-			IL_0057: ldstr "i"
-			IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0061: stloc.s 11
-			IL_0063: ldloc.s 11
-			IL_0065: stloc.1
-			IL_0066: ldloc.1
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006c: stloc.s 8
-			IL_006e: ldloc.s 8
-			IL_0070: ldstr "exec"
-			IL_0075: ldarg.2
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_007b: stloc.s 8
-			IL_007d: ldloc.s 8
-			IL_007f: stloc.2
-			IL_0080: ldloc.2
-			IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0086: stloc.s 12
-			IL_0088: ldloc.s 12
-			IL_008a: brfalse IL_00d3
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 8
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_0012: ldloc.s 8
+			IL_0014: ldarg.3
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_001a: stloc.s 9
+			IL_001c: ldloc.s 9
+			IL_001e: stloc.0
+			IL_001f: ldloc.0
+			IL_0020: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0025: stloc.s 10
+			IL_0027: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_002c: ldloc.s 10
+			IL_002e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0033: stloc.s 10
+			IL_0035: ldloc.s 10
+			IL_0037: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
+			IL_003c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0041: stloc.s 10
+			IL_0043: ldloc.s 10
+			IL_0045: ldstr "i"
+			IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_004f: stloc.s 11
+			IL_0051: ldloc.s 11
+			IL_0053: stloc.1
+			IL_0054: ldloc.1
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005a: stloc.s 9
+			IL_005c: ldloc.s 9
+			IL_005e: ldstr "exec"
+			IL_0063: ldarg.2
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0069: stloc.s 9
+			IL_006b: ldloc.s 9
+			IL_006d: stloc.2
+			IL_006e: ldloc.2
+			IL_006f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0074: stloc.s 12
+			IL_0076: ldloc.s 12
+			IL_0078: brfalse IL_00c1
 
-			IL_008f: ldloc.2
-			IL_0090: ldc.r8 1
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_009e: stloc.s 8
-			IL_00a0: ldloc.s 8
-			IL_00a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00a7: stloc.s 12
-			IL_00a9: ldloc.s 12
-			IL_00ab: brtrue IL_00c6
+			IL_007d: ldloc.2
+			IL_007e: ldc.r8 1
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_008c: stloc.s 9
+			IL_008e: ldloc.s 9
+			IL_0090: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0095: stloc.s 12
+			IL_0097: ldloc.s 12
+			IL_0099: brtrue IL_00b4
 
-			IL_00b0: ldloc.2
-			IL_00b1: ldc.r8 2
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00bf: stloc.s 14
-			IL_00c1: br IL_00ca
+			IL_009e: ldloc.2
+			IL_009f: ldc.r8 2
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00ad: stloc.s 14
+			IL_00af: br IL_00b8
 
-			IL_00c6: ldloc.s 8
-			IL_00c8: stloc.s 14
+			IL_00b4: ldloc.s 9
+			IL_00b6: stloc.s 14
 
-			IL_00ca: ldloc.s 14
-			IL_00cc: stloc.s 15
-			IL_00ce: br IL_00d6
+			IL_00b8: ldloc.s 14
+			IL_00ba: stloc.s 15
+			IL_00bc: br IL_00c4
 
-			IL_00d3: ldloc.2
-			IL_00d4: stloc.s 15
+			IL_00c1: ldloc.2
+			IL_00c2: stloc.s 15
 
-			IL_00d6: ldloc.s 15
-			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00dd: stloc.s 12
-			IL_00df: ldloc.s 12
-			IL_00e1: brtrue IL_00f2
+			IL_00c4: ldloc.s 15
+			IL_00c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00cb: stloc.s 12
+			IL_00cd: ldloc.s 12
+			IL_00cf: brtrue IL_00e0
 
-			IL_00e6: ldstr ""
-			IL_00eb: stloc.s 15
-			IL_00ed: br IL_00f2
+			IL_00d4: ldstr ""
+			IL_00d9: stloc.s 15
+			IL_00db: br IL_00e0
 
-			IL_00f2: ldloc.s 15
-			IL_00f4: stloc.3
-			IL_00f5: ldloc.3
-			IL_00f6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00fb: ldc.i4.0
-			IL_00fc: ceq
-			IL_00fe: stloc.s 12
-			IL_0100: ldloc.s 12
-			IL_0102: brfalse IL_0115
+			IL_00e0: ldloc.s 15
+			IL_00e2: stloc.3
+			IL_00e3: ldloc.3
+			IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00e9: ldc.i4.0
+			IL_00ea: ceq
+			IL_00ec: stloc.s 12
+			IL_00ee: ldloc.s 12
+			IL_00f0: brfalse IL_0103
 
-			IL_0107: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/Scope/Block_L215C13::.ctor()
-			IL_010c: stloc.s 4
-			IL_010e: ldc.i4.0
-			IL_010f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0114: ret
+			IL_00f5: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/Scope/Block_L215C13::.ctor()
+			IL_00fa: stloc.s 4
+			IL_00fc: ldc.i4.0
+			IL_00fd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0102: ret
 
-			IL_0115: ldloc.3
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011b: stloc.s 8
-			IL_011d: ldloc.s 8
-			IL_011f: ldstr "indexOf"
-			IL_0124: ldstr "#"
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_012e: stloc.s 8
-			IL_0130: ldloc.s 8
-			IL_0132: stloc.s 5
-			IL_0134: ldloc.s 5
-			IL_0136: stloc.s 8
-			IL_0138: ldloc.s 8
-			IL_013a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_013f: stloc.s 17
-			IL_0141: ldloc.s 17
-			IL_0143: ldc.r8 0.0
-			IL_014c: clt
-			IL_014e: ldc.i4.0
-			IL_014f: ceq
-			IL_0151: brfalse IL_0185
+			IL_0103: ldloc.3
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0109: stloc.s 9
+			IL_010b: ldloc.s 9
+			IL_010d: castclass [System.Runtime]System.String
+			IL_0112: ldstr "#"
+			IL_0117: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_011c: stloc.s 17
+			IL_011e: ldloc.s 17
+			IL_0120: box [System.Runtime]System.Double
+			IL_0125: stloc.s 5
+			IL_0127: ldloc.s 5
+			IL_0129: stloc.s 9
+			IL_012b: ldloc.s 9
+			IL_012d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0132: stloc.s 17
+			IL_0134: ldloc.s 17
+			IL_0136: ldc.r8 0.0
+			IL_013f: clt
+			IL_0141: ldc.i4.0
+			IL_0142: ceq
+			IL_0144: brfalse IL_0178
 
-			IL_0156: ldloc.3
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_015c: stloc.s 8
-			IL_015e: ldloc.s 8
-			IL_0160: ldstr "substring"
-			IL_0165: ldc.r8 0.0
-			IL_016e: box [System.Runtime]System.Double
-			IL_0173: ldloc.s 5
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_017a: stloc.s 8
-			IL_017c: ldloc.s 8
-			IL_017e: stloc.s 6
-			IL_0180: br IL_0188
+			IL_0149: ldloc.3
+			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014f: stloc.s 9
+			IL_0151: ldloc.s 9
+			IL_0153: castclass [System.Runtime]System.String
+			IL_0158: ldc.r8 0.0
+			IL_0161: box [System.Runtime]System.Double
+			IL_0166: ldloc.s 5
+			IL_0168: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_016d: stloc.s 10
+			IL_016f: ldloc.s 10
+			IL_0171: stloc.s 6
+			IL_0173: br IL_017b
 
-			IL_0185: ldloc.3
-			IL_0186: stloc.s 6
+			IL_0178: ldloc.3
+			IL_0179: stloc.s 6
 
-			IL_0188: ldloc.s 5
-			IL_018a: stloc.s 8
-			IL_018c: ldloc.s 8
-			IL_018e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0193: stloc.s 17
-			IL_0195: ldloc.s 17
-			IL_0197: ldc.r8 0.0
-			IL_01a0: clt
-			IL_01a2: ldc.i4.0
-			IL_01a3: ceq
-			IL_01a5: brfalse IL_01e1
+			IL_017b: ldloc.s 5
+			IL_017d: stloc.s 9
+			IL_017f: ldloc.s 9
+			IL_0181: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0186: stloc.s 17
+			IL_0188: ldloc.s 17
+			IL_018a: ldc.r8 0.0
+			IL_0193: clt
+			IL_0195: ldc.i4.0
+			IL_0196: ceq
+			IL_0198: brfalse IL_01d4
 
-			IL_01aa: ldloc.3
-			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b0: stloc.s 8
-			IL_01b2: ldloc.s 5
-			IL_01b4: stloc.s 18
-			IL_01b6: ldloc.s 18
-			IL_01b8: ldc.r8 1
-			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_01c6: stloc.s 15
-			IL_01c8: ldloc.s 8
-			IL_01ca: ldstr "substring"
-			IL_01cf: ldloc.s 15
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01d6: stloc.s 8
-			IL_01d8: ldloc.s 8
-			IL_01da: stloc.s 7
-			IL_01dc: br IL_01e8
+			IL_019d: ldloc.3
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a3: stloc.s 9
+			IL_01a5: ldloc.s 5
+			IL_01a7: stloc.s 18
+			IL_01a9: ldloc.s 18
+			IL_01ab: ldc.r8 1
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01b9: stloc.s 15
+			IL_01bb: ldloc.s 9
+			IL_01bd: castclass [System.Runtime]System.String
+			IL_01c2: ldloc.s 15
+			IL_01c4: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_01c9: stloc.s 10
+			IL_01cb: ldloc.s 10
+			IL_01cd: stloc.s 7
+			IL_01cf: br IL_01db
 
-			IL_01e1: ldstr ""
-			IL_01e6: stloc.s 7
+			IL_01d4: ldstr ""
+			IL_01d9: stloc.s 7
 
-			IL_01e8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01ed: dup
-			IL_01ee: ldstr "href"
-			IL_01f3: ldloc.3
+			IL_01db: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01e0: dup
+			IL_01e1: ldstr "href"
+			IL_01e6: ldloc.3
+			IL_01e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01ec: dup
+			IL_01ed: ldstr "filePart"
+			IL_01f2: ldloc.s 6
 			IL_01f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_01f9: dup
-			IL_01fa: ldstr "filePart"
-			IL_01ff: ldloc.s 6
+			IL_01fa: ldstr "fragment"
+			IL_01ff: ldloc.s 7
 			IL_0201: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0206: dup
-			IL_0207: ldstr "fragment"
-			IL_020c: ldloc.s 7
-			IL_020e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0213: stloc.s 19
-			IL_0215: ldloc.s 19
-			IL_0217: ret
+			IL_0206: stloc.s 19
+			IL_0208: ldloc.s 19
+			IL_020a: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -3942,7 +3772,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c42
+				// Method begins at RVA 0x49be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3968,7 +3798,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x33ac
+			// Method begins at RVA 0x3344
 			// Header size: 12
 			// Code size: 152 (0x98)
 			.maxstack 8
@@ -4075,7 +3905,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c54
+					// Method begins at RVA 0x49d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4095,7 +3925,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c5d
+					// Method begins at RVA 0x49d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4115,7 +3945,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c66
+					// Method begins at RVA 0x49e2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4139,7 +3969,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c78
+						// Method begins at RVA 0x49f4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4159,7 +3989,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c81
+						// Method begins at RVA 0x49fd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4177,7 +4007,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c6f
+					// Method begins at RVA 0x49eb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4197,7 +4027,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c8a
+					// Method begins at RVA 0x4a06
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4217,7 +4047,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c93
+					// Method begins at RVA 0x4a0f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4257,7 +4087,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c4b
+				// Method begins at RVA 0x49c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4281,9 +4111,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3450
+			// Method begins at RVA 0x33e8
 			// Header size: 12
-			// Code size: 3543 (0xdd7)
+			// Code size: 3333 (0xd05)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -4542,7 +4372,7 @@
 
 			IL_0186: ldloc.0
 			IL_0187: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_018c: switch (IL_01a1, IL_0597, IL_086a, IL_0a3b)
+			IL_018c: switch (IL_01a1, IL_0577, IL_081c, IL_09db)
 
 			IL_01a1: ldarg.0
 			IL_01a2: ldc.i4.1
@@ -4550,1363 +4380,1297 @@
 			IL_01a4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
 			IL_01a9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::parseArgs
 			IL_01ae: stloc.s 29
-			IL_01b0: ldstr "parseArgs"
-			IL_01b5: ldloc.s 29
-			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01bc: stloc.s 29
-			IL_01be: ldc.i4.1
-			IL_01bf: newarr [System.Runtime]System.Object
-			IL_01c4: dup
-			IL_01c5: ldc.i4.0
-			IL_01c6: ldarg.0
-			IL_01c7: ldc.i4.1
-			IL_01c8: ldelem.ref
-			IL_01c9: stelem.ref
-			IL_01ca: stloc.s 30
-			IL_01cc: ldstr "process"
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01b0: ldc.i4.1
+			IL_01b1: newarr [System.Runtime]System.Object
+			IL_01b6: dup
+			IL_01b7: ldc.i4.0
+			IL_01b8: ldarg.0
+			IL_01b9: ldc.i4.1
+			IL_01ba: ldelem.ref
+			IL_01bb: stelem.ref
+			IL_01bc: stloc.s 30
+			IL_01be: ldstr "process"
+			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01c8: stloc.s 31
+			IL_01ca: ldloc.s 31
+			IL_01cc: ldstr "argv"
+			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_01d6: stloc.s 31
-			IL_01d8: ldloc.s 31
-			IL_01da: ldstr "argv"
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01e4: stloc.s 31
-			IL_01e6: ldloc.s 29
-			IL_01e8: ldloc.s 30
-			IL_01ea: ldloc.s 31
-			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01f1: stloc.s 31
-			IL_01f3: ldloc.s 31
-			IL_01f5: stloc.1
-			IL_01f6: ldloc.1
-			IL_01f7: ldstr "section"
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0201: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0206: ldc.i4.0
-			IL_0207: ceq
-			IL_0209: stloc.s 32
-			IL_020b: ldloc.s 32
-			IL_020d: brfalse IL_025b
+			IL_01d8: ldloc.s 29
+			IL_01da: ldloc.s 30
+			IL_01dc: ldloc.s 31
+			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_01e3: stloc.s 31
+			IL_01e5: ldloc.s 31
+			IL_01e7: stloc.1
+			IL_01e8: ldloc.1
+			IL_01e9: ldstr "section"
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01f8: ldc.i4.0
+			IL_01f9: ceq
+			IL_01fb: stloc.s 32
+			IL_01fd: ldloc.s 32
+			IL_01ff: brfalse IL_024d
 
-			IL_0212: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L254C21::.ctor()
-			IL_0217: stloc.2
-			IL_0218: ldstr "Missing required --section (e.g. 27.3)."
-			IL_021d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0222: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0227: stloc.s 31
-			IL_0229: ldloc.s 31
-			IL_022b: stloc.3
-			IL_022c: ldloc.0
-			IL_022d: ldc.i4.m1
-			IL_022e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0233: ldloc.0
-			IL_0234: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0239: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_023e: ldarg.0
-			IL_023f: ldc.i4.1
-			IL_0240: newarr [System.Runtime]System.Object
-			IL_0245: dup
-			IL_0246: ldc.i4.0
-			IL_0247: ldloc.3
-			IL_0248: stelem.ref
-			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_024e: pop
-			IL_024f: ldloc.0
-			IL_0250: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0255: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_025a: ret
+			IL_0204: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L254C21::.ctor()
+			IL_0209: stloc.2
+			IL_020a: ldstr "Missing required --section (e.g. 27.3)."
+			IL_020f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0214: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0219: stloc.s 31
+			IL_021b: ldloc.s 31
+			IL_021d: stloc.3
+			IL_021e: ldloc.0
+			IL_021f: ldc.i4.m1
+			IL_0220: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0225: ldloc.0
+			IL_0226: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_022b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0230: ldarg.0
+			IL_0231: ldc.i4.1
+			IL_0232: newarr [System.Runtime]System.Object
+			IL_0237: dup
+			IL_0238: ldc.i4.0
+			IL_0239: ldloc.3
+			IL_023a: stelem.ref
+			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0240: pop
+			IL_0241: ldloc.0
+			IL_0242: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0247: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_024c: ret
 
-			IL_025b: ldloc.1
-			IL_025c: ldstr "outFile"
-			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0266: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_026b: ldc.i4.0
-			IL_026c: ceq
-			IL_026e: stloc.s 32
-			IL_0270: ldloc.s 32
-			IL_0272: brfalse IL_02c3
+			IL_024d: ldloc.1
+			IL_024e: ldstr "outFile"
+			IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0258: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_025d: ldc.i4.0
+			IL_025e: ceq
+			IL_0260: stloc.s 32
+			IL_0262: ldloc.s 32
+			IL_0264: brfalse IL_02b5
 
-			IL_0277: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L258C21::.ctor()
-			IL_027c: stloc.s 4
-			IL_027e: ldstr "Missing required --out <output.html>."
-			IL_0283: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0288: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_028d: stloc.s 31
-			IL_028f: ldloc.s 31
-			IL_0291: stloc.s 5
-			IL_0293: ldloc.0
-			IL_0294: ldc.i4.m1
-			IL_0295: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_029a: ldloc.0
-			IL_029b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_02a5: ldarg.0
-			IL_02a6: ldc.i4.1
-			IL_02a7: newarr [System.Runtime]System.Object
-			IL_02ac: dup
-			IL_02ad: ldc.i4.0
-			IL_02ae: ldloc.s 5
-			IL_02b0: stelem.ref
-			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02b6: pop
-			IL_02b7: ldloc.0
-			IL_02b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02bd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02c2: ret
+			IL_0269: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L258C21::.ctor()
+			IL_026e: stloc.s 4
+			IL_0270: ldstr "Missing required --out <output.html>."
+			IL_0275: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_027a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_027f: stloc.s 31
+			IL_0281: ldloc.s 31
+			IL_0283: stloc.s 5
+			IL_0285: ldloc.0
+			IL_0286: ldc.i4.m1
+			IL_0287: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_028c: ldloc.0
+			IL_028d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0292: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0297: ldarg.0
+			IL_0298: ldc.i4.1
+			IL_0299: newarr [System.Runtime]System.Object
+			IL_029e: dup
+			IL_029f: ldc.i4.0
+			IL_02a0: ldloc.s 5
+			IL_02a2: stelem.ref
+			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02a8: pop
+			IL_02a9: ldloc.0
+			IL_02aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02af: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02b4: ret
 
-			IL_02c3: ldloc.1
-			IL_02c4: ldstr "url"
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02d3: stloc.s 32
-			IL_02d5: ldloc.s 32
-			IL_02d7: brfalse IL_02f1
+			IL_02b5: ldloc.1
+			IL_02b6: ldstr "url"
+			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02c5: stloc.s 32
+			IL_02c7: ldloc.s 32
+			IL_02c9: brfalse IL_02e3
 
-			IL_02dc: ldc.r8 1
-			IL_02e5: box [System.Runtime]System.Double
-			IL_02ea: stloc.s 6
-			IL_02ec: br IL_0301
+			IL_02ce: ldc.r8 1
+			IL_02d7: box [System.Runtime]System.Double
+			IL_02dc: stloc.s 6
+			IL_02de: br IL_02f3
 
-			IL_02f1: ldc.r8 0.0
-			IL_02fa: box [System.Runtime]System.Double
-			IL_02ff: stloc.s 6
+			IL_02e3: ldc.r8 0.0
+			IL_02ec: box [System.Runtime]System.Double
+			IL_02f1: stloc.s 6
 
-			IL_0301: ldloc.s 6
-			IL_0303: stloc.s 33
-			IL_0305: ldloc.1
-			IL_0306: ldstr "auto"
-			IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0310: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0315: stloc.s 32
-			IL_0317: ldloc.s 32
-			IL_0319: brfalse IL_0333
+			IL_02f3: ldloc.s 6
+			IL_02f5: stloc.s 33
+			IL_02f7: ldloc.1
+			IL_02f8: ldstr "auto"
+			IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0302: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0307: stloc.s 32
+			IL_0309: ldloc.s 32
+			IL_030b: brfalse IL_0325
 
-			IL_031e: ldc.r8 1
-			IL_0327: box [System.Runtime]System.Double
-			IL_032c: stloc.s 7
-			IL_032e: br IL_0343
+			IL_0310: ldc.r8 1
+			IL_0319: box [System.Runtime]System.Double
+			IL_031e: stloc.s 7
+			IL_0320: br IL_0335
 
-			IL_0333: ldc.r8 0.0
-			IL_033c: box [System.Runtime]System.Double
-			IL_0341: stloc.s 7
+			IL_0325: ldc.r8 0.0
+			IL_032e: box [System.Runtime]System.Double
+			IL_0333: stloc.s 7
 
-			IL_0343: ldloc.s 33
-			IL_0345: ldloc.s 7
-			IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_034c: stloc.s 33
-			IL_034e: ldloc.s 33
-			IL_0350: stloc.s 8
-			IL_0352: ldloc.s 8
-			IL_0354: stloc.s 33
-			IL_0356: ldloc.s 33
-			IL_0358: ldc.r8 1
-			IL_0361: box [System.Runtime]System.Double
-			IL_0366: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_036b: stloc.s 32
-			IL_036d: ldloc.s 32
-			IL_036f: brfalse IL_03c0
+			IL_0335: ldloc.s 33
+			IL_0337: ldloc.s 7
+			IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_033e: stloc.s 33
+			IL_0340: ldloc.s 33
+			IL_0342: stloc.s 8
+			IL_0344: ldloc.s 8
+			IL_0346: stloc.s 33
+			IL_0348: ldloc.s 33
+			IL_034a: ldc.r8 1
+			IL_0353: box [System.Runtime]System.Double
+			IL_0358: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_035d: stloc.s 32
+			IL_035f: ldloc.s 32
+			IL_0361: brfalse IL_03b2
 
-			IL_0374: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L263C28::.ctor()
-			IL_0379: stloc.s 9
-			IL_037b: ldstr "Provide exactly one input mode: --url or --auto."
-			IL_0380: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0385: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_038a: stloc.s 31
-			IL_038c: ldloc.s 31
-			IL_038e: stloc.s 10
-			IL_0390: ldloc.0
-			IL_0391: ldc.i4.m1
-			IL_0392: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0397: ldloc.0
-			IL_0398: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_039d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_03a2: ldarg.0
-			IL_03a3: ldc.i4.1
-			IL_03a4: newarr [System.Runtime]System.Object
-			IL_03a9: dup
-			IL_03aa: ldc.i4.0
-			IL_03ab: ldloc.s 10
-			IL_03ad: stelem.ref
-			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03b3: pop
-			IL_03b4: ldloc.0
-			IL_03b5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03ba: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03bf: ret
+			IL_0366: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L263C28::.ctor()
+			IL_036b: stloc.s 9
+			IL_036d: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_0372: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0377: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_037c: stloc.s 31
+			IL_037e: ldloc.s 31
+			IL_0380: stloc.s 10
+			IL_0382: ldloc.0
+			IL_0383: ldc.i4.m1
+			IL_0384: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0389: ldloc.0
+			IL_038a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_038f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0394: ldarg.0
+			IL_0395: ldc.i4.1
+			IL_0396: newarr [System.Runtime]System.Object
+			IL_039b: dup
+			IL_039c: ldc.i4.0
+			IL_039d: ldloc.s 10
+			IL_039f: stelem.ref
+			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03a5: pop
+			IL_03a6: ldloc.0
+			IL_03a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03ac: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03b1: ret
 
-			IL_03c0: ldnull
-			IL_03c1: stloc.s 11
-			IL_03c3: ldloc.1
-			IL_03c4: ldstr "id"
-			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ce: stloc.s 31
-			IL_03d0: ldloc.s 31
-			IL_03d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03d7: stloc.s 32
-			IL_03d9: ldloc.s 32
-			IL_03db: brtrue IL_03ec
+			IL_03b2: ldnull
+			IL_03b3: stloc.s 11
+			IL_03b5: ldloc.1
+			IL_03b6: ldstr "id"
+			IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c0: stloc.s 31
+			IL_03c2: ldloc.s 31
+			IL_03c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03c9: stloc.s 32
+			IL_03cb: ldloc.s 32
+			IL_03cd: brtrue IL_03de
 
-			IL_03e0: ldstr ""
-			IL_03e5: stloc.s 34
-			IL_03e7: br IL_03f0
+			IL_03d2: ldstr ""
+			IL_03d7: stloc.s 34
+			IL_03d9: br IL_03e2
 
-			IL_03ec: ldloc.s 31
-			IL_03ee: stloc.s 34
+			IL_03de: ldloc.s 31
+			IL_03e0: stloc.s 34
 
-			IL_03f0: ldloc.s 34
-			IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03f7: stloc.s 31
-			IL_03f9: ldloc.s 31
-			IL_03fb: ldstr "trim"
-			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0405: stloc.s 31
-			IL_0407: ldloc.s 31
-			IL_0409: stloc.s 12
-			IL_040b: ldstr ""
-			IL_0410: stloc.s 13
-			IL_0412: ldloc.1
-			IL_0413: ldstr "auto"
-			IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_041d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0422: stloc.s 32
-			IL_0424: ldloc.s 32
-			IL_0426: brfalse IL_08cf
+			IL_03e2: ldloc.s 34
+			IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03e9: stloc.s 31
+			IL_03eb: ldloc.s 31
+			IL_03ed: castclass [System.Runtime]System.String
+			IL_03f2: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_03f7: stloc.s 35
+			IL_03f9: ldloc.s 35
+			IL_03fb: stloc.s 12
+			IL_03fd: ldstr ""
+			IL_0402: stloc.s 13
+			IL_0404: ldloc.1
+			IL_0405: ldstr "auto"
+			IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_040f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0414: stloc.s 32
+			IL_0416: ldloc.s 32
+			IL_0418: brfalse IL_0881
 
-			IL_042b: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
-			IL_0430: stloc.s 14
-			IL_0432: ldloc.1
-			IL_0433: ldstr "indexUrl"
-			IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_041d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
+			IL_0422: stloc.s 14
+			IL_0424: ldloc.1
+			IL_0425: ldstr "indexUrl"
+			IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0434: stloc.s 31
+			IL_0436: ldloc.s 31
+			IL_0438: ldstr "trim"
+			IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_0442: stloc.s 31
 			IL_0444: ldloc.s 31
-			IL_0446: ldstr "trim"
-			IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0450: stloc.s 31
-			IL_0452: ldloc.s 31
-			IL_0454: stloc.s 15
-			IL_0456: ldarg.0
-			IL_0457: ldc.i4.1
-			IL_0458: ldelem.ref
-			IL_0459: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_045e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0463: stloc.s 31
-			IL_0465: ldstr "fetchText"
-			IL_046a: ldloc.s 31
-			IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0471: stloc.s 31
-			IL_0473: ldloc.s 31
+			IL_0446: stloc.s 15
+			IL_0448: ldarg.0
+			IL_0449: ldc.i4.1
+			IL_044a: ldelem.ref
+			IL_044b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0450: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_0455: ldc.i4.1
+			IL_0456: newarr [System.Runtime]System.Object
+			IL_045b: dup
+			IL_045c: ldc.i4.0
+			IL_045d: ldarg.0
+			IL_045e: ldc.i4.1
+			IL_045f: ldelem.ref
+			IL_0460: stelem.ref
+			IL_0461: ldloc.s 15
+			IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0468: stloc.s 31
+			IL_046a: ldloc.0
+			IL_046b: ldc.i4.1
+			IL_046c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0471: ldloc.0
+			IL_0472: ldloc.s 31
+			IL_0474: ldarg.0
 			IL_0475: ldc.i4.1
-			IL_0476: newarr [System.Runtime]System.Object
-			IL_047b: dup
-			IL_047c: ldc.i4.0
-			IL_047d: ldarg.0
-			IL_047e: ldc.i4.1
-			IL_047f: ldelem.ref
-			IL_0480: stelem.ref
-			IL_0481: ldloc.s 15
-			IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0488: stloc.s 31
-			IL_048a: ldloc.0
-			IL_048b: ldc.i4.1
-			IL_048c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0491: ldloc.0
-			IL_0492: ldloc.s 31
-			IL_0494: ldarg.0
-			IL_0495: ldc.i4.1
-			IL_0496: ldloc.0
-			IL_0497: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_049c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_04a1: ldloc.0
-			IL_04a2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0476: ldloc.0
+			IL_0477: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_047c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0481: ldloc.0
+			IL_0482: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0487: dup
+			IL_0488: ldc.i4.0
+			IL_0489: ldloc.1
+			IL_048a: stelem.ref
+			IL_048b: dup
+			IL_048c: ldc.i4.1
+			IL_048d: ldloc.2
+			IL_048e: stelem.ref
+			IL_048f: dup
+			IL_0490: ldc.i4.2
+			IL_0491: ldloc.3
+			IL_0492: stelem.ref
+			IL_0493: dup
+			IL_0494: ldc.i4.3
+			IL_0495: ldloc.s 4
+			IL_0497: stelem.ref
+			IL_0498: dup
+			IL_0499: ldc.i4.4
+			IL_049a: ldloc.s 5
+			IL_049c: stelem.ref
+			IL_049d: dup
+			IL_049e: ldc.i4.5
+			IL_049f: ldloc.s 6
+			IL_04a1: stelem.ref
+			IL_04a2: dup
+			IL_04a3: ldc.i4.6
+			IL_04a4: ldloc.s 7
+			IL_04a6: stelem.ref
 			IL_04a7: dup
-			IL_04a8: ldc.i4.0
-			IL_04a9: ldloc.1
-			IL_04aa: stelem.ref
-			IL_04ab: dup
-			IL_04ac: ldc.i4.1
-			IL_04ad: ldloc.2
-			IL_04ae: stelem.ref
-			IL_04af: dup
-			IL_04b0: ldc.i4.2
-			IL_04b1: ldloc.3
-			IL_04b2: stelem.ref
-			IL_04b3: dup
-			IL_04b4: ldc.i4.3
-			IL_04b5: ldloc.s 4
-			IL_04b7: stelem.ref
-			IL_04b8: dup
-			IL_04b9: ldc.i4.4
-			IL_04ba: ldloc.s 5
+			IL_04a8: ldc.i4.7
+			IL_04a9: ldloc.s 8
+			IL_04ab: stelem.ref
+			IL_04ac: dup
+			IL_04ad: ldc.i4.8
+			IL_04ae: ldloc.s 9
+			IL_04b0: stelem.ref
+			IL_04b1: dup
+			IL_04b2: ldc.i4.s 9
+			IL_04b4: ldloc.s 10
+			IL_04b6: stelem.ref
+			IL_04b7: dup
+			IL_04b8: ldc.i4.s 10
+			IL_04ba: ldloc.s 11
 			IL_04bc: stelem.ref
 			IL_04bd: dup
-			IL_04be: ldc.i4.5
-			IL_04bf: ldloc.s 6
-			IL_04c1: stelem.ref
-			IL_04c2: dup
-			IL_04c3: ldc.i4.6
-			IL_04c4: ldloc.s 7
-			IL_04c6: stelem.ref
-			IL_04c7: dup
-			IL_04c8: ldc.i4.7
-			IL_04c9: ldloc.s 8
-			IL_04cb: stelem.ref
-			IL_04cc: dup
-			IL_04cd: ldc.i4.8
-			IL_04ce: ldloc.s 9
-			IL_04d0: stelem.ref
-			IL_04d1: dup
-			IL_04d2: ldc.i4.s 9
-			IL_04d4: ldloc.s 10
-			IL_04d6: stelem.ref
-			IL_04d7: dup
-			IL_04d8: ldc.i4.s 10
-			IL_04da: ldloc.s 11
-			IL_04dc: stelem.ref
-			IL_04dd: dup
-			IL_04de: ldc.i4.s 11
-			IL_04e0: ldloc.s 12
-			IL_04e2: stelem.ref
-			IL_04e3: dup
-			IL_04e4: ldc.i4.s 12
-			IL_04e6: ldloc.s 13
-			IL_04e8: stelem.ref
-			IL_04e9: dup
-			IL_04ea: ldc.i4.s 13
-			IL_04ec: ldloc.s 14
-			IL_04ee: stelem.ref
-			IL_04ef: dup
-			IL_04f0: ldc.i4.s 14
-			IL_04f2: ldloc.s 15
-			IL_04f4: stelem.ref
-			IL_04f5: dup
-			IL_04f6: ldc.i4.s 15
-			IL_04f8: ldloc.s 16
-			IL_04fa: stelem.ref
-			IL_04fb: dup
-			IL_04fc: ldc.i4.s 16
-			IL_04fe: ldloc.s 17
-			IL_0500: stelem.ref
-			IL_0501: dup
-			IL_0502: ldc.i4.s 17
-			IL_0504: ldloc.s 18
-			IL_0506: stelem.ref
-			IL_0507: dup
-			IL_0508: ldc.i4.s 18
-			IL_050a: ldloc.s 19
-			IL_050c: stelem.ref
-			IL_050d: dup
-			IL_050e: ldc.i4.s 19
-			IL_0510: ldloc.s 20
-			IL_0512: stelem.ref
-			IL_0513: dup
-			IL_0514: ldc.i4.s 20
-			IL_0516: ldloc.s 21
-			IL_0518: stelem.ref
-			IL_0519: dup
-			IL_051a: ldc.i4.s 21
-			IL_051c: ldloc.s 22
-			IL_051e: stelem.ref
-			IL_051f: dup
-			IL_0520: ldc.i4.s 22
-			IL_0522: ldloc.s 23
-			IL_0524: stelem.ref
-			IL_0525: dup
-			IL_0526: ldc.i4.s 23
-			IL_0528: ldloc.s 24
-			IL_052a: stelem.ref
-			IL_052b: dup
-			IL_052c: ldc.i4.s 24
-			IL_052e: ldloc.s 25
-			IL_0530: stelem.ref
-			IL_0531: dup
-			IL_0532: ldc.i4.s 25
-			IL_0534: ldloc.s 26
-			IL_0536: stelem.ref
-			IL_0537: dup
-			IL_0538: ldc.i4.s 26
-			IL_053a: ldloc.s 27
-			IL_053c: stelem.ref
-			IL_053d: dup
-			IL_053e: ldc.i4.s 27
-			IL_0540: ldloc.s 28
-			IL_0542: stelem.ref
-			IL_0543: dup
-			IL_0544: ldc.i4.s 28
-			IL_0546: ldloc.s 29
-			IL_0548: stelem.ref
-			IL_0549: dup
-			IL_054a: ldc.i4.s 29
-			IL_054c: ldloc.s 30
-			IL_054e: stelem.ref
-			IL_054f: dup
-			IL_0550: ldc.i4.s 30
-			IL_0552: ldloc.s 31
-			IL_0554: stelem.ref
-			IL_0555: dup
-			IL_0556: ldc.i4.s 31
-			IL_0558: ldloc.s 32
-			IL_055a: box [System.Runtime]System.Boolean
-			IL_055f: stelem.ref
-			IL_0560: dup
-			IL_0561: ldc.i4.s 32
-			IL_0563: ldloc.s 33
-			IL_0565: stelem.ref
-			IL_0566: dup
-			IL_0567: ldc.i4.s 33
-			IL_0569: ldloc.s 34
-			IL_056b: stelem.ref
-			IL_056c: dup
-			IL_056d: ldc.i4.s 34
-			IL_056f: ldloc.s 35
-			IL_0571: stelem.ref
-			IL_0572: dup
-			IL_0573: ldc.i4.s 35
-			IL_0575: ldloc.s 36
-			IL_0577: stelem.ref
-			IL_0578: dup
-			IL_0579: ldc.i4.s 36
-			IL_057b: ldloc.s 37
-			IL_057d: stelem.ref
-			IL_057e: dup
-			IL_057f: ldc.i4.s 37
-			IL_0581: ldloc.s 38
-			IL_0583: stelem.ref
-			IL_0584: dup
-			IL_0585: ldc.i4.s 38
-			IL_0587: ldloc.s 39
-			IL_0589: stelem.ref
-			IL_058a: pop
-			IL_058b: ldloc.0
-			IL_058c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0591: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0596: ret
+			IL_04be: ldc.i4.s 11
+			IL_04c0: ldloc.s 12
+			IL_04c2: stelem.ref
+			IL_04c3: dup
+			IL_04c4: ldc.i4.s 12
+			IL_04c6: ldloc.s 13
+			IL_04c8: stelem.ref
+			IL_04c9: dup
+			IL_04ca: ldc.i4.s 13
+			IL_04cc: ldloc.s 14
+			IL_04ce: stelem.ref
+			IL_04cf: dup
+			IL_04d0: ldc.i4.s 14
+			IL_04d2: ldloc.s 15
+			IL_04d4: stelem.ref
+			IL_04d5: dup
+			IL_04d6: ldc.i4.s 15
+			IL_04d8: ldloc.s 16
+			IL_04da: stelem.ref
+			IL_04db: dup
+			IL_04dc: ldc.i4.s 16
+			IL_04de: ldloc.s 17
+			IL_04e0: stelem.ref
+			IL_04e1: dup
+			IL_04e2: ldc.i4.s 17
+			IL_04e4: ldloc.s 18
+			IL_04e6: stelem.ref
+			IL_04e7: dup
+			IL_04e8: ldc.i4.s 18
+			IL_04ea: ldloc.s 19
+			IL_04ec: stelem.ref
+			IL_04ed: dup
+			IL_04ee: ldc.i4.s 19
+			IL_04f0: ldloc.s 20
+			IL_04f2: stelem.ref
+			IL_04f3: dup
+			IL_04f4: ldc.i4.s 20
+			IL_04f6: ldloc.s 21
+			IL_04f8: stelem.ref
+			IL_04f9: dup
+			IL_04fa: ldc.i4.s 21
+			IL_04fc: ldloc.s 22
+			IL_04fe: stelem.ref
+			IL_04ff: dup
+			IL_0500: ldc.i4.s 22
+			IL_0502: ldloc.s 23
+			IL_0504: stelem.ref
+			IL_0505: dup
+			IL_0506: ldc.i4.s 23
+			IL_0508: ldloc.s 24
+			IL_050a: stelem.ref
+			IL_050b: dup
+			IL_050c: ldc.i4.s 24
+			IL_050e: ldloc.s 25
+			IL_0510: stelem.ref
+			IL_0511: dup
+			IL_0512: ldc.i4.s 25
+			IL_0514: ldloc.s 26
+			IL_0516: stelem.ref
+			IL_0517: dup
+			IL_0518: ldc.i4.s 26
+			IL_051a: ldloc.s 27
+			IL_051c: stelem.ref
+			IL_051d: dup
+			IL_051e: ldc.i4.s 27
+			IL_0520: ldloc.s 28
+			IL_0522: stelem.ref
+			IL_0523: dup
+			IL_0524: ldc.i4.s 28
+			IL_0526: ldloc.s 29
+			IL_0528: stelem.ref
+			IL_0529: dup
+			IL_052a: ldc.i4.s 29
+			IL_052c: ldloc.s 30
+			IL_052e: stelem.ref
+			IL_052f: dup
+			IL_0530: ldc.i4.s 30
+			IL_0532: ldloc.s 31
+			IL_0534: stelem.ref
+			IL_0535: dup
+			IL_0536: ldc.i4.s 31
+			IL_0538: ldloc.s 32
+			IL_053a: box [System.Runtime]System.Boolean
+			IL_053f: stelem.ref
+			IL_0540: dup
+			IL_0541: ldc.i4.s 32
+			IL_0543: ldloc.s 33
+			IL_0545: stelem.ref
+			IL_0546: dup
+			IL_0547: ldc.i4.s 33
+			IL_0549: ldloc.s 34
+			IL_054b: stelem.ref
+			IL_054c: dup
+			IL_054d: ldc.i4.s 34
+			IL_054f: ldloc.s 35
+			IL_0551: stelem.ref
+			IL_0552: dup
+			IL_0553: ldc.i4.s 35
+			IL_0555: ldloc.s 36
+			IL_0557: stelem.ref
+			IL_0558: dup
+			IL_0559: ldc.i4.s 36
+			IL_055b: ldloc.s 37
+			IL_055d: stelem.ref
+			IL_055e: dup
+			IL_055f: ldc.i4.s 37
+			IL_0561: ldloc.s 38
+			IL_0563: stelem.ref
+			IL_0564: dup
+			IL_0565: ldc.i4.s 38
+			IL_0567: ldloc.s 39
+			IL_0569: stelem.ref
+			IL_056a: pop
+			IL_056b: ldloc.0
+			IL_056c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0571: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0576: ret
 
-			IL_0597: ldloc.0
-			IL_0598: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_059d: stloc.s 31
-			IL_059f: ldloc.s 31
-			IL_05a1: stloc.s 16
-			IL_05a3: ldarg.0
-			IL_05a4: ldc.i4.1
-			IL_05a5: ldelem.ref
-			IL_05a6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_05ab: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
-			IL_05b0: stloc.s 31
-			IL_05b2: ldstr "resolveSectionLinkFromMultipageIndexHtml"
-			IL_05b7: ldloc.s 31
-			IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_05be: stloc.s 31
-			IL_05c0: ldc.i4.1
-			IL_05c1: newarr [System.Runtime]System.Object
-			IL_05c6: dup
-			IL_05c7: ldc.i4.0
-			IL_05c8: ldarg.0
-			IL_05c9: ldc.i4.1
-			IL_05ca: ldelem.ref
-			IL_05cb: stelem.ref
-			IL_05cc: stloc.s 30
-			IL_05ce: ldloc.1
-			IL_05cf: ldstr "section"
-			IL_05d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05de: stloc.s 29
-			IL_05e0: ldloc.s 29
-			IL_05e2: ldstr "trim"
-			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_05ec: stloc.s 29
-			IL_05ee: ldloc.s 31
-			IL_05f0: ldloc.s 30
-			IL_05f2: ldloc.s 16
-			IL_05f4: ldloc.s 29
-			IL_05f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05fb: stloc.s 29
-			IL_05fd: ldloc.s 29
-			IL_05ff: stloc.s 17
-			IL_0601: ldloc.s 17
-			IL_0603: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0608: ldc.i4.0
-			IL_0609: ceq
-			IL_060b: stloc.s 32
-			IL_060d: ldloc.s 32
-			IL_060f: brfalse IL_069f
+			IL_0577: ldloc.0
+			IL_0578: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_057d: stloc.s 31
+			IL_057f: ldloc.s 31
+			IL_0581: stloc.s 16
+			IL_0583: ldarg.0
+			IL_0584: ldc.i4.1
+			IL_0585: ldelem.ref
+			IL_0586: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_058b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+			IL_0590: stloc.s 31
+			IL_0592: ldc.i4.1
+			IL_0593: newarr [System.Runtime]System.Object
+			IL_0598: dup
+			IL_0599: ldc.i4.0
+			IL_059a: ldarg.0
+			IL_059b: ldc.i4.1
+			IL_059c: ldelem.ref
+			IL_059d: stelem.ref
+			IL_059e: stloc.s 30
+			IL_05a0: ldloc.1
+			IL_05a1: ldstr "section"
+			IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05b0: stloc.s 29
+			IL_05b2: ldloc.s 29
+			IL_05b4: ldstr "trim"
+			IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_05be: stloc.s 29
+			IL_05c0: ldloc.s 31
+			IL_05c2: ldloc.s 30
+			IL_05c4: ldloc.s 16
+			IL_05c6: ldloc.s 29
+			IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05cd: stloc.s 29
+			IL_05cf: ldloc.s 29
+			IL_05d1: stloc.s 17
+			IL_05d3: ldloc.s 17
+			IL_05d5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05da: ldc.i4.0
+			IL_05db: ceq
+			IL_05dd: stloc.s 32
+			IL_05df: ldloc.s 32
+			IL_05e1: brfalse IL_0671
 
-			IL_0614: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L275C15::.ctor()
-			IL_0619: stloc.s 18
-			IL_061b: ldloc.1
-			IL_061c: ldstr "section"
-			IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0626: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_062b: stloc.s 35
-			IL_062d: ldstr "Could not find section '"
-			IL_0632: ldloc.s 35
-			IL_0634: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0639: stloc.s 35
-			IL_063b: ldloc.s 35
-			IL_063d: ldstr "' in multipage index: "
-			IL_0642: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0647: stloc.s 35
-			IL_0649: ldloc.s 15
-			IL_064b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0650: stloc.s 36
-			IL_0652: ldloc.s 35
-			IL_0654: ldloc.s 36
-			IL_0656: call string [System.Runtime]System.String::Concat(string, string)
-			IL_065b: stloc.s 36
-			IL_065d: ldloc.s 36
-			IL_065f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0664: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0669: stloc.s 29
-			IL_066b: ldloc.s 29
-			IL_066d: stloc.s 19
-			IL_066f: ldloc.0
-			IL_0670: ldc.i4.m1
-			IL_0671: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0676: ldloc.0
-			IL_0677: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_067c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0681: ldarg.0
-			IL_0682: ldc.i4.1
-			IL_0683: newarr [System.Runtime]System.Object
-			IL_0688: dup
-			IL_0689: ldc.i4.0
-			IL_068a: ldloc.s 19
-			IL_068c: stelem.ref
-			IL_068d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0692: pop
-			IL_0693: ldloc.0
-			IL_0694: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0699: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_069e: ret
+			IL_05e6: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L275C15::.ctor()
+			IL_05eb: stloc.s 18
+			IL_05ed: ldloc.1
+			IL_05ee: ldstr "section"
+			IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05f8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05fd: stloc.s 35
+			IL_05ff: ldstr "Could not find section '"
+			IL_0604: ldloc.s 35
+			IL_0606: call string [System.Runtime]System.String::Concat(string, string)
+			IL_060b: stloc.s 35
+			IL_060d: ldloc.s 35
+			IL_060f: ldstr "' in multipage index: "
+			IL_0614: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0619: stloc.s 35
+			IL_061b: ldloc.s 15
+			IL_061d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0622: stloc.s 36
+			IL_0624: ldloc.s 35
+			IL_0626: ldloc.s 36
+			IL_0628: call string [System.Runtime]System.String::Concat(string, string)
+			IL_062d: stloc.s 36
+			IL_062f: ldloc.s 36
+			IL_0631: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0636: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_063b: stloc.s 29
+			IL_063d: ldloc.s 29
+			IL_063f: stloc.s 19
+			IL_0641: ldloc.0
+			IL_0642: ldc.i4.m1
+			IL_0643: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0648: ldloc.0
+			IL_0649: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_064e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0653: ldarg.0
+			IL_0654: ldc.i4.1
+			IL_0655: newarr [System.Runtime]System.Object
+			IL_065a: dup
+			IL_065b: ldc.i4.0
+			IL_065c: ldloc.s 19
+			IL_065e: stelem.ref
+			IL_065f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0664: pop
+			IL_0665: ldloc.0
+			IL_0666: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_066b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0670: ret
 
-			IL_069f: ldarg.0
-			IL_06a0: ldc.i4.1
-			IL_06a1: ldelem.ref
-			IL_06a2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_06a7: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_06ac: stloc.s 29
-			IL_06ae: ldstr "NodeUrl"
-			IL_06b3: ldloc.s 29
-			IL_06b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06ba: stloc.s 29
-			IL_06bc: ldloc.s 17
-			IL_06be: ldstr "filePart"
-			IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06c8: stloc.s 31
-			IL_06ca: ldloc.s 31
-			IL_06cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_06d1: stloc.s 32
-			IL_06d3: ldloc.s 32
-			IL_06d5: brtrue IL_06ed
+			IL_0671: ldarg.0
+			IL_0672: ldc.i4.1
+			IL_0673: ldelem.ref
+			IL_0674: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0679: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_067e: stloc.s 29
+			IL_0680: ldloc.s 17
+			IL_0682: ldstr "filePart"
+			IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_068c: stloc.s 31
+			IL_068e: ldloc.s 31
+			IL_0690: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0695: stloc.s 32
+			IL_0697: ldloc.s 32
+			IL_0699: brtrue IL_06b1
 
-			IL_06da: ldloc.s 17
-			IL_06dc: ldstr "href"
-			IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06e6: stloc.s 37
-			IL_06e8: br IL_06f1
+			IL_069e: ldloc.s 17
+			IL_06a0: ldstr "href"
+			IL_06a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06aa: stloc.s 37
+			IL_06ac: br IL_06b5
 
-			IL_06ed: ldloc.s 31
-			IL_06ef: stloc.s 37
+			IL_06b1: ldloc.s 31
+			IL_06b3: stloc.s 37
 
-			IL_06f1: ldc.i4.2
-			IL_06f2: newarr [System.Runtime]System.Object
-			IL_06f7: dup
-			IL_06f8: ldc.i4.0
-			IL_06f9: ldloc.s 37
-			IL_06fb: stelem.ref
-			IL_06fc: dup
-			IL_06fd: ldc.i4.1
-			IL_06fe: ldloc.s 15
-			IL_0700: stelem.ref
-			IL_0701: stloc.s 30
-			IL_0703: ldloc.s 29
-			IL_0705: ldloc.s 30
-			IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_070c: stloc.s 29
-			IL_070e: ldloc.s 29
-			IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0715: stloc.s 29
+			IL_06b5: ldc.i4.2
+			IL_06b6: newarr [System.Runtime]System.Object
+			IL_06bb: dup
+			IL_06bc: ldc.i4.0
+			IL_06bd: ldloc.s 37
+			IL_06bf: stelem.ref
+			IL_06c0: dup
+			IL_06c1: ldc.i4.1
+			IL_06c2: ldloc.s 15
+			IL_06c4: stelem.ref
+			IL_06c5: stloc.s 30
+			IL_06c7: ldloc.s 29
+			IL_06c9: ldloc.s 30
+			IL_06cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_06d0: stloc.s 29
+			IL_06d2: ldloc.s 29
+			IL_06d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06d9: stloc.s 29
+			IL_06db: ldloc.s 29
+			IL_06dd: ldstr "toString"
+			IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_06e7: stloc.s 29
+			IL_06e9: ldloc.s 29
+			IL_06eb: stloc.s 20
+			IL_06ed: ldarg.0
+			IL_06ee: ldc.i4.1
+			IL_06ef: ldelem.ref
+			IL_06f0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_06f5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_06fa: ldc.i4.1
+			IL_06fb: newarr [System.Runtime]System.Object
+			IL_0700: dup
+			IL_0701: ldc.i4.0
+			IL_0702: ldarg.0
+			IL_0703: ldc.i4.1
+			IL_0704: ldelem.ref
+			IL_0705: stelem.ref
+			IL_0706: ldloc.s 20
+			IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_070d: stloc.s 29
+			IL_070f: ldloc.0
+			IL_0710: ldc.i4.2
+			IL_0711: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0716: ldloc.0
 			IL_0717: ldloc.s 29
-			IL_0719: ldstr "toString"
-			IL_071e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0723: stloc.s 29
-			IL_0725: ldloc.s 29
-			IL_0727: stloc.s 20
-			IL_0729: ldarg.0
-			IL_072a: ldc.i4.1
-			IL_072b: ldelem.ref
-			IL_072c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0731: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0736: stloc.s 29
-			IL_0738: ldstr "fetchText"
-			IL_073d: ldloc.s 29
-			IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0744: stloc.s 29
-			IL_0746: ldloc.s 29
-			IL_0748: ldc.i4.1
-			IL_0749: newarr [System.Runtime]System.Object
-			IL_074e: dup
-			IL_074f: ldc.i4.0
-			IL_0750: ldarg.0
-			IL_0751: ldc.i4.1
-			IL_0752: ldelem.ref
-			IL_0753: stelem.ref
-			IL_0754: ldloc.s 20
-			IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_075b: stloc.s 29
-			IL_075d: ldloc.0
-			IL_075e: ldc.i4.2
-			IL_075f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0764: ldloc.0
-			IL_0765: ldloc.s 29
-			IL_0767: ldarg.0
-			IL_0768: ldc.i4.2
-			IL_0769: ldloc.0
-			IL_076a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_076f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0774: ldloc.0
-			IL_0775: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0719: ldarg.0
+			IL_071a: ldc.i4.2
+			IL_071b: ldloc.0
+			IL_071c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0721: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0726: ldloc.0
+			IL_0727: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_072c: dup
+			IL_072d: ldc.i4.0
+			IL_072e: ldloc.1
+			IL_072f: stelem.ref
+			IL_0730: dup
+			IL_0731: ldc.i4.1
+			IL_0732: ldloc.2
+			IL_0733: stelem.ref
+			IL_0734: dup
+			IL_0735: ldc.i4.2
+			IL_0736: ldloc.3
+			IL_0737: stelem.ref
+			IL_0738: dup
+			IL_0739: ldc.i4.3
+			IL_073a: ldloc.s 4
+			IL_073c: stelem.ref
+			IL_073d: dup
+			IL_073e: ldc.i4.4
+			IL_073f: ldloc.s 5
+			IL_0741: stelem.ref
+			IL_0742: dup
+			IL_0743: ldc.i4.5
+			IL_0744: ldloc.s 6
+			IL_0746: stelem.ref
+			IL_0747: dup
+			IL_0748: ldc.i4.6
+			IL_0749: ldloc.s 7
+			IL_074b: stelem.ref
+			IL_074c: dup
+			IL_074d: ldc.i4.7
+			IL_074e: ldloc.s 8
+			IL_0750: stelem.ref
+			IL_0751: dup
+			IL_0752: ldc.i4.8
+			IL_0753: ldloc.s 9
+			IL_0755: stelem.ref
+			IL_0756: dup
+			IL_0757: ldc.i4.s 9
+			IL_0759: ldloc.s 10
+			IL_075b: stelem.ref
+			IL_075c: dup
+			IL_075d: ldc.i4.s 10
+			IL_075f: ldloc.s 11
+			IL_0761: stelem.ref
+			IL_0762: dup
+			IL_0763: ldc.i4.s 11
+			IL_0765: ldloc.s 12
+			IL_0767: stelem.ref
+			IL_0768: dup
+			IL_0769: ldc.i4.s 12
+			IL_076b: ldloc.s 13
+			IL_076d: stelem.ref
+			IL_076e: dup
+			IL_076f: ldc.i4.s 13
+			IL_0771: ldloc.s 14
+			IL_0773: stelem.ref
+			IL_0774: dup
+			IL_0775: ldc.i4.s 14
+			IL_0777: ldloc.s 15
+			IL_0779: stelem.ref
 			IL_077a: dup
-			IL_077b: ldc.i4.0
-			IL_077c: ldloc.1
-			IL_077d: stelem.ref
-			IL_077e: dup
-			IL_077f: ldc.i4.1
-			IL_0780: ldloc.2
-			IL_0781: stelem.ref
-			IL_0782: dup
-			IL_0783: ldc.i4.2
-			IL_0784: ldloc.3
+			IL_077b: ldc.i4.s 15
+			IL_077d: ldloc.s 16
+			IL_077f: stelem.ref
+			IL_0780: dup
+			IL_0781: ldc.i4.s 16
+			IL_0783: ldloc.s 17
 			IL_0785: stelem.ref
 			IL_0786: dup
-			IL_0787: ldc.i4.3
-			IL_0788: ldloc.s 4
-			IL_078a: stelem.ref
-			IL_078b: dup
-			IL_078c: ldc.i4.4
-			IL_078d: ldloc.s 5
-			IL_078f: stelem.ref
-			IL_0790: dup
-			IL_0791: ldc.i4.5
-			IL_0792: ldloc.s 6
-			IL_0794: stelem.ref
-			IL_0795: dup
-			IL_0796: ldc.i4.6
-			IL_0797: ldloc.s 7
-			IL_0799: stelem.ref
-			IL_079a: dup
-			IL_079b: ldc.i4.7
-			IL_079c: ldloc.s 8
-			IL_079e: stelem.ref
-			IL_079f: dup
-			IL_07a0: ldc.i4.8
-			IL_07a1: ldloc.s 9
+			IL_0787: ldc.i4.s 17
+			IL_0789: ldloc.s 18
+			IL_078b: stelem.ref
+			IL_078c: dup
+			IL_078d: ldc.i4.s 18
+			IL_078f: ldloc.s 19
+			IL_0791: stelem.ref
+			IL_0792: dup
+			IL_0793: ldc.i4.s 19
+			IL_0795: ldloc.s 20
+			IL_0797: stelem.ref
+			IL_0798: dup
+			IL_0799: ldc.i4.s 20
+			IL_079b: ldloc.s 21
+			IL_079d: stelem.ref
+			IL_079e: dup
+			IL_079f: ldc.i4.s 21
+			IL_07a1: ldloc.s 22
 			IL_07a3: stelem.ref
 			IL_07a4: dup
-			IL_07a5: ldc.i4.s 9
-			IL_07a7: ldloc.s 10
+			IL_07a5: ldc.i4.s 22
+			IL_07a7: ldloc.s 23
 			IL_07a9: stelem.ref
 			IL_07aa: dup
-			IL_07ab: ldc.i4.s 10
-			IL_07ad: ldloc.s 11
+			IL_07ab: ldc.i4.s 23
+			IL_07ad: ldloc.s 24
 			IL_07af: stelem.ref
 			IL_07b0: dup
-			IL_07b1: ldc.i4.s 11
-			IL_07b3: ldloc.s 12
+			IL_07b1: ldc.i4.s 24
+			IL_07b3: ldloc.s 25
 			IL_07b5: stelem.ref
 			IL_07b6: dup
-			IL_07b7: ldc.i4.s 12
-			IL_07b9: ldloc.s 13
+			IL_07b7: ldc.i4.s 25
+			IL_07b9: ldloc.s 26
 			IL_07bb: stelem.ref
 			IL_07bc: dup
-			IL_07bd: ldc.i4.s 13
-			IL_07bf: ldloc.s 14
+			IL_07bd: ldc.i4.s 26
+			IL_07bf: ldloc.s 27
 			IL_07c1: stelem.ref
 			IL_07c2: dup
-			IL_07c3: ldc.i4.s 14
-			IL_07c5: ldloc.s 15
+			IL_07c3: ldc.i4.s 27
+			IL_07c5: ldloc.s 28
 			IL_07c7: stelem.ref
 			IL_07c8: dup
-			IL_07c9: ldc.i4.s 15
-			IL_07cb: ldloc.s 16
+			IL_07c9: ldc.i4.s 28
+			IL_07cb: ldloc.s 29
 			IL_07cd: stelem.ref
 			IL_07ce: dup
-			IL_07cf: ldc.i4.s 16
-			IL_07d1: ldloc.s 17
+			IL_07cf: ldc.i4.s 29
+			IL_07d1: ldloc.s 30
 			IL_07d3: stelem.ref
 			IL_07d4: dup
-			IL_07d5: ldc.i4.s 17
-			IL_07d7: ldloc.s 18
+			IL_07d5: ldc.i4.s 30
+			IL_07d7: ldloc.s 31
 			IL_07d9: stelem.ref
 			IL_07da: dup
-			IL_07db: ldc.i4.s 18
-			IL_07dd: ldloc.s 19
-			IL_07df: stelem.ref
-			IL_07e0: dup
-			IL_07e1: ldc.i4.s 19
-			IL_07e3: ldloc.s 20
-			IL_07e5: stelem.ref
-			IL_07e6: dup
-			IL_07e7: ldc.i4.s 20
-			IL_07e9: ldloc.s 21
-			IL_07eb: stelem.ref
-			IL_07ec: dup
-			IL_07ed: ldc.i4.s 21
-			IL_07ef: ldloc.s 22
-			IL_07f1: stelem.ref
-			IL_07f2: dup
-			IL_07f3: ldc.i4.s 22
-			IL_07f5: ldloc.s 23
-			IL_07f7: stelem.ref
-			IL_07f8: dup
-			IL_07f9: ldc.i4.s 23
-			IL_07fb: ldloc.s 24
-			IL_07fd: stelem.ref
-			IL_07fe: dup
-			IL_07ff: ldc.i4.s 24
-			IL_0801: ldloc.s 25
-			IL_0803: stelem.ref
-			IL_0804: dup
-			IL_0805: ldc.i4.s 25
-			IL_0807: ldloc.s 26
-			IL_0809: stelem.ref
-			IL_080a: dup
-			IL_080b: ldc.i4.s 26
-			IL_080d: ldloc.s 27
-			IL_080f: stelem.ref
-			IL_0810: dup
-			IL_0811: ldc.i4.s 27
-			IL_0813: ldloc.s 28
-			IL_0815: stelem.ref
-			IL_0816: dup
-			IL_0817: ldc.i4.s 28
-			IL_0819: ldloc.s 29
-			IL_081b: stelem.ref
-			IL_081c: dup
-			IL_081d: ldc.i4.s 29
-			IL_081f: ldloc.s 30
-			IL_0821: stelem.ref
-			IL_0822: dup
-			IL_0823: ldc.i4.s 30
-			IL_0825: ldloc.s 31
-			IL_0827: stelem.ref
-			IL_0828: dup
-			IL_0829: ldc.i4.s 31
-			IL_082b: ldloc.s 32
-			IL_082d: box [System.Runtime]System.Boolean
-			IL_0832: stelem.ref
-			IL_0833: dup
-			IL_0834: ldc.i4.s 32
-			IL_0836: ldloc.s 33
-			IL_0838: stelem.ref
-			IL_0839: dup
-			IL_083a: ldc.i4.s 33
-			IL_083c: ldloc.s 34
-			IL_083e: stelem.ref
-			IL_083f: dup
-			IL_0840: ldc.i4.s 34
-			IL_0842: ldloc.s 35
-			IL_0844: stelem.ref
-			IL_0845: dup
-			IL_0846: ldc.i4.s 35
-			IL_0848: ldloc.s 36
-			IL_084a: stelem.ref
-			IL_084b: dup
-			IL_084c: ldc.i4.s 36
-			IL_084e: ldloc.s 37
-			IL_0850: stelem.ref
-			IL_0851: dup
-			IL_0852: ldc.i4.s 37
-			IL_0854: ldloc.s 38
-			IL_0856: stelem.ref
-			IL_0857: dup
-			IL_0858: ldc.i4.s 38
-			IL_085a: ldloc.s 39
-			IL_085c: stelem.ref
-			IL_085d: pop
-			IL_085e: ldloc.0
-			IL_085f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0864: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0869: ret
+			IL_07db: ldc.i4.s 31
+			IL_07dd: ldloc.s 32
+			IL_07df: box [System.Runtime]System.Boolean
+			IL_07e4: stelem.ref
+			IL_07e5: dup
+			IL_07e6: ldc.i4.s 32
+			IL_07e8: ldloc.s 33
+			IL_07ea: stelem.ref
+			IL_07eb: dup
+			IL_07ec: ldc.i4.s 33
+			IL_07ee: ldloc.s 34
+			IL_07f0: stelem.ref
+			IL_07f1: dup
+			IL_07f2: ldc.i4.s 34
+			IL_07f4: ldloc.s 35
+			IL_07f6: stelem.ref
+			IL_07f7: dup
+			IL_07f8: ldc.i4.s 35
+			IL_07fa: ldloc.s 36
+			IL_07fc: stelem.ref
+			IL_07fd: dup
+			IL_07fe: ldc.i4.s 36
+			IL_0800: ldloc.s 37
+			IL_0802: stelem.ref
+			IL_0803: dup
+			IL_0804: ldc.i4.s 37
+			IL_0806: ldloc.s 38
+			IL_0808: stelem.ref
+			IL_0809: dup
+			IL_080a: ldc.i4.s 38
+			IL_080c: ldloc.s 39
+			IL_080e: stelem.ref
+			IL_080f: pop
+			IL_0810: ldloc.0
+			IL_0811: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0816: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_081b: ret
 
-			IL_086a: ldloc.0
-			IL_086b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_0870: stloc.s 29
-			IL_0872: ldloc.s 29
-			IL_0874: stloc.s 11
-			IL_0876: ldloc.s 20
-			IL_0878: stloc.s 29
-			IL_087a: ldloc.s 29
-			IL_087c: stloc.s 13
-			IL_087e: ldloc.s 12
-			IL_0880: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0885: ldc.i4.0
-			IL_0886: ceq
-			IL_0888: stloc.s 32
-			IL_088a: ldloc.s 32
-			IL_088c: brfalse IL_08ca
+			IL_081c: ldloc.0
+			IL_081d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_0822: stloc.s 29
+			IL_0824: ldloc.s 29
+			IL_0826: stloc.s 11
+			IL_0828: ldloc.s 20
+			IL_082a: stloc.s 29
+			IL_082c: ldloc.s 29
+			IL_082e: stloc.s 13
+			IL_0830: ldloc.s 12
+			IL_0832: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0837: ldc.i4.0
+			IL_0838: ceq
+			IL_083a: stloc.s 32
+			IL_083c: ldloc.s 32
+			IL_083e: brfalse IL_087c
 
-			IL_0891: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
-			IL_0896: stloc.s 21
-			IL_0898: ldloc.s 17
-			IL_089a: ldstr "fragment"
-			IL_089f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08a4: stloc.s 29
-			IL_08a6: ldloc.s 29
-			IL_08a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_08ad: stloc.s 32
-			IL_08af: ldloc.s 32
-			IL_08b1: brtrue IL_08c2
+			IL_0843: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
+			IL_0848: stloc.s 21
+			IL_084a: ldloc.s 17
+			IL_084c: ldstr "fragment"
+			IL_0851: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0856: stloc.s 29
+			IL_0858: ldloc.s 29
+			IL_085a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_085f: stloc.s 32
+			IL_0861: ldloc.s 32
+			IL_0863: brtrue IL_0874
 
-			IL_08b6: ldstr ""
-			IL_08bb: stloc.s 38
-			IL_08bd: br IL_08c6
+			IL_0868: ldstr ""
+			IL_086d: stloc.s 38
+			IL_086f: br IL_0878
 
-			IL_08c2: ldloc.s 29
-			IL_08c4: stloc.s 38
+			IL_0874: ldloc.s 29
+			IL_0876: stloc.s 38
 
-			IL_08c6: ldloc.s 38
-			IL_08c8: stloc.s 12
+			IL_0878: ldloc.s 38
+			IL_087a: stloc.s 12
 
-			IL_08ca: br IL_0a4f
+			IL_087c: br IL_09ef
 
-			IL_08cf: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
-			IL_08d4: stloc.s 22
-			IL_08d6: ldloc.1
-			IL_08d7: ldstr "url"
-			IL_08dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_08e6: stloc.s 29
-			IL_08e8: ldloc.s 29
-			IL_08ea: ldstr "trim"
-			IL_08ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_08f4: stloc.s 29
-			IL_08f6: ldloc.s 29
-			IL_08f8: stloc.s 23
-			IL_08fa: ldarg.0
-			IL_08fb: ldc.i4.1
-			IL_08fc: ldelem.ref
-			IL_08fd: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0902: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0907: stloc.s 29
-			IL_0909: ldstr "fetchText"
-			IL_090e: ldloc.s 29
-			IL_0910: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0915: stloc.s 29
-			IL_0917: ldloc.s 29
-			IL_0919: ldc.i4.1
-			IL_091a: newarr [System.Runtime]System.Object
-			IL_091f: dup
-			IL_0920: ldc.i4.0
-			IL_0921: ldarg.0
-			IL_0922: ldc.i4.1
-			IL_0923: ldelem.ref
-			IL_0924: stelem.ref
-			IL_0925: ldloc.s 23
-			IL_0927: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_092c: stloc.s 29
-			IL_092e: ldloc.0
-			IL_092f: ldc.i4.3
-			IL_0930: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0935: ldloc.0
-			IL_0936: ldloc.s 29
-			IL_0938: ldarg.0
-			IL_0939: ldc.i4.3
-			IL_093a: ldloc.0
-			IL_093b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0940: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0945: ldloc.0
-			IL_0946: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0881: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
+			IL_0886: stloc.s 22
+			IL_0888: ldloc.1
+			IL_0889: ldstr "url"
+			IL_088e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0893: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0898: stloc.s 29
+			IL_089a: ldloc.s 29
+			IL_089c: ldstr "trim"
+			IL_08a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_08a6: stloc.s 29
+			IL_08a8: ldloc.s 29
+			IL_08aa: stloc.s 23
+			IL_08ac: ldarg.0
+			IL_08ad: ldc.i4.1
+			IL_08ae: ldelem.ref
+			IL_08af: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_08b4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_08b9: ldc.i4.1
+			IL_08ba: newarr [System.Runtime]System.Object
+			IL_08bf: dup
+			IL_08c0: ldc.i4.0
+			IL_08c1: ldarg.0
+			IL_08c2: ldc.i4.1
+			IL_08c3: ldelem.ref
+			IL_08c4: stelem.ref
+			IL_08c5: ldloc.s 23
+			IL_08c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_08cc: stloc.s 29
+			IL_08ce: ldloc.0
+			IL_08cf: ldc.i4.3
+			IL_08d0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08d5: ldloc.0
+			IL_08d6: ldloc.s 29
+			IL_08d8: ldarg.0
+			IL_08d9: ldc.i4.3
+			IL_08da: ldloc.0
+			IL_08db: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_08e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_08e5: ldloc.0
+			IL_08e6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08eb: dup
+			IL_08ec: ldc.i4.0
+			IL_08ed: ldloc.1
+			IL_08ee: stelem.ref
+			IL_08ef: dup
+			IL_08f0: ldc.i4.1
+			IL_08f1: ldloc.2
+			IL_08f2: stelem.ref
+			IL_08f3: dup
+			IL_08f4: ldc.i4.2
+			IL_08f5: ldloc.3
+			IL_08f6: stelem.ref
+			IL_08f7: dup
+			IL_08f8: ldc.i4.3
+			IL_08f9: ldloc.s 4
+			IL_08fb: stelem.ref
+			IL_08fc: dup
+			IL_08fd: ldc.i4.4
+			IL_08fe: ldloc.s 5
+			IL_0900: stelem.ref
+			IL_0901: dup
+			IL_0902: ldc.i4.5
+			IL_0903: ldloc.s 6
+			IL_0905: stelem.ref
+			IL_0906: dup
+			IL_0907: ldc.i4.6
+			IL_0908: ldloc.s 7
+			IL_090a: stelem.ref
+			IL_090b: dup
+			IL_090c: ldc.i4.7
+			IL_090d: ldloc.s 8
+			IL_090f: stelem.ref
+			IL_0910: dup
+			IL_0911: ldc.i4.8
+			IL_0912: ldloc.s 9
+			IL_0914: stelem.ref
+			IL_0915: dup
+			IL_0916: ldc.i4.s 9
+			IL_0918: ldloc.s 10
+			IL_091a: stelem.ref
+			IL_091b: dup
+			IL_091c: ldc.i4.s 10
+			IL_091e: ldloc.s 11
+			IL_0920: stelem.ref
+			IL_0921: dup
+			IL_0922: ldc.i4.s 11
+			IL_0924: ldloc.s 12
+			IL_0926: stelem.ref
+			IL_0927: dup
+			IL_0928: ldc.i4.s 12
+			IL_092a: ldloc.s 13
+			IL_092c: stelem.ref
+			IL_092d: dup
+			IL_092e: ldc.i4.s 13
+			IL_0930: ldloc.s 14
+			IL_0932: stelem.ref
+			IL_0933: dup
+			IL_0934: ldc.i4.s 14
+			IL_0936: ldloc.s 15
+			IL_0938: stelem.ref
+			IL_0939: dup
+			IL_093a: ldc.i4.s 15
+			IL_093c: ldloc.s 16
+			IL_093e: stelem.ref
+			IL_093f: dup
+			IL_0940: ldc.i4.s 16
+			IL_0942: ldloc.s 17
+			IL_0944: stelem.ref
+			IL_0945: dup
+			IL_0946: ldc.i4.s 17
+			IL_0948: ldloc.s 18
+			IL_094a: stelem.ref
 			IL_094b: dup
-			IL_094c: ldc.i4.0
-			IL_094d: ldloc.1
-			IL_094e: stelem.ref
-			IL_094f: dup
-			IL_0950: ldc.i4.1
-			IL_0951: ldloc.2
-			IL_0952: stelem.ref
-			IL_0953: dup
-			IL_0954: ldc.i4.2
-			IL_0955: ldloc.3
+			IL_094c: ldc.i4.s 18
+			IL_094e: ldloc.s 19
+			IL_0950: stelem.ref
+			IL_0951: dup
+			IL_0952: ldc.i4.s 19
+			IL_0954: ldloc.s 20
 			IL_0956: stelem.ref
 			IL_0957: dup
-			IL_0958: ldc.i4.3
-			IL_0959: ldloc.s 4
-			IL_095b: stelem.ref
-			IL_095c: dup
-			IL_095d: ldc.i4.4
-			IL_095e: ldloc.s 5
-			IL_0960: stelem.ref
-			IL_0961: dup
-			IL_0962: ldc.i4.5
-			IL_0963: ldloc.s 6
-			IL_0965: stelem.ref
-			IL_0966: dup
-			IL_0967: ldc.i4.6
-			IL_0968: ldloc.s 7
-			IL_096a: stelem.ref
-			IL_096b: dup
-			IL_096c: ldc.i4.7
-			IL_096d: ldloc.s 8
-			IL_096f: stelem.ref
-			IL_0970: dup
-			IL_0971: ldc.i4.8
-			IL_0972: ldloc.s 9
+			IL_0958: ldc.i4.s 20
+			IL_095a: ldloc.s 21
+			IL_095c: stelem.ref
+			IL_095d: dup
+			IL_095e: ldc.i4.s 21
+			IL_0960: ldloc.s 22
+			IL_0962: stelem.ref
+			IL_0963: dup
+			IL_0964: ldc.i4.s 22
+			IL_0966: ldloc.s 23
+			IL_0968: stelem.ref
+			IL_0969: dup
+			IL_096a: ldc.i4.s 23
+			IL_096c: ldloc.s 24
+			IL_096e: stelem.ref
+			IL_096f: dup
+			IL_0970: ldc.i4.s 24
+			IL_0972: ldloc.s 25
 			IL_0974: stelem.ref
 			IL_0975: dup
-			IL_0976: ldc.i4.s 9
-			IL_0978: ldloc.s 10
+			IL_0976: ldc.i4.s 25
+			IL_0978: ldloc.s 26
 			IL_097a: stelem.ref
 			IL_097b: dup
-			IL_097c: ldc.i4.s 10
-			IL_097e: ldloc.s 11
+			IL_097c: ldc.i4.s 26
+			IL_097e: ldloc.s 27
 			IL_0980: stelem.ref
 			IL_0981: dup
-			IL_0982: ldc.i4.s 11
-			IL_0984: ldloc.s 12
+			IL_0982: ldc.i4.s 27
+			IL_0984: ldloc.s 28
 			IL_0986: stelem.ref
 			IL_0987: dup
-			IL_0988: ldc.i4.s 12
-			IL_098a: ldloc.s 13
+			IL_0988: ldc.i4.s 28
+			IL_098a: ldloc.s 29
 			IL_098c: stelem.ref
 			IL_098d: dup
-			IL_098e: ldc.i4.s 13
-			IL_0990: ldloc.s 14
+			IL_098e: ldc.i4.s 29
+			IL_0990: ldloc.s 30
 			IL_0992: stelem.ref
 			IL_0993: dup
-			IL_0994: ldc.i4.s 14
-			IL_0996: ldloc.s 15
+			IL_0994: ldc.i4.s 30
+			IL_0996: ldloc.s 31
 			IL_0998: stelem.ref
 			IL_0999: dup
-			IL_099a: ldc.i4.s 15
-			IL_099c: ldloc.s 16
-			IL_099e: stelem.ref
-			IL_099f: dup
-			IL_09a0: ldc.i4.s 16
-			IL_09a2: ldloc.s 17
-			IL_09a4: stelem.ref
-			IL_09a5: dup
-			IL_09a6: ldc.i4.s 17
-			IL_09a8: ldloc.s 18
-			IL_09aa: stelem.ref
-			IL_09ab: dup
-			IL_09ac: ldc.i4.s 18
-			IL_09ae: ldloc.s 19
-			IL_09b0: stelem.ref
-			IL_09b1: dup
-			IL_09b2: ldc.i4.s 19
-			IL_09b4: ldloc.s 20
-			IL_09b6: stelem.ref
-			IL_09b7: dup
-			IL_09b8: ldc.i4.s 20
-			IL_09ba: ldloc.s 21
-			IL_09bc: stelem.ref
-			IL_09bd: dup
-			IL_09be: ldc.i4.s 21
-			IL_09c0: ldloc.s 22
-			IL_09c2: stelem.ref
-			IL_09c3: dup
-			IL_09c4: ldc.i4.s 22
-			IL_09c6: ldloc.s 23
-			IL_09c8: stelem.ref
-			IL_09c9: dup
-			IL_09ca: ldc.i4.s 23
-			IL_09cc: ldloc.s 24
-			IL_09ce: stelem.ref
-			IL_09cf: dup
-			IL_09d0: ldc.i4.s 24
-			IL_09d2: ldloc.s 25
-			IL_09d4: stelem.ref
-			IL_09d5: dup
-			IL_09d6: ldc.i4.s 25
-			IL_09d8: ldloc.s 26
-			IL_09da: stelem.ref
-			IL_09db: dup
-			IL_09dc: ldc.i4.s 26
-			IL_09de: ldloc.s 27
-			IL_09e0: stelem.ref
-			IL_09e1: dup
-			IL_09e2: ldc.i4.s 27
-			IL_09e4: ldloc.s 28
-			IL_09e6: stelem.ref
-			IL_09e7: dup
-			IL_09e8: ldc.i4.s 28
-			IL_09ea: ldloc.s 29
-			IL_09ec: stelem.ref
-			IL_09ed: dup
-			IL_09ee: ldc.i4.s 29
-			IL_09f0: ldloc.s 30
-			IL_09f2: stelem.ref
-			IL_09f3: dup
-			IL_09f4: ldc.i4.s 30
-			IL_09f6: ldloc.s 31
-			IL_09f8: stelem.ref
-			IL_09f9: dup
-			IL_09fa: ldc.i4.s 31
-			IL_09fc: ldloc.s 32
-			IL_09fe: box [System.Runtime]System.Boolean
-			IL_0a03: stelem.ref
-			IL_0a04: dup
-			IL_0a05: ldc.i4.s 32
-			IL_0a07: ldloc.s 33
-			IL_0a09: stelem.ref
-			IL_0a0a: dup
-			IL_0a0b: ldc.i4.s 33
-			IL_0a0d: ldloc.s 34
-			IL_0a0f: stelem.ref
-			IL_0a10: dup
-			IL_0a11: ldc.i4.s 34
-			IL_0a13: ldloc.s 35
-			IL_0a15: stelem.ref
-			IL_0a16: dup
-			IL_0a17: ldc.i4.s 35
-			IL_0a19: ldloc.s 36
-			IL_0a1b: stelem.ref
-			IL_0a1c: dup
-			IL_0a1d: ldc.i4.s 36
-			IL_0a1f: ldloc.s 37
-			IL_0a21: stelem.ref
-			IL_0a22: dup
-			IL_0a23: ldc.i4.s 37
-			IL_0a25: ldloc.s 38
-			IL_0a27: stelem.ref
-			IL_0a28: dup
-			IL_0a29: ldc.i4.s 38
-			IL_0a2b: ldloc.s 39
-			IL_0a2d: stelem.ref
-			IL_0a2e: pop
-			IL_0a2f: ldloc.0
-			IL_0a30: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a35: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a3a: ret
+			IL_099a: ldc.i4.s 31
+			IL_099c: ldloc.s 32
+			IL_099e: box [System.Runtime]System.Boolean
+			IL_09a3: stelem.ref
+			IL_09a4: dup
+			IL_09a5: ldc.i4.s 32
+			IL_09a7: ldloc.s 33
+			IL_09a9: stelem.ref
+			IL_09aa: dup
+			IL_09ab: ldc.i4.s 33
+			IL_09ad: ldloc.s 34
+			IL_09af: stelem.ref
+			IL_09b0: dup
+			IL_09b1: ldc.i4.s 34
+			IL_09b3: ldloc.s 35
+			IL_09b5: stelem.ref
+			IL_09b6: dup
+			IL_09b7: ldc.i4.s 35
+			IL_09b9: ldloc.s 36
+			IL_09bb: stelem.ref
+			IL_09bc: dup
+			IL_09bd: ldc.i4.s 36
+			IL_09bf: ldloc.s 37
+			IL_09c1: stelem.ref
+			IL_09c2: dup
+			IL_09c3: ldc.i4.s 37
+			IL_09c5: ldloc.s 38
+			IL_09c7: stelem.ref
+			IL_09c8: dup
+			IL_09c9: ldc.i4.s 38
+			IL_09cb: ldloc.s 39
+			IL_09cd: stelem.ref
+			IL_09ce: pop
+			IL_09cf: ldloc.0
+			IL_09d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09d5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09da: ret
 
-			IL_0a3b: ldloc.0
-			IL_0a3c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_0a41: stloc.s 29
-			IL_0a43: ldloc.s 29
-			IL_0a45: stloc.s 11
-			IL_0a47: ldloc.s 23
-			IL_0a49: stloc.s 29
-			IL_0a4b: ldloc.s 29
-			IL_0a4d: stloc.s 13
+			IL_09db: ldloc.0
+			IL_09dc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_09e1: stloc.s 29
+			IL_09e3: ldloc.s 29
+			IL_09e5: stloc.s 11
+			IL_09e7: ldloc.s 23
+			IL_09e9: stloc.s 29
+			IL_09eb: ldloc.s 29
+			IL_09ed: stloc.s 13
 
-			IL_0a4f: ldloc.s 12
-			IL_0a51: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0a56: ldc.i4.0
-			IL_0a57: ceq
-			IL_0a59: stloc.s 32
-			IL_0a5b: ldloc.s 32
-			IL_0a5d: brfalse IL_0ad9
+			IL_09ef: ldloc.s 12
+			IL_09f1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_09f6: ldc.i4.0
+			IL_09f7: ceq
+			IL_09f9: stloc.s 32
+			IL_09fb: ldloc.s 32
+			IL_09fd: brfalse IL_0a79
 
-			IL_0a62: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
-			IL_0a67: stloc.s 24
-			IL_0a69: ldloc.1
-			IL_0a6a: ldstr "section"
-			IL_0a6f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a74: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a79: stloc.s 36
-			IL_0a7b: ldstr "Could not infer an element id for section '"
-			IL_0a80: ldloc.s 36
-			IL_0a82: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a87: stloc.s 36
-			IL_0a89: ldloc.s 36
-			IL_0a8b: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0a90: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a95: stloc.s 36
-			IL_0a97: ldloc.s 36
-			IL_0a99: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a9e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0aa3: stloc.s 29
-			IL_0aa5: ldloc.s 29
-			IL_0aa7: stloc.s 25
-			IL_0aa9: ldloc.0
-			IL_0aaa: ldc.i4.m1
-			IL_0aab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0ab0: ldloc.0
-			IL_0ab1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ab6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0abb: ldarg.0
-			IL_0abc: ldc.i4.1
-			IL_0abd: newarr [System.Runtime]System.Object
-			IL_0ac2: dup
-			IL_0ac3: ldc.i4.0
-			IL_0ac4: ldloc.s 25
-			IL_0ac6: stelem.ref
-			IL_0ac7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0acc: pop
-			IL_0acd: ldloc.0
-			IL_0ace: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ad3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0ad8: ret
+			IL_0a02: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
+			IL_0a07: stloc.s 24
+			IL_0a09: ldloc.1
+			IL_0a0a: ldstr "section"
+			IL_0a0f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a14: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a19: stloc.s 36
+			IL_0a1b: ldstr "Could not infer an element id for section '"
+			IL_0a20: ldloc.s 36
+			IL_0a22: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a27: stloc.s 36
+			IL_0a29: ldloc.s 36
+			IL_0a2b: ldstr "'. Try passing --id sec-... explicitly."
+			IL_0a30: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a35: stloc.s 36
+			IL_0a37: ldloc.s 36
+			IL_0a39: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a3e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0a43: stloc.s 29
+			IL_0a45: ldloc.s 29
+			IL_0a47: stloc.s 25
+			IL_0a49: ldloc.0
+			IL_0a4a: ldc.i4.m1
+			IL_0a4b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0a50: ldloc.0
+			IL_0a51: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a56: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0a5b: ldarg.0
+			IL_0a5c: ldc.i4.1
+			IL_0a5d: newarr [System.Runtime]System.Object
+			IL_0a62: dup
+			IL_0a63: ldc.i4.0
+			IL_0a64: ldloc.s 25
+			IL_0a66: stelem.ref
+			IL_0a67: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0a6c: pop
+			IL_0a6d: ldloc.0
+			IL_0a6e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a73: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0a78: ret
 
-			IL_0ad9: ldarg.0
-			IL_0ada: ldc.i4.1
-			IL_0adb: ldelem.ref
-			IL_0adc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0ae1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
-			IL_0ae6: stloc.s 29
-			IL_0ae8: ldstr "extractElementById"
-			IL_0aed: ldloc.s 29
-			IL_0aef: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0af4: stloc.s 29
-			IL_0af6: ldloc.s 29
+			IL_0a79: ldarg.0
+			IL_0a7a: ldc.i4.1
+			IL_0a7b: ldelem.ref
+			IL_0a7c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a81: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+			IL_0a86: ldc.i4.1
+			IL_0a87: newarr [System.Runtime]System.Object
+			IL_0a8c: dup
+			IL_0a8d: ldc.i4.0
+			IL_0a8e: ldarg.0
+			IL_0a8f: ldc.i4.1
+			IL_0a90: ldelem.ref
+			IL_0a91: stelem.ref
+			IL_0a92: ldloc.s 11
+			IL_0a94: ldloc.s 12
+			IL_0a96: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0a9b: stloc.s 29
+			IL_0a9d: ldloc.s 29
+			IL_0a9f: stloc.s 26
+			IL_0aa1: ldarg.0
+			IL_0aa2: ldc.i4.1
+			IL_0aa3: ldelem.ref
+			IL_0aa4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0aa9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0aae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ab3: stloc.s 29
+			IL_0ab5: ldstr "process"
+			IL_0aba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0abf: stloc.s 31
+			IL_0ac1: ldloc.s 31
+			IL_0ac3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ac8: stloc.s 31
+			IL_0aca: ldloc.s 31
+			IL_0acc: ldstr "cwd"
+			IL_0ad1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0ad6: stloc.s 31
+			IL_0ad8: ldloc.s 29
+			IL_0ada: ldstr "join"
+			IL_0adf: ldloc.s 31
+			IL_0ae1: ldloc.1
+			IL_0ae2: ldstr "outFile"
+			IL_0ae7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0aec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0af1: stloc.s 31
+			IL_0af3: ldloc.s 31
+			IL_0af5: stloc.s 27
+			IL_0af7: ldarg.0
 			IL_0af8: ldc.i4.1
-			IL_0af9: newarr [System.Runtime]System.Object
-			IL_0afe: dup
-			IL_0aff: ldc.i4.0
-			IL_0b00: ldarg.0
-			IL_0b01: ldc.i4.1
-			IL_0b02: ldelem.ref
-			IL_0b03: stelem.ref
-			IL_0b04: ldloc.s 11
-			IL_0b06: ldloc.s 12
-			IL_0b08: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b0d: stloc.s 29
-			IL_0b0f: ldloc.s 29
-			IL_0b11: stloc.s 26
-			IL_0b13: ldarg.0
-			IL_0b14: ldc.i4.1
-			IL_0b15: ldelem.ref
-			IL_0b16: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b1b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0af9: ldelem.ref
+			IL_0afa: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0aff: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_0b04: stloc.s 31
+			IL_0b06: ldc.i4.1
+			IL_0b07: newarr [System.Runtime]System.Object
+			IL_0b0c: dup
+			IL_0b0d: ldc.i4.0
+			IL_0b0e: ldarg.0
+			IL_0b0f: ldc.i4.1
+			IL_0b10: ldelem.ref
+			IL_0b11: stelem.ref
+			IL_0b12: stloc.s 30
+			IL_0b14: ldloc.s 26
+			IL_0b16: ldstr "html"
+			IL_0b1b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0b20: stloc.s 29
-			IL_0b22: ldstr "path"
-			IL_0b27: ldloc.s 29
-			IL_0b29: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0b2e: stloc.s 29
-			IL_0b30: ldloc.s 29
-			IL_0b32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b37: stloc.s 29
-			IL_0b39: ldstr "process"
-			IL_0b3e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b43: stloc.s 31
-			IL_0b45: ldloc.s 31
-			IL_0b47: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b4c: stloc.s 31
-			IL_0b4e: ldloc.s 31
-			IL_0b50: ldstr "cwd"
-			IL_0b55: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0b5a: stloc.s 31
-			IL_0b5c: ldloc.s 29
-			IL_0b5e: ldstr "join"
-			IL_0b63: ldloc.s 31
-			IL_0b65: ldloc.1
-			IL_0b66: ldstr "outFile"
-			IL_0b6b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b70: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0b75: stloc.s 31
-			IL_0b77: ldloc.s 31
-			IL_0b79: stloc.s 27
-			IL_0b7b: ldarg.0
-			IL_0b7c: ldc.i4.1
-			IL_0b7d: ldelem.ref
-			IL_0b7e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b83: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_0b88: stloc.s 31
-			IL_0b8a: ldstr "wrapAsStandaloneHtml"
-			IL_0b8f: ldloc.s 31
-			IL_0b91: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0b96: stloc.s 31
-			IL_0b98: ldc.i4.1
-			IL_0b99: newarr [System.Runtime]System.Object
-			IL_0b9e: dup
-			IL_0b9f: ldc.i4.0
-			IL_0ba0: ldarg.0
-			IL_0ba1: ldc.i4.1
-			IL_0ba2: ldelem.ref
-			IL_0ba3: stelem.ref
-			IL_0ba4: stloc.s 30
-			IL_0ba6: ldloc.s 26
-			IL_0ba8: ldstr "html"
-			IL_0bad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bb2: stloc.s 29
-			IL_0bb4: ldloc.1
-			IL_0bb5: ldstr "section"
-			IL_0bba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bbf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0bc4: stloc.s 36
-			IL_0bc6: ldstr "ECMA-262 "
-			IL_0bcb: ldloc.s 36
-			IL_0bcd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0bd2: stloc.s 36
-			IL_0bd4: ldloc.s 31
-			IL_0bd6: ldloc.s 30
-			IL_0bd8: ldloc.s 29
-			IL_0bda: ldloc.s 36
-			IL_0bdc: ldloc.s 13
-			IL_0bde: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0be3: stloc.s 29
-			IL_0be5: ldloc.s 29
-			IL_0be7: stloc.s 28
-			IL_0be9: ldarg.0
-			IL_0bea: ldc.i4.1
-			IL_0beb: ldelem.ref
-			IL_0bec: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0bf1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0bf6: stloc.s 29
-			IL_0bf8: ldstr "fs"
-			IL_0bfd: ldloc.s 29
-			IL_0bff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0c04: stloc.s 29
-			IL_0c06: ldloc.s 29
-			IL_0c08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0c0d: stloc.s 29
-			IL_0c0f: ldloc.s 29
-			IL_0c11: ldstr "writeFileSync"
-			IL_0c16: ldloc.s 27
-			IL_0c18: ldloc.s 28
-			IL_0c1a: ldstr "utf8"
-			IL_0c1f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0c24: pop
-			IL_0c25: ldstr "console"
-			IL_0c2a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0c2f: stloc.s 29
-			IL_0c31: ldloc.s 29
-			IL_0c33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0c38: stloc.s 29
-			IL_0c3a: ldarg.0
-			IL_0c3b: ldc.i4.1
-			IL_0c3c: ldelem.ref
-			IL_0c3d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0c42: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0c47: stloc.s 31
-			IL_0c49: ldstr "normalize"
-			IL_0c4e: ldloc.s 31
-			IL_0c50: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0c55: stloc.s 31
-			IL_0c57: ldc.i4.1
-			IL_0c58: newarr [System.Runtime]System.Object
-			IL_0c5d: dup
-			IL_0c5e: ldc.i4.0
-			IL_0c5f: ldarg.0
-			IL_0c60: ldc.i4.1
-			IL_0c61: ldelem.ref
-			IL_0c62: stelem.ref
-			IL_0c63: stloc.s 30
-			IL_0c65: ldloc.1
-			IL_0c66: ldstr "section"
-			IL_0c6b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c70: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0c75: stloc.s 36
-			IL_0c77: ldstr "Extracted section "
-			IL_0c7c: ldloc.s 36
-			IL_0c7e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0c83: stloc.s 36
-			IL_0c85: ldloc.s 36
-			IL_0c87: ldstr " (id="
-			IL_0c8c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0c91: stloc.s 36
-			IL_0c93: ldloc.s 12
-			IL_0c95: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0c9a: stloc.s 35
-			IL_0c9c: ldloc.s 36
-			IL_0c9e: ldloc.s 35
-			IL_0ca0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ca5: stloc.s 35
-			IL_0ca7: ldloc.s 35
-			IL_0ca9: ldstr ", tag="
-			IL_0cae: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0cb3: stloc.s 35
-			IL_0cb5: ldloc.s 26
-			IL_0cb7: ldstr "tagName"
-			IL_0cbc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cc1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0cc6: stloc.s 36
-			IL_0cc8: ldloc.s 35
-			IL_0cca: ldloc.s 36
-			IL_0ccc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0cd1: stloc.s 36
-			IL_0cd3: ldloc.s 36
-			IL_0cd5: ldstr ") -> "
-			IL_0cda: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0cdf: stloc.s 36
-			IL_0ce1: ldloc.s 27
-			IL_0ce3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ce8: stloc.s 35
-			IL_0cea: ldloc.s 36
-			IL_0cec: ldloc.s 35
-			IL_0cee: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0cf3: stloc.s 35
-			IL_0cf5: ldloc.s 31
-			IL_0cf7: ldloc.s 30
-			IL_0cf9: ldloc.s 35
-			IL_0cfb: ldloc.s 27
-			IL_0cfd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0d02: stloc.s 31
-			IL_0d04: ldloc.s 29
-			IL_0d06: ldstr "log"
-			IL_0d0b: ldloc.s 31
-			IL_0d0d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0d12: pop
-			IL_0d13: ldstr "console"
-			IL_0d18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0d1d: stloc.s 31
-			IL_0d1f: ldloc.s 31
-			IL_0d21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0d26: stloc.s 31
-			IL_0d28: ldarg.0
-			IL_0d29: ldc.i4.1
-			IL_0d2a: ldelem.ref
-			IL_0d2b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0d30: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0d35: stloc.s 29
-			IL_0d37: ldstr "normalize"
-			IL_0d3c: ldloc.s 29
-			IL_0d3e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0d43: stloc.s 29
-			IL_0d45: ldc.i4.1
-			IL_0d46: newarr [System.Runtime]System.Object
-			IL_0d4b: dup
-			IL_0d4c: ldc.i4.0
-			IL_0d4d: ldarg.0
-			IL_0d4e: ldc.i4.1
-			IL_0d4f: ldelem.ref
-			IL_0d50: stelem.ref
-			IL_0d51: stloc.s 30
-			IL_0d53: ldarg.0
-			IL_0d54: ldc.i4.1
-			IL_0d55: ldelem.ref
-			IL_0d56: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0d5b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0d60: stloc.s 39
-			IL_0d62: ldstr "fs"
-			IL_0d67: ldloc.s 39
-			IL_0d69: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0d6e: stloc.s 39
-			IL_0d70: ldloc.s 39
-			IL_0d72: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0d77: stloc.s 39
-			IL_0d79: ldloc.s 39
-			IL_0d7b: ldstr "readFileSync"
-			IL_0d80: ldloc.s 27
-			IL_0d82: ldstr "utf8"
-			IL_0d87: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0d8c: stloc.s 39
-			IL_0d8e: ldloc.s 29
-			IL_0d90: ldloc.s 30
-			IL_0d92: ldloc.s 39
-			IL_0d94: ldloc.s 27
-			IL_0d96: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0d9b: stloc.s 39
-			IL_0d9d: ldloc.s 31
-			IL_0d9f: ldstr "log"
-			IL_0da4: ldloc.s 39
-			IL_0da6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0dab: pop
-			IL_0dac: ldloc.0
-			IL_0dad: ldc.i4.m1
-			IL_0dae: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0db3: ldloc.0
-			IL_0db4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0db9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0dbe: ldarg.0
-			IL_0dbf: ldc.i4.1
-			IL_0dc0: newarr [System.Runtime]System.Object
-			IL_0dc5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0dca: pop
-			IL_0dcb: ldloc.0
-			IL_0dcc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0dd1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0dd6: ret
+			IL_0b22: ldloc.1
+			IL_0b23: ldstr "section"
+			IL_0b28: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b2d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b32: stloc.s 36
+			IL_0b34: ldstr "ECMA-262 "
+			IL_0b39: ldloc.s 36
+			IL_0b3b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b40: stloc.s 36
+			IL_0b42: ldloc.s 31
+			IL_0b44: ldloc.s 30
+			IL_0b46: ldloc.s 29
+			IL_0b48: ldloc.s 36
+			IL_0b4a: ldloc.s 13
+			IL_0b4c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0b51: stloc.s 29
+			IL_0b53: ldloc.s 29
+			IL_0b55: stloc.s 28
+			IL_0b57: ldarg.0
+			IL_0b58: ldc.i4.1
+			IL_0b59: ldelem.ref
+			IL_0b5a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b5f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0b64: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b69: stloc.s 29
+			IL_0b6b: ldloc.s 29
+			IL_0b6d: ldstr "writeFileSync"
+			IL_0b72: ldloc.s 27
+			IL_0b74: ldloc.s 28
+			IL_0b76: ldstr "utf8"
+			IL_0b7b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0b80: pop
+			IL_0b81: ldstr "console"
+			IL_0b86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b8b: stloc.s 29
+			IL_0b8d: ldloc.s 29
+			IL_0b8f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b94: stloc.s 29
+			IL_0b96: ldarg.0
+			IL_0b97: ldc.i4.1
+			IL_0b98: ldelem.ref
+			IL_0b99: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b9e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0ba3: stloc.s 31
+			IL_0ba5: ldc.i4.1
+			IL_0ba6: newarr [System.Runtime]System.Object
+			IL_0bab: dup
+			IL_0bac: ldc.i4.0
+			IL_0bad: ldarg.0
+			IL_0bae: ldc.i4.1
+			IL_0baf: ldelem.ref
+			IL_0bb0: stelem.ref
+			IL_0bb1: stloc.s 30
+			IL_0bb3: ldloc.1
+			IL_0bb4: ldstr "section"
+			IL_0bb9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bbe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0bc3: stloc.s 36
+			IL_0bc5: ldstr "Extracted section "
+			IL_0bca: ldloc.s 36
+			IL_0bcc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bd1: stloc.s 36
+			IL_0bd3: ldloc.s 36
+			IL_0bd5: ldstr " (id="
+			IL_0bda: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bdf: stloc.s 36
+			IL_0be1: ldloc.s 12
+			IL_0be3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0be8: stloc.s 35
+			IL_0bea: ldloc.s 36
+			IL_0bec: ldloc.s 35
+			IL_0bee: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bf3: stloc.s 35
+			IL_0bf5: ldloc.s 35
+			IL_0bf7: ldstr ", tag="
+			IL_0bfc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c01: stloc.s 35
+			IL_0c03: ldloc.s 26
+			IL_0c05: ldstr "tagName"
+			IL_0c0a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c0f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0c14: stloc.s 36
+			IL_0c16: ldloc.s 35
+			IL_0c18: ldloc.s 36
+			IL_0c1a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c1f: stloc.s 36
+			IL_0c21: ldloc.s 36
+			IL_0c23: ldstr ") -> "
+			IL_0c28: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c2d: stloc.s 36
+			IL_0c2f: ldloc.s 27
+			IL_0c31: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0c36: stloc.s 35
+			IL_0c38: ldloc.s 36
+			IL_0c3a: ldloc.s 35
+			IL_0c3c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c41: stloc.s 35
+			IL_0c43: ldloc.s 31
+			IL_0c45: ldloc.s 30
+			IL_0c47: ldloc.s 35
+			IL_0c49: ldloc.s 27
+			IL_0c4b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0c50: stloc.s 31
+			IL_0c52: ldloc.s 29
+			IL_0c54: ldstr "log"
+			IL_0c59: ldloc.s 31
+			IL_0c5b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0c60: pop
+			IL_0c61: ldstr "console"
+			IL_0c66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0c6b: stloc.s 31
+			IL_0c6d: ldloc.s 31
+			IL_0c6f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0c74: stloc.s 31
+			IL_0c76: ldarg.0
+			IL_0c77: ldc.i4.1
+			IL_0c78: ldelem.ref
+			IL_0c79: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0c7e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0c83: stloc.s 29
+			IL_0c85: ldc.i4.1
+			IL_0c86: newarr [System.Runtime]System.Object
+			IL_0c8b: dup
+			IL_0c8c: ldc.i4.0
+			IL_0c8d: ldarg.0
+			IL_0c8e: ldc.i4.1
+			IL_0c8f: ldelem.ref
+			IL_0c90: stelem.ref
+			IL_0c91: stloc.s 30
+			IL_0c93: ldarg.0
+			IL_0c94: ldc.i4.1
+			IL_0c95: ldelem.ref
+			IL_0c96: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0c9b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0ca0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ca5: stloc.s 39
+			IL_0ca7: ldloc.s 39
+			IL_0ca9: ldstr "readFileSync"
+			IL_0cae: ldloc.s 27
+			IL_0cb0: ldstr "utf8"
+			IL_0cb5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0cba: stloc.s 39
+			IL_0cbc: ldloc.s 29
+			IL_0cbe: ldloc.s 30
+			IL_0cc0: ldloc.s 39
+			IL_0cc2: ldloc.s 27
+			IL_0cc4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0cc9: stloc.s 39
+			IL_0ccb: ldloc.s 31
+			IL_0ccd: ldstr "log"
+			IL_0cd2: ldloc.s 39
+			IL_0cd4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0cd9: pop
+			IL_0cda: ldloc.0
+			IL_0cdb: ldc.i4.m1
+			IL_0cdc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0ce1: ldloc.0
+			IL_0ce2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0ce7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0cec: ldarg.0
+			IL_0ced: ldc.i4.1
+			IL_0cee: newarr [System.Runtime]System.Object
+			IL_0cf3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0cf8: pop
+			IL_0cf9: ldloc.0
+			IL_0cfa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0cff: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0d04: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5946,7 +5710,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4ad1
+			// Method begins at RVA 0x484d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -6212,7 +5976,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4c9c
+		// Method begins at RVA 0x4a18
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38e8
+				// Method begins at RVA 0x3736
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,7 +47,7 @@
 			)
 			// Method begins at RVA 0x22b0
 			// Header size: 12
-			// Code size: 53 (0x35)
+			// Code size: 39 (0x27)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -55,25 +55,19 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
-			IL_0006: stloc.0
-			IL_0007: ldstr "fs"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "readFileSync"
-			IL_0020: ldarg.2
-			IL_0021: ldstr "utf8"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_002b: stloc.0
-			IL_002c: ldloc.0
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_0032: stloc.0
-			IL_0033: ldloc.0
-			IL_0034: ret
+			IL_000d: ldstr "readFileSync"
+			IL_0012: ldarg.2
+			IL_0013: ldstr "utf8"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_001d: stloc.0
+			IL_001e: ldloc.0
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_0024: stloc.0
+			IL_0025: ldloc.0
+			IL_0026: ret
 		} // end of method readJson::__js_call__
 
 	} // end of class readJson
@@ -89,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38f1
+				// Method begins at RVA 0x373f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -113,7 +107,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22f4
+			// Method begins at RVA 0x22e4
 			// Header size: 12
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -163,7 +157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38fa
+				// Method begins at RVA 0x3748
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -187,7 +181,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2338
+			// Method begins at RVA 0x2328
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -230,7 +224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3903
+				// Method begins at RVA 0x3751
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -255,7 +249,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2374
+			// Method begins at RVA 0x2364
 			// Header size: 12
 			// Code size: 122 (0x7a)
 			.maxstack 8
@@ -337,7 +331,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x390c
+				// Method begins at RVA 0x375a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -364,9 +358,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x23fc
+			// Method begins at RVA 0x23ec
 			// Header size: 12
-			// Code size: 313 (0x139)
+			// Code size: 287 (0x11f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -420,84 +414,74 @@
 			IL_0070: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0075: stloc.s 5
 			IL_0077: ldloc.s 5
-			IL_0079: brfalse IL_00d0
+			IL_0079: brfalse IL_00c4
 
 			IL_007e: ldarg.0
 			IL_007f: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
 			IL_0084: stloc.3
-			IL_0085: ldstr "fmtCode"
-			IL_008a: ldloc.3
-			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0090: stloc.3
-			IL_0091: ldc.i4.1
-			IL_0092: newarr [System.Runtime]System.Object
-			IL_0097: dup
-			IL_0098: ldc.i4.0
-			IL_0099: ldarg.0
-			IL_009a: stelem.ref
-			IL_009b: stloc.s 6
-			IL_009d: ldloc.3
-			IL_009e: ldloc.s 6
-			IL_00a0: ldarg.2
-			IL_00a1: ldstr "nodeVersionTarget"
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00b0: stloc.3
-			IL_00b1: ldloc.3
-			IL_00b2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00b7: stloc.s 7
-			IL_00b9: ldstr "Target: "
-			IL_00be: ldloc.s 7
-			IL_00c0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00c5: stloc.s 7
-			IL_00c7: ldloc.1
-			IL_00c8: ldloc.s 7
-			IL_00ca: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_00cf: pop
+			IL_0085: ldc.i4.1
+			IL_0086: newarr [System.Runtime]System.Object
+			IL_008b: dup
+			IL_008c: ldc.i4.0
+			IL_008d: ldarg.0
+			IL_008e: stelem.ref
+			IL_008f: stloc.s 6
+			IL_0091: ldloc.3
+			IL_0092: ldloc.s 6
+			IL_0094: ldarg.2
+			IL_0095: ldstr "nodeVersionTarget"
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00a4: stloc.3
+			IL_00a5: ldloc.3
+			IL_00a6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00ab: stloc.s 7
+			IL_00ad: ldstr "Target: "
+			IL_00b2: ldloc.s 7
+			IL_00b4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00b9: stloc.s 7
+			IL_00bb: ldloc.1
+			IL_00bc: ldloc.s 7
+			IL_00be: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00c3: pop
 
-			IL_00d0: ldarg.0
-			IL_00d1: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-			IL_00d6: stloc.3
-			IL_00d7: ldstr "fmtCode"
-			IL_00dc: ldloc.3
-			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00e2: stloc.3
-			IL_00e3: ldloc.3
-			IL_00e4: ldc.i4.1
-			IL_00e5: newarr [System.Runtime]System.Object
-			IL_00ea: dup
-			IL_00eb: ldc.i4.0
-			IL_00ec: ldarg.0
-			IL_00ed: stelem.ref
-			IL_00ee: ldloc.0
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00f4: stloc.3
-			IL_00f5: ldloc.3
-			IL_00f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00fb: stloc.s 7
-			IL_00fd: ldstr "Generated: "
-			IL_0102: ldloc.s 7
-			IL_0104: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0109: stloc.s 7
-			IL_010b: ldloc.1
-			IL_010c: ldloc.s 7
-			IL_010e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0113: pop
-			IL_0114: ldloc.1
-			IL_0115: ldstr ""
-			IL_011a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_011f: pop
-			IL_0120: ldloc.1
-			IL_0121: ldc.i4.1
-			IL_0122: newarr [System.Runtime]System.Object
-			IL_0127: dup
-			IL_0128: ldc.i4.0
-			IL_0129: ldstr "\n"
-			IL_012e: stelem.ref
-			IL_012f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0134: stloc.s 7
-			IL_0136: ldloc.s 7
-			IL_0138: ret
+			IL_00c4: ldarg.0
+			IL_00c5: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+			IL_00ca: ldc.i4.1
+			IL_00cb: newarr [System.Runtime]System.Object
+			IL_00d0: dup
+			IL_00d1: ldc.i4.0
+			IL_00d2: ldarg.0
+			IL_00d3: stelem.ref
+			IL_00d4: ldloc.0
+			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00da: stloc.3
+			IL_00db: ldloc.3
+			IL_00dc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00e1: stloc.s 7
+			IL_00e3: ldstr "Generated: "
+			IL_00e8: ldloc.s 7
+			IL_00ea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00ef: stloc.s 7
+			IL_00f1: ldloc.1
+			IL_00f2: ldloc.s 7
+			IL_00f4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00f9: pop
+			IL_00fa: ldloc.1
+			IL_00fb: ldstr ""
+			IL_0100: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0105: pop
+			IL_0106: ldloc.1
+			IL_0107: ldc.i4.1
+			IL_0108: newarr [System.Runtime]System.Object
+			IL_010d: dup
+			IL_010e: ldc.i4.0
+			IL_010f: ldstr "\n"
+			IL_0114: stelem.ref
+			IL_0115: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_011a: stloc.s 7
+			IL_011c: ldloc.s 7
+			IL_011e: ret
 		} // end of method renderHeader::__js_call__
 
 	} // end of class renderHeader
@@ -523,7 +507,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x391e
+					// Method begins at RVA 0x376c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -548,55 +532,49 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3888
+				// Method begins at RVA 0x36e4
 				// Header size: 12
-				// Code size: 75 (0x4b)
+				// Code size: 61 (0x3d)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object[],
+					[0] object[],
+					[1] object,
 					[2] string
 				)
 
-				IL_0000: ldarg.0
-				IL_0001: ldc.i4.0
-				IL_0002: ldelem.ref
-				IL_0003: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-				IL_0008: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-				IL_000d: stloc.0
-				IL_000e: ldstr "fmtCode"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldc.i4.2
-				IL_001b: newarr [System.Runtime]System.Object
-				IL_0020: dup
-				IL_0021: ldc.i4.0
-				IL_0022: ldarg.0
-				IL_0023: ldc.i4.0
-				IL_0024: ldelem.ref
-				IL_0025: stelem.ref
-				IL_0026: dup
-				IL_0027: ldc.i4.1
-				IL_0028: ldarg.0
-				IL_0029: ldc.i4.1
-				IL_002a: ldelem.ref
-				IL_002b: stelem.ref
-				IL_002c: stloc.1
-				IL_002d: ldloc.0
-				IL_002e: ldloc.1
-				IL_002f: ldarg.2
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0035: stloc.0
-				IL_0036: ldloc.0
-				IL_0037: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_003c: stloc.2
-				IL_003d: ldstr "- "
-				IL_0042: ldloc.2
-				IL_0043: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0048: stloc.2
-				IL_0049: ldloc.2
-				IL_004a: ret
+				IL_0000: ldc.i4.2
+				IL_0001: newarr [System.Runtime]System.Object
+				IL_0006: dup
+				IL_0007: ldc.i4.0
+				IL_0008: ldarg.0
+				IL_0009: ldc.i4.0
+				IL_000a: ldelem.ref
+				IL_000b: stelem.ref
+				IL_000c: dup
+				IL_000d: ldc.i4.1
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: stelem.ref
+				IL_0012: stloc.0
+				IL_0013: ldarg.0
+				IL_0014: ldc.i4.0
+				IL_0015: ldelem.ref
+				IL_0016: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+				IL_001b: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+				IL_0020: ldloc.0
+				IL_0021: ldarg.2
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0027: stloc.1
+				IL_0028: ldloc.1
+				IL_0029: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_002e: stloc.2
+				IL_002f: ldstr "- "
+				IL_0034: ldloc.2
+				IL_0035: call string [System.Runtime]System.String::Concat(string, string)
+				IL_003a: stloc.2
+				IL_003b: ldloc.2
+				IL_003c: ret
 			} // end of method ArrowFunction_L42C20::__js_call__
 
 		} // end of class ArrowFunction_L42C20
@@ -608,7 +586,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3915
+				// Method begins at RVA 0x3763
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -635,96 +613,90 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2544
+			// Method begins at RVA 0x2518
 			// Header size: 12
-			// Code size: 191 (0xbf)
+			// Code size: 177 (0xb1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/Scope,
 				[1] object,
-				[2] object,
-				[3] object[],
+				[2] object[],
+				[3] object,
 				[4] bool,
 				[5] object
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldarg.0
-			IL_0007: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::asArray
-			IL_000c: stloc.2
-			IL_000d: ldstr "asArray"
-			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldc.i4.1
-			IL_001a: newarr [System.Runtime]System.Object
-			IL_001f: dup
-			IL_0020: ldc.i4.0
-			IL_0021: ldarg.0
-			IL_0022: stelem.ref
-			IL_0023: stloc.3
-			IL_0024: ldloc.2
-			IL_0025: ldloc.3
-			IL_0026: ldarg.2
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_002c: stloc.2
-			IL_002d: ldloc.2
-			IL_002e: stloc.1
-			IL_002f: ldloc.1
-			IL_0030: ldstr "length"
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_003f: ldc.i4.0
-			IL_0040: ceq
-			IL_0042: stloc.s 4
-			IL_0044: ldloc.s 4
-			IL_0046: brfalse IL_0051
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: stloc.2
+			IL_0011: ldarg.0
+			IL_0012: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::asArray
+			IL_0017: ldloc.2
+			IL_0018: ldarg.2
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_001e: stloc.3
+			IL_001f: ldloc.3
+			IL_0020: stloc.1
+			IL_0021: ldloc.1
+			IL_0022: ldstr "length"
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0031: ldc.i4.0
+			IL_0032: ceq
+			IL_0034: stloc.s 4
+			IL_0036: ldloc.s 4
+			IL_0038: brfalse IL_0043
 
-			IL_004b: ldstr ""
-			IL_0050: ret
+			IL_003d: ldstr ""
+			IL_0042: ret
 
-			IL_0051: ldloc.1
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0057: stloc.2
-			IL_0058: ldnull
-			IL_0059: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20::__js_call__(object[], object, object)
-			IL_005f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0064: ldc.i4.2
-			IL_0065: newarr [System.Runtime]System.Object
-			IL_006a: dup
-			IL_006b: ldc.i4.0
-			IL_006c: ldarg.0
-			IL_006d: stelem.ref
-			IL_006e: dup
-			IL_006f: ldc.i4.1
-			IL_0070: ldloc.0
-			IL_0071: stelem.ref
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_007c: ldc.i4.1
-			IL_007d: conv.r8
-			IL_007e: ldstr ""
-			IL_0083: ldc.i4.0
-			IL_0084: ldc.i4.1
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_008f: stloc.s 5
-			IL_0091: ldloc.2
-			IL_0092: ldstr "map"
-			IL_0097: ldloc.s 5
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_009e: stloc.s 5
-			IL_00a0: ldloc.s 5
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a7: stloc.s 5
-			IL_00a9: ldloc.s 5
-			IL_00ab: ldstr "join"
-			IL_00b0: ldstr "\n"
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ba: stloc.s 5
-			IL_00bc: ldloc.s 5
-			IL_00be: ret
+			IL_0043: ldloc.1
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0049: stloc.3
+			IL_004a: ldnull
+			IL_004b: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20::__js_call__(object[], object, object)
+			IL_0051: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0056: ldc.i4.2
+			IL_0057: newarr [System.Runtime]System.Object
+			IL_005c: dup
+			IL_005d: ldc.i4.0
+			IL_005e: ldarg.0
+			IL_005f: stelem.ref
+			IL_0060: dup
+			IL_0061: ldc.i4.1
+			IL_0062: ldloc.0
+			IL_0063: stelem.ref
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_006e: ldc.i4.1
+			IL_006f: conv.r8
+			IL_0070: ldstr ""
+			IL_0075: ldc.i4.0
+			IL_0076: ldc.i4.1
+			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0081: stloc.s 5
+			IL_0083: ldloc.3
+			IL_0084: ldstr "map"
+			IL_0089: ldloc.s 5
+			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0090: stloc.s 5
+			IL_0092: ldloc.s 5
+			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0099: stloc.s 5
+			IL_009b: ldloc.s 5
+			IL_009d: ldstr "join"
+			IL_00a2: ldstr "\n"
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00ac: stloc.s 5
+			IL_00ae: ldloc.s 5
+			IL_00b0: ret
 		} // end of method renderImplementation::__js_call__
 
 	} // end of class renderImplementation
@@ -740,7 +712,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3927
+				// Method begins at RVA 0x3775
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -764,7 +736,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3939
+					// Method begins at RVA 0x3787
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -782,7 +754,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3930
+				// Method begins at RVA 0x377e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -809,9 +781,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2610
+			// Method begins at RVA 0x25d8
 			// Header size: 12
-			// Code size: 650 (0x28a)
+			// Code size: 636 (0x27c)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -904,7 +876,7 @@
 					IL_0099: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_009e: stloc.s 7
 					IL_00a0: ldloc.s 7
-					IL_00a2: brtrue IL_0257
+					IL_00a2: brtrue IL_0249
 
 					IL_00a7: ldloc.s 12
 					IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -1003,91 +975,87 @@
 					IL_01ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_01bf: stloc.s 7
 					IL_01c1: ldloc.s 7
-					IL_01c3: brfalse IL_0213
+					IL_01c3: brfalse IL_0205
 
 					IL_01c8: ldarg.0
 					IL_01c9: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::link
 					IL_01ce: stloc.s 12
-					IL_01d0: ldstr "link"
-					IL_01d5: ldloc.s 12
-					IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_01dc: stloc.s 12
-					IL_01de: ldc.i4.1
-					IL_01df: newarr [System.Runtime]System.Object
-					IL_01e4: dup
-					IL_01e5: ldc.i4.0
-					IL_01e6: ldarg.0
-					IL_01e7: stelem.ref
-					IL_01e8: stloc.s 18
-					IL_01ea: ldloc.s 4
-					IL_01ec: ldstr "docs"
-					IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01f6: stloc.s 19
-					IL_01f8: ldloc.s 12
-					IL_01fa: ldloc.s 18
+					IL_01d0: ldc.i4.1
+					IL_01d1: newarr [System.Runtime]System.Object
+					IL_01d6: dup
+					IL_01d7: ldc.i4.0
+					IL_01d8: ldarg.0
+					IL_01d9: stelem.ref
+					IL_01da: stloc.s 18
+					IL_01dc: ldloc.s 4
+					IL_01de: ldstr "docs"
+					IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01e8: stloc.s 19
+					IL_01ea: ldloc.s 12
+					IL_01ec: ldloc.s 18
+					IL_01ee: ldloc.s 19
+					IL_01f0: ldstr "docs"
+					IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+					IL_01fa: stloc.s 19
 					IL_01fc: ldloc.s 19
-					IL_01fe: ldstr "docs"
-					IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-					IL_0208: stloc.s 19
-					IL_020a: ldloc.s 19
-					IL_020c: stloc.s 6
-					IL_020e: br IL_021a
+					IL_01fe: stloc.s 6
+					IL_0200: br IL_020c
 
-					IL_0213: ldstr ""
-					IL_0218: stloc.s 6
+					IL_0205: ldstr ""
+					IL_020a: stloc.s 6
 
-					IL_021a: ldloc.s 6
-					IL_021c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0221: stloc.s 16
-					IL_0223: ldloc.s 14
-					IL_0225: ldloc.s 16
+					IL_020c: ldloc.s 6
+					IL_020e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0213: stloc.s 16
+					IL_0215: ldloc.s 14
+					IL_0217: ldloc.s 16
+					IL_0219: call string [System.Runtime]System.String::Concat(string, string)
+					IL_021e: stloc.s 16
+					IL_0220: ldloc.s 16
+					IL_0222: ldstr " |"
 					IL_0227: call string [System.Runtime]System.String::Concat(string, string)
 					IL_022c: stloc.s 16
-					IL_022e: ldloc.s 16
-					IL_0230: ldstr " |"
-					IL_0235: call string [System.Runtime]System.String::Concat(string, string)
-					IL_023a: stloc.s 16
-					IL_023c: ldloc.0
-					IL_023d: ldloc.s 16
-					IL_023f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0244: pop
-					IL_0245: br IL_008f
+					IL_022e: ldloc.0
+					IL_022f: ldloc.s 16
+					IL_0231: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0236: pop
+					IL_0237: br IL_008f
 				// end loop
-				IL_024a: ldloc.1
-				IL_024b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0250: ldc.i4.1
-				IL_0251: stloc.3
-				IL_0252: leave IL_0271
+				IL_023c: ldloc.1
+				IL_023d: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0242: ldc.i4.1
+				IL_0243: stloc.3
+				IL_0244: leave IL_0263
 
-				IL_0257: ldc.i4.1
-				IL_0258: stloc.2
-				IL_0259: leave IL_0271
+				IL_0249: ldc.i4.1
+				IL_024a: stloc.2
+				IL_024b: leave IL_0263
 			} // end .try
 			finally
 			{
-				IL_025e: ldloc.2
-				IL_025f: brtrue IL_0270
+				IL_0250: ldloc.2
+				IL_0251: brtrue IL_0262
 
-				IL_0264: ldloc.3
-				IL_0265: brtrue IL_0270
+				IL_0256: ldloc.3
+				IL_0257: brtrue IL_0262
 
-				IL_026a: ldloc.1
-				IL_026b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_025c: ldloc.1
+				IL_025d: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_0270: endfinally
+				IL_0262: endfinally
 			} // end handler
 
-			IL_0271: ldloc.0
-			IL_0272: ldc.i4.1
-			IL_0273: newarr [System.Runtime]System.Object
-			IL_0278: dup
-			IL_0279: ldc.i4.0
-			IL_027a: ldstr "\n"
-			IL_027f: stelem.ref
-			IL_0280: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0285: stloc.s 16
-			IL_0287: ldloc.s 16
-			IL_0289: ret
+			IL_0263: ldloc.0
+			IL_0264: ldc.i4.1
+			IL_0265: newarr [System.Runtime]System.Object
+			IL_026a: dup
+			IL_026b: ldc.i4.0
+			IL_026c: ldstr "\n"
+			IL_0271: stelem.ref
+			IL_0272: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0277: stloc.s 16
+			IL_0279: ldloc.s 16
+			IL_027b: ret
 		} // end of method renderApisTable::__js_call__
 
 	} // end of class renderApisTable
@@ -1103,7 +1071,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3942
+				// Method begins at RVA 0x3790
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1127,7 +1095,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3954
+					// Method begins at RVA 0x37a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1151,7 +1119,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3966
+						// Method begins at RVA 0x37b4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1169,7 +1137,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x395d
+					// Method begins at RVA 0x37ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1187,7 +1155,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x394b
+				// Method begins at RVA 0x3799
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1214,9 +1182,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x28c4
+			// Method begins at RVA 0x287c
 			// Header size: 12
-			// Code size: 825 (0x339)
+			// Code size: 783 (0x30f)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -1282,7 +1250,7 @@
 					IL_003c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_0041: stloc.s 15
 					IL_0043: ldloc.s 15
-					IL_0045: brtrue IL_0306
+					IL_0045: brtrue IL_02dc
 
 					IL_004a: ldloc.s 18
 					IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -1332,251 +1300,239 @@
 					IL_00cc: ldloc.s 15
 					IL_00ce: brfalse IL_00d8
 
-					IL_00d3: br IL_02f4
+					IL_00d3: br IL_02ca
 
 					IL_00d8: ldarg.0
 					IL_00d9: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
 					IL_00de: stloc.s 18
-					IL_00e0: ldstr "fmtCode"
-					IL_00e5: ldloc.s 18
-					IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_00ec: stloc.s 18
-					IL_00ee: ldc.i4.1
-					IL_00ef: newarr [System.Runtime]System.Object
-					IL_00f4: dup
-					IL_00f5: ldc.i4.0
-					IL_00f6: ldarg.0
-					IL_00f7: stelem.ref
-					IL_00f8: stloc.s 22
-					IL_00fa: ldloc.s 4
-					IL_00fc: ldstr "name"
-					IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0106: stloc.s 23
-					IL_0108: ldloc.s 23
-					IL_010a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_010f: stloc.s 15
-					IL_0111: ldloc.s 15
-					IL_0113: brtrue IL_0124
+					IL_00e0: ldc.i4.1
+					IL_00e1: newarr [System.Runtime]System.Object
+					IL_00e6: dup
+					IL_00e7: ldc.i4.0
+					IL_00e8: ldarg.0
+					IL_00e9: stelem.ref
+					IL_00ea: stloc.s 22
+					IL_00ec: ldloc.s 4
+					IL_00ee: ldstr "name"
+					IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_00f8: stloc.s 23
+					IL_00fa: ldloc.s 23
+					IL_00fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0101: stloc.s 15
+					IL_0103: ldloc.s 15
+					IL_0105: brtrue IL_0116
 
-					IL_0118: ldstr ""
-					IL_011d: stloc.s 24
-					IL_011f: br IL_0128
+					IL_010a: ldstr ""
+					IL_010f: stloc.s 24
+					IL_0111: br IL_011a
 
-					IL_0124: ldloc.s 23
-					IL_0126: stloc.s 24
+					IL_0116: ldloc.s 23
+					IL_0118: stloc.s 24
 
-					IL_0128: ldloc.s 18
-					IL_012a: ldloc.s 22
-					IL_012c: ldloc.s 24
-					IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0133: stloc.s 18
-					IL_0135: ldloc.s 18
-					IL_0137: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_011a: ldloc.s 18
+					IL_011c: ldloc.s 22
+					IL_011e: ldloc.s 24
+					IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0125: stloc.s 18
+					IL_0127: ldloc.s 18
+					IL_0129: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_012e: stloc.s 25
+					IL_0130: ldstr "- "
+					IL_0135: ldloc.s 25
+					IL_0137: call string [System.Runtime]System.String::Concat(string, string)
 					IL_013c: stloc.s 25
-					IL_013e: ldstr "- "
-					IL_0143: ldloc.s 25
-					IL_0145: call string [System.Runtime]System.String::Concat(string, string)
-					IL_014a: stloc.s 25
-					IL_014c: ldloc.0
-					IL_014d: ldloc.s 25
-					IL_014f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0154: pop
-					IL_0155: ldloc.s 4
-					IL_0157: ldstr "tests"
-					IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0161: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-					IL_0166: stloc.s 6
-					IL_0168: ldc.i4.0
-					IL_0169: stloc.s 7
-					IL_016b: ldc.i4.0
-					IL_016c: stloc.s 8
+					IL_013e: ldloc.0
+					IL_013f: ldloc.s 25
+					IL_0141: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0146: pop
+					IL_0147: ldloc.s 4
+					IL_0149: ldstr "tests"
+					IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+					IL_0158: stloc.s 6
+					IL_015a: ldc.i4.0
+					IL_015b: stloc.s 7
+					IL_015d: ldc.i4.0
+					IL_015e: stloc.s 8
 					.try
 					{
-						// loop start (head: IL_016e)
-							IL_016e: ldloc.s 6
-							IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-							IL_0175: stloc.s 18
-							IL_0177: ldloc.s 18
-							IL_0179: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-							IL_017e: stloc.s 15
-							IL_0180: ldloc.s 15
-							IL_0182: brtrue IL_02d6
+						// loop start (head: IL_0160)
+							IL_0160: ldloc.s 6
+							IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+							IL_0167: stloc.s 18
+							IL_0169: ldloc.s 18
+							IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+							IL_0170: stloc.s 15
+							IL_0172: ldloc.s 15
+							IL_0174: brtrue IL_02ac
 
-							IL_0187: ldloc.s 18
-							IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-							IL_018e: stloc.s 18
-							IL_0190: ldloc.s 18
-							IL_0192: stloc.s 9
-							IL_0194: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/Scope_ForOf_L58C7/Scope_ForOf_L61C9/Block_L61C31::.ctor()
-							IL_0199: stloc.s 10
-							IL_019b: ldloc.s 9
-							IL_019d: ldstr "name"
-							IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_01a7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_01ac: stloc.s 15
-							IL_01ae: ldloc.s 15
-							IL_01b0: brfalse IL_01f7
+							IL_0179: ldloc.s 18
+							IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+							IL_0180: stloc.s 18
+							IL_0182: ldloc.s 18
+							IL_0184: stloc.s 9
+							IL_0186: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/Scope_ForOf_L58C7/Scope_ForOf_L61C9/Block_L61C31::.ctor()
+							IL_018b: stloc.s 10
+							IL_018d: ldloc.s 9
+							IL_018f: ldstr "name"
+							IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_0199: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_019e: stloc.s 15
+							IL_01a0: ldloc.s 15
+							IL_01a2: brfalse IL_01db
 
-							IL_01b5: ldarg.0
-							IL_01b6: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-							IL_01bb: stloc.s 18
-							IL_01bd: ldstr "fmtCode"
-							IL_01c2: ldloc.s 18
-							IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-							IL_01c9: stloc.s 18
-							IL_01cb: ldc.i4.1
-							IL_01cc: newarr [System.Runtime]System.Object
-							IL_01d1: dup
-							IL_01d2: ldc.i4.0
-							IL_01d3: ldarg.0
-							IL_01d4: stelem.ref
-							IL_01d5: stloc.s 22
-							IL_01d7: ldloc.s 18
-							IL_01d9: ldloc.s 22
-							IL_01db: ldloc.s 9
-							IL_01dd: ldstr "name"
-							IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-							IL_01ec: stloc.s 18
-							IL_01ee: ldloc.s 18
-							IL_01f0: stloc.s 11
-							IL_01f2: br IL_01fe
+							IL_01a7: ldarg.0
+							IL_01a8: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+							IL_01ad: stloc.s 18
+							IL_01af: ldc.i4.1
+							IL_01b0: newarr [System.Runtime]System.Object
+							IL_01b5: dup
+							IL_01b6: ldc.i4.0
+							IL_01b7: ldarg.0
+							IL_01b8: stelem.ref
+							IL_01b9: stloc.s 22
+							IL_01bb: ldloc.s 18
+							IL_01bd: ldloc.s 22
+							IL_01bf: ldloc.s 9
+							IL_01c1: ldstr "name"
+							IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+							IL_01d0: stloc.s 18
+							IL_01d2: ldloc.s 18
+							IL_01d4: stloc.s 11
+							IL_01d6: br IL_01e2
 
-							IL_01f7: ldstr ""
-							IL_01fc: stloc.s 11
+							IL_01db: ldstr ""
+							IL_01e0: stloc.s 11
 
-							IL_01fe: ldloc.s 11
-							IL_0200: stloc.s 12
-							IL_0202: ldloc.s 9
-							IL_0204: ldstr "file"
-							IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_020e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_0213: stloc.s 15
-							IL_0215: ldloc.s 15
-							IL_0217: brfalse IL_0283
+							IL_01e2: ldloc.s 11
+							IL_01e4: stloc.s 12
+							IL_01e6: ldloc.s 9
+							IL_01e8: ldstr "file"
+							IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_01f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_01f7: stloc.s 15
+							IL_01f9: ldloc.s 15
+							IL_01fb: brfalse IL_0259
 
-							IL_021c: ldarg.0
-							IL_021d: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-							IL_0222: stloc.s 18
-							IL_0224: ldstr "fmtCode"
-							IL_0229: ldloc.s 18
-							IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-							IL_0230: stloc.s 18
-							IL_0232: ldc.i4.1
-							IL_0233: newarr [System.Runtime]System.Object
-							IL_0238: dup
-							IL_0239: ldc.i4.0
-							IL_023a: ldarg.0
-							IL_023b: stelem.ref
-							IL_023c: stloc.s 22
-							IL_023e: ldloc.s 18
-							IL_0240: ldloc.s 22
-							IL_0242: ldloc.s 9
-							IL_0244: ldstr "file"
-							IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-							IL_0253: stloc.s 18
-							IL_0255: ldloc.s 18
-							IL_0257: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_025c: stloc.s 25
-							IL_025e: ldstr " ("
-							IL_0263: ldloc.s 25
-							IL_0265: call string [System.Runtime]System.String::Concat(string, string)
-							IL_026a: stloc.s 25
-							IL_026c: ldloc.s 25
-							IL_026e: ldstr ")"
-							IL_0273: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0278: stloc.s 25
-							IL_027a: ldloc.s 25
-							IL_027c: stloc.s 13
-							IL_027e: br IL_028a
+							IL_0200: ldarg.0
+							IL_0201: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+							IL_0206: stloc.s 18
+							IL_0208: ldc.i4.1
+							IL_0209: newarr [System.Runtime]System.Object
+							IL_020e: dup
+							IL_020f: ldc.i4.0
+							IL_0210: ldarg.0
+							IL_0211: stelem.ref
+							IL_0212: stloc.s 22
+							IL_0214: ldloc.s 18
+							IL_0216: ldloc.s 22
+							IL_0218: ldloc.s 9
+							IL_021a: ldstr "file"
+							IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+							IL_0229: stloc.s 18
+							IL_022b: ldloc.s 18
+							IL_022d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0232: stloc.s 25
+							IL_0234: ldstr " ("
+							IL_0239: ldloc.s 25
+							IL_023b: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0240: stloc.s 25
+							IL_0242: ldloc.s 25
+							IL_0244: ldstr ")"
+							IL_0249: call string [System.Runtime]System.String::Concat(string, string)
+							IL_024e: stloc.s 25
+							IL_0250: ldloc.s 25
+							IL_0252: stloc.s 13
+							IL_0254: br IL_0260
 
-							IL_0283: ldstr ""
-							IL_0288: stloc.s 13
+							IL_0259: ldstr ""
+							IL_025e: stloc.s 13
 
-							IL_028a: ldloc.s 13
-							IL_028c: stloc.s 14
-							IL_028e: ldloc.s 12
-							IL_0290: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_0295: stloc.s 25
-							IL_0297: ldstr "  - "
-							IL_029c: ldloc.s 25
-							IL_029e: call string [System.Runtime]System.String::Concat(string, string)
-							IL_02a3: stloc.s 25
-							IL_02a5: ldloc.s 14
-							IL_02a7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_02ac: stloc.s 26
-							IL_02ae: ldloc.s 25
-							IL_02b0: ldloc.s 26
-							IL_02b2: call string [System.Runtime]System.String::Concat(string, string)
-							IL_02b7: stloc.s 26
-							IL_02b9: ldloc.0
-							IL_02ba: ldloc.s 26
-							IL_02bc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-							IL_02c1: pop
-							IL_02c2: br IL_016e
+							IL_0260: ldloc.s 13
+							IL_0262: stloc.s 14
+							IL_0264: ldloc.s 12
+							IL_0266: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_026b: stloc.s 25
+							IL_026d: ldstr "  - "
+							IL_0272: ldloc.s 25
+							IL_0274: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0279: stloc.s 25
+							IL_027b: ldloc.s 14
+							IL_027d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0282: stloc.s 26
+							IL_0284: ldloc.s 25
+							IL_0286: ldloc.s 26
+							IL_0288: call string [System.Runtime]System.String::Concat(string, string)
+							IL_028d: stloc.s 26
+							IL_028f: ldloc.0
+							IL_0290: ldloc.s 26
+							IL_0292: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+							IL_0297: pop
+							IL_0298: br IL_0160
 						// end loop
-						IL_02c7: ldloc.s 6
-						IL_02c9: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-						IL_02ce: ldc.i4.1
-						IL_02cf: stloc.s 8
-						IL_02d1: leave IL_02f4
+						IL_029d: ldloc.s 6
+						IL_029f: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+						IL_02a4: ldc.i4.1
+						IL_02a5: stloc.s 8
+						IL_02a7: leave IL_02ca
 
-						IL_02d6: ldc.i4.1
-						IL_02d7: stloc.s 7
-						IL_02d9: leave IL_02f4
+						IL_02ac: ldc.i4.1
+						IL_02ad: stloc.s 7
+						IL_02af: leave IL_02ca
 					} // end .try
 					finally
 					{
-						IL_02de: ldloc.s 7
-						IL_02e0: brtrue IL_02f3
+						IL_02b4: ldloc.s 7
+						IL_02b6: brtrue IL_02c9
 
-						IL_02e5: ldloc.s 8
-						IL_02e7: brtrue IL_02f3
+						IL_02bb: ldloc.s 8
+						IL_02bd: brtrue IL_02c9
 
-						IL_02ec: ldloc.s 6
-						IL_02ee: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+						IL_02c2: ldloc.s 6
+						IL_02c4: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-						IL_02f3: endfinally
+						IL_02c9: endfinally
 					} // end handler
 
-					IL_02f4: br IL_0032
+					IL_02ca: br IL_0032
 				// end loop
-				IL_02f9: ldloc.1
-				IL_02fa: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_02ff: ldc.i4.1
-				IL_0300: stloc.3
-				IL_0301: leave IL_0320
+				IL_02cf: ldloc.1
+				IL_02d0: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_02d5: ldc.i4.1
+				IL_02d6: stloc.3
+				IL_02d7: leave IL_02f6
 
-				IL_0306: ldc.i4.1
-				IL_0307: stloc.2
-				IL_0308: leave IL_0320
+				IL_02dc: ldc.i4.1
+				IL_02dd: stloc.2
+				IL_02de: leave IL_02f6
 			} // end .try
 			finally
 			{
-				IL_030d: ldloc.2
-				IL_030e: brtrue IL_031f
+				IL_02e3: ldloc.2
+				IL_02e4: brtrue IL_02f5
 
-				IL_0313: ldloc.3
-				IL_0314: brtrue IL_031f
+				IL_02e9: ldloc.3
+				IL_02ea: brtrue IL_02f5
 
-				IL_0319: ldloc.1
-				IL_031a: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_02ef: ldloc.1
+				IL_02f0: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_031f: endfinally
+				IL_02f5: endfinally
 			} // end handler
 
-			IL_0320: ldloc.0
-			IL_0321: ldc.i4.1
-			IL_0322: newarr [System.Runtime]System.Object
-			IL_0327: dup
-			IL_0328: ldc.i4.0
-			IL_0329: ldstr "\n"
-			IL_032e: stelem.ref
-			IL_032f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0334: stloc.s 26
-			IL_0336: ldloc.s 26
-			IL_0338: ret
+			IL_02f6: ldloc.0
+			IL_02f7: ldc.i4.1
+			IL_02f8: newarr [System.Runtime]System.Object
+			IL_02fd: dup
+			IL_02fe: ldc.i4.0
+			IL_02ff: ldstr "\n"
+			IL_0304: stelem.ref
+			IL_0305: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_030a: stloc.s 26
+			IL_030c: ldloc.s 26
+			IL_030e: ret
 		} // end of method renderApiTests::__js_call__
 
 	} // end of class renderApiTests
@@ -1592,7 +1548,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x396f
+				// Method begins at RVA 0x37bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1620,7 +1576,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x398a
+						// Method begins at RVA 0x37d8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1640,7 +1596,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3993
+						// Method begins at RVA 0x37e1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1660,7 +1616,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x399c
+						// Method begins at RVA 0x37ea
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1678,7 +1634,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3981
+					// Method begins at RVA 0x37cf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1696,7 +1652,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3978
+				// Method begins at RVA 0x37c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1723,9 +1679,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2c40
+			// Method begins at RVA 0x2bcc
 			// Header size: 12
-			// Code size: 836 (0x344)
+			// Code size: 780 (0x30c)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -1797,7 +1753,7 @@
 					IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_0068: stloc.s 12
 					IL_006a: ldloc.s 12
-					IL_006c: brtrue IL_0311
+					IL_006c: brtrue IL_02d9
 
 					IL_0071: ldloc.s 11
 					IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -1842,238 +1798,222 @@
 					IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00fa: stloc.s 12
 					IL_00fc: ldloc.s 12
-					IL_00fe: brfalse IL_015c
+					IL_00fe: brfalse IL_014e
 
 					IL_0103: ldarg.0
 					IL_0104: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::link
 					IL_0109: stloc.s 11
-					IL_010b: ldstr "link"
-					IL_0110: ldloc.s 11
-					IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0117: stloc.s 11
-					IL_0119: ldc.i4.1
-					IL_011a: newarr [System.Runtime]System.Object
-					IL_011f: dup
-					IL_0120: ldc.i4.0
-					IL_0121: ldarg.0
-					IL_0122: stelem.ref
-					IL_0123: stloc.s 17
-					IL_0125: ldloc.s 11
-					IL_0127: ldloc.s 17
-					IL_0129: ldloc.s 4
-					IL_012b: ldstr "docs"
-					IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_013a: stloc.s 11
-					IL_013c: ldloc.s 11
-					IL_013e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_010b: ldc.i4.1
+					IL_010c: newarr [System.Runtime]System.Object
+					IL_0111: dup
+					IL_0112: ldc.i4.0
+					IL_0113: ldarg.0
+					IL_0114: stelem.ref
+					IL_0115: stloc.s 17
+					IL_0117: ldloc.s 11
+					IL_0119: ldloc.s 17
+					IL_011b: ldloc.s 4
+					IL_011d: ldstr "docs"
+					IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_012c: stloc.s 11
+					IL_012e: ldloc.s 11
+					IL_0130: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0135: stloc.s 16
+					IL_0137: ldstr "Docs: "
+					IL_013c: ldloc.s 16
+					IL_013e: call string [System.Runtime]System.String::Concat(string, string)
 					IL_0143: stloc.s 16
-					IL_0145: ldstr "Docs: "
-					IL_014a: ldloc.s 16
-					IL_014c: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0151: stloc.s 16
-					IL_0153: ldloc.0
-					IL_0154: ldloc.s 16
-					IL_0156: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_015b: pop
+					IL_0145: ldloc.0
+					IL_0146: ldloc.s 16
+					IL_0148: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_014d: pop
 
-					IL_015c: ldloc.s 4
-					IL_015e: ldstr "implementation"
-					IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0168: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_016d: stloc.s 12
-					IL_016f: ldloc.s 12
-					IL_0171: brfalse IL_01cb
+					IL_014e: ldloc.s 4
+					IL_0150: ldstr "implementation"
+					IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_015f: stloc.s 12
+					IL_0161: ldloc.s 12
+					IL_0163: brfalse IL_01af
 
-					IL_0176: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L77C26::.ctor()
-					IL_017b: stloc.s 6
-					IL_017d: ldloc.0
-					IL_017e: ldstr "Implementation:"
-					IL_0183: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0188: pop
-					IL_0189: ldarg.0
-					IL_018a: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderImplementation
-					IL_018f: stloc.s 11
-					IL_0191: ldstr "renderImplementation"
-					IL_0196: ldloc.s 11
-					IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_019d: stloc.s 11
-					IL_019f: ldc.i4.1
-					IL_01a0: newarr [System.Runtime]System.Object
-					IL_01a5: dup
-					IL_01a6: ldc.i4.0
-					IL_01a7: ldarg.0
-					IL_01a8: stelem.ref
-					IL_01a9: stloc.s 17
-					IL_01ab: ldloc.s 11
-					IL_01ad: ldloc.s 17
-					IL_01af: ldloc.s 4
-					IL_01b1: ldstr "implementation"
-					IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_01c0: stloc.s 11
-					IL_01c2: ldloc.0
-					IL_01c3: ldloc.s 11
-					IL_01c5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01ca: pop
+					IL_0168: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L77C26::.ctor()
+					IL_016d: stloc.s 6
+					IL_016f: ldloc.0
+					IL_0170: ldstr "Implementation:"
+					IL_0175: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_017a: pop
+					IL_017b: ldarg.0
+					IL_017c: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderImplementation
+					IL_0181: stloc.s 11
+					IL_0183: ldc.i4.1
+					IL_0184: newarr [System.Runtime]System.Object
+					IL_0189: dup
+					IL_018a: ldc.i4.0
+					IL_018b: ldarg.0
+					IL_018c: stelem.ref
+					IL_018d: stloc.s 17
+					IL_018f: ldloc.s 11
+					IL_0191: ldloc.s 17
+					IL_0193: ldloc.s 4
+					IL_0195: ldstr "implementation"
+					IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_01a4: stloc.s 11
+					IL_01a6: ldloc.0
+					IL_01a7: ldloc.s 11
+					IL_01a9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01ae: pop
 
-					IL_01cb: ldloc.0
-					IL_01cc: ldstr ""
-					IL_01d1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01d6: pop
-					IL_01d7: ldarg.0
-					IL_01d8: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderApisTable
-					IL_01dd: stloc.s 11
-					IL_01df: ldstr "renderApisTable"
-					IL_01e4: ldloc.s 11
-					IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_01eb: stloc.s 11
-					IL_01ed: ldc.i4.1
-					IL_01ee: newarr [System.Runtime]System.Object
-					IL_01f3: dup
-					IL_01f4: ldc.i4.0
-					IL_01f5: ldarg.0
-					IL_01f6: stelem.ref
-					IL_01f7: stloc.s 17
-					IL_01f9: ldloc.s 4
-					IL_01fb: ldstr "apis"
-					IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0205: stloc.s 18
-					IL_0207: ldloc.s 18
-					IL_0209: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_020e: stloc.s 12
-					IL_0210: ldloc.s 12
-					IL_0212: brtrue IL_0224
+					IL_01af: ldloc.0
+					IL_01b0: ldstr ""
+					IL_01b5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01ba: pop
+					IL_01bb: ldarg.0
+					IL_01bc: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderApisTable
+					IL_01c1: stloc.s 11
+					IL_01c3: ldc.i4.1
+					IL_01c4: newarr [System.Runtime]System.Object
+					IL_01c9: dup
+					IL_01ca: ldc.i4.0
+					IL_01cb: ldarg.0
+					IL_01cc: stelem.ref
+					IL_01cd: stloc.s 17
+					IL_01cf: ldloc.s 4
+					IL_01d1: ldstr "apis"
+					IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01db: stloc.s 18
+					IL_01dd: ldloc.s 18
+					IL_01df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_01e4: stloc.s 12
+					IL_01e6: ldloc.s 12
+					IL_01e8: brtrue IL_01fa
 
-					IL_0217: ldc.i4.0
-					IL_0218: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_021d: stloc.s 19
-					IL_021f: br IL_0228
+					IL_01ed: ldc.i4.0
+					IL_01ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_01f3: stloc.s 19
+					IL_01f5: br IL_01fe
 
-					IL_0224: ldloc.s 18
-					IL_0226: stloc.s 19
+					IL_01fa: ldloc.s 18
+					IL_01fc: stloc.s 19
 
-					IL_0228: ldloc.s 11
-					IL_022a: ldloc.s 17
-					IL_022c: ldloc.s 19
-					IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0233: stloc.s 11
-					IL_0235: ldloc.s 11
-					IL_0237: stloc.s 7
-					IL_0239: ldloc.s 7
-					IL_023b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0240: stloc.s 12
-					IL_0242: ldloc.s 12
-					IL_0244: brfalse IL_0265
+					IL_01fe: ldloc.s 11
+					IL_0200: ldloc.s 17
+					IL_0202: ldloc.s 19
+					IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0209: stloc.s 11
+					IL_020b: ldloc.s 11
+					IL_020d: stloc.s 7
+					IL_020f: ldloc.s 7
+					IL_0211: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0216: stloc.s 12
+					IL_0218: ldloc.s 12
+					IL_021a: brfalse IL_023b
 
-					IL_0249: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L83C15::.ctor()
-					IL_024e: stloc.s 8
-					IL_0250: ldloc.0
-					IL_0251: ldloc.s 7
-					IL_0253: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0258: pop
-					IL_0259: ldloc.0
-					IL_025a: ldstr ""
-					IL_025f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0264: pop
+					IL_021f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L83C15::.ctor()
+					IL_0224: stloc.s 8
+					IL_0226: ldloc.0
+					IL_0227: ldloc.s 7
+					IL_0229: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_022e: pop
+					IL_022f: ldloc.0
+					IL_0230: ldstr ""
+					IL_0235: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_023a: pop
 
-					IL_0265: ldarg.0
-					IL_0266: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderApiTests
-					IL_026b: stloc.s 11
-					IL_026d: ldstr "renderApiTests"
-					IL_0272: ldloc.s 11
-					IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0279: stloc.s 11
-					IL_027b: ldc.i4.1
-					IL_027c: newarr [System.Runtime]System.Object
-					IL_0281: dup
-					IL_0282: ldc.i4.0
-					IL_0283: ldarg.0
-					IL_0284: stelem.ref
-					IL_0285: stloc.s 17
-					IL_0287: ldloc.s 4
-					IL_0289: ldstr "apis"
-					IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0293: stloc.s 18
-					IL_0295: ldloc.s 18
-					IL_0297: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_029c: stloc.s 12
-					IL_029e: ldloc.s 12
-					IL_02a0: brtrue IL_02b2
+					IL_023b: ldarg.0
+					IL_023c: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderApiTests
+					IL_0241: stloc.s 11
+					IL_0243: ldc.i4.1
+					IL_0244: newarr [System.Runtime]System.Object
+					IL_0249: dup
+					IL_024a: ldc.i4.0
+					IL_024b: ldarg.0
+					IL_024c: stelem.ref
+					IL_024d: stloc.s 17
+					IL_024f: ldloc.s 4
+					IL_0251: ldstr "apis"
+					IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_025b: stloc.s 18
+					IL_025d: ldloc.s 18
+					IL_025f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0264: stloc.s 12
+					IL_0266: ldloc.s 12
+					IL_0268: brtrue IL_027a
 
-					IL_02a5: ldc.i4.0
-					IL_02a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_02ab: stloc.s 20
-					IL_02ad: br IL_02b6
+					IL_026d: ldc.i4.0
+					IL_026e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_0273: stloc.s 20
+					IL_0275: br IL_027e
 
-					IL_02b2: ldloc.s 18
-					IL_02b4: stloc.s 20
+					IL_027a: ldloc.s 18
+					IL_027c: stloc.s 20
 
-					IL_02b6: ldloc.s 11
-					IL_02b8: ldloc.s 17
-					IL_02ba: ldloc.s 20
-					IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_02c1: stloc.s 11
-					IL_02c3: ldloc.s 11
-					IL_02c5: stloc.s 9
-					IL_02c7: ldloc.s 9
-					IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02ce: stloc.s 12
-					IL_02d0: ldloc.s 12
-					IL_02d2: brfalse IL_02ff
+					IL_027e: ldloc.s 11
+					IL_0280: ldloc.s 17
+					IL_0282: ldloc.s 20
+					IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0289: stloc.s 11
+					IL_028b: ldloc.s 11
+					IL_028d: stloc.s 9
+					IL_028f: ldloc.s 9
+					IL_0291: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0296: stloc.s 12
+					IL_0298: ldloc.s 12
+					IL_029a: brfalse IL_02c7
 
-					IL_02d7: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L88C15::.ctor()
-					IL_02dc: stloc.s 10
-					IL_02de: ldloc.0
-					IL_02df: ldstr "Tests:"
-					IL_02e4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_02e9: pop
-					IL_02ea: ldloc.0
-					IL_02eb: ldloc.s 9
-					IL_02ed: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_02f2: pop
-					IL_02f3: ldloc.0
-					IL_02f4: ldstr ""
-					IL_02f9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_02fe: pop
+					IL_029f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L88C15::.ctor()
+					IL_02a4: stloc.s 10
+					IL_02a6: ldloc.0
+					IL_02a7: ldstr "Tests:"
+					IL_02ac: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_02b1: pop
+					IL_02b2: ldloc.0
+					IL_02b3: ldloc.s 9
+					IL_02b5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_02ba: pop
+					IL_02bb: ldloc.0
+					IL_02bc: ldstr ""
+					IL_02c1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_02c6: pop
 
-					IL_02ff: br IL_0059
+					IL_02c7: br IL_0059
 				// end loop
-				IL_0304: ldloc.1
-				IL_0305: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_030a: ldc.i4.1
-				IL_030b: stloc.3
-				IL_030c: leave IL_032b
+				IL_02cc: ldloc.1
+				IL_02cd: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_02d2: ldc.i4.1
+				IL_02d3: stloc.3
+				IL_02d4: leave IL_02f3
 
-				IL_0311: ldc.i4.1
-				IL_0312: stloc.2
-				IL_0313: leave IL_032b
+				IL_02d9: ldc.i4.1
+				IL_02da: stloc.2
+				IL_02db: leave IL_02f3
 			} // end .try
 			finally
 			{
-				IL_0318: ldloc.2
-				IL_0319: brtrue IL_032a
+				IL_02e0: ldloc.2
+				IL_02e1: brtrue IL_02f2
 
-				IL_031e: ldloc.3
-				IL_031f: brtrue IL_032a
+				IL_02e6: ldloc.3
+				IL_02e7: brtrue IL_02f2
 
-				IL_0324: ldloc.1
-				IL_0325: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_02ec: ldloc.1
+				IL_02ed: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_032a: endfinally
+				IL_02f2: endfinally
 			} // end handler
 
-			IL_032b: ldloc.0
-			IL_032c: ldc.i4.1
-			IL_032d: newarr [System.Runtime]System.Object
-			IL_0332: dup
-			IL_0333: ldc.i4.0
-			IL_0334: ldstr "\n"
-			IL_0339: stelem.ref
-			IL_033a: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_033f: stloc.s 16
-			IL_0341: ldloc.s 16
-			IL_0343: ret
+			IL_02f3: ldloc.0
+			IL_02f4: ldc.i4.1
+			IL_02f5: newarr [System.Runtime]System.Object
+			IL_02fa: dup
+			IL_02fb: ldc.i4.0
+			IL_02fc: ldstr "\n"
+			IL_0301: stelem.ref
+			IL_0302: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0307: stloc.s 16
+			IL_0309: ldloc.s 16
+			IL_030b: ret
 		} // end of method renderModules::__js_call__
 
 	} // end of class renderModules
@@ -2089,7 +2029,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39a5
+				// Method begins at RVA 0x37f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2117,7 +2057,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x39c0
+						// Method begins at RVA 0x380e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2137,7 +2077,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x39c9
+						// Method begins at RVA 0x3817
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2157,7 +2097,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x39d2
+						// Method begins at RVA 0x3820
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2181,7 +2121,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x39e4
+							// Method begins at RVA 0x3832
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2199,7 +2139,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x39db
+						// Method begins at RVA 0x3829
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2217,7 +2157,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x39b7
+					// Method begins at RVA 0x3805
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2235,7 +2175,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39ae
+				// Method begins at RVA 0x37fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2262,9 +2202,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2fac
+			// Method begins at RVA 0x2f00
 			// Header size: 12
-			// Code size: 1117 (0x45d)
+			// Code size: 1061 (0x425)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -2341,7 +2281,7 @@
 					IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_0068: stloc.s 19
 					IL_006a: ldloc.s 19
-					IL_006c: brtrue IL_042a
+					IL_006c: brtrue IL_03f2
 
 					IL_0071: ldloc.s 18
 					IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -2386,335 +2326,319 @@
 					IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00fa: stloc.s 19
 					IL_00fc: ldloc.s 19
-					IL_00fe: brfalse IL_015c
+					IL_00fe: brfalse IL_014e
 
 					IL_0103: ldarg.0
 					IL_0104: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::link
 					IL_0109: stloc.s 18
-					IL_010b: ldstr "link"
-					IL_0110: ldloc.s 18
-					IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0117: stloc.s 18
-					IL_0119: ldc.i4.1
-					IL_011a: newarr [System.Runtime]System.Object
-					IL_011f: dup
-					IL_0120: ldc.i4.0
-					IL_0121: ldarg.0
-					IL_0122: stelem.ref
-					IL_0123: stloc.s 24
-					IL_0125: ldloc.s 18
-					IL_0127: ldloc.s 24
-					IL_0129: ldloc.s 4
-					IL_012b: ldstr "docs"
-					IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_013a: stloc.s 18
-					IL_013c: ldloc.s 18
-					IL_013e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_010b: ldc.i4.1
+					IL_010c: newarr [System.Runtime]System.Object
+					IL_0111: dup
+					IL_0112: ldc.i4.0
+					IL_0113: ldarg.0
+					IL_0114: stelem.ref
+					IL_0115: stloc.s 24
+					IL_0117: ldloc.s 18
+					IL_0119: ldloc.s 24
+					IL_011b: ldloc.s 4
+					IL_011d: ldstr "docs"
+					IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_012c: stloc.s 18
+					IL_012e: ldloc.s 18
+					IL_0130: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0135: stloc.s 23
+					IL_0137: ldstr "Docs: "
+					IL_013c: ldloc.s 23
+					IL_013e: call string [System.Runtime]System.String::Concat(string, string)
 					IL_0143: stloc.s 23
-					IL_0145: ldstr "Docs: "
-					IL_014a: ldloc.s 23
-					IL_014c: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0151: stloc.s 23
-					IL_0153: ldloc.0
-					IL_0154: ldloc.s 23
-					IL_0156: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_015b: pop
+					IL_0145: ldloc.0
+					IL_0146: ldloc.s 23
+					IL_0148: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_014d: pop
 
-					IL_015c: ldloc.s 4
-					IL_015e: ldstr "implementation"
-					IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0168: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_016d: stloc.s 19
-					IL_016f: ldloc.s 19
-					IL_0171: brfalse IL_01cb
+					IL_014e: ldloc.s 4
+					IL_0150: ldstr "implementation"
+					IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_015f: stloc.s 19
+					IL_0161: ldloc.s 19
+					IL_0163: brfalse IL_01af
 
-					IL_0176: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L104C26::.ctor()
-					IL_017b: stloc.s 6
-					IL_017d: ldloc.0
-					IL_017e: ldstr "Implementation:"
-					IL_0183: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0188: pop
-					IL_0189: ldarg.0
-					IL_018a: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderImplementation
-					IL_018f: stloc.s 18
-					IL_0191: ldstr "renderImplementation"
-					IL_0196: ldloc.s 18
-					IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_019d: stloc.s 18
-					IL_019f: ldc.i4.1
-					IL_01a0: newarr [System.Runtime]System.Object
-					IL_01a5: dup
-					IL_01a6: ldc.i4.0
-					IL_01a7: ldarg.0
-					IL_01a8: stelem.ref
-					IL_01a9: stloc.s 24
-					IL_01ab: ldloc.s 18
-					IL_01ad: ldloc.s 24
+					IL_0168: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L104C26::.ctor()
+					IL_016d: stloc.s 6
+					IL_016f: ldloc.0
+					IL_0170: ldstr "Implementation:"
+					IL_0175: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_017a: pop
+					IL_017b: ldarg.0
+					IL_017c: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderImplementation
+					IL_0181: stloc.s 18
+					IL_0183: ldc.i4.1
+					IL_0184: newarr [System.Runtime]System.Object
+					IL_0189: dup
+					IL_018a: ldc.i4.0
+					IL_018b: ldarg.0
+					IL_018c: stelem.ref
+					IL_018d: stloc.s 24
+					IL_018f: ldloc.s 18
+					IL_0191: ldloc.s 24
+					IL_0193: ldloc.s 4
+					IL_0195: ldstr "implementation"
+					IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_01a4: stloc.s 18
+					IL_01a6: ldloc.0
+					IL_01a7: ldloc.s 18
+					IL_01a9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01ae: pop
+
 					IL_01af: ldloc.s 4
-					IL_01b1: ldstr "implementation"
+					IL_01b1: ldstr "notes"
 					IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_01c0: stloc.s 18
-					IL_01c2: ldloc.0
-					IL_01c3: ldloc.s 18
-					IL_01c5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01ca: pop
+					IL_01bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_01c0: stloc.s 19
+					IL_01c2: ldloc.s 19
+					IL_01c4: brfalse IL_01ef
 
-					IL_01cb: ldloc.s 4
-					IL_01cd: ldstr "notes"
-					IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01dc: stloc.s 19
-					IL_01de: ldloc.s 19
-					IL_01e0: brfalse IL_020b
+					IL_01c9: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L108C17::.ctor()
+					IL_01ce: stloc.s 7
+					IL_01d0: ldloc.0
+					IL_01d1: ldstr "Notes:"
+					IL_01d6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01db: pop
+					IL_01dc: ldloc.0
+					IL_01dd: ldloc.s 4
+					IL_01df: ldstr "notes"
+					IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01e9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01ee: pop
 
-					IL_01e5: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L108C17::.ctor()
-					IL_01ea: stloc.s 7
-					IL_01ec: ldloc.0
-					IL_01ed: ldstr "Notes:"
-					IL_01f2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01f7: pop
-					IL_01f8: ldloc.0
-					IL_01f9: ldloc.s 4
-					IL_01fb: ldstr "notes"
-					IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0205: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_020a: pop
+					IL_01ef: ldloc.s 4
+					IL_01f1: ldstr "tests"
+					IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01fb: stloc.s 18
+					IL_01fd: ldloc.s 18
+					IL_01ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0204: stloc.s 19
+					IL_0206: ldloc.s 19
+					IL_0208: brfalse IL_022a
 
-					IL_020b: ldloc.s 4
-					IL_020d: ldstr "tests"
-					IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0217: stloc.s 18
-					IL_0219: ldloc.s 18
-					IL_021b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0220: stloc.s 19
-					IL_0222: ldloc.s 19
-					IL_0224: brfalse IL_0246
+					IL_020d: ldloc.s 4
+					IL_020f: ldstr "tests"
+					IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0219: ldstr "length"
+					IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0223: stloc.s 25
+					IL_0225: br IL_022e
 
-					IL_0229: ldloc.s 4
-					IL_022b: ldstr "tests"
-					IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0235: ldstr "length"
-					IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_023f: stloc.s 25
-					IL_0241: br IL_024a
+					IL_022a: ldloc.s 18
+					IL_022c: stloc.s 25
 
-					IL_0246: ldloc.s 18
-					IL_0248: stloc.s 25
+					IL_022e: ldloc.s 25
+					IL_0230: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0235: stloc.s 19
+					IL_0237: ldloc.s 19
+					IL_0239: brfalse IL_03d4
 
-					IL_024a: ldloc.s 25
-					IL_024c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0251: stloc.s 19
-					IL_0253: ldloc.s 19
-					IL_0255: brfalse IL_040c
-
-					IL_025a: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L112C35::.ctor()
-					IL_025f: stloc.s 8
-					IL_0261: ldloc.0
-					IL_0262: ldstr "Tests:"
-					IL_0267: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_026c: pop
-					IL_026d: ldloc.s 4
-					IL_026f: ldstr "tests"
-					IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0279: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-					IL_027e: stloc.s 9
-					IL_0280: ldc.i4.0
-					IL_0281: stloc.s 10
-					IL_0283: ldc.i4.0
-					IL_0284: stloc.s 11
+					IL_023e: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L112C35::.ctor()
+					IL_0243: stloc.s 8
+					IL_0245: ldloc.0
+					IL_0246: ldstr "Tests:"
+					IL_024b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0250: pop
+					IL_0251: ldloc.s 4
+					IL_0253: ldstr "tests"
+					IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_025d: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+					IL_0262: stloc.s 9
+					IL_0264: ldc.i4.0
+					IL_0265: stloc.s 10
+					IL_0267: ldc.i4.0
+					IL_0268: stloc.s 11
 					.try
 					{
-						// loop start (head: IL_0286)
-							IL_0286: ldloc.s 9
-							IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-							IL_028d: stloc.s 18
-							IL_028f: ldloc.s 18
-							IL_0291: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-							IL_0296: stloc.s 19
-							IL_0298: ldloc.s 19
-							IL_029a: brtrue IL_03ee
+						// loop start (head: IL_026a)
+							IL_026a: ldloc.s 9
+							IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+							IL_0271: stloc.s 18
+							IL_0273: ldloc.s 18
+							IL_0275: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+							IL_027a: stloc.s 19
+							IL_027c: ldloc.s 19
+							IL_027e: brtrue IL_03b6
 
-							IL_029f: ldloc.s 18
-							IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-							IL_02a6: stloc.s 18
-							IL_02a8: ldloc.s 18
-							IL_02aa: stloc.s 12
-							IL_02ac: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Scope_ForOf_L114C11/Block_L114C31::.ctor()
-							IL_02b1: stloc.s 13
-							IL_02b3: ldloc.s 12
-							IL_02b5: ldstr "name"
-							IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_02bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_02c4: stloc.s 19
-							IL_02c6: ldloc.s 19
-							IL_02c8: brfalse IL_030f
+							IL_0283: ldloc.s 18
+							IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+							IL_028a: stloc.s 18
+							IL_028c: ldloc.s 18
+							IL_028e: stloc.s 12
+							IL_0290: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Scope_ForOf_L114C11/Block_L114C31::.ctor()
+							IL_0295: stloc.s 13
+							IL_0297: ldloc.s 12
+							IL_0299: ldstr "name"
+							IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_02a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_02a8: stloc.s 19
+							IL_02aa: ldloc.s 19
+							IL_02ac: brfalse IL_02e5
 
-							IL_02cd: ldarg.0
-							IL_02ce: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-							IL_02d3: stloc.s 18
-							IL_02d5: ldstr "fmtCode"
-							IL_02da: ldloc.s 18
-							IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-							IL_02e1: stloc.s 18
-							IL_02e3: ldc.i4.1
-							IL_02e4: newarr [System.Runtime]System.Object
-							IL_02e9: dup
-							IL_02ea: ldc.i4.0
-							IL_02eb: ldarg.0
-							IL_02ec: stelem.ref
-							IL_02ed: stloc.s 24
-							IL_02ef: ldloc.s 18
-							IL_02f1: ldloc.s 24
-							IL_02f3: ldloc.s 12
-							IL_02f5: ldstr "name"
-							IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-							IL_0304: stloc.s 18
-							IL_0306: ldloc.s 18
-							IL_0308: stloc.s 14
-							IL_030a: br IL_0316
+							IL_02b1: ldarg.0
+							IL_02b2: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+							IL_02b7: stloc.s 18
+							IL_02b9: ldc.i4.1
+							IL_02ba: newarr [System.Runtime]System.Object
+							IL_02bf: dup
+							IL_02c0: ldc.i4.0
+							IL_02c1: ldarg.0
+							IL_02c2: stelem.ref
+							IL_02c3: stloc.s 24
+							IL_02c5: ldloc.s 18
+							IL_02c7: ldloc.s 24
+							IL_02c9: ldloc.s 12
+							IL_02cb: ldstr "name"
+							IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+							IL_02da: stloc.s 18
+							IL_02dc: ldloc.s 18
+							IL_02de: stloc.s 14
+							IL_02e0: br IL_02ec
 
-							IL_030f: ldstr ""
-							IL_0314: stloc.s 14
+							IL_02e5: ldstr ""
+							IL_02ea: stloc.s 14
 
-							IL_0316: ldloc.s 14
-							IL_0318: stloc.s 15
-							IL_031a: ldloc.s 12
-							IL_031c: ldstr "file"
-							IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_0326: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_032b: stloc.s 19
-							IL_032d: ldloc.s 19
-							IL_032f: brfalse IL_039b
+							IL_02ec: ldloc.s 14
+							IL_02ee: stloc.s 15
+							IL_02f0: ldloc.s 12
+							IL_02f2: ldstr "file"
+							IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_02fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_0301: stloc.s 19
+							IL_0303: ldloc.s 19
+							IL_0305: brfalse IL_0363
 
-							IL_0334: ldarg.0
-							IL_0335: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-							IL_033a: stloc.s 18
-							IL_033c: ldstr "fmtCode"
-							IL_0341: ldloc.s 18
-							IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-							IL_0348: stloc.s 18
-							IL_034a: ldc.i4.1
-							IL_034b: newarr [System.Runtime]System.Object
-							IL_0350: dup
-							IL_0351: ldc.i4.0
-							IL_0352: ldarg.0
-							IL_0353: stelem.ref
-							IL_0354: stloc.s 24
-							IL_0356: ldloc.s 18
-							IL_0358: ldloc.s 24
-							IL_035a: ldloc.s 12
-							IL_035c: ldstr "file"
-							IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-							IL_036b: stloc.s 18
-							IL_036d: ldloc.s 18
-							IL_036f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_0374: stloc.s 23
-							IL_0376: ldstr " ("
-							IL_037b: ldloc.s 23
-							IL_037d: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0382: stloc.s 23
-							IL_0384: ldloc.s 23
-							IL_0386: ldstr ")"
-							IL_038b: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0390: stloc.s 23
-							IL_0392: ldloc.s 23
-							IL_0394: stloc.s 16
-							IL_0396: br IL_03a2
+							IL_030a: ldarg.0
+							IL_030b: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+							IL_0310: stloc.s 18
+							IL_0312: ldc.i4.1
+							IL_0313: newarr [System.Runtime]System.Object
+							IL_0318: dup
+							IL_0319: ldc.i4.0
+							IL_031a: ldarg.0
+							IL_031b: stelem.ref
+							IL_031c: stloc.s 24
+							IL_031e: ldloc.s 18
+							IL_0320: ldloc.s 24
+							IL_0322: ldloc.s 12
+							IL_0324: ldstr "file"
+							IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+							IL_0333: stloc.s 18
+							IL_0335: ldloc.s 18
+							IL_0337: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_033c: stloc.s 23
+							IL_033e: ldstr " ("
+							IL_0343: ldloc.s 23
+							IL_0345: call string [System.Runtime]System.String::Concat(string, string)
+							IL_034a: stloc.s 23
+							IL_034c: ldloc.s 23
+							IL_034e: ldstr ")"
+							IL_0353: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0358: stloc.s 23
+							IL_035a: ldloc.s 23
+							IL_035c: stloc.s 16
+							IL_035e: br IL_036a
 
-							IL_039b: ldstr ""
-							IL_03a0: stloc.s 16
+							IL_0363: ldstr ""
+							IL_0368: stloc.s 16
 
-							IL_03a2: ldloc.s 16
-							IL_03a4: stloc.s 17
-							IL_03a6: ldloc.s 15
-							IL_03a8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_03ad: stloc.s 23
-							IL_03af: ldstr "- "
-							IL_03b4: ldloc.s 23
-							IL_03b6: call string [System.Runtime]System.String::Concat(string, string)
-							IL_03bb: stloc.s 23
-							IL_03bd: ldloc.s 17
-							IL_03bf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_03c4: stloc.s 22
-							IL_03c6: ldloc.s 23
-							IL_03c8: ldloc.s 22
-							IL_03ca: call string [System.Runtime]System.String::Concat(string, string)
-							IL_03cf: stloc.s 22
-							IL_03d1: ldloc.0
-							IL_03d2: ldloc.s 22
-							IL_03d4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-							IL_03d9: pop
-							IL_03da: br IL_0286
+							IL_036a: ldloc.s 16
+							IL_036c: stloc.s 17
+							IL_036e: ldloc.s 15
+							IL_0370: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0375: stloc.s 23
+							IL_0377: ldstr "- "
+							IL_037c: ldloc.s 23
+							IL_037e: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0383: stloc.s 23
+							IL_0385: ldloc.s 17
+							IL_0387: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_038c: stloc.s 22
+							IL_038e: ldloc.s 23
+							IL_0390: ldloc.s 22
+							IL_0392: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0397: stloc.s 22
+							IL_0399: ldloc.0
+							IL_039a: ldloc.s 22
+							IL_039c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+							IL_03a1: pop
+							IL_03a2: br IL_026a
 						// end loop
-						IL_03df: ldloc.s 9
-						IL_03e1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-						IL_03e6: ldc.i4.1
-						IL_03e7: stloc.s 11
-						IL_03e9: leave IL_040c
+						IL_03a7: ldloc.s 9
+						IL_03a9: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+						IL_03ae: ldc.i4.1
+						IL_03af: stloc.s 11
+						IL_03b1: leave IL_03d4
 
-						IL_03ee: ldc.i4.1
-						IL_03ef: stloc.s 10
-						IL_03f1: leave IL_040c
+						IL_03b6: ldc.i4.1
+						IL_03b7: stloc.s 10
+						IL_03b9: leave IL_03d4
 					} // end .try
 					finally
 					{
-						IL_03f6: ldloc.s 10
-						IL_03f8: brtrue IL_040b
+						IL_03be: ldloc.s 10
+						IL_03c0: brtrue IL_03d3
 
-						IL_03fd: ldloc.s 11
-						IL_03ff: brtrue IL_040b
+						IL_03c5: ldloc.s 11
+						IL_03c7: brtrue IL_03d3
 
-						IL_0404: ldloc.s 9
-						IL_0406: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+						IL_03cc: ldloc.s 9
+						IL_03ce: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-						IL_040b: endfinally
+						IL_03d3: endfinally
 					} // end handler
 
-					IL_040c: ldloc.0
-					IL_040d: ldstr ""
-					IL_0412: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0417: pop
-					IL_0418: br IL_0059
+					IL_03d4: ldloc.0
+					IL_03d5: ldstr ""
+					IL_03da: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_03df: pop
+					IL_03e0: br IL_0059
 				// end loop
-				IL_041d: ldloc.1
-				IL_041e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0423: ldc.i4.1
-				IL_0424: stloc.3
-				IL_0425: leave IL_0444
+				IL_03e5: ldloc.1
+				IL_03e6: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_03eb: ldc.i4.1
+				IL_03ec: stloc.3
+				IL_03ed: leave IL_040c
 
-				IL_042a: ldc.i4.1
-				IL_042b: stloc.2
-				IL_042c: leave IL_0444
+				IL_03f2: ldc.i4.1
+				IL_03f3: stloc.2
+				IL_03f4: leave IL_040c
 			} // end .try
 			finally
 			{
-				IL_0431: ldloc.2
-				IL_0432: brtrue IL_0443
+				IL_03f9: ldloc.2
+				IL_03fa: brtrue IL_040b
 
-				IL_0437: ldloc.3
-				IL_0438: brtrue IL_0443
+				IL_03ff: ldloc.3
+				IL_0400: brtrue IL_040b
 
-				IL_043d: ldloc.1
-				IL_043e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_0405: ldloc.1
+				IL_0406: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_0443: endfinally
+				IL_040b: endfinally
 			} // end handler
 
-			IL_0444: ldloc.0
-			IL_0445: ldc.i4.1
-			IL_0446: newarr [System.Runtime]System.Object
-			IL_044b: dup
-			IL_044c: ldc.i4.0
-			IL_044d: ldstr "\n"
-			IL_0452: stelem.ref
-			IL_0453: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0458: stloc.s 22
-			IL_045a: ldloc.s 22
-			IL_045c: ret
+			IL_040c: ldloc.0
+			IL_040d: ldc.i4.1
+			IL_040e: newarr [System.Runtime]System.Object
+			IL_0413: dup
+			IL_0414: ldc.i4.0
+			IL_0415: ldstr "\n"
+			IL_041a: stelem.ref
+			IL_041b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0420: stloc.s 22
+			IL_0422: ldloc.s 22
+			IL_0424: ret
 		} // end of method renderGlobals::__js_call__
 
 	} // end of class renderGlobals
@@ -2730,7 +2654,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39ed
+				// Method begins at RVA 0x383b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2750,7 +2674,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39f6
+				// Method begins at RVA 0x3844
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2774,7 +2698,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x344c
+			// Method begins at RVA 0x3368
 			// Header size: 12
 			// Code size: 278 (0x116)
 			.maxstack 8
@@ -2927,7 +2851,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39ff
+				// Method begins at RVA 0x384d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2953,9 +2877,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x3580
+			// Method begins at RVA 0x349c
 			// Header size: 12
-			// Code size: 764 (0x2fc)
+			// Code size: 570 (0x23a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2975,293 +2899,229 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_0006: stloc.s 7
-			IL_0008: ldstr "path"
-			IL_000d: ldloc.s 7
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 7
-			IL_0016: ldloc.s 7
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001d: stloc.s 7
-			IL_001f: ldarg.0
-			IL_0020: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::__dirname
-			IL_0025: stloc.s 8
-			IL_0027: ldstr "__dirname"
-			IL_002c: ldloc.s 8
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0033: stloc.s 8
-			IL_0035: ldloc.s 7
-			IL_0037: ldstr "resolve"
-			IL_003c: ldloc.s 8
-			IL_003e: ldstr ".."
-			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0048: stloc.s 8
-			IL_004a: ldloc.s 8
-			IL_004c: stloc.0
-			IL_004d: ldarg.0
-			IL_004e: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_0053: stloc.s 8
-			IL_0055: ldstr "path"
-			IL_005a: ldloc.s 8
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0061: stloc.s 8
-			IL_0063: ldloc.s 8
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006a: stloc.s 8
-			IL_006c: ldc.i4.4
-			IL_006d: newarr [System.Runtime]System.Object
-			IL_0072: dup
-			IL_0073: ldc.i4.0
-			IL_0074: ldloc.0
-			IL_0075: stelem.ref
-			IL_0076: dup
-			IL_0077: ldc.i4.1
-			IL_0078: ldstr "docs"
-			IL_007d: stelem.ref
-			IL_007e: dup
-			IL_007f: ldc.i4.2
-			IL_0080: ldstr "nodejs"
-			IL_0085: stelem.ref
-			IL_0086: dup
-			IL_0087: ldc.i4.3
-			IL_0088: ldstr "NodeSupport.json"
-			IL_008d: stelem.ref
-			IL_008e: stloc.s 9
-			IL_0090: ldloc.s 8
-			IL_0092: ldstr "join"
-			IL_0097: ldloc.s 9
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_009e: stloc.s 8
-			IL_00a0: ldloc.s 8
-			IL_00a2: stloc.1
-			IL_00a3: ldarg.0
-			IL_00a4: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_00a9: stloc.s 8
-			IL_00ab: ldstr "path"
-			IL_00b0: ldloc.s 8
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00b7: stloc.s 8
-			IL_00b9: ldloc.s 8
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c0: stloc.s 8
-			IL_00c2: ldc.i4.4
-			IL_00c3: newarr [System.Runtime]System.Object
-			IL_00c8: dup
-			IL_00c9: ldc.i4.0
-			IL_00ca: ldloc.0
-			IL_00cb: stelem.ref
-			IL_00cc: dup
-			IL_00cd: ldc.i4.1
-			IL_00ce: ldstr "docs"
-			IL_00d3: stelem.ref
-			IL_00d4: dup
-			IL_00d5: ldc.i4.2
-			IL_00d6: ldstr "nodejs"
-			IL_00db: stelem.ref
-			IL_00dc: dup
-			IL_00dd: ldc.i4.3
-			IL_00de: ldstr "NodeSupport.md"
-			IL_00e3: stelem.ref
-			IL_00e4: stloc.s 9
-			IL_00e6: ldloc.s 8
-			IL_00e8: ldstr "join"
-			IL_00ed: ldloc.s 9
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_00f4: stloc.s 8
-			IL_00f6: ldloc.s 8
-			IL_00f8: stloc.2
-			IL_00f9: ldarg.0
-			IL_00fa: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::readJson
-			IL_00ff: stloc.s 8
-			IL_0101: ldstr "readJson"
-			IL_0106: ldloc.s 8
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_010d: stloc.s 8
-			IL_010f: ldloc.s 8
-			IL_0111: ldc.i4.1
-			IL_0112: newarr [System.Runtime]System.Object
-			IL_0117: dup
-			IL_0118: ldc.i4.0
-			IL_0119: ldarg.0
-			IL_011a: stelem.ref
-			IL_011b: ldloc.1
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0121: stloc.s 8
-			IL_0123: ldloc.s 8
-			IL_0125: stloc.3
-			IL_0126: ldc.i4.0
-			IL_0127: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_012c: stloc.s 4
-			IL_012e: ldarg.0
-			IL_012f: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderHeader
-			IL_0134: stloc.s 8
-			IL_0136: ldstr "renderHeader"
-			IL_013b: ldloc.s 8
-			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0142: stloc.s 8
-			IL_0144: ldloc.s 8
-			IL_0146: ldc.i4.1
-			IL_0147: newarr [System.Runtime]System.Object
-			IL_014c: dup
-			IL_014d: ldc.i4.0
-			IL_014e: ldarg.0
-			IL_014f: stelem.ref
-			IL_0150: ldloc.3
-			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0156: stloc.s 8
-			IL_0158: ldloc.s 4
-			IL_015a: ldloc.s 8
-			IL_015c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0161: pop
-			IL_0162: ldarg.0
-			IL_0163: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderModules
-			IL_0168: stloc.s 8
-			IL_016a: ldstr "renderModules"
-			IL_016f: ldloc.s 8
-			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0176: stloc.s 8
-			IL_0178: ldloc.s 8
-			IL_017a: ldc.i4.1
-			IL_017b: newarr [System.Runtime]System.Object
-			IL_0180: dup
-			IL_0181: ldc.i4.0
-			IL_0182: ldarg.0
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.s 7
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::__dirname
+			IL_0013: stloc.s 8
+			IL_0015: ldloc.s 7
+			IL_0017: ldstr "resolve"
+			IL_001c: ldloc.s 8
+			IL_001e: ldstr ".."
+			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0028: stloc.s 8
+			IL_002a: ldloc.s 8
+			IL_002c: stloc.0
+			IL_002d: ldarg.0
+			IL_002e: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0038: stloc.s 8
+			IL_003a: ldc.i4.4
+			IL_003b: newarr [System.Runtime]System.Object
+			IL_0040: dup
+			IL_0041: ldc.i4.0
+			IL_0042: ldloc.0
+			IL_0043: stelem.ref
+			IL_0044: dup
+			IL_0045: ldc.i4.1
+			IL_0046: ldstr "docs"
+			IL_004b: stelem.ref
+			IL_004c: dup
+			IL_004d: ldc.i4.2
+			IL_004e: ldstr "nodejs"
+			IL_0053: stelem.ref
+			IL_0054: dup
+			IL_0055: ldc.i4.3
+			IL_0056: ldstr "NodeSupport.json"
+			IL_005b: stelem.ref
+			IL_005c: stloc.s 9
+			IL_005e: ldloc.s 8
+			IL_0060: ldstr "join"
+			IL_0065: ldloc.s 9
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_006c: stloc.s 8
+			IL_006e: ldloc.s 8
+			IL_0070: stloc.1
+			IL_0071: ldarg.0
+			IL_0072: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_007c: stloc.s 8
+			IL_007e: ldc.i4.4
+			IL_007f: newarr [System.Runtime]System.Object
+			IL_0084: dup
+			IL_0085: ldc.i4.0
+			IL_0086: ldloc.0
+			IL_0087: stelem.ref
+			IL_0088: dup
+			IL_0089: ldc.i4.1
+			IL_008a: ldstr "docs"
+			IL_008f: stelem.ref
+			IL_0090: dup
+			IL_0091: ldc.i4.2
+			IL_0092: ldstr "nodejs"
+			IL_0097: stelem.ref
+			IL_0098: dup
+			IL_0099: ldc.i4.3
+			IL_009a: ldstr "NodeSupport.md"
+			IL_009f: stelem.ref
+			IL_00a0: stloc.s 9
+			IL_00a2: ldloc.s 8
+			IL_00a4: ldstr "join"
+			IL_00a9: ldloc.s 9
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_00b0: stloc.s 8
+			IL_00b2: ldloc.s 8
+			IL_00b4: stloc.2
+			IL_00b5: ldarg.0
+			IL_00b6: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::readJson
+			IL_00bb: ldc.i4.1
+			IL_00bc: newarr [System.Runtime]System.Object
+			IL_00c1: dup
+			IL_00c2: ldc.i4.0
+			IL_00c3: ldarg.0
+			IL_00c4: stelem.ref
+			IL_00c5: ldloc.1
+			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00cb: stloc.s 8
+			IL_00cd: ldloc.s 8
+			IL_00cf: stloc.3
+			IL_00d0: ldc.i4.0
+			IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00d6: stloc.s 4
+			IL_00d8: ldarg.0
+			IL_00d9: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderHeader
+			IL_00de: ldc.i4.1
+			IL_00df: newarr [System.Runtime]System.Object
+			IL_00e4: dup
+			IL_00e5: ldc.i4.0
+			IL_00e6: ldarg.0
+			IL_00e7: stelem.ref
+			IL_00e8: ldloc.3
+			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00ee: stloc.s 8
+			IL_00f0: ldloc.s 4
+			IL_00f2: ldloc.s 8
+			IL_00f4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00f9: pop
+			IL_00fa: ldarg.0
+			IL_00fb: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderModules
+			IL_0100: ldc.i4.1
+			IL_0101: newarr [System.Runtime]System.Object
+			IL_0106: dup
+			IL_0107: ldc.i4.0
+			IL_0108: ldarg.0
+			IL_0109: stelem.ref
+			IL_010a: ldloc.3
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0110: stloc.s 8
+			IL_0112: ldloc.s 4
+			IL_0114: ldloc.s 8
+			IL_0116: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_011b: pop
+			IL_011c: ldarg.0
+			IL_011d: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderGlobals
+			IL_0122: ldc.i4.1
+			IL_0123: newarr [System.Runtime]System.Object
+			IL_0128: dup
+			IL_0129: ldc.i4.0
+			IL_012a: ldarg.0
+			IL_012b: stelem.ref
+			IL_012c: ldloc.3
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0132: stloc.s 8
+			IL_0134: ldloc.s 4
+			IL_0136: ldloc.s 8
+			IL_0138: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_013d: pop
+			IL_013e: ldarg.0
+			IL_013f: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderLimitations
+			IL_0144: ldc.i4.1
+			IL_0145: newarr [System.Runtime]System.Object
+			IL_014a: dup
+			IL_014b: ldc.i4.0
+			IL_014c: ldarg.0
+			IL_014d: stelem.ref
+			IL_014e: ldloc.3
+			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0154: stloc.s 8
+			IL_0156: ldloc.s 8
+			IL_0158: stloc.s 5
+			IL_015a: ldloc.s 5
+			IL_015c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0161: stloc.s 10
+			IL_0163: ldloc.s 10
+			IL_0165: brfalse IL_0174
+
+			IL_016a: ldloc.s 4
+			IL_016c: ldloc.s 5
+			IL_016e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0173: pop
+
+			IL_0174: ldloc.s 4
+			IL_0176: ldc.i4.1
+			IL_0177: newarr [System.Runtime]System.Object
+			IL_017c: dup
+			IL_017d: ldc.i4.0
+			IL_017e: ldstr "\n\n"
 			IL_0183: stelem.ref
-			IL_0184: ldloc.3
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_018a: stloc.s 8
-			IL_018c: ldloc.s 4
-			IL_018e: ldloc.s 8
-			IL_0190: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0195: pop
-			IL_0196: ldarg.0
-			IL_0197: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderGlobals
-			IL_019c: stloc.s 8
-			IL_019e: ldstr "renderGlobals"
-			IL_01a3: ldloc.s 8
-			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01aa: stloc.s 8
-			IL_01ac: ldloc.s 8
-			IL_01ae: ldc.i4.1
-			IL_01af: newarr [System.Runtime]System.Object
-			IL_01b4: dup
-			IL_01b5: ldc.i4.0
-			IL_01b6: ldarg.0
-			IL_01b7: stelem.ref
-			IL_01b8: ldloc.3
-			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01be: stloc.s 8
-			IL_01c0: ldloc.s 4
-			IL_01c2: ldloc.s 8
-			IL_01c4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_01c9: pop
-			IL_01ca: ldarg.0
-			IL_01cb: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderLimitations
-			IL_01d0: stloc.s 8
-			IL_01d2: ldstr "renderLimitations"
-			IL_01d7: ldloc.s 8
-			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01de: stloc.s 8
-			IL_01e0: ldloc.s 8
-			IL_01e2: ldc.i4.1
-			IL_01e3: newarr [System.Runtime]System.Object
-			IL_01e8: dup
-			IL_01e9: ldc.i4.0
-			IL_01ea: ldarg.0
-			IL_01eb: stelem.ref
-			IL_01ec: ldloc.3
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01f2: stloc.s 8
-			IL_01f4: ldloc.s 8
-			IL_01f6: stloc.s 5
-			IL_01f8: ldloc.s 5
-			IL_01fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01ff: stloc.s 10
-			IL_0201: ldloc.s 10
-			IL_0203: brfalse IL_0212
-
-			IL_0208: ldloc.s 4
-			IL_020a: ldloc.s 5
-			IL_020c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0211: pop
-
-			IL_0212: ldloc.s 4
-			IL_0214: ldc.i4.1
-			IL_0215: newarr [System.Runtime]System.Object
-			IL_021a: dup
-			IL_021b: ldc.i4.0
-			IL_021c: ldstr "\n\n"
-			IL_0221: stelem.ref
-			IL_0222: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0184: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0189: stloc.s 11
+			IL_018b: ldloc.s 11
+			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0192: stloc.s 8
+			IL_0194: ldstr "\\r?\\n"
+			IL_0199: ldstr "g"
+			IL_019e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_01a3: stloc.s 12
+			IL_01a5: ldloc.s 8
+			IL_01a7: ldstr "replace"
+			IL_01ac: ldloc.s 12
+			IL_01ae: ldstr "\n"
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01b8: stloc.s 8
+			IL_01ba: ldloc.s 8
+			IL_01bc: stloc.s 6
+			IL_01be: ldarg.0
+			IL_01bf: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
+			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c9: stloc.s 8
+			IL_01cb: ldloc.s 8
+			IL_01cd: ldstr "writeFileSync"
+			IL_01d2: ldloc.2
+			IL_01d3: ldloc.s 6
+			IL_01d5: ldstr "utf8"
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01df: pop
+			IL_01e0: ldstr "console"
+			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ea: stloc.s 8
+			IL_01ec: ldloc.s 8
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f3: stloc.s 8
+			IL_01f5: ldarg.0
+			IL_01f6: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0200: stloc.s 7
+			IL_0202: ldloc.s 7
+			IL_0204: ldstr "relative"
+			IL_0209: ldloc.0
+			IL_020a: ldloc.2
+			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0210: stloc.s 7
+			IL_0212: ldloc.s 7
+			IL_0214: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0219: stloc.s 11
+			IL_021b: ldstr "Wrote "
+			IL_0220: ldloc.s 11
+			IL_0222: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0227: stloc.s 11
-			IL_0229: ldloc.s 11
-			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0230: stloc.s 8
-			IL_0232: ldstr "\\r?\\n"
-			IL_0237: ldstr "g"
-			IL_023c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0241: stloc.s 12
-			IL_0243: ldloc.s 8
-			IL_0245: ldstr "replace"
-			IL_024a: ldloc.s 12
-			IL_024c: ldstr "\n"
-			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0256: stloc.s 8
-			IL_0258: ldloc.s 8
-			IL_025a: stloc.s 6
-			IL_025c: ldarg.0
-			IL_025d: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
-			IL_0262: stloc.s 8
-			IL_0264: ldstr "fs"
-			IL_0269: ldloc.s 8
-			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0270: stloc.s 8
-			IL_0272: ldloc.s 8
-			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0279: stloc.s 8
-			IL_027b: ldloc.s 8
-			IL_027d: ldstr "writeFileSync"
-			IL_0282: ldloc.2
-			IL_0283: ldloc.s 6
-			IL_0285: ldstr "utf8"
-			IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_028f: pop
-			IL_0290: ldstr "console"
-			IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_029a: stloc.s 8
-			IL_029c: ldloc.s 8
-			IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a3: stloc.s 8
-			IL_02a5: ldarg.0
-			IL_02a6: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_02ab: stloc.s 7
-			IL_02ad: ldstr "path"
-			IL_02b2: ldloc.s 7
-			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02b9: stloc.s 7
-			IL_02bb: ldloc.s 7
-			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02c2: stloc.s 7
-			IL_02c4: ldloc.s 7
-			IL_02c6: ldstr "relative"
-			IL_02cb: ldloc.0
-			IL_02cc: ldloc.2
-			IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02d2: stloc.s 7
-			IL_02d4: ldloc.s 7
-			IL_02d6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02db: stloc.s 11
-			IL_02dd: ldstr "Wrote "
-			IL_02e2: ldloc.s 11
-			IL_02e4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02e9: stloc.s 11
-			IL_02eb: ldloc.s 8
-			IL_02ed: ldstr "log"
-			IL_02f2: ldloc.s 11
-			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02f9: pop
-			IL_02fa: ldnull
-			IL_02fb: ret
+			IL_0229: ldloc.s 8
+			IL_022b: ldstr "log"
+			IL_0230: ldloc.s 11
+			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0237: pop
+			IL_0238: ldnull
+			IL_0239: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -3304,7 +3164,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x38df
+			// Method begins at RVA 0x372d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3592,7 +3452,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3a08
+		// Method begins at RVA 0x3856
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ModernFlags_Basic.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ModernFlags_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2541
+				// Method begins at RVA 0x253d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x254a
+				// Method begins at RVA 0x2546
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2553
+				// Method begins at RVA 0x254f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x255c
+				// Method begins at RVA 0x2558
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2538
+			// Method begins at RVA 0x2534
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1214 (0x4be)
+		// Code size: 1209 (0x4b9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope,
@@ -234,9 +234,9 @@
 		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0128: stloc.s 15
 		IL_012a: ldloc.s 15
-		IL_012c: ldstr "test"
+		IL_012c: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_0131: ldstr "\ud83d\ude00"
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0136: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_013b: stloc.s 15
 		IL_013d: ldloc.s 14
 		IL_013f: ldstr "log"
@@ -257,9 +257,9 @@
 		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0179: stloc.s 14
 		IL_017b: ldloc.s 14
-		IL_017d: ldstr "test"
+		IL_017d: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_0182: ldstr "\ud83d\ude00"
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0187: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_018c: stloc.s 14
 		IL_018e: ldloc.s 15
 		IL_0190: ldstr "log"
@@ -280,9 +280,9 @@
 		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_01ca: stloc.s 15
 		IL_01cc: ldloc.s 15
-		IL_01ce: ldstr "test"
+		IL_01ce: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_01d3: ldstr "\n"
-		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_01dd: stloc.s 15
 		IL_01df: ldloc.s 14
 		IL_01e1: ldstr "log"
@@ -303,9 +303,9 @@
 		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_021b: stloc.s 14
 		IL_021d: ldloc.s 14
-		IL_021f: ldstr "test"
+		IL_021f: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_0224: ldstr "\r"
-		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0229: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_022e: stloc.s 14
 		IL_0230: ldloc.s 15
 		IL_0232: ldstr "log"
@@ -326,9 +326,9 @@
 		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_026c: stloc.s 15
 		IL_026e: ldloc.s 15
-		IL_0270: ldstr "test"
+		IL_0270: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_0275: ldstr "\u2028"
-		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_027a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_027f: stloc.s 15
 		IL_0281: ldloc.s 14
 		IL_0283: ldstr "log"
@@ -349,9 +349,9 @@
 		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_02bd: stloc.s 14
 		IL_02bf: ldloc.s 14
-		IL_02c1: ldstr "test"
+		IL_02c1: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_02c6: ldstr "\u2029"
-		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_02d0: stloc.s 14
 		IL_02d2: ldloc.s 15
 		IL_02d4: ldstr "log"
@@ -377,7 +377,7 @@
 			IL_0313: ldstr "no-error"
 			IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_031d: pop
-			IL_031e: leave IL_0407
+			IL_031e: leave IL_0402
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -436,98 +436,97 @@
 			IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_03ba: stloc.s 15
 			IL_03bc: ldloc.s 15
-			IL_03be: ldstr "indexOf"
+			IL_03be: castclass [System.Runtime]System.String
 			IL_03c3: ldstr "v"
-			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03cd: stloc.s 15
-			IL_03cf: ldloc.s 15
-			IL_03d1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_03d6: stloc.s 17
-			IL_03d8: ldloc.s 17
-			IL_03da: ldc.r8 0.0
-			IL_03e3: clt
-			IL_03e5: ldc.i4.0
-			IL_03e6: ceq
-			IL_03e8: stloc.s 18
-			IL_03ea: ldloc.s 18
-			IL_03ec: box [System.Runtime]System.Boolean
-			IL_03f1: stloc.s 19
-			IL_03f3: ldloc.s 14
-			IL_03f5: ldstr "log"
-			IL_03fa: ldloc.s 19
-			IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0401: pop
-			IL_0402: leave IL_0407
+			IL_03c8: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_03cd: stloc.s 17
+			IL_03cf: ldloc.s 17
+			IL_03d1: stloc.s 17
+			IL_03d3: ldloc.s 17
+			IL_03d5: ldc.r8 0.0
+			IL_03de: clt
+			IL_03e0: ldc.i4.0
+			IL_03e1: ceq
+			IL_03e3: stloc.s 18
+			IL_03e5: ldloc.s 18
+			IL_03e7: box [System.Runtime]System.Boolean
+			IL_03ec: stloc.s 19
+			IL_03ee: ldloc.s 14
+			IL_03f0: ldstr "log"
+			IL_03f5: ldloc.s 19
+			IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03fc: pop
+			IL_03fd: leave IL_0402
 		} // end handler
 		.try
 		{
-			IL_0407: newobj instance void Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope/Block_L25C4::.ctor()
-			IL_040c: stloc.s 7
-			IL_040e: ldstr "a"
-			IL_0413: ldstr "gg"
-			IL_0418: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_041d: pop
-			IL_041e: ldstr "console"
-			IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0428: stloc.s 14
-			IL_042a: ldloc.s 14
-			IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0431: stloc.s 14
-			IL_0433: ldloc.s 14
-			IL_0435: ldstr "log"
-			IL_043a: ldstr "no-error"
-			IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0444: pop
-			IL_0445: leave IL_04ba
+			IL_0402: newobj instance void Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope/Block_L25C4::.ctor()
+			IL_0407: stloc.s 7
+			IL_0409: ldstr "a"
+			IL_040e: ldstr "gg"
+			IL_0413: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0418: pop
+			IL_0419: ldstr "console"
+			IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0423: stloc.s 14
+			IL_0425: ldloc.s 14
+			IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_042c: stloc.s 14
+			IL_042e: ldloc.s 14
+			IL_0430: ldstr "log"
+			IL_0435: ldstr "no-error"
+			IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_043f: pop
+			IL_0440: leave IL_04b5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_044a: stloc.s 8
-			IL_044c: ldloc.s 8
-			IL_044e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0453: dup
-			IL_0454: brtrue IL_046a
+			IL_0445: stloc.s 8
+			IL_0447: ldloc.s 8
+			IL_0449: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_044e: dup
+			IL_044f: brtrue IL_0465
 
-			IL_0459: pop
-			IL_045a: ldloc.s 8
-			IL_045c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0461: dup
-			IL_0462: brtrue IL_0476
+			IL_0454: pop
+			IL_0455: ldloc.s 8
+			IL_0457: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_045c: dup
+			IL_045d: brtrue IL_0471
 
-			IL_0467: pop
-			IL_0468: rethrow
+			IL_0462: pop
+			IL_0463: rethrow
 
-			IL_046a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_046f: stloc.s 9
-			IL_0471: br IL_0478
+			IL_0465: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_046a: stloc.s 9
+			IL_046c: br IL_0473
 
-			IL_0476: stloc.s 9
+			IL_0471: stloc.s 9
 
-			IL_0478: ldloc.s 9
-			IL_047a: stloc.s 14
-			IL_047c: ldloc.s 14
-			IL_047e: stloc.s 10
-			IL_0480: newobj instance void Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope/Block_L28C12::.ctor()
-			IL_0485: stloc.s 11
-			IL_0487: ldstr "console"
-			IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0491: stloc.s 14
-			IL_0493: ldloc.s 14
-			IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_049a: stloc.s 14
-			IL_049c: ldloc.s 14
-			IL_049e: ldstr "log"
-			IL_04a3: ldloc.s 10
-			IL_04a5: ldstr "name"
-			IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_04b4: pop
-			IL_04b5: leave IL_04ba
+			IL_0473: ldloc.s 9
+			IL_0475: stloc.s 14
+			IL_0477: ldloc.s 14
+			IL_0479: stloc.s 10
+			IL_047b: newobj instance void Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope/Block_L28C12::.ctor()
+			IL_0480: stloc.s 11
+			IL_0482: ldstr "console"
+			IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_048c: stloc.s 14
+			IL_048e: ldloc.s 14
+			IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0495: stloc.s 14
+			IL_0497: ldloc.s 14
+			IL_0499: ldstr "log"
+			IL_049e: ldloc.s 10
+			IL_04a0: ldstr "name"
+			IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_04af: pop
+			IL_04b0: leave IL_04b5
 		} // end handler
 
-		IL_04ba: ldnull
-		IL_04bb: stloc.s 12
-		IL_04bd: ret
+		IL_04b5: ldnull
+		IL_04b6: stloc.s 12
+		IL_04b8: ret
 	} // end of method IntrinsicCallables_RegExp_ModernFlags_Basic::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_ModernFlags_Basic
@@ -539,7 +538,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2565
+		// Method begins at RVA 0x2561
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Test_LastIndex_Global.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Test_LastIndex_Global.verified.txt
@@ -84,9 +84,9 @@
 		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0066: stloc.s 5
 		IL_0068: ldloc.s 5
-		IL_006a: ldstr "test"
+		IL_006a: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_006f: ldloc.2
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0070: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_0075: stloc.s 5
 		IL_0077: ldloc.s 4
 		IL_0079: ldstr "log"
@@ -116,9 +116,9 @@
 		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00ce: stloc.s 4
 		IL_00d0: ldloc.s 4
-		IL_00d2: ldstr "test"
+		IL_00d2: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_00d7: ldloc.2
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_00dd: stloc.s 4
 		IL_00df: ldloc.s 5
 		IL_00e1: ldstr "log"
@@ -148,9 +148,9 @@
 		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0136: stloc.s 5
 		IL_0138: ldloc.s 5
-		IL_013a: ldstr "test"
+		IL_013a: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_013f: ldloc.2
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0140: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_0145: stloc.s 5
 		IL_0147: ldloc.s 4
 		IL_0149: ldstr "log"
@@ -180,9 +180,9 @@
 		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_019e: stloc.s 4
 		IL_01a0: ldloc.s 4
-		IL_01a2: ldstr "test"
+		IL_01a2: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_01a7: ldloc.2
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_01ad: stloc.s 4
 		IL_01af: ldloc.s 5
 		IL_01b1: ldstr "log"

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Test_LastIndex_Sticky.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Test_LastIndex_Sticky.verified.txt
@@ -77,9 +77,9 @@
 		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_004f: stloc.s 5
 		IL_0051: ldloc.s 5
-		IL_0053: ldstr "test"
+		IL_0053: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_0058: ldloc.2
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0059: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_005e: stloc.s 5
 		IL_0060: ldloc.s 4
 		IL_0062: ldstr "log"
@@ -109,9 +109,9 @@
 		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00b7: stloc.s 4
 		IL_00b9: ldloc.s 4
-		IL_00bb: ldstr "test"
+		IL_00bb: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_00c0: ldloc.2
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_00c6: stloc.s 4
 		IL_00c8: ldloc.s 5
 		IL_00ca: ldstr "log"
@@ -141,9 +141,9 @@
 		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_011f: stloc.s 5
 		IL_0121: ldloc.s 5
-		IL_0123: ldstr "test"
+		IL_0123: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_0128: ldloc.2
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0129: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_012e: stloc.s 5
 		IL_0130: ldloc.s 4
 		IL_0132: ldstr "log"
@@ -173,9 +173,9 @@
 		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0187: stloc.s 4
 		IL_0189: ldloc.s 4
-		IL_018b: ldstr "test"
+		IL_018b: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_0190: ldloc.2
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0191: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_0196: stloc.s 4
 		IL_0198: ldloc.s 5
 		IL_019a: ldstr "log"
@@ -211,9 +211,9 @@
 		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0205: stloc.s 5
 		IL_0207: ldloc.s 5
-		IL_0209: ldstr "test"
+		IL_0209: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_020e: ldloc.2
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_020f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_0214: stloc.s 5
 		IL_0216: ldloc.s 4
 		IL_0218: ldstr "log"
@@ -249,9 +249,9 @@
 		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0283: stloc.s 4
 		IL_0285: ldloc.s 4
-		IL_0287: ldstr "test"
+		IL_0287: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_028c: ldloc.2
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_028d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_0292: stloc.s 4
 		IL_0294: ldloc.s 5
 		IL_0296: ldstr "log"

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_From_HelperChain.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_From_HelperChain.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2948
+				// Method begins at RVA 0x293c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2951
+				// Method begins at RVA 0x2945
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x295a
+				// Method begins at RVA 0x294e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -202,7 +202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2963
+				// Method begins at RVA 0x2957
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -259,7 +259,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x296c
+				// Method begins at RVA 0x2960
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -324,7 +324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2975
+				// Method begins at RVA 0x2969
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -381,7 +381,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x297e
+				// Method begins at RVA 0x2972
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -410,29 +410,22 @@
 			)
 			// Method begins at RVA 0x28dc
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 22 (0x16)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Iterator_From_HelperChain/Scope::total
-			IL_0006: stloc.0
-			IL_0007: ldstr "total"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldarg.2
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001a: stloc.1
-			IL_001b: ldarg.0
-			IL_001c: ldloc.1
-			IL_001d: stfld object Modules.Iterator_From_HelperChain/Scope::total
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0006: ldarg.2
+			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_000c: stloc.0
+			IL_000d: ldarg.0
+			IL_000e: ldloc.0
+			IL_000f: stfld object Modules.Iterator_From_HelperChain/Scope::total
+			IL_0014: ldnull
+			IL_0015: ret
 		} // end of method ArrowFunction_L20C34::__js_call__
 
 	} // end of class ArrowFunction_L20C34
@@ -455,7 +448,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2987
+				// Method begins at RVA 0x297b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -479,7 +472,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x290c
+			// Method begins at RVA 0x2900
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -521,7 +514,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x293f
+			// Method begins at RVA 0x2933
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1166,7 +1159,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2990
+		// Method begins at RVA 0x2984
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3296
+					// Method begins at RVA 0x31b6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,26 +46,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2cc0
-				// Header size: 12
-				// Code size: 28 (0x1c)
+				// Method begins at RVA 0x2cbd
+				// Header size: 1
+				// Code size: 14 (0xe)
 				.maxstack 8
-				.locals init (
-					[0] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
 				IL_0008: ldfld object Modules.Iterator_Helper_Cleanup/makeIterable/Scope::closed
-				IL_000d: stloc.0
-				IL_000e: ldstr "closed"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ret
+				IL_000d: ret
 			} // end of method FunctionExpression_L6C17::__js_call__
 
 		} // end of class FunctionExpression_L6C17
@@ -85,7 +76,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x32a8
+						// Method begins at RVA 0x31c8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -109,99 +100,62 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2fb8
+					// Method begins at RVA 0x2f7c
 					// Header size: 12
-					// Code size: 205 (0xcd)
+					// Code size: 131 (0x83)
 					.maxstack 8
 					.locals init (
 						[0] object,
-						[1] float64,
-						[2] object,
-						[3] object,
-						[4] object,
-						[5] float64,
-						[6] bool,
-						[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+						[1] object,
+						[2] float64
 					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.2
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope
-					IL_0008: ldfld object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope::'value'
-					IL_000d: stloc.0
-					IL_000e: ldstr "value"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldloc.0
-					IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0020: stloc.1
-					IL_0021: ldloc.1
-					IL_0022: ldc.r8 1
-					IL_002b: add
-					IL_002c: stloc.1
-					IL_002d: ldloc.1
-					IL_002e: box [System.Runtime]System.Double
-					IL_0033: stloc.2
-					IL_0034: ldarg.0
-					IL_0035: ldc.i4.2
-					IL_0036: ldelem.ref
-					IL_0037: castclass Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope
-					IL_003c: ldloc.2
-					IL_003d: stfld object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope::'value'
-					IL_0042: ldarg.0
-					IL_0043: ldc.i4.2
-					IL_0044: ldelem.ref
-					IL_0045: castclass Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope
-					IL_004a: ldfld object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope::'value'
-					IL_004f: stloc.0
-					IL_0050: ldstr "value"
-					IL_0055: ldloc.0
-					IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_005b: stloc.0
-					IL_005c: ldarg.0
-					IL_005d: ldc.i4.2
-					IL_005e: ldelem.ref
-					IL_005f: castclass Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope
-					IL_0064: ldfld object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope::'value'
-					IL_0069: stloc.3
-					IL_006a: ldstr "value"
-					IL_006f: ldloc.3
-					IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0075: stloc.3
-					IL_0076: ldarg.0
-					IL_0077: ldc.i4.1
-					IL_0078: ldelem.ref
-					IL_0079: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
-					IL_007e: ldfld object Modules.Iterator_Helper_Cleanup/makeIterable/Scope::limit
-					IL_0083: stloc.s 4
-					IL_0085: ldstr "limit"
-					IL_008a: ldloc.s 4
-					IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0091: stloc.s 4
-					IL_0093: ldloc.3
-					IL_0094: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0099: stloc.1
-					IL_009a: ldloc.s 4
-					IL_009c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_00a1: stloc.s 5
-					IL_00a3: ldloc.1
-					IL_00a4: ldloc.s 5
-					IL_00a6: cgt
-					IL_00a8: stloc.s 6
-					IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-					IL_00af: dup
-					IL_00b0: ldstr "value"
-					IL_00b5: ldloc.0
-					IL_00b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_00bb: dup
-					IL_00bc: ldstr "done"
-					IL_00c1: ldloc.s 6
-					IL_00c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-					IL_00c8: stloc.s 7
-					IL_00ca: ldloc.s 7
-					IL_00cc: ret
+					IL_0008: ldarg.0
+					IL_0009: ldc.i4.2
+					IL_000a: ldelem.ref
+					IL_000b: castclass Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope
+					IL_0010: ldfld object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope::'value'
+					IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_001a: ldc.r8 1
+					IL_0023: add
+					IL_0024: box [System.Runtime]System.Double
+					IL_0029: stfld object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope::'value'
+					IL_002e: ldarg.0
+					IL_002f: ldc.i4.2
+					IL_0030: ldelem.ref
+					IL_0031: castclass Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope
+					IL_0036: ldfld object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope::'value'
+					IL_003b: stloc.0
+					IL_003c: ldarg.0
+					IL_003d: ldc.i4.1
+					IL_003e: ldelem.ref
+					IL_003f: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
+					IL_0044: ldfld object Modules.Iterator_Helper_Cleanup/makeIterable/Scope::limit
+					IL_0049: stloc.1
+					IL_004a: ldarg.0
+					IL_004b: ldc.i4.2
+					IL_004c: ldelem.ref
+					IL_004d: castclass Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope
+					IL_0052: ldfld object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope::'value'
+					IL_0057: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_005c: stloc.2
+					IL_005d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+					IL_0062: dup
+					IL_0063: ldstr "value"
+					IL_0068: ldloc.0
+					IL_0069: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_006e: dup
+					IL_006f: ldstr "done"
+					IL_0074: ldloc.2
+					IL_0075: ldloc.1
+					IL_0076: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_007b: cgt
+					IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+					IL_0082: ret
 				} // end of method FunctionExpression_L13C24::__js_call__
 
 			} // end of class FunctionExpression_L13C24
@@ -217,7 +171,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x32b1
+						// Method begins at RVA 0x31d1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -241,48 +195,31 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3094
+					// Method begins at RVA 0x300c
 					// Header size: 12
-					// Code size: 84 (0x54)
+					// Code size: 64 (0x40)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] float64,
-						[2] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.1
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
-					IL_0008: ldfld object Modules.Iterator_Helper_Cleanup/makeIterable/Scope::closed
-					IL_000d: stloc.0
-					IL_000e: ldstr "closed"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldloc.0
-					IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0020: stloc.1
-					IL_0021: ldloc.1
-					IL_0022: ldc.r8 1
-					IL_002b: add
-					IL_002c: stloc.1
-					IL_002d: ldloc.1
-					IL_002e: box [System.Runtime]System.Double
-					IL_0033: stloc.2
-					IL_0034: ldarg.0
-					IL_0035: ldc.i4.1
-					IL_0036: ldelem.ref
-					IL_0037: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
-					IL_003c: ldloc.2
-					IL_003d: stfld object Modules.Iterator_Helper_Cleanup/makeIterable/Scope::closed
-					IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-					IL_0047: dup
-					IL_0048: ldstr "done"
-					IL_004d: ldc.i4.1
-					IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-					IL_0053: ret
+					IL_0008: ldarg.0
+					IL_0009: ldc.i4.1
+					IL_000a: ldelem.ref
+					IL_000b: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
+					IL_0010: ldfld object Modules.Iterator_Helper_Cleanup/makeIterable/Scope::closed
+					IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_001a: ldc.r8 1
+					IL_0023: add
+					IL_0024: box [System.Runtime]System.Double
+					IL_0029: stfld object Modules.Iterator_Helper_Cleanup/makeIterable/Scope::closed
+					IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+					IL_0033: dup
+					IL_0034: ldstr "done"
+					IL_0039: ldc.i4.1
+					IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+					IL_003f: ret
 				} // end of method FunctionExpression_L17C26::__js_call__
 
 			} // end of class FunctionExpression_L17C26
@@ -301,7 +238,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x329f
+					// Method begins at RVA 0x31bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -325,7 +262,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ce8
+				// Method begins at RVA 0x2ccc
 				// Header size: 12
 				// Code size: 168 (0xa8)
 				.maxstack 8
@@ -434,7 +371,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x328d
+				// Method begins at RVA 0x31ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -570,7 +507,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32ba
+				// Method begins at RVA 0x31da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -623,7 +560,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32c3
+				// Method begins at RVA 0x31e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -698,7 +635,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32de
+				// Method begins at RVA 0x31fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -778,7 +715,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3314
+							// Method begins at RVA 0x3234
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -796,7 +733,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x330b
+						// Method begins at RVA 0x322b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -820,15 +757,13 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x30f4
+					// Method begins at RVA 0x3058
 					// Header size: 12
-					// Code size: 140 (0x8c)
+					// Code size: 110 (0x6e)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/Scope/Block_L65C26,
-						[1] object,
-						[2] bool,
-						[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+						[1] bool
 					)
 
 					IL_0000: ldarg.0
@@ -836,55 +771,41 @@
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope
 					IL_0008: ldfld object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope::done
-					IL_000d: stloc.1
-					IL_000e: ldstr "done"
+					IL_000d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0012: stloc.1
 					IL_0013: ldloc.1
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.1
-					IL_001a: ldloc.1
-					IL_001b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0020: stloc.2
-					IL_0021: ldloc.2
-					IL_0022: brfalse IL_003f
+					IL_0014: brfalse IL_0031
 
-					IL_0027: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/Scope/Block_L65C26::.ctor()
-					IL_002c: stloc.0
-					IL_002d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-					IL_0032: dup
-					IL_0033: ldstr "done"
-					IL_0038: ldc.i4.1
-					IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-					IL_003e: ret
+					IL_0019: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/Scope/Block_L65C26::.ctor()
+					IL_001e: stloc.0
+					IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+					IL_0024: dup
+					IL_0025: ldstr "done"
+					IL_002a: ldc.i4.1
+					IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+					IL_0030: ret
 
-					IL_003f: ldarg.0
-					IL_0040: ldc.i4.2
-					IL_0041: ldelem.ref
-					IL_0042: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope
-					IL_0047: ldc.i4.1
-					IL_0048: box [System.Runtime]System.Boolean
-					IL_004d: stfld object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope::done
-					IL_0052: ldarg.0
-					IL_0053: ldc.i4.1
-					IL_0054: ldelem.ref
-					IL_0055: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope
-					IL_005a: ldfld object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope::'value'
-					IL_005f: stloc.1
-					IL_0060: ldstr "value"
-					IL_0065: ldloc.1
-					IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_006b: stloc.1
-					IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-					IL_0071: dup
-					IL_0072: ldstr "value"
-					IL_0077: ldloc.1
-					IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_007d: dup
-					IL_007e: ldstr "done"
-					IL_0083: ldc.i4.0
-					IL_0084: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-					IL_0089: stloc.3
-					IL_008a: ldloc.3
-					IL_008b: ret
+					IL_0031: ldarg.0
+					IL_0032: ldc.i4.2
+					IL_0033: ldelem.ref
+					IL_0034: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope
+					IL_0039: ldc.i4.1
+					IL_003a: box [System.Runtime]System.Boolean
+					IL_003f: stfld object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope::done
+					IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+					IL_0049: dup
+					IL_004a: ldstr "value"
+					IL_004f: ldarg.0
+					IL_0050: ldc.i4.1
+					IL_0051: ldelem.ref
+					IL_0052: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope
+					IL_0057: ldfld object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope::'value'
+					IL_005c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_0061: dup
+					IL_0062: ldstr "done"
+					IL_0067: ldc.i4.0
+					IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+					IL_006d: ret
 				} // end of method FunctionExpression_flatHelper::__js_call__
 
 			} // end of class FunctionExpression_flatHelper
@@ -900,7 +821,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x331d
+						// Method begins at RVA 0x323d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -924,48 +845,31 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x318c
+					// Method begins at RVA 0x30d4
 					// Header size: 12
-					// Code size: 84 (0x54)
+					// Code size: 64 (0x40)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] float64,
-						[2] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.0
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Iterator_Helper_Cleanup/Scope
-					IL_0008: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
-					IL_000d: stloc.0
-					IL_000e: ldstr "flatInnerClosed"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldloc.0
-					IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0020: stloc.1
-					IL_0021: ldloc.1
-					IL_0022: ldc.r8 1
-					IL_002b: add
-					IL_002c: stloc.1
-					IL_002d: ldloc.1
-					IL_002e: box [System.Runtime]System.Double
-					IL_0033: stloc.2
-					IL_0034: ldarg.0
-					IL_0035: ldc.i4.0
-					IL_0036: ldelem.ref
-					IL_0037: castclass Modules.Iterator_Helper_Cleanup/Scope
-					IL_003c: ldloc.2
-					IL_003d: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
-					IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-					IL_0047: dup
-					IL_0048: ldstr "done"
-					IL_004d: ldc.i4.1
-					IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-					IL_0053: ret
+					IL_0008: ldarg.0
+					IL_0009: ldc.i4.0
+					IL_000a: ldelem.ref
+					IL_000b: castclass Modules.Iterator_Helper_Cleanup/Scope
+					IL_0010: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
+					IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_001a: ldc.r8 1
+					IL_0023: add
+					IL_0024: box [System.Runtime]System.Double
+					IL_0029: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
+					IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+					IL_0033: dup
+					IL_0034: ldstr "done"
+					IL_0039: ldc.i4.1
+					IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+					IL_003f: ret
 				} // end of method FunctionExpression_flatHelper_L72C18::__js_call__
 
 			} // end of class FunctionExpression_flatHelper_L72C18
@@ -984,7 +888,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3302
+					// Method begins at RVA 0x3222
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1008,7 +912,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d9c
+				// Method begins at RVA 0x2d80
 				// Header size: 12
 				// Code size: 160 (0xa0)
 				.maxstack 8
@@ -1115,7 +1019,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32f9
+				// Method begins at RVA 0x3219
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1214,7 +1118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3326
+				// Method begins at RVA 0x3246
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1290,7 +1194,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3353
+						// Method begins at RVA 0x3273
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1308,7 +1212,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x334a
+					// Method begins at RVA 0x326a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1332,14 +1236,13 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e48
+				// Method begins at RVA 0x2e2c
 				// Header size: 12
-				// Code size: 120 (0x78)
+				// Code size: 106 (0x6a)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/Scope/Block_L100C29,
-					[1] object,
-					[2] bool
+					[1] bool
 				)
 
 				IL_0000: ldarg.0
@@ -1347,43 +1250,37 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope
 				IL_0008: ldfld object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope::emitted
-				IL_000d: stloc.1
-				IL_000e: ldstr "emitted"
+				IL_000d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0012: stloc.1
 				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldloc.1
-				IL_001b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0020: stloc.2
-				IL_0021: ldloc.2
-				IL_0022: brfalse IL_003f
+				IL_0014: brfalse IL_0031
 
-				IL_0027: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/Scope/Block_L100C29::.ctor()
-				IL_002c: stloc.0
-				IL_002d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0032: dup
-				IL_0033: ldstr "done"
-				IL_0038: ldc.i4.1
-				IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_003e: ret
+				IL_0019: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/Scope/Block_L100C29::.ctor()
+				IL_001e: stloc.0
+				IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0024: dup
+				IL_0025: ldstr "done"
+				IL_002a: ldc.i4.1
+				IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0030: ret
 
-				IL_003f: ldarg.0
-				IL_0040: ldc.i4.1
-				IL_0041: ldelem.ref
-				IL_0042: castclass Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope
-				IL_0047: ldc.i4.1
-				IL_0048: box [System.Runtime]System.Boolean
-				IL_004d: stfld object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope::emitted
-				IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0057: dup
-				IL_0058: ldstr "value"
-				IL_005d: ldc.r8 1
-				IL_0066: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-				IL_006b: dup
-				IL_006c: ldstr "done"
-				IL_0071: ldc.i4.0
-				IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0077: ret
+				IL_0031: ldarg.0
+				IL_0032: ldc.i4.1
+				IL_0033: ldelem.ref
+				IL_0034: castclass Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope
+				IL_0039: ldc.i4.1
+				IL_003a: box [System.Runtime]System.Boolean
+				IL_003f: stfld object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope::emitted
+				IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0049: dup
+				IL_004a: ldstr "value"
+				IL_004f: ldc.r8 1
+				IL_0058: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+				IL_005d: dup
+				IL_005e: ldstr "done"
+				IL_0063: ldc.i4.0
+				IL_0064: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0069: ret
 			} // end of method FunctionExpression_flatThrowHelper::__js_call__
 
 		} // end of class FunctionExpression_flatThrowHelper
@@ -1399,7 +1296,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x335c
+					// Method begins at RVA 0x327c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1423,48 +1320,31 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ecc
+				// Method begins at RVA 0x2ea4
 				// Header size: 12
-				// Code size: 84 (0x54)
+				// Code size: 64 (0x40)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] float64,
-					[2] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.0
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Iterator_Helper_Cleanup/Scope
-				IL_0008: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-				IL_000d: stloc.0
-				IL_000e: ldstr "flatThrowOuterClosed"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldc.r8 1
-				IL_002b: add
-				IL_002c: stloc.1
-				IL_002d: ldloc.1
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: stloc.2
-				IL_0034: ldarg.0
-				IL_0035: ldc.i4.0
-				IL_0036: ldelem.ref
-				IL_0037: castclass Modules.Iterator_Helper_Cleanup/Scope
-				IL_003c: ldloc.2
-				IL_003d: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-				IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0047: dup
-				IL_0048: ldstr "done"
-				IL_004d: ldc.i4.1
-				IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0053: ret
+				IL_0008: ldarg.0
+				IL_0009: ldc.i4.0
+				IL_000a: ldelem.ref
+				IL_000b: castclass Modules.Iterator_Helper_Cleanup/Scope
+				IL_0010: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+				IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001a: ldc.r8 1
+				IL_0023: add
+				IL_0024: box [System.Runtime]System.Double
+				IL_0029: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+				IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0033: dup
+				IL_0034: ldstr "done"
+				IL_0039: ldc.i4.1
+				IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_003f: ret
 			} // end of method FunctionExpression_flatThrowHelper_L107C18::__js_call__
 
 		} // end of class FunctionExpression_flatThrowHelper_L107C18
@@ -1483,7 +1363,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3341
+				// Method begins at RVA 0x3261
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1605,7 +1485,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3377
+						// Method begins at RVA 0x3297
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1628,7 +1508,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x31ec
+					// Method begins at RVA 0x3120
 					// Header size: 12
 					// Code size: 41 (0x29)
 					.maxstack 8
@@ -1672,7 +1552,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3380
+						// Method begins at RVA 0x32a0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1696,48 +1576,31 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3224
+					// Method begins at RVA 0x3158
 					// Header size: 12
-					// Code size: 84 (0x54)
+					// Code size: 64 (0x40)
 					.maxstack 8
-					.locals init (
-						[0] object,
-						[1] float64,
-						[2] object
-					)
 
 					IL_0000: ldarg.0
 					IL_0001: ldc.i4.0
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Iterator_Helper_Cleanup/Scope
-					IL_0008: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-					IL_000d: stloc.0
-					IL_000e: ldstr "flatThrowInnerClosed"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldloc.0
-					IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0020: stloc.1
-					IL_0021: ldloc.1
-					IL_0022: ldc.r8 1
-					IL_002b: add
-					IL_002c: stloc.1
-					IL_002d: ldloc.1
-					IL_002e: box [System.Runtime]System.Double
-					IL_0033: stloc.2
-					IL_0034: ldarg.0
-					IL_0035: ldc.i4.0
-					IL_0036: ldelem.ref
-					IL_0037: castclass Modules.Iterator_Helper_Cleanup/Scope
-					IL_003c: ldloc.2
-					IL_003d: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-					IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-					IL_0047: dup
-					IL_0048: ldstr "done"
-					IL_004d: ldc.i4.1
-					IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-					IL_0053: ret
+					IL_0008: ldarg.0
+					IL_0009: ldc.i4.0
+					IL_000a: ldelem.ref
+					IL_000b: castclass Modules.Iterator_Helper_Cleanup/Scope
+					IL_0010: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+					IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_001a: ldc.r8 1
+					IL_0023: add
+					IL_0024: box [System.Runtime]System.Double
+					IL_0029: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+					IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+					IL_0033: dup
+					IL_0034: ldstr "done"
+					IL_0039: ldc.i4.1
+					IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+					IL_003f: ret
 				} // end of method FunctionExpression_flatThrowHelper_L119C18::__js_call__
 
 			} // end of class FunctionExpression_flatThrowHelper_L119C18
@@ -1749,7 +1612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x336e
+					// Method begins at RVA 0x328e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1773,7 +1636,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f2c
+				// Method begins at RVA 0x2ef0
 				// Header size: 12
 				// Code size: 127 (0x7f)
 				.maxstack 8
@@ -1859,7 +1722,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3365
+				// Method begins at RVA 0x3285
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1961,7 +1824,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32cc
+				// Method begins at RVA 0x31ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1981,7 +1844,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32d5
+				// Method begins at RVA 0x31f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2001,7 +1864,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32e7
+				// Method begins at RVA 0x3207
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2021,7 +1884,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32f0
+				// Method begins at RVA 0x3210
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2041,7 +1904,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x332f
+				// Method begins at RVA 0x324f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2061,7 +1924,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3338
+				// Method begins at RVA 0x3258
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2081,7 +1944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3389
+				// Method begins at RVA 0x32a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2101,7 +1964,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3392
+				// Method begins at RVA 0x32b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2125,7 +1988,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3284
+			// Method begins at RVA 0x31a4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3018,7 +2881,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x339b
+		// Method begins at RVA 0x32bb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Next_Return.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Next_Return.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27c2
+					// Method begins at RVA 0x2776
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,82 +48,49 @@
 				)
 				// Method begins at RVA 0x2684
 				// Header size: 12
-				// Code size: 174 (0xae)
+				// Code size: 118 (0x76)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] float64,
-					[2] object,
-					[3] object,
-					[4] bool,
-					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+					[0] object
 				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.1
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope
-				IL_0008: ldfld object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope::'value'
-				IL_000d: stloc.0
-				IL_000e: ldstr "value"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldc.r8 1
-				IL_002b: add
-				IL_002c: stloc.1
-				IL_002d: ldloc.1
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: stloc.2
-				IL_0034: ldarg.0
-				IL_0035: ldc.i4.1
-				IL_0036: ldelem.ref
-				IL_0037: castclass Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope
-				IL_003c: ldloc.2
-				IL_003d: stfld object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope::'value'
-				IL_0042: ldarg.0
-				IL_0043: ldc.i4.1
-				IL_0044: ldelem.ref
-				IL_0045: castclass Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope
-				IL_004a: ldfld object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope::'value'
-				IL_004f: stloc.0
-				IL_0050: ldstr "value"
-				IL_0055: ldloc.0
-				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005b: stloc.0
-				IL_005c: ldarg.0
-				IL_005d: ldc.i4.1
-				IL_005e: ldelem.ref
-				IL_005f: castclass Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope
-				IL_0064: ldfld object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope::'value'
-				IL_0069: stloc.3
-				IL_006a: ldstr "value"
-				IL_006f: ldloc.3
-				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0075: stloc.3
-				IL_0076: ldloc.3
-				IL_0077: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007c: stloc.1
-				IL_007d: ldloc.1
-				IL_007e: ldc.r8 3
-				IL_0087: cgt
-				IL_0089: stloc.s 4
-				IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0090: dup
-				IL_0091: ldstr "value"
-				IL_0096: ldloc.0
-				IL_0097: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_009c: dup
-				IL_009d: ldstr "done"
-				IL_00a2: ldloc.s 4
-				IL_00a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_00a9: stloc.s 5
-				IL_00ab: ldloc.s 5
-				IL_00ad: ret
+				IL_0008: ldarg.0
+				IL_0009: ldc.i4.1
+				IL_000a: ldelem.ref
+				IL_000b: castclass Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope
+				IL_0010: ldfld object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope::'value'
+				IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001a: ldc.r8 1
+				IL_0023: add
+				IL_0024: box [System.Runtime]System.Double
+				IL_0029: stfld object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope::'value'
+				IL_002e: ldarg.0
+				IL_002f: ldc.i4.1
+				IL_0030: ldelem.ref
+				IL_0031: castclass Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope
+				IL_0036: ldfld object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope::'value'
+				IL_003b: stloc.0
+				IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0041: dup
+				IL_0042: ldstr "value"
+				IL_0047: ldloc.0
+				IL_0048: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_004d: dup
+				IL_004e: ldstr "done"
+				IL_0053: ldarg.0
+				IL_0054: ldc.i4.1
+				IL_0055: ldelem.ref
+				IL_0056: castclass Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope
+				IL_005b: ldfld object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope::'value'
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: ldc.r8 3
+				IL_006e: cgt
+				IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0075: ret
 			} // end of method FunctionExpression_iterable::__js_call__
 
 		} // end of class FunctionExpression_iterable
@@ -139,7 +106,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27cb
+					// Method begins at RVA 0x277f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -163,52 +130,35 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2740
+				// Method begins at RVA 0x2708
 				// Header size: 12
-				// Code size: 100 (0x64)
+				// Code size: 80 (0x50)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] float64,
-					[2] object
-				)
 
 				IL_0000: ldarg.0
 				IL_0001: ldc.i4.0
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Iterator_Helper_Next_Return/Scope
-				IL_0008: ldfld object Modules.Iterator_Helper_Next_Return/Scope::closed
-				IL_000d: stloc.0
-				IL_000e: ldstr "closed"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldc.r8 1
-				IL_002b: add
-				IL_002c: stloc.1
-				IL_002d: ldloc.1
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: stloc.2
-				IL_0034: ldarg.0
-				IL_0035: ldc.i4.0
-				IL_0036: ldelem.ref
-				IL_0037: castclass Modules.Iterator_Helper_Next_Return/Scope
-				IL_003c: ldloc.2
-				IL_003d: stfld object Modules.Iterator_Helper_Next_Return/Scope::closed
-				IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0047: dup
-				IL_0048: ldstr "value"
-				IL_004d: ldstr "closed"
-				IL_0052: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0057: dup
-				IL_0058: ldstr "done"
-				IL_005d: ldc.i4.1
-				IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0063: ret
+				IL_0008: ldarg.0
+				IL_0009: ldc.i4.0
+				IL_000a: ldelem.ref
+				IL_000b: castclass Modules.Iterator_Helper_Next_Return/Scope
+				IL_0010: ldfld object Modules.Iterator_Helper_Next_Return/Scope::closed
+				IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001a: ldc.r8 1
+				IL_0023: add
+				IL_0024: box [System.Runtime]System.Double
+				IL_0029: stfld object Modules.Iterator_Helper_Next_Return/Scope::closed
+				IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0033: dup
+				IL_0034: ldstr "value"
+				IL_0039: ldstr "closed"
+				IL_003e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0043: dup
+				IL_0044: ldstr "done"
+				IL_0049: ldc.i4.1
+				IL_004a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_004f: ret
 			} // end of method FunctionExpression_iterable_L12C18::__js_call__
 
 		} // end of class FunctionExpression_iterable_L12C18
@@ -227,7 +177,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27b9
+				// Method begins at RVA 0x276d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -348,7 +298,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d4
+				// Method begins at RVA 0x2788
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -401,7 +351,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27b0
+			// Method begins at RVA 0x2764
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -884,7 +834,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27dd
+		// Method begins at RVA 0x2791
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x29f8
+						// Method begins at RVA 0x2972
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29ef
+					// Method begins at RVA 0x2969
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -70,16 +70,14 @@
 				)
 				// Method begins at RVA 0x26e0
 				// Header size: 12
-				// Code size: 260 (0x104)
+				// Code size: 200 (0xc8)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/Scope/Block_L14C44,
 					[1] object,
-					[2] object,
-					[3] float64,
-					[4] float64,
-					[5] object,
-					[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+					[2] float64,
+					[3] object,
+					[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
 				IL_0000: ldarg.0
@@ -88,101 +86,75 @@
 				IL_0003: castclass Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope
 				IL_0008: ldfld object Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope::index
 				IL_000d: stloc.1
-				IL_000e: ldstr "index"
-				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldarg.0
-				IL_001b: ldc.i4.1
-				IL_001c: ldelem.ref
-				IL_001d: castclass Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope
-				IL_0022: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope::entries
-				IL_0027: stloc.2
-				IL_0028: ldstr "entries"
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: castclass Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope
+				IL_0016: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope::entries
+				IL_001b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0020: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+				IL_0025: conv.r8
+				IL_0026: stloc.2
+				IL_0027: ldloc.1
+				IL_0028: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_002d: ldloc.2
-				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0033: stloc.2
-				IL_0034: ldloc.2
-				IL_0035: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.1
-				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.s 4
-				IL_0045: ldloc.3
-				IL_0046: clt
-				IL_0048: brfalse IL_00e6
+				IL_002e: clt
+				IL_0030: brfalse IL_00aa
 
-				IL_004d: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/Scope/Block_L14C44::.ctor()
-				IL_0052: stloc.0
-				IL_0053: ldarg.0
-				IL_0054: ldc.i4.1
-				IL_0055: ldelem.ref
-				IL_0056: castclass Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope
-				IL_005b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope::entries
-				IL_0060: stloc.1
-				IL_0061: ldstr "entries"
-				IL_0066: ldloc.1
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006c: stloc.1
-				IL_006d: ldarg.0
-				IL_006e: ldc.i4.1
-				IL_006f: ldelem.ref
-				IL_0070: castclass Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope
-				IL_0075: ldfld object Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope::index
-				IL_007a: stloc.2
-				IL_007b: ldstr "index"
-				IL_0080: ldloc.2
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0086: stloc.2
-				IL_0087: ldloc.2
-				IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_008d: stloc.3
-				IL_008e: ldloc.3
-				IL_008f: box [System.Runtime]System.Double
-				IL_0094: stloc.s 5
-				IL_0096: ldloc.s 5
-				IL_0098: stloc.2
-				IL_0099: ldloc.3
-				IL_009a: ldc.r8 1
-				IL_00a3: add
-				IL_00a4: stloc.3
-				IL_00a5: ldloc.3
-				IL_00a6: box [System.Runtime]System.Double
-				IL_00ab: stloc.s 5
-				IL_00ad: ldarg.0
-				IL_00ae: ldc.i4.1
-				IL_00af: ldelem.ref
-				IL_00b0: castclass Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope
-				IL_00b5: ldloc.s 5
-				IL_00b7: stfld object Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope::index
-				IL_00bc: ldloc.1
-				IL_00bd: ldloc.2
-				IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00c3: stloc.2
-				IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00c9: dup
-				IL_00ca: ldstr "value"
-				IL_00cf: ldloc.2
-				IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_00d5: dup
-				IL_00d6: ldstr "done"
-				IL_00db: ldc.i4.0
-				IL_00dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_00e1: stloc.s 6
-				IL_00e3: ldloc.s 6
-				IL_00e5: ret
+				IL_0035: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/Scope/Block_L14C44::.ctor()
+				IL_003a: stloc.0
+				IL_003b: ldarg.0
+				IL_003c: ldc.i4.1
+				IL_003d: ldelem.ref
+				IL_003e: castclass Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope
+				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope::entries
+				IL_0048: stloc.1
+				IL_0049: ldarg.0
+				IL_004a: ldc.i4.1
+				IL_004b: ldelem.ref
+				IL_004c: castclass Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope
+				IL_0051: ldfld object Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope::index
+				IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005b: stloc.2
+				IL_005c: ldloc.2
+				IL_005d: box [System.Runtime]System.Double
+				IL_0062: stloc.3
+				IL_0063: ldarg.0
+				IL_0064: ldc.i4.1
+				IL_0065: ldelem.ref
+				IL_0066: castclass Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope
+				IL_006b: ldloc.2
+				IL_006c: ldc.r8 1
+				IL_0075: add
+				IL_0076: box [System.Runtime]System.Double
+				IL_007b: stfld object Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope::index
+				IL_0080: ldloc.1
+				IL_0081: ldloc.3
+				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0087: stloc.3
+				IL_0088: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_008d: dup
+				IL_008e: ldstr "value"
+				IL_0093: ldloc.3
+				IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0099: dup
+				IL_009a: ldstr "done"
+				IL_009f: ldc.i4.0
+				IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_00a5: stloc.s 4
+				IL_00a7: ldloc.s 4
+				IL_00a9: ret
 
-				IL_00e6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00eb: dup
-				IL_00ec: ldstr "value"
-				IL_00f1: ldnull
-				IL_00f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_00f7: dup
-				IL_00f8: ldstr "done"
-				IL_00fd: ldc.i4.1
-				IL_00fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0103: ret
+				IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_00af: dup
+				IL_00b0: ldstr "value"
+				IL_00b5: ldnull
+				IL_00b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_00bb: dup
+				IL_00bc: ldstr "done"
+				IL_00c1: ldc.i4.1
+				IL_00c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_00c7: ret
 			} // end of method FunctionExpression_iterable::__js_call__
 
 		} // end of class FunctionExpression_iterable
@@ -203,7 +175,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29e6
+				// Method begins at RVA 0x2960
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -341,7 +313,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a13
+						// Method begins at RVA 0x298d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -359,7 +331,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a0a
+					// Method begins at RVA 0x2984
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -383,18 +355,16 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x27f0
+				// Method begins at RVA 0x27b4
 				// Header size: 12
-				// Code size: 260 (0x104)
+				// Code size: 200 (0xc8)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/Scope/Block_L40C44,
 					[1] object,
-					[2] object,
-					[3] float64,
-					[4] float64,
-					[5] object,
-					[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+					[2] float64,
+					[3] object,
+					[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
 				IL_0000: ldarg.0
@@ -403,101 +373,75 @@
 				IL_0003: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
 				IL_0008: ldfld object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope::index
 				IL_000d: stloc.1
-				IL_000e: ldstr "index"
-				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldarg.0
-				IL_001b: ldc.i4.1
-				IL_001c: ldelem.ref
-				IL_001d: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
-				IL_0022: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope::entries
-				IL_0027: stloc.2
-				IL_0028: ldstr "entries"
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
+				IL_0016: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope::entries
+				IL_001b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0020: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+				IL_0025: conv.r8
+				IL_0026: stloc.2
+				IL_0027: ldloc.1
+				IL_0028: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_002d: ldloc.2
-				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0033: stloc.2
-				IL_0034: ldloc.2
-				IL_0035: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.1
-				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.s 4
-				IL_0045: ldloc.3
-				IL_0046: clt
-				IL_0048: brfalse IL_00e6
+				IL_002e: clt
+				IL_0030: brfalse IL_00aa
 
-				IL_004d: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/Scope/Block_L40C44::.ctor()
-				IL_0052: stloc.0
-				IL_0053: ldarg.0
-				IL_0054: ldc.i4.1
-				IL_0055: ldelem.ref
-				IL_0056: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
-				IL_005b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope::entries
-				IL_0060: stloc.1
-				IL_0061: ldstr "entries"
-				IL_0066: ldloc.1
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006c: stloc.1
-				IL_006d: ldarg.0
-				IL_006e: ldc.i4.1
-				IL_006f: ldelem.ref
-				IL_0070: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
-				IL_0075: ldfld object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope::index
-				IL_007a: stloc.2
-				IL_007b: ldstr "index"
-				IL_0080: ldloc.2
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0086: stloc.2
-				IL_0087: ldloc.2
-				IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_008d: stloc.3
-				IL_008e: ldloc.3
-				IL_008f: box [System.Runtime]System.Double
-				IL_0094: stloc.s 5
-				IL_0096: ldloc.s 5
-				IL_0098: stloc.2
-				IL_0099: ldloc.3
-				IL_009a: ldc.r8 1
-				IL_00a3: add
-				IL_00a4: stloc.3
-				IL_00a5: ldloc.3
-				IL_00a6: box [System.Runtime]System.Double
-				IL_00ab: stloc.s 5
-				IL_00ad: ldarg.0
-				IL_00ae: ldc.i4.1
-				IL_00af: ldelem.ref
-				IL_00b0: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
-				IL_00b5: ldloc.s 5
-				IL_00b7: stfld object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope::index
-				IL_00bc: ldloc.1
-				IL_00bd: ldloc.2
-				IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00c3: stloc.2
-				IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00c9: dup
-				IL_00ca: ldstr "value"
-				IL_00cf: ldloc.2
-				IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_00d5: dup
-				IL_00d6: ldstr "done"
-				IL_00db: ldc.i4.0
-				IL_00dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_00e1: stloc.s 6
-				IL_00e3: ldloc.s 6
-				IL_00e5: ret
+				IL_0035: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/Scope/Block_L40C44::.ctor()
+				IL_003a: stloc.0
+				IL_003b: ldarg.0
+				IL_003c: ldc.i4.1
+				IL_003d: ldelem.ref
+				IL_003e: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
+				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope::entries
+				IL_0048: stloc.1
+				IL_0049: ldarg.0
+				IL_004a: ldc.i4.1
+				IL_004b: ldelem.ref
+				IL_004c: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
+				IL_0051: ldfld object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope::index
+				IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005b: stloc.2
+				IL_005c: ldloc.2
+				IL_005d: box [System.Runtime]System.Double
+				IL_0062: stloc.3
+				IL_0063: ldarg.0
+				IL_0064: ldc.i4.1
+				IL_0065: ldelem.ref
+				IL_0066: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
+				IL_006b: ldloc.2
+				IL_006c: ldc.r8 1
+				IL_0075: add
+				IL_0076: box [System.Runtime]System.Double
+				IL_007b: stfld object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope::index
+				IL_0080: ldloc.1
+				IL_0081: ldloc.3
+				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0087: stloc.3
+				IL_0088: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_008d: dup
+				IL_008e: ldstr "value"
+				IL_0093: ldloc.3
+				IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0099: dup
+				IL_009a: ldstr "done"
+				IL_009f: ldc.i4.0
+				IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_00a5: stloc.s 4
+				IL_00a7: ldloc.s 4
+				IL_00a9: ret
 
-				IL_00e6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00eb: dup
-				IL_00ec: ldstr "value"
-				IL_00f1: ldnull
-				IL_00f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_00f7: dup
-				IL_00f8: ldstr "done"
-				IL_00fd: ldc.i4.1
-				IL_00fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0103: ret
+				IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_00af: dup
+				IL_00b0: ldstr "value"
+				IL_00b5: ldnull
+				IL_00b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_00bb: dup
+				IL_00bc: ldstr "done"
+				IL_00c1: ldc.i4.1
+				IL_00c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_00c7: ret
 			} // end of method FunctionExpression_closableIterable::__js_call__
 
 		} // end of class FunctionExpression_closableIterable
@@ -513,7 +457,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a1c
+					// Method begins at RVA 0x2996
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,7 +481,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2900
+				// Method begins at RVA 0x2888
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -575,7 +519,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a01
+				// Method begins at RVA 0x297b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -726,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a37
+						// Method begins at RVA 0x29b1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -744,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a2e
+					// Method begins at RVA 0x29a8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -768,14 +712,13 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2928
+				// Method begins at RVA 0x28b0
 				// Header size: 12
-				// Code size: 131 (0x83)
+				// Code size: 117 (0x75)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/Scope/Block_L71C27,
-					[1] object,
-					[2] bool
+					[1] bool
 				)
 
 				IL_0000: ldarg.0
@@ -783,49 +726,43 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope
 				IL_0008: ldfld object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope::done
-				IL_000d: stloc.1
-				IL_000e: ldstr "done"
-				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldloc.1
-				IL_001b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0020: ldc.i4.0
-				IL_0021: ceq
-				IL_0023: stloc.2
-				IL_0024: ldloc.2
-				IL_0025: brfalse IL_0065
+				IL_000d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0012: ldc.i4.0
+				IL_0013: ceq
+				IL_0015: stloc.1
+				IL_0016: ldloc.1
+				IL_0017: brfalse IL_0057
 
-				IL_002a: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/Scope/Block_L71C27::.ctor()
-				IL_002f: stloc.0
-				IL_0030: ldarg.0
-				IL_0031: ldc.i4.1
-				IL_0032: ldelem.ref
-				IL_0033: castclass Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope
-				IL_0038: ldc.i4.1
-				IL_0039: box [System.Runtime]System.Boolean
-				IL_003e: stfld object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope::done
-				IL_0043: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0048: dup
-				IL_0049: ldstr "value"
-				IL_004e: ldstr "ab"
-				IL_0053: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0058: dup
-				IL_0059: ldstr "done"
-				IL_005e: ldc.i4.0
-				IL_005f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0064: ret
+				IL_001c: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/Scope/Block_L71C27::.ctor()
+				IL_0021: stloc.0
+				IL_0022: ldarg.0
+				IL_0023: ldc.i4.1
+				IL_0024: ldelem.ref
+				IL_0025: castclass Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope
+				IL_002a: ldc.i4.1
+				IL_002b: box [System.Runtime]System.Boolean
+				IL_0030: stfld object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope::done
+				IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_003a: dup
+				IL_003b: ldstr "value"
+				IL_0040: ldstr "ab"
+				IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_004a: dup
+				IL_004b: ldstr "done"
+				IL_0050: ldc.i4.0
+				IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0056: ret
 
-				IL_0065: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_006a: dup
-				IL_006b: ldstr "value"
-				IL_0070: ldnull
-				IL_0071: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0076: dup
-				IL_0077: ldstr "done"
-				IL_007c: ldc.i4.1
-				IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0082: ret
+				IL_0057: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_005c: dup
+				IL_005d: ldstr "value"
+				IL_0062: ldnull
+				IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0068: dup
+				IL_0069: ldstr "done"
+				IL_006e: ldc.i4.1
+				IL_006f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0074: ret
 			} // end of method FunctionExpression_invalidIterable::__js_call__
 
 		} // end of class FunctionExpression_invalidIterable
@@ -841,7 +778,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a40
+					// Method begins at RVA 0x29ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -865,7 +802,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x29b7
+				// Method begins at RVA 0x2931
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -901,7 +838,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a25
+				// Method begins at RVA 0x299f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1025,7 +962,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a49
+				// Method begins at RVA 0x29c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1045,7 +982,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a52
+				// Method begins at RVA 0x29cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1067,7 +1004,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29dd
+			// Method begins at RVA 0x2957
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1461,7 +1398,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a5b
+		// Method begins at RVA 0x29d5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_ForEach_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_ForEach_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2295
+				// Method begins at RVA 0x2277
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,73 +49,60 @@
 			)
 			// Method begins at RVA 0x21e8
 			// Header size: 12
-			// Code size: 152 (0x98)
+			// Code size: 122 (0x7a)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
-				[2] object,
-				[3] bool,
-				[4] object
+				[2] bool,
+				[3] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Map_ForEach_Basic/Scope::seen
-			IL_0006: stloc.0
-			IL_0007: ldstr "seen"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_001f: ldstr "prefix"
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0029: ldstr ":"
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0033: stloc.1
-			IL_0034: ldloc.1
-			IL_0035: ldarg.3
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_003b: stloc.1
-			IL_003c: ldloc.1
-			IL_003d: ldstr "="
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0047: stloc.1
-			IL_0048: ldloc.1
-			IL_0049: ldarg.2
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_004f: stloc.1
-			IL_0050: ldloc.1
-			IL_0051: ldstr ":"
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_005b: stloc.1
-			IL_005c: ldarg.0
-			IL_005d: ldfld object Modules.Map_ForEach_Basic/Scope::map
-			IL_0062: stloc.2
-			IL_0063: ldstr "map"
-			IL_0068: ldloc.2
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_006e: stloc.2
-			IL_006f: ldarg.s receiver
-			IL_0071: ldloc.2
-			IL_0072: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0077: stloc.3
-			IL_0078: ldloc.3
-			IL_0079: box [System.Runtime]System.Boolean
-			IL_007e: stloc.s 4
-			IL_0080: ldloc.1
-			IL_0081: ldloc.s 4
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0088: stloc.1
-			IL_0089: ldloc.0
-			IL_008a: ldstr "push"
-			IL_008f: ldloc.1
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0095: pop
-			IL_0096: ldnull
-			IL_0097: ret
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0011: ldstr "prefix"
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001b: ldstr ":"
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0025: stloc.1
+			IL_0026: ldloc.1
+			IL_0027: ldarg.3
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_002d: stloc.1
+			IL_002e: ldloc.1
+			IL_002f: ldstr "="
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0039: stloc.1
+			IL_003a: ldloc.1
+			IL_003b: ldarg.2
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0041: stloc.1
+			IL_0042: ldloc.1
+			IL_0043: ldstr ":"
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004d: stloc.1
+			IL_004e: ldarg.s receiver
+			IL_0050: ldarg.0
+			IL_0051: ldfld object Modules.Map_ForEach_Basic/Scope::map
+			IL_0056: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_005b: stloc.2
+			IL_005c: ldloc.2
+			IL_005d: box [System.Runtime]System.Boolean
+			IL_0062: stloc.3
+			IL_0063: ldloc.1
+			IL_0064: ldloc.3
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_006a: stloc.1
+			IL_006b: ldloc.0
+			IL_006c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0071: ldloc.1
+			IL_0072: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0077: pop
+			IL_0078: ldnull
+			IL_0079: ret
 		} // end of method FunctionExpression_L11C12::__js_call__
 
 	} // end of class FunctionExpression_L11C12
@@ -135,7 +122,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x228c
+			// Method begins at RVA 0x226e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -301,7 +288,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x229e
+		// Method begins at RVA 0x2280
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35a4
+						// Method begins at RVA 0x3540
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x359b
+					// Method begins at RVA 0x3537
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3592
+				// Method begins at RVA 0x352e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,7 +103,7 @@
 			)
 			// Method begins at RVA 0x2664
 			// Header size: 12
-			// Code size: 378 (0x17a)
+			// Code size: 310 (0x136)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/Scope/Block_L214C0,
@@ -113,13 +113,12 @@
 				[4] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/Scope/Block_L214C0/Block_L221C1,
 				[5] object,
 				[6] object,
-				[7] object,
-				[8] float64,
-				[9] float64,
-				[10] object,
-				[11] object[],
-				[12] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve,
-				[13] object
+				[7] float64,
+				[8] object,
+				[9] object[],
+				[10] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve,
+				[11] float64,
+				[12] object
 			)
 
 			IL_0000: ldarg.3
@@ -135,129 +134,107 @@
 			IL_0025: stloc.1
 			IL_0026: ldarg.0
 			IL_0027: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
-			IL_002c: stloc.s 6
-			IL_002e: ldstr "performance"
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0031: stloc.s 6
 			IL_0033: ldloc.s 6
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003a: stloc.s 6
-			IL_003c: ldloc.s 6
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0043: stloc.s 6
-			IL_0045: ldloc.s 6
-			IL_0047: ldstr "now"
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0051: stloc.s 6
-			IL_0053: ldloc.s 6
-			IL_0055: stloc.2
-			IL_0056: ldloc.2
-			IL_0057: stloc.s 6
-			IL_0059: ldstr "NOW_UNITS_PER_SECOND"
-			IL_005e: ldarg.0
-			IL_005f: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::NOW_UNITS_PER_SECOND
-			IL_0064: box [System.Runtime]System.Double
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_006e: stloc.s 7
-			IL_0070: ldarg.3
-			IL_0071: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0076: stloc.s 8
-			IL_0078: ldloc.s 7
-			IL_007a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_007f: stloc.s 9
-			IL_0081: ldloc.s 8
-			IL_0083: ldloc.s 9
-			IL_0085: mul
-			IL_0086: stloc.s 9
-			IL_0088: ldloc.s 6
-			IL_008a: ldloc.s 9
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0091: stloc.s 10
-			IL_0093: ldloc.s 10
-			IL_0095: stloc.3
-			// loop start (head: IL_0096)
-				IL_0096: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/Scope/Block_L214C0/Block_L221C1::.ctor()
-				IL_009b: stloc.s 4
-				IL_009d: ldc.i4.1
-				IL_009e: newarr [System.Runtime]System.Object
-				IL_00a3: dup
-				IL_00a4: ldc.i4.0
-				IL_00a5: ldarg.0
-				IL_00a6: stelem.ref
-				IL_00a7: stloc.s 11
-				IL_00a9: ldloc.s 11
-				IL_00ab: ldc.i4.1
-				IL_00ac: newarr [System.Runtime]System.Object
-				IL_00b1: dup
-				IL_00b2: ldc.i4.0
-				IL_00b3: ldarg.2
-				IL_00b4: stelem.ref
-				IL_00b5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-				IL_00ba: ldarg.2
-				IL_00bb: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::.ctor(object[], object)
-				IL_00c0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-				IL_00c5: stloc.s 12
-				IL_00c7: ldloc.s 12
-				IL_00c9: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_00ce: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_00d3: ldstr "prototype"
-				IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-				IL_00dd: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-				IL_00e2: ldloc.s 12
-				IL_00e4: stloc.s 5
-				IL_00e6: ldloc.s 5
-				IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ed: stloc.s 6
-				IL_00ef: ldloc.s 6
-				IL_00f1: isinst Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_00f6: dup
-				IL_00f7: brfalse IL_0107
+			IL_0035: ldstr "now"
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_003f: stloc.s 6
+			IL_0041: ldloc.s 6
+			IL_0043: stloc.2
+			IL_0044: ldloc.2
+			IL_0045: stloc.s 6
+			IL_0047: ldarg.0
+			IL_0048: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::NOW_UNITS_PER_SECOND
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 6
+			IL_0051: ldarg.3
+			IL_0052: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0057: ldloc.s 7
+			IL_0059: mul
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_005f: stloc.s 8
+			IL_0061: ldloc.s 8
+			IL_0063: stloc.3
+			// loop start (head: IL_0064)
+				IL_0064: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/Scope/Block_L214C0/Block_L221C1::.ctor()
+				IL_0069: stloc.s 4
+				IL_006b: ldc.i4.1
+				IL_006c: newarr [System.Runtime]System.Object
+				IL_0071: dup
+				IL_0072: ldc.i4.0
+				IL_0073: ldarg.0
+				IL_0074: stelem.ref
+				IL_0075: stloc.s 9
+				IL_0077: ldloc.s 9
+				IL_0079: ldc.i4.1
+				IL_007a: newarr [System.Runtime]System.Object
+				IL_007f: dup
+				IL_0080: ldc.i4.0
+				IL_0081: ldarg.2
+				IL_0082: stelem.ref
+				IL_0083: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+				IL_0088: ldarg.2
+				IL_0089: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::.ctor(object[], object)
+				IL_008e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+				IL_0093: stloc.s 10
+				IL_0095: ldloc.s 10
+				IL_0097: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+				IL_009c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+				IL_00a1: ldstr "prototype"
+				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+				IL_00ab: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+				IL_00b0: ldloc.s 10
+				IL_00b2: stloc.s 5
+				IL_00b4: ldloc.s 5
+				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00bb: stloc.s 6
+				IL_00bd: ldloc.s 6
+				IL_00bf: isinst Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+				IL_00c4: dup
+				IL_00c5: brfalse IL_00d5
 
-				IL_00fc: callvirt instance class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::runSieve()
-				IL_0101: pop
-				IL_0102: br IL_0115
+				IL_00ca: callvirt instance class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::runSieve()
+				IL_00cf: pop
+				IL_00d0: br IL_00e3
 
-				IL_0107: pop
-				IL_0108: ldloc.s 6
-				IL_010a: ldstr "runSieve"
-				IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0114: pop
+				IL_00d5: pop
+				IL_00d6: ldloc.s 6
+				IL_00d8: ldstr "runSieve"
+				IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_00e2: pop
 
-				IL_0115: ldloc.1
-				IL_0116: ldc.r8 1
-				IL_011f: add
-				IL_0120: stloc.1
-				IL_0121: ldarg.0
-				IL_0122: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
-				IL_0127: stloc.s 6
-				IL_0129: ldstr "performance"
-				IL_012e: ldloc.s 6
-				IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0135: stloc.s 6
-				IL_0137: ldloc.s 6
-				IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_013e: stloc.s 6
-				IL_0140: ldloc.s 6
-				IL_0142: ldstr "now"
-				IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_014c: stloc.s 6
-				IL_014e: ldloc.s 6
-				IL_0150: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0155: stloc.s 9
-				IL_0157: ldloc.3
-				IL_0158: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_015d: stloc.s 8
-				IL_015f: ldloc.s 9
-				IL_0161: ldloc.s 8
-				IL_0163: clt
-				IL_0165: brfalse IL_016f
+				IL_00e3: ldloc.1
+				IL_00e4: ldc.r8 1
+				IL_00ed: add
+				IL_00ee: stloc.1
+				IL_00ef: ldarg.0
+				IL_00f0: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
+				IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00fa: stloc.s 6
+				IL_00fc: ldloc.s 6
+				IL_00fe: ldstr "now"
+				IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0108: stloc.s 6
+				IL_010a: ldloc.s 6
+				IL_010c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0111: stloc.s 7
+				IL_0113: ldloc.3
+				IL_0114: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0119: stloc.s 11
+				IL_011b: ldloc.s 7
+				IL_011d: ldloc.s 11
+				IL_011f: clt
+				IL_0121: brfalse IL_012b
 
-				IL_016a: br IL_0096
+				IL_0126: br IL_0064
 			// end loop
 
-			IL_016f: ldloc.1
-			IL_0170: box [System.Runtime]System.Double
-			IL_0175: stloc.s 13
-			IL_0177: ldloc.s 13
-			IL_0179: ret
+			IL_012b: ldloc.1
+			IL_012c: box [System.Runtime]System.Double
+			IL_0131: stloc.s 12
+			IL_0133: ldloc.s 12
+			IL_0135: ret
 		} // end of method ArrowFunction_L213C23::__js_call__
 
 	} // end of class ArrowFunction_L213C23
@@ -288,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35ad
+				// Method begins at RVA 0x3549
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -315,7 +292,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x27ec
+			// Method begins at RVA 0x27a8
 			// Header size: 12
 			// Code size: 584 (0x248)
 			.maxstack 8
@@ -552,7 +529,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3484
+				// Method begins at RVA 0x3420
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -572,7 +549,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x348d
+				// Method begins at RVA 0x3429
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -592,7 +569,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3496
+				// Method begins at RVA 0x3432
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -620,7 +597,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34b1
+						// Method begins at RVA 0x344d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -644,7 +621,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x34c3
+							// Method begins at RVA 0x345f
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -662,7 +639,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34ba
+						// Method begins at RVA 0x3456
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -680,7 +657,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34a8
+					// Method begins at RVA 0x3444
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -708,7 +685,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x34de
+							// Method begins at RVA 0x347a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -726,7 +703,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34d5
+						// Method begins at RVA 0x3471
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -744,7 +721,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34cc
+					// Method begins at RVA 0x3468
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -768,7 +745,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34f0
+						// Method begins at RVA 0x348c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -786,7 +763,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34e7
+					// Method begins at RVA 0x3483
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -804,7 +781,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x349f
+				// Method begins at RVA 0x343b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -824,7 +801,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34f9
+				// Method begins at RVA 0x3495
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -848,7 +825,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x350b
+					// Method begins at RVA 0x34a7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -866,7 +843,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3502
+				// Method begins at RVA 0x349e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -894,7 +871,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2aa8
+			// Method begins at RVA 0x2a64
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -943,7 +920,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2dbc
+			// Method begins at RVA 0x2d58
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -1013,9 +990,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b44
+			// Method begins at RVA 0x2b00
 			// Header size: 12
-			// Code size: 620 (0x26c)
+			// Code size: 588 (0x24c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26,
@@ -1037,297 +1014,286 @@
 				[16] float64,
 				[17] float64,
 				[18] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29/Block_L92C36,
-				[19] object,
-				[20] float64
+				[19] float64
 			)
 
-			IL_0000: ldstr "WORD_SIZE"
-			IL_0005: ldarg.0
-			IL_0006: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::_scopes
-			IL_000b: ldc.i4.0
-			IL_000c: ldelem.ref
-			IL_000d: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-			IL_0012: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::WORD_SIZE
-			IL_0017: box [System.Runtime]System.Double
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0021: stloc.s 19
-			IL_0023: ldloc.s 19
-			IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002a: stloc.s 20
-			IL_002c: ldloc.s 20
-			IL_002e: ldc.r8 2
-			IL_0037: div
-			IL_0038: stloc.s 20
-			IL_003a: ldarg.2
-			IL_003b: ldloc.s 20
-			IL_003d: cgt
-			IL_003f: brfalse IL_0172
+			IL_0000: ldarg.2
+			IL_0001: ldarg.0
+			IL_0002: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::_scopes
+			IL_0007: ldc.i4.0
+			IL_0008: ldelem.ref
+			IL_0009: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+			IL_000e: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::WORD_SIZE
+			IL_0013: ldc.r8 2
+			IL_001c: div
+			IL_001d: cgt
+			IL_001f: brfalse IL_0152
 
-			IL_0044: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26::.ctor()
-			IL_0049: stloc.0
-			IL_004a: ldarg.1
-			IL_004b: ldc.r8 32
-			IL_0054: ldarg.2
-			IL_0055: mul
-			IL_0056: add
-			IL_0057: stloc.1
-			IL_0058: ldloc.1
-			IL_0059: stloc.s 20
-			IL_005b: ldloc.s 20
-			IL_005d: ldarg.3
-			IL_005e: cgt
-			IL_0060: brfalse IL_0098
+			IL_0024: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26::.ctor()
+			IL_0029: stloc.0
+			IL_002a: ldarg.1
+			IL_002b: ldc.r8 32
+			IL_0034: ldarg.2
+			IL_0035: mul
+			IL_0036: add
+			IL_0037: stloc.1
+			IL_0038: ldloc.1
+			IL_0039: stloc.s 19
+			IL_003b: ldloc.s 19
+			IL_003d: ldarg.3
+			IL_003e: cgt
+			IL_0040: brfalse IL_0078
 
-			IL_0065: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26/Block_L60C39::.ctor()
-			IL_006a: stloc.2
-			IL_006b: ldarg.1
-			IL_006c: stloc.3
-			// loop start (head: IL_006d)
-				IL_006d: ldloc.3
-				IL_006e: stloc.s 20
-				IL_0070: ldloc.s 20
-				IL_0072: ldarg.3
-				IL_0073: clt
-				IL_0075: brfalse IL_0096
+			IL_0045: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26/Block_L60C39::.ctor()
+			IL_004a: stloc.2
+			IL_004b: ldarg.1
+			IL_004c: stloc.3
+			// loop start (head: IL_004d)
+				IL_004d: ldloc.3
+				IL_004e: stloc.s 19
+				IL_0050: ldloc.s 19
+				IL_0052: ldarg.3
+				IL_0053: clt
+				IL_0055: brfalse IL_0076
 
-				IL_007a: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26/Scope_For_L62C9/Block_L62C69::.ctor()
-				IL_007f: stloc.s 4
-				IL_0081: ldarg.0
-				IL_0082: ldloc.3
-				IL_0083: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
-				IL_0088: pop
-				IL_0089: ldloc.3
-				IL_008a: ldarg.2
-				IL_008b: add
-				IL_008c: stloc.s 20
-				IL_008e: ldloc.s 20
-				IL_0090: stloc.3
-				IL_0091: br IL_006d
+				IL_005a: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26/Scope_For_L62C9/Block_L62C69::.ctor()
+				IL_005f: stloc.s 4
+				IL_0061: ldarg.0
+				IL_0062: ldloc.3
+				IL_0063: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
+				IL_0068: pop
+				IL_0069: ldloc.3
+				IL_006a: ldarg.2
+				IL_006b: add
+				IL_006c: stloc.s 19
+				IL_006e: ldloc.s 19
+				IL_0070: stloc.3
+				IL_0071: br IL_004d
 			// end loop
 
-			IL_0096: ldnull
-			IL_0097: ret
+			IL_0076: ldnull
+			IL_0077: ret
 
-			IL_0098: ldarg.3
-			IL_0099: conv.i4
-			IL_009a: conv.u4
-			IL_009b: ldc.r8 5
-			IL_00a4: conv.i4
-			IL_00a5: shr.un
-			IL_00a6: conv.r.un
-			IL_00a7: stloc.s 20
-			IL_00a9: ldloc.s 20
-			IL_00ab: stloc.s 5
-			IL_00ad: ldarg.1
-			IL_00ae: stloc.s 6
-			// loop start (head: IL_00b0)
-				IL_00b0: ldloc.s 6
-				IL_00b2: stloc.s 20
-				IL_00b4: ldloc.s 20
-				IL_00b6: ldloc.1
-				IL_00b7: clt
-				IL_00b9: brfalse IL_0170
+			IL_0078: ldarg.3
+			IL_0079: conv.i4
+			IL_007a: conv.u4
+			IL_007b: ldc.r8 5
+			IL_0084: conv.i4
+			IL_0085: shr.un
+			IL_0086: conv.r.un
+			IL_0087: stloc.s 19
+			IL_0089: ldloc.s 19
+			IL_008b: stloc.s 5
+			IL_008d: ldarg.1
+			IL_008e: stloc.s 6
+			// loop start (head: IL_0090)
+				IL_0090: ldloc.s 6
+				IL_0092: stloc.s 19
+				IL_0094: ldloc.s 19
+				IL_0096: ldloc.1
+				IL_0097: clt
+				IL_0099: brfalse IL_0150
 
-				IL_00be: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75::.ctor()
-				IL_00c3: stloc.s 7
-				IL_00c5: ldloc.s 6
-				IL_00c7: stloc.s 20
-				IL_00c9: ldloc.s 20
-				IL_00cb: conv.i4
-				IL_00cc: conv.u4
-				IL_00cd: ldc.r8 5
-				IL_00d6: conv.i4
-				IL_00d7: shr.un
-				IL_00d8: conv.r.un
-				IL_00d9: stloc.s 20
-				IL_00db: ldloc.s 20
-				IL_00dd: stloc.s 8
-				IL_00df: ldloc.s 6
-				IL_00e1: stloc.s 20
-				IL_00e3: ldloc.s 20
-				IL_00e5: conv.i4
-				IL_00e6: ldc.r8 31
-				IL_00ef: conv.i4
-				IL_00f0: and
-				IL_00f1: conv.r8
-				IL_00f2: stloc.s 20
-				IL_00f4: ldloc.s 20
-				IL_00f6: stloc.s 9
-				IL_00f8: ldc.r8 1
-				IL_0101: conv.i4
-				IL_0102: ldloc.s 9
-				IL_0104: conv.i4
-				IL_0105: shl
-				IL_0106: conv.r8
-				IL_0107: stloc.s 20
-				IL_0109: ldloc.s 20
-				IL_010b: stloc.s 10
-				// loop start (head: IL_010d)
-					IL_010d: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75/Block_L73C7::.ctor()
-					IL_0112: stloc.s 11
-					IL_0114: ldarg.0
-					IL_0115: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-					IL_011a: ldloc.s 8
-					IL_011c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_0121: stloc.s 20
-					IL_0123: ldloc.s 20
-					IL_0125: stloc.s 20
-					IL_0127: ldloc.s 20
-					IL_0129: conv.i4
-					IL_012a: ldloc.s 10
-					IL_012c: conv.i4
-					IL_012d: or
-					IL_012e: conv.r8
-					IL_012f: stloc.s 20
-					IL_0131: ldarg.0
-					IL_0132: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-					IL_0137: ldloc.s 8
-					IL_0139: ldloc.s 20
-					IL_013b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_0140: ldloc.s 8
-					IL_0142: ldarg.2
-					IL_0143: add
-					IL_0144: stloc.s 20
-					IL_0146: ldloc.s 20
-					IL_0148: stloc.s 8
-					IL_014a: ldloc.s 8
-					IL_014c: stloc.s 20
-					IL_014e: ldloc.s 20
-					IL_0150: ldloc.s 5
-					IL_0152: cgt
-					IL_0154: ldc.i4.0
-					IL_0155: ceq
-					IL_0157: brfalse IL_0161
+				IL_009e: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75::.ctor()
+				IL_00a3: stloc.s 7
+				IL_00a5: ldloc.s 6
+				IL_00a7: stloc.s 19
+				IL_00a9: ldloc.s 19
+				IL_00ab: conv.i4
+				IL_00ac: conv.u4
+				IL_00ad: ldc.r8 5
+				IL_00b6: conv.i4
+				IL_00b7: shr.un
+				IL_00b8: conv.r.un
+				IL_00b9: stloc.s 19
+				IL_00bb: ldloc.s 19
+				IL_00bd: stloc.s 8
+				IL_00bf: ldloc.s 6
+				IL_00c1: stloc.s 19
+				IL_00c3: ldloc.s 19
+				IL_00c5: conv.i4
+				IL_00c6: ldc.r8 31
+				IL_00cf: conv.i4
+				IL_00d0: and
+				IL_00d1: conv.r8
+				IL_00d2: stloc.s 19
+				IL_00d4: ldloc.s 19
+				IL_00d6: stloc.s 9
+				IL_00d8: ldc.r8 1
+				IL_00e1: conv.i4
+				IL_00e2: ldloc.s 9
+				IL_00e4: conv.i4
+				IL_00e5: shl
+				IL_00e6: conv.r8
+				IL_00e7: stloc.s 19
+				IL_00e9: ldloc.s 19
+				IL_00eb: stloc.s 10
+				// loop start (head: IL_00ed)
+					IL_00ed: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75/Block_L73C7::.ctor()
+					IL_00f2: stloc.s 11
+					IL_00f4: ldarg.0
+					IL_00f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+					IL_00fa: ldloc.s 8
+					IL_00fc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_0101: stloc.s 19
+					IL_0103: ldloc.s 19
+					IL_0105: stloc.s 19
+					IL_0107: ldloc.s 19
+					IL_0109: conv.i4
+					IL_010a: ldloc.s 10
+					IL_010c: conv.i4
+					IL_010d: or
+					IL_010e: conv.r8
+					IL_010f: stloc.s 19
+					IL_0111: ldarg.0
+					IL_0112: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+					IL_0117: ldloc.s 8
+					IL_0119: ldloc.s 19
+					IL_011b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_0120: ldloc.s 8
+					IL_0122: ldarg.2
+					IL_0123: add
+					IL_0124: stloc.s 19
+					IL_0126: ldloc.s 19
+					IL_0128: stloc.s 8
+					IL_012a: ldloc.s 8
+					IL_012c: stloc.s 19
+					IL_012e: ldloc.s 19
+					IL_0130: ldloc.s 5
+					IL_0132: cgt
+					IL_0134: ldc.i4.0
+					IL_0135: ceq
+					IL_0137: brfalse IL_0141
 
-					IL_015c: br IL_010d
+					IL_013c: br IL_00ed
 				// end loop
 
-				IL_0161: ldloc.s 6
-				IL_0163: ldarg.2
-				IL_0164: add
-				IL_0165: stloc.s 20
-				IL_0167: ldloc.s 20
-				IL_0169: stloc.s 6
-				IL_016b: br IL_00b0
+				IL_0141: ldloc.s 6
+				IL_0143: ldarg.2
+				IL_0144: add
+				IL_0145: stloc.s 19
+				IL_0147: ldloc.s 19
+				IL_0149: stloc.s 6
+				IL_014b: br IL_0090
 			// end loop
 
-			IL_0170: ldnull
-			IL_0171: ret
+			IL_0150: ldnull
+			IL_0151: ret
 
-			IL_0172: ldarg.1
-			IL_0173: stloc.s 12
-			IL_0175: ldloc.s 12
-			IL_0177: stloc.s 20
-			IL_0179: ldloc.s 20
-			IL_017b: conv.i4
-			IL_017c: conv.u4
-			IL_017d: ldc.r8 5
-			IL_0186: conv.i4
-			IL_0187: shr.un
-			IL_0188: conv.r.un
-			IL_0189: stloc.s 20
-			IL_018b: ldloc.s 20
-			IL_018d: stloc.s 13
-			IL_018f: ldarg.0
-			IL_0190: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_0195: ldloc.s 13
-			IL_0197: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_019c: stloc.s 20
-			IL_019e: ldloc.s 20
-			IL_01a0: stloc.s 14
-			// loop start (head: IL_01a2)
-				IL_01a2: ldloc.s 12
-				IL_01a4: stloc.s 20
-				IL_01a6: ldloc.s 20
-				IL_01a8: ldarg.3
-				IL_01a9: clt
-				IL_01ab: brfalse IL_025b
+			IL_0152: ldarg.1
+			IL_0153: stloc.s 12
+			IL_0155: ldloc.s 12
+			IL_0157: stloc.s 19
+			IL_0159: ldloc.s 19
+			IL_015b: conv.i4
+			IL_015c: conv.u4
+			IL_015d: ldc.r8 5
+			IL_0166: conv.i4
+			IL_0167: shr.un
+			IL_0168: conv.r.un
+			IL_0169: stloc.s 19
+			IL_016b: ldloc.s 19
+			IL_016d: stloc.s 13
+			IL_016f: ldarg.0
+			IL_0170: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_0175: ldloc.s 13
+			IL_0177: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_017c: stloc.s 19
+			IL_017e: ldloc.s 19
+			IL_0180: stloc.s 14
+			// loop start (head: IL_0182)
+				IL_0182: ldloc.s 12
+				IL_0184: stloc.s 19
+				IL_0186: ldloc.s 19
+				IL_0188: ldarg.3
+				IL_0189: clt
+				IL_018b: brfalse IL_023b
 
-				IL_01b0: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29::.ctor()
-				IL_01b5: stloc.s 15
-				IL_01b7: ldloc.s 12
-				IL_01b9: stloc.s 20
-				IL_01bb: ldloc.s 20
-				IL_01bd: conv.i4
-				IL_01be: ldc.r8 31
-				IL_01c7: conv.i4
-				IL_01c8: and
-				IL_01c9: conv.r8
-				IL_01ca: stloc.s 20
-				IL_01cc: ldloc.s 20
-				IL_01ce: stloc.s 16
-				IL_01d0: ldc.r8 1
-				IL_01d9: conv.i4
-				IL_01da: ldloc.s 16
-				IL_01dc: conv.i4
-				IL_01dd: shl
-				IL_01de: conv.r8
-				IL_01df: stloc.s 20
-				IL_01e1: ldloc.s 14
-				IL_01e3: conv.i4
-				IL_01e4: ldloc.s 20
-				IL_01e6: conv.i4
-				IL_01e7: or
-				IL_01e8: conv.r8
-				IL_01e9: stloc.s 20
-				IL_01eb: ldloc.s 20
-				IL_01ed: stloc.s 14
-				IL_01ef: ldloc.s 12
-				IL_01f1: ldarg.2
-				IL_01f2: add
-				IL_01f3: stloc.s 20
-				IL_01f5: ldloc.s 20
-				IL_01f7: stloc.s 12
-				IL_01f9: ldloc.s 12
-				IL_01fb: stloc.s 20
-				IL_01fd: ldloc.s 20
-				IL_01ff: conv.i4
-				IL_0200: conv.u4
-				IL_0201: ldc.r8 5
-				IL_020a: conv.i4
-				IL_020b: shr.un
-				IL_020c: conv.r.un
-				IL_020d: stloc.s 20
-				IL_020f: ldloc.s 20
-				IL_0211: stloc.s 17
-				IL_0213: ldloc.s 17
-				IL_0215: stloc.s 20
-				IL_0217: ldloc.s 20
-				IL_0219: ldloc.s 13
-				IL_021b: ceq
-				IL_021d: ldc.i4.0
-				IL_021e: ceq
-				IL_0220: brfalse IL_0256
+				IL_0190: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29::.ctor()
+				IL_0195: stloc.s 15
+				IL_0197: ldloc.s 12
+				IL_0199: stloc.s 19
+				IL_019b: ldloc.s 19
+				IL_019d: conv.i4
+				IL_019e: ldc.r8 31
+				IL_01a7: conv.i4
+				IL_01a8: and
+				IL_01a9: conv.r8
+				IL_01aa: stloc.s 19
+				IL_01ac: ldloc.s 19
+				IL_01ae: stloc.s 16
+				IL_01b0: ldc.r8 1
+				IL_01b9: conv.i4
+				IL_01ba: ldloc.s 16
+				IL_01bc: conv.i4
+				IL_01bd: shl
+				IL_01be: conv.r8
+				IL_01bf: stloc.s 19
+				IL_01c1: ldloc.s 14
+				IL_01c3: conv.i4
+				IL_01c4: ldloc.s 19
+				IL_01c6: conv.i4
+				IL_01c7: or
+				IL_01c8: conv.r8
+				IL_01c9: stloc.s 19
+				IL_01cb: ldloc.s 19
+				IL_01cd: stloc.s 14
+				IL_01cf: ldloc.s 12
+				IL_01d1: ldarg.2
+				IL_01d2: add
+				IL_01d3: stloc.s 19
+				IL_01d5: ldloc.s 19
+				IL_01d7: stloc.s 12
+				IL_01d9: ldloc.s 12
+				IL_01db: stloc.s 19
+				IL_01dd: ldloc.s 19
+				IL_01df: conv.i4
+				IL_01e0: conv.u4
+				IL_01e1: ldc.r8 5
+				IL_01ea: conv.i4
+				IL_01eb: shr.un
+				IL_01ec: conv.r.un
+				IL_01ed: stloc.s 19
+				IL_01ef: ldloc.s 19
+				IL_01f1: stloc.s 17
+				IL_01f3: ldloc.s 17
+				IL_01f5: stloc.s 19
+				IL_01f7: ldloc.s 19
+				IL_01f9: ldloc.s 13
+				IL_01fb: ceq
+				IL_01fd: ldc.i4.0
+				IL_01fe: ceq
+				IL_0200: brfalse IL_0236
 
-				IL_0225: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29/Block_L92C36::.ctor()
-				IL_022a: stloc.s 18
-				IL_022c: ldarg.0
-				IL_022d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-				IL_0232: ldloc.s 13
-				IL_0234: ldloc.s 14
-				IL_0236: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_023b: ldloc.s 17
-				IL_023d: stloc.s 20
-				IL_023f: ldloc.s 20
-				IL_0241: stloc.s 13
-				IL_0243: ldarg.0
-				IL_0244: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-				IL_0249: ldloc.s 13
-				IL_024b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_0250: stloc.s 20
-				IL_0252: ldloc.s 20
-				IL_0254: stloc.s 14
+				IL_0205: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29/Block_L92C36::.ctor()
+				IL_020a: stloc.s 18
+				IL_020c: ldarg.0
+				IL_020d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+				IL_0212: ldloc.s 13
+				IL_0214: ldloc.s 14
+				IL_0216: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_021b: ldloc.s 17
+				IL_021d: stloc.s 19
+				IL_021f: ldloc.s 19
+				IL_0221: stloc.s 13
+				IL_0223: ldarg.0
+				IL_0224: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+				IL_0229: ldloc.s 13
+				IL_022b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_0230: stloc.s 19
+				IL_0232: ldloc.s 19
+				IL_0234: stloc.s 14
 
-				IL_0256: br IL_01a2
+				IL_0236: br IL_0182
 			// end loop
 
-			IL_025b: ldarg.0
-			IL_025c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_0261: ldloc.s 13
-			IL_0263: ldloc.s 14
-			IL_0265: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_026a: ldnull
-			IL_026b: ret
+			IL_023b: ldarg.0
+			IL_023c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_0241: ldloc.s 13
+			IL_0243: ldloc.s 14
+			IL_0245: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_024a: ldnull
+			IL_024b: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -1338,7 +1304,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e20
+			// Method begins at RVA 0x2dbc
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1402,7 +1368,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2af8
+			// Method begins at RVA 0x2ab4
 			// Header size: 12
 			// Code size: 62 (0x3e)
 			.maxstack 8
@@ -1452,7 +1418,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3514
+				// Method begins at RVA 0x34b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1472,7 +1438,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x351d
+				// Method begins at RVA 0x34b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1496,7 +1462,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x352f
+					// Method begins at RVA 0x34cb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1514,7 +1480,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3526
+				// Method begins at RVA 0x34c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1534,7 +1500,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3538
+				// Method begins at RVA 0x34d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1562,7 +1528,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3553
+						// Method begins at RVA 0x34ef
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1580,7 +1546,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x354a
+					// Method begins at RVA 0x34e6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1598,7 +1564,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3541
+				// Method begins at RVA 0x34dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1622,7 +1588,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3565
+					// Method begins at RVA 0x3501
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1646,7 +1612,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3577
+						// Method begins at RVA 0x3513
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1664,7 +1630,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x356e
+					// Method begins at RVA 0x350a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1682,7 +1648,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x355c
+				// Method begins at RVA 0x34f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1706,7 +1672,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3589
+					// Method begins at RVA 0x3525
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1724,7 +1690,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3580
+				// Method begins at RVA 0x351c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1754,7 +1720,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a40
+			// Method begins at RVA 0x29fc
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -1811,7 +1777,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e7c
+			// Method begins at RVA 0x2e18
 			// Header size: 12
 			// Code size: 318 (0x13e)
 			.maxstack 8
@@ -1958,7 +1924,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3298
+			// Method begins at RVA 0x3234
 			// Header size: 12
 			// Code size: 170 (0xaa)
 			.maxstack 8
@@ -2047,7 +2013,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3350
+			// Method begins at RVA 0x32ec
 			// Header size: 12
 			// Code size: 287 (0x11f)
 			.maxstack 8
@@ -2178,7 +2144,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fc8
+			// Method begins at RVA 0x2f64
 			// Header size: 12
 			// Code size: 706 (0x2c2)
 			.maxstack 8
@@ -2445,7 +2411,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x347b
+			// Method begins at RVA 0x3417
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3127,7 +3093,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x35b6
+		// Method begins at RVA 0x3552
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFile_NonZero.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFile_NonZero.verified.txt
@@ -29,7 +29,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23aa
+				// Method begins at RVA 0x239c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -60,7 +60,7 @@
 			)
 			// Method begins at RVA 0x2184
 			// Header size: 12
-			// Code size: 518 (0x206)
+			// Code size: 504 (0x1f8)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -238,25 +238,21 @@
 			IL_01c0: ldstr "Cannot access 'child' before initialization"
 			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_01ca: stloc.s 6
-			IL_01cc: ldstr "child"
-			IL_01d1: ldloc.s 6
-			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01d8: stloc.s 6
-			IL_01da: ldloc.s 6
-			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01cc: ldloc.s 6
+			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01d3: stloc.s 6
+			IL_01d5: ldloc.s 6
+			IL_01d7: ldstr "kill"
+			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_01e1: stloc.s 6
-			IL_01e3: ldloc.s 6
-			IL_01e5: ldstr "kill"
-			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01ef: stloc.s 6
-			IL_01f1: ldloc.0
-			IL_01f2: ldstr "log"
-			IL_01f7: ldstr "kill after callback:"
-			IL_01fc: ldloc.s 6
-			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0203: pop
-			IL_0204: ldnull
-			IL_0205: ret
+			IL_01e3: ldloc.0
+			IL_01e4: ldstr "log"
+			IL_01e9: ldstr "kill after callback:"
+			IL_01ee: ldloc.s 6
+			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01f5: pop
+			IL_01f6: ldnull
+			IL_01f7: ret
 		} // end of method ArrowFunction_L11C49::__js_call__
 
 	} // end of class ArrowFunction_L11C49
@@ -275,7 +271,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2396
+			// Method begins at RVA 0x2388
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -436,7 +432,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23b3
+		// Method begins at RVA 0x23a5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Exec_Callback.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Exec_Callback.verified.txt
@@ -29,7 +29,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e0
+				// Method begins at RVA 0x22d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -60,7 +60,7 @@
 			)
 			// Method begins at RVA 0x21cc
 			// Header size: 12
-			// Code size: 244 (0xf4)
+			// Code size: 232 (0xe8)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -133,25 +133,21 @@
 			IL_00b6: ldstr "Cannot access 'child' before initialization"
 			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_00c0: stloc.0
-			IL_00c1: ldstr "child"
-			IL_00c6: ldloc.0
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00cc: stloc.0
-			IL_00cd: ldloc.0
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c1: ldloc.0
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c7: stloc.0
+			IL_00c8: ldloc.0
+			IL_00c9: ldstr "kill"
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_00d3: stloc.0
-			IL_00d4: ldloc.0
-			IL_00d5: ldstr "kill"
-			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00df: stloc.0
-			IL_00e0: ldloc.3
-			IL_00e1: ldstr "log"
-			IL_00e6: ldstr "kill after callback:"
-			IL_00eb: ldloc.0
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f1: pop
-			IL_00f2: ldnull
-			IL_00f3: ret
+			IL_00d4: ldloc.3
+			IL_00d5: ldstr "log"
+			IL_00da: ldstr "kill after callback:"
+			IL_00df: ldloc.0
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00e5: pop
+			IL_00e6: ldnull
+			IL_00e7: ret
 		} // end of method ArrowFunction_L9C42::__js_call__
 
 	} // end of class ArrowFunction_L9C42
@@ -170,7 +166,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22cc
+			// Method begins at RVA 0x22c0
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -345,7 +341,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e9
+		// Method begins at RVA 0x22dd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Kill_And_Env.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Kill_And_Env.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2762
+				// Method begins at RVA 0x273a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,29 +54,22 @@
 			)
 			// Method begins at RVA 0x242c
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 22 (0x16)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::stderr
-			IL_0006: stloc.0
-			IL_0007: ldstr "stderr"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldarg.2
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001a: stloc.1
-			IL_001b: ldarg.0
-			IL_001c: ldloc.1
-			IL_001d: stfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::stderr
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0006: ldarg.2
+			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_000c: stloc.0
+			IL_000d: ldarg.0
+			IL_000e: ldloc.0
+			IL_000f: stfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::stderr
+			IL_0014: ldnull
+			IL_0015: ret
 		} // end of method ArrowFunction_L20C25::__js_call__
 
 	} // end of class ArrowFunction_L20C25
@@ -99,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x276b
+				// Method begins at RVA 0x2743
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,9 +119,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x245c
+			// Method begins at RVA 0x2450
 			// Header size: 12
-			// Code size: 173 (0xad)
+			// Code size: 159 (0x9f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -171,27 +164,21 @@
 			IL_006d: stloc.0
 			IL_006e: ldarg.0
 			IL_006f: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-			IL_0074: stloc.1
-			IL_0075: ldstr "child"
+			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0079: stloc.1
 			IL_007a: ldloc.1
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0080: stloc.1
-			IL_0081: ldloc.1
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0087: stloc.1
-			IL_0088: ldloc.1
-			IL_0089: ldstr "kill"
-			IL_008e: ldstr "SIGTERM"
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0098: stloc.1
-			IL_0099: ldloc.0
-			IL_009a: ldstr "log"
-			IL_009f: ldstr "kill result:"
-			IL_00a4: ldloc.1
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00aa: pop
-			IL_00ab: ldnull
-			IL_00ac: ret
+			IL_007b: ldstr "kill"
+			IL_0080: ldstr "SIGTERM"
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_008a: stloc.1
+			IL_008b: ldloc.0
+			IL_008c: ldstr "log"
+			IL_0091: ldstr "kill result:"
+			IL_0096: ldloc.1
+			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_009c: pop
+			IL_009d: ldnull
+			IL_009e: ret
 		} // end of method ArrowFunction_L24C21::__js_call__
 
 	} // end of class ArrowFunction_L24C21
@@ -207,7 +194,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2774
+				// Method begins at RVA 0x274c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -230,7 +217,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2518
+			// Method begins at RVA 0x24fc
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -277,7 +264,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x277d
+				// Method begins at RVA 0x2755
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -302,7 +289,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2550
+			// Method begins at RVA 0x2534
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -382,7 +369,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2786
+				// Method begins at RVA 0x275e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -410,9 +397,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x25e0
+			// Method begins at RVA 0x25c4
 			// Header size: 12
-			// Code size: 204 (0xcc)
+			// Code size: 190 (0xbe)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -473,26 +460,20 @@
 			IL_0091: stloc.0
 			IL_0092: ldarg.0
 			IL_0093: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::stderr
-			IL_0098: stloc.3
-			IL_0099: ldstr "stderr"
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009d: stloc.3
 			IL_009e: ldloc.3
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a4: stloc.3
-			IL_00a5: ldloc.3
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ab: stloc.3
-			IL_00ac: ldloc.3
-			IL_00ad: ldstr "trim"
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00b7: stloc.3
-			IL_00b8: ldloc.0
-			IL_00b9: ldstr "log"
-			IL_00be: ldstr "stderr:"
-			IL_00c3: ldloc.3
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00c9: pop
-			IL_00ca: ldnull
-			IL_00cb: ret
+			IL_009f: ldstr "trim"
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00a9: stloc.3
+			IL_00aa: ldloc.0
+			IL_00ab: ldstr "log"
+			IL_00b0: ldstr "stderr:"
+			IL_00b5: ldloc.3
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00bb: pop
+			IL_00bc: ldnull
+			IL_00bd: ret
 		} // end of method ArrowFunction_L40C19::__js_call__
 
 	} // end of class ArrowFunction_L40C19
@@ -513,7 +494,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2759
+				// Method begins at RVA 0x2731
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -535,7 +516,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2750
+			// Method begins at RVA 0x2728
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -857,7 +838,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2798
+				// Method begins at RVA 0x2770
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -883,7 +864,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x26b8
+			// Method begins at RVA 0x2690
 			// Header size: 12
 			// Code size: 137 (0x89)
 			.maxstack 8
@@ -954,7 +935,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27a1
+				// Method begins at RVA 0x2779
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -977,7 +958,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x274d
+			// Method begins at RVA 0x2725
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -995,7 +976,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x278f
+			// Method begins at RVA 0x2767
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1102,7 +1083,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27aa
+		// Method begins at RVA 0x2782
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_MessagePassing.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_MessagePassing.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c73
+				// Method begins at RVA 0x2c23
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,29 +54,22 @@
 			)
 			// Method begins at RVA 0x25dc
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 22 (0x16)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stdout
-			IL_0006: stloc.0
-			IL_0007: ldstr "stdout"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldarg.2
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001a: stloc.1
-			IL_001b: ldarg.0
-			IL_001c: ldloc.1
-			IL_001d: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stdout
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0006: ldarg.2
+			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_000c: stloc.0
+			IL_000d: ldarg.0
+			IL_000e: ldloc.0
+			IL_000f: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stdout
+			IL_0014: ldnull
+			IL_0015: ret
 		} // end of method ArrowFunction_L22C25::__js_call__
 
 	} // end of class ArrowFunction_L22C25
@@ -99,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c7c
+				// Method begins at RVA 0x2c2c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,31 +119,24 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x260c
+			// Method begins at RVA 0x2600
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 22 (0x16)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stderr
-			IL_0006: stloc.0
-			IL_0007: ldstr "stderr"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldarg.2
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001a: stloc.1
-			IL_001b: ldarg.0
-			IL_001c: ldloc.1
-			IL_001d: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stderr
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0006: ldarg.2
+			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_000c: stloc.0
+			IL_000d: ldarg.0
+			IL_000e: ldloc.0
+			IL_000f: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stderr
+			IL_0014: ldnull
+			IL_0015: ret
 		} // end of method ArrowFunction_L26C25::__js_call__
 
 	} // end of class ArrowFunction_L26C25
@@ -174,7 +160,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c8e
+					// Method begins at RVA 0x2c3e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -195,7 +181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c85
+				// Method begins at RVA 0x2c35
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -222,9 +208,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x263c
+			// Method begins at RVA 0x2624
 			// Header size: 12
-			// Code size: 337 (0x151)
+			// Code size: 323 (0x143)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L30C21/Scope/Block_L31C35,
@@ -240,7 +226,7 @@
 			IL_0010: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0015: stloc.1
 			IL_0016: ldloc.1
-			IL_0017: brfalse IL_00f3
+			IL_0017: brfalse IL_00e5
 
 			IL_001c: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L30C21/Scope/Block_L31C35::.ctor()
 			IL_0021: stloc.0
@@ -280,66 +266,60 @@
 			IL_008f: stloc.2
 			IL_0090: ldarg.0
 			IL_0091: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-			IL_0096: stloc.3
-			IL_0097: ldstr "child"
+			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009b: stloc.3
 			IL_009c: ldloc.3
-			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a2: stloc.3
-			IL_00a3: ldloc.3
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a9: stloc.3
-			IL_00aa: ldloc.3
-			IL_00ab: ldstr "send"
-			IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00b5: dup
-			IL_00b6: ldstr "stage"
-			IL_00bb: ldstr "parent"
-			IL_00c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00c5: dup
-			IL_00c6: ldstr "value"
-			IL_00cb: ldc.r8 41
-			IL_00d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00de: stloc.3
-			IL_00df: ldloc.2
-			IL_00e0: ldstr "log"
-			IL_00e5: ldstr "send result:"
-			IL_00ea: ldloc.3
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f0: pop
-			IL_00f1: ldnull
-			IL_00f2: ret
+			IL_009d: ldstr "send"
+			IL_00a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00a7: dup
+			IL_00a8: ldstr "stage"
+			IL_00ad: ldstr "parent"
+			IL_00b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00b7: dup
+			IL_00b8: ldstr "value"
+			IL_00bd: ldc.r8 41
+			IL_00c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00d0: stloc.3
+			IL_00d1: ldloc.2
+			IL_00d2: ldstr "log"
+			IL_00d7: ldstr "send result:"
+			IL_00dc: ldloc.3
+			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00e2: pop
+			IL_00e3: ldnull
+			IL_00e4: ret
 
-			IL_00f3: ldstr "console"
-			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00fd: stloc.3
-			IL_00fe: ldloc.3
-			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0104: stloc.3
-			IL_0105: ldloc.3
-			IL_0106: ldstr "log"
-			IL_010b: ldstr "reply stage:"
-			IL_0110: ldarg.2
-			IL_0111: ldstr "stage"
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0120: pop
-			IL_0121: ldstr "console"
-			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_012b: stloc.3
-			IL_012c: ldloc.3
-			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0132: stloc.3
-			IL_0133: ldloc.3
-			IL_0134: ldstr "log"
-			IL_0139: ldstr "reply value:"
-			IL_013e: ldarg.2
-			IL_013f: ldstr "value"
-			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_014e: pop
-			IL_014f: ldnull
-			IL_0150: ret
+			IL_00e5: ldstr "console"
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ef: stloc.3
+			IL_00f0: ldloc.3
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f6: stloc.3
+			IL_00f7: ldloc.3
+			IL_00f8: ldstr "log"
+			IL_00fd: ldstr "reply stage:"
+			IL_0102: ldarg.2
+			IL_0103: ldstr "stage"
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0112: pop
+			IL_0113: ldstr "console"
+			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_011d: stloc.3
+			IL_011e: ldloc.3
+			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0124: stloc.3
+			IL_0125: ldloc.3
+			IL_0126: ldstr "log"
+			IL_012b: ldstr "reply value:"
+			IL_0130: ldarg.2
+			IL_0131: ldstr "value"
+			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0140: pop
+			IL_0141: ldnull
+			IL_0142: ret
 		} // end of method ArrowFunction_L30C21::__js_call__
 
 	} // end of class ArrowFunction_L30C21
@@ -355,7 +335,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c97
+				// Method begins at RVA 0x2c47
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -378,7 +358,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x279c
+			// Method begins at RVA 0x2774
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -423,7 +403,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ca0
+				// Method begins at RVA 0x2c50
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -447,7 +427,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27d4
+			// Method begins at RVA 0x27ac
 			// Header size: 12
 			// Code size: 70 (0x46)
 			.maxstack 8
@@ -511,7 +491,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ca9
+				// Method begins at RVA 0x2c59
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -536,7 +516,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2828
+			// Method begins at RVA 0x2800
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -616,7 +596,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2cb2
+				// Method begins at RVA 0x2c62
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -644,9 +624,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x28b8
+			// Method begins at RVA 0x2890
 			// Header size: 12
-			// Code size: 278 (0x116)
+			// Code size: 250 (0xfa)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -707,52 +687,40 @@
 			IL_0091: stloc.0
 			IL_0092: ldarg.0
 			IL_0093: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stdout
-			IL_0098: stloc.3
-			IL_0099: ldstr "stdout"
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009d: stloc.3
 			IL_009e: ldloc.3
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a4: stloc.3
-			IL_00a5: ldloc.3
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ab: stloc.3
-			IL_00ac: ldloc.3
-			IL_00ad: ldstr "trim"
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00b7: stloc.3
-			IL_00b8: ldloc.0
-			IL_00b9: ldstr "log"
-			IL_00be: ldstr "stdout:"
-			IL_00c3: ldloc.3
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00c9: pop
-			IL_00ca: ldstr "console"
-			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00d4: stloc.3
-			IL_00d5: ldloc.3
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00db: stloc.3
-			IL_00dc: ldarg.0
-			IL_00dd: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stderr
-			IL_00e2: stloc.0
-			IL_00e3: ldstr "stderr"
-			IL_00e8: ldloc.0
-			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ee: stloc.0
-			IL_00ef: ldloc.0
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f5: stloc.0
-			IL_00f6: ldloc.0
-			IL_00f7: ldstr "trim"
-			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0101: stloc.0
-			IL_0102: ldloc.3
-			IL_0103: ldstr "log"
-			IL_0108: ldstr "stderr:"
-			IL_010d: ldloc.0
-			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0113: pop
-			IL_0114: ldnull
-			IL_0115: ret
+			IL_009f: ldstr "trim"
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00a9: stloc.3
+			IL_00aa: ldloc.0
+			IL_00ab: ldstr "log"
+			IL_00b0: ldstr "stdout:"
+			IL_00b5: ldloc.3
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00bb: pop
+			IL_00bc: ldstr "console"
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c6: stloc.3
+			IL_00c7: ldloc.3
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00cd: stloc.3
+			IL_00ce: ldarg.0
+			IL_00cf: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stderr
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d9: stloc.0
+			IL_00da: ldloc.0
+			IL_00db: ldstr "trim"
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00e5: stloc.0
+			IL_00e6: ldloc.3
+			IL_00e7: ldstr "log"
+			IL_00ec: ldstr "stderr:"
+			IL_00f1: ldloc.0
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00f7: pop
+			IL_00f8: ldnull
+			IL_00f9: ret
 		} // end of method ArrowFunction_L56C19::__js_call__
 
 	} // end of class ArrowFunction_L56C19
@@ -774,7 +742,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c6a
+				// Method begins at RVA 0x2c1a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -797,7 +765,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2c61
+			// Method begins at RVA 0x2c11
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1228,7 +1196,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2cc4
+				// Method begins at RVA 0x2c74
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1251,7 +1219,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29dc
+			// Method begins at RVA 0x2998
 			// Header size: 12
 			// Code size: 46 (0x2e)
 			.maxstack 8
@@ -1295,7 +1263,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ccd
+				// Method begins at RVA 0x2c7d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1322,9 +1290,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2a18
+			// Method begins at RVA 0x29d4
 			// Header size: 12
-			// Code size: 275 (0x113)
+			// Code size: 261 (0x105)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1335,91 +1303,85 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing_Child/Scope::fallbackExit
-			IL_0006: stloc.0
-			IL_0007: ldstr "fallbackExit"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::clearTimeout(object)
-			IL_0019: pop
-			IL_001a: ldstr "console"
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0024: stloc.0
-			IL_0025: ldloc.0
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002b: stloc.0
-			IL_002c: ldloc.0
-			IL_002d: ldstr "log"
-			IL_0032: ldstr "child received:"
-			IL_0037: ldarg.2
-			IL_0038: ldstr "value"
-			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0047: pop
-			IL_0048: ldstr "console"
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0052: stloc.0
-			IL_0053: ldloc.0
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0059: stloc.0
-			IL_005a: ldstr "process"
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0064: stloc.1
-			IL_0065: ldloc.1
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006b: stloc.1
-			IL_006c: ldarg.2
-			IL_006d: ldstr "value"
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0077: ldc.r8 1
-			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0085: stloc.2
-			IL_0086: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_008b: dup
-			IL_008c: ldstr "stage"
-			IL_0091: ldstr "child"
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_009b: dup
-			IL_009c: ldstr "value"
-			IL_00a1: ldloc.2
-			IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00a7: stloc.3
-			IL_00a8: ldloc.1
-			IL_00a9: ldstr "send"
-			IL_00ae: ldloc.3
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00b4: stloc.1
-			IL_00b5: ldloc.0
-			IL_00b6: ldstr "log"
-			IL_00bb: ldstr "reply sent:"
-			IL_00c0: ldloc.1
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00c6: pop
-			IL_00c7: ldstr "process"
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00d1: stloc.1
-			IL_00d2: ldloc.1
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d8: stloc.1
-			IL_00d9: ldloc.1
-			IL_00da: ldstr "disconnect"
-			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00e4: pop
-			IL_00e5: ldstr "process"
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ef: stloc.1
-			IL_00f0: ldloc.1
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f6: stloc.1
-			IL_00f7: ldloc.1
-			IL_00f8: ldstr "exit"
-			IL_00fd: ldc.r8 0.0
-			IL_0106: box [System.Runtime]System.Double
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0110: pop
-			IL_0111: ldnull
-			IL_0112: ret
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::clearTimeout(object)
+			IL_000b: pop
+			IL_000c: ldstr "console"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0016: stloc.0
+			IL_0017: ldloc.0
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001d: stloc.0
+			IL_001e: ldloc.0
+			IL_001f: ldstr "log"
+			IL_0024: ldstr "child received:"
+			IL_0029: ldarg.2
+			IL_002a: ldstr "value"
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0039: pop
+			IL_003a: ldstr "console"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0044: stloc.0
+			IL_0045: ldloc.0
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_004b: stloc.0
+			IL_004c: ldstr "process"
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0056: stloc.1
+			IL_0057: ldloc.1
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005d: stloc.1
+			IL_005e: ldarg.2
+			IL_005f: ldstr "value"
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0069: ldc.r8 1
+			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0077: stloc.2
+			IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_007d: dup
+			IL_007e: ldstr "stage"
+			IL_0083: ldstr "child"
+			IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_008d: dup
+			IL_008e: ldstr "value"
+			IL_0093: ldloc.2
+			IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0099: stloc.3
+			IL_009a: ldloc.1
+			IL_009b: ldstr "send"
+			IL_00a0: ldloc.3
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00a6: stloc.1
+			IL_00a7: ldloc.0
+			IL_00a8: ldstr "log"
+			IL_00ad: ldstr "reply sent:"
+			IL_00b2: ldloc.1
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00b8: pop
+			IL_00b9: ldstr "process"
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c3: stloc.1
+			IL_00c4: ldloc.1
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ca: stloc.1
+			IL_00cb: ldloc.1
+			IL_00cc: ldstr "disconnect"
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00d6: pop
+			IL_00d7: ldstr "process"
+			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00e1: stloc.1
+			IL_00e2: ldloc.1
+			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e8: stloc.1
+			IL_00e9: ldloc.1
+			IL_00ea: ldstr "exit"
+			IL_00ef: ldc.r8 0.0
+			IL_00f8: box [System.Runtime]System.Double
+			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0102: pop
+			IL_0103: ldnull
+			IL_0104: ret
 		} // end of method ArrowFunction_L7C23::__js_call__
 
 	} // end of class ArrowFunction_L7C23
@@ -1435,7 +1397,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2cd6
+				// Method begins at RVA 0x2c86
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1461,7 +1423,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2b38
+			// Method begins at RVA 0x2ae8
 			// Header size: 12
 			// Code size: 285 (0x11d)
 			.maxstack 8
@@ -1583,7 +1545,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2cbb
+			// Method begins at RVA 0x2c6b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1733,7 +1695,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2cdf
+		// Method begins at RVA 0x2c8f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ae3
+					// Method begins at RVA 0x2a5f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -54,13 +54,12 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2754
+				// Method begins at RVA 0x273c
 				// Header size: 12
-				// Code size: 50 (0x32)
+				// Code size: 36 (0x24)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldarg.0
@@ -68,23 +67,17 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
 				IL_0008: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stdout
-				IL_000d: stloc.0
-				IL_000e: ldstr "stdout"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ldarg.2
-				IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0021: stloc.1
-				IL_0022: ldarg.0
-				IL_0023: ldc.i4.1
-				IL_0024: ldelem.ref
-				IL_0025: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
-				IL_002a: ldloc.1
-				IL_002b: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stdout
-				IL_0030: ldnull
-				IL_0031: ret
+				IL_000d: ldarg.2
+				IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0013: stloc.0
+				IL_0014: ldarg.0
+				IL_0015: ldc.i4.1
+				IL_0016: ldelem.ref
+				IL_0017: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
+				IL_001c: ldloc.0
+				IL_001d: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stdout
+				IL_0022: ldnull
+				IL_0023: ret
 			} // end of method ArrowFunction_L18C29::__js_call__
 
 		} // end of class ArrowFunction_L18C29
@@ -107,7 +100,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aec
+					// Method begins at RVA 0x2a68
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,13 +125,12 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2794
+				// Method begins at RVA 0x276c
 				// Header size: 12
-				// Code size: 50 (0x32)
+				// Code size: 36 (0x24)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldarg.0
@@ -146,23 +138,17 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
 				IL_0008: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
-				IL_000d: stloc.0
-				IL_000e: ldstr "stderr"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ldarg.2
-				IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0021: stloc.1
-				IL_0022: ldarg.0
-				IL_0023: ldc.i4.1
-				IL_0024: ldelem.ref
-				IL_0025: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
-				IL_002a: ldloc.1
-				IL_002b: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
-				IL_0030: ldnull
-				IL_0031: ret
+				IL_000d: ldarg.2
+				IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0013: stloc.0
+				IL_0014: ldarg.0
+				IL_0015: ldc.i4.1
+				IL_0016: ldelem.ref
+				IL_0017: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
+				IL_001c: ldloc.0
+				IL_001d: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
+				IL_0022: ldnull
+				IL_0023: ret
 			} // end of method ArrowFunction_L22C29::__js_call__
 
 		} // end of class ArrowFunction_L22C29
@@ -185,7 +171,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2af5
+					// Method begins at RVA 0x2a71
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -210,9 +196,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x27d4
+				// Method begins at RVA 0x279c
 				// Header size: 12
-				// Code size: 134 (0x86)
+				// Code size: 120 (0x78)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -244,27 +230,21 @@
 				IL_0042: ldelem.ref
 				IL_0043: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
 				IL_0048: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-				IL_004d: stloc.1
-				IL_004e: ldstr "child"
+				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0052: stloc.1
 				IL_0053: ldloc.1
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0059: stloc.1
-				IL_005a: ldloc.1
-				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0060: stloc.1
-				IL_0061: ldloc.1
-				IL_0062: ldstr "send"
-				IL_0067: ldstr "shutdown"
-				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0071: stloc.1
-				IL_0072: ldloc.0
-				IL_0073: ldstr "log"
-				IL_0078: ldstr "silent true send:"
-				IL_007d: ldloc.1
-				IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0083: pop
-				IL_0084: ldnull
-				IL_0085: ret
+				IL_0054: ldstr "send"
+				IL_0059: ldstr "shutdown"
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0063: stloc.1
+				IL_0064: ldloc.0
+				IL_0065: ldstr "log"
+				IL_006a: ldstr "silent true send:"
+				IL_006f: ldloc.1
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0075: pop
+				IL_0076: ldnull
+				IL_0077: ret
 			} // end of method ArrowFunction_L26C25::__js_call__
 
 		} // end of class ArrowFunction_L26C25
@@ -287,7 +267,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2afe
+					// Method begins at RVA 0x2a7a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -312,9 +292,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2868
+				// Method begins at RVA 0x2820
 				// Header size: 12
-				// Code size: 325 (0x145)
+				// Code size: 283 (0x11b)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -347,108 +327,90 @@
 				IL_0038: ldelem.ref
 				IL_0039: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
 				IL_003e: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stdout
-				IL_0043: stloc.1
-				IL_0044: ldstr "stdout"
+				IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0048: stloc.1
 				IL_0049: ldloc.1
-				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_004f: stloc.1
-				IL_0050: ldloc.1
-				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0056: stloc.1
-				IL_0057: ldloc.1
-				IL_0058: ldstr "indexOf"
-				IL_005d: ldstr "silent child stdout"
-				IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0067: stloc.1
-				IL_0068: ldloc.1
-				IL_0069: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_006e: stloc.2
-				IL_006f: ldloc.2
-				IL_0070: ldc.r8 0.0
-				IL_0079: clt
-				IL_007b: ldc.i4.0
-				IL_007c: ceq
-				IL_007e: stloc.3
-				IL_007f: ldloc.3
-				IL_0080: box [System.Runtime]System.Boolean
-				IL_0085: stloc.s 4
-				IL_0087: ldloc.0
-				IL_0088: ldstr "log"
-				IL_008d: ldstr "silent true stdout marker:"
-				IL_0092: ldloc.s 4
-				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0099: pop
-				IL_009a: ldstr "console"
-				IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00a4: stloc.0
-				IL_00a5: ldloc.0
-				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ab: stloc.0
-				IL_00ac: ldarg.0
-				IL_00ad: ldc.i4.1
-				IL_00ae: ldelem.ref
-				IL_00af: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
-				IL_00b4: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
-				IL_00b9: stloc.1
-				IL_00ba: ldstr "stderr"
-				IL_00bf: ldloc.1
-				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00c5: stloc.1
-				IL_00c6: ldloc.1
-				IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00cc: stloc.1
-				IL_00cd: ldloc.1
-				IL_00ce: ldstr "indexOf"
-				IL_00d3: ldstr "silent child stderr"
-				IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00dd: stloc.1
-				IL_00de: ldloc.1
-				IL_00df: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00e4: stloc.2
-				IL_00e5: ldloc.2
-				IL_00e6: ldc.r8 0.0
-				IL_00ef: clt
-				IL_00f1: ldc.i4.0
-				IL_00f2: ceq
-				IL_00f4: stloc.3
-				IL_00f5: ldloc.3
-				IL_00f6: box [System.Runtime]System.Boolean
-				IL_00fb: stloc.s 4
-				IL_00fd: ldloc.0
-				IL_00fe: ldstr "log"
-				IL_0103: ldstr "silent true stderr marker:"
-				IL_0108: ldloc.s 4
-				IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_010f: pop
-				IL_0110: ldarg.0
-				IL_0111: ldc.i4.0
-				IL_0112: ldelem.ref
-				IL_0113: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-				IL_0118: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::runSilentFalse
-				IL_011d: stloc.0
-				IL_011e: ldstr "runSilentFalse"
-				IL_0123: ldloc.0
-				IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0129: stloc.0
-				IL_012a: ldloc.0
-				IL_012b: ldc.i4.2
-				IL_012c: newarr [System.Runtime]System.Object
-				IL_0131: dup
-				IL_0132: ldc.i4.0
-				IL_0133: ldarg.0
-				IL_0134: ldc.i4.0
-				IL_0135: ldelem.ref
-				IL_0136: stelem.ref
-				IL_0137: dup
-				IL_0138: ldc.i4.1
-				IL_0139: ldarg.0
-				IL_013a: ldc.i4.1
-				IL_013b: ldelem.ref
-				IL_013c: stelem.ref
-				IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0142: pop
-				IL_0143: ldnull
-				IL_0144: ret
+				IL_004a: ldstr "indexOf"
+				IL_004f: ldstr "silent child stdout"
+				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0059: stloc.1
+				IL_005a: ldloc.1
+				IL_005b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0060: stloc.2
+				IL_0061: ldloc.2
+				IL_0062: ldc.r8 0.0
+				IL_006b: clt
+				IL_006d: ldc.i4.0
+				IL_006e: ceq
+				IL_0070: stloc.3
+				IL_0071: ldloc.3
+				IL_0072: box [System.Runtime]System.Boolean
+				IL_0077: stloc.s 4
+				IL_0079: ldloc.0
+				IL_007a: ldstr "log"
+				IL_007f: ldstr "silent true stdout marker:"
+				IL_0084: ldloc.s 4
+				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_008b: pop
+				IL_008c: ldstr "console"
+				IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0096: stloc.0
+				IL_0097: ldloc.0
+				IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_009d: stloc.0
+				IL_009e: ldarg.0
+				IL_009f: ldc.i4.1
+				IL_00a0: ldelem.ref
+				IL_00a1: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
+				IL_00a6: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
+				IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00b0: stloc.1
+				IL_00b1: ldloc.1
+				IL_00b2: ldstr "indexOf"
+				IL_00b7: ldstr "silent child stderr"
+				IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00c1: stloc.1
+				IL_00c2: ldloc.1
+				IL_00c3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00c8: stloc.2
+				IL_00c9: ldloc.2
+				IL_00ca: ldc.r8 0.0
+				IL_00d3: clt
+				IL_00d5: ldc.i4.0
+				IL_00d6: ceq
+				IL_00d8: stloc.3
+				IL_00d9: ldloc.3
+				IL_00da: box [System.Runtime]System.Boolean
+				IL_00df: stloc.s 4
+				IL_00e1: ldloc.0
+				IL_00e2: ldstr "log"
+				IL_00e7: ldstr "silent true stderr marker:"
+				IL_00ec: ldloc.s 4
+				IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00f3: pop
+				IL_00f4: ldarg.0
+				IL_00f5: ldc.i4.0
+				IL_00f6: ldelem.ref
+				IL_00f7: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
+				IL_00fc: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::runSilentFalse
+				IL_0101: ldc.i4.2
+				IL_0102: newarr [System.Runtime]System.Object
+				IL_0107: dup
+				IL_0108: ldc.i4.0
+				IL_0109: ldarg.0
+				IL_010a: ldc.i4.0
+				IL_010b: ldelem.ref
+				IL_010c: stelem.ref
+				IL_010d: dup
+				IL_010e: ldc.i4.1
+				IL_010f: ldarg.0
+				IL_0110: ldc.i4.1
+				IL_0111: ldelem.ref
+				IL_0112: stelem.ref
+				IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0118: pop
+				IL_0119: ldnull
+				IL_011a: ret
 			} // end of method ArrowFunction_L31C23::__js_call__
 
 		} // end of class ArrowFunction_L31C23
@@ -471,7 +433,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ada
+				// Method begins at RVA 0x2a56
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -499,7 +461,7 @@
 			)
 			// Method begins at RVA 0x226c
 			// Header size: 12
-			// Code size: 763 (0x2fb)
+			// Code size: 749 (0x2ed)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope,
@@ -514,265 +476,259 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::childProcess
-			IL_000c: stloc.1
-			IL_000d: ldstr "childProcess"
-			IL_0012: ldloc.1
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.1
-			IL_0019: ldloc.1
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.1
-			IL_0020: ldc.i4.1
-			IL_0021: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0026: dup
-			IL_0027: ldstr "emit-stdio"
-			IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0031: stloc.2
-			IL_0032: ldloc.1
-			IL_0033: ldstr "fork"
-			IL_0038: ldstr "./Require_ChildProcess_Fork_Silent_Child"
-			IL_003d: ldloc.2
-			IL_003e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0043: dup
-			IL_0044: ldstr "silent"
-			IL_0049: ldc.i4.1
-			IL_004a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0054: stloc.1
-			IL_0055: ldloc.0
-			IL_0056: ldloc.1
-			IL_0057: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_005c: ldstr "console"
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0066: stloc.1
-			IL_0067: ldloc.1
-			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006d: stloc.1
-			IL_006e: ldloc.0
-			IL_006f: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_0074: ldstr "stdout"
-			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_007e: stloc.3
-			IL_007f: ldloc.3
-			IL_0080: ldc.i4.0
-			IL_0081: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0086: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_008b: stloc.s 4
-			IL_008d: ldloc.s 4
-			IL_008f: box [System.Runtime]System.Boolean
-			IL_0094: stloc.s 5
-			IL_0096: ldloc.1
-			IL_0097: ldstr "log"
-			IL_009c: ldstr "silent true stdout piped:"
-			IL_00a1: ldloc.s 5
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00a8: pop
-			IL_00a9: ldstr "console"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b3: stloc.1
-			IL_00b4: ldloc.1
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ba: stloc.1
-			IL_00bb: ldloc.0
-			IL_00bc: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_00c1: ldstr "stderr"
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00cb: stloc.3
-			IL_00cc: ldloc.3
-			IL_00cd: ldc.i4.0
-			IL_00ce: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d8: stloc.s 4
-			IL_00da: ldloc.s 4
-			IL_00dc: box [System.Runtime]System.Boolean
-			IL_00e1: stloc.s 5
-			IL_00e3: ldloc.1
-			IL_00e4: ldstr "log"
-			IL_00e9: ldstr "silent true stderr piped:"
-			IL_00ee: ldloc.s 5
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f5: pop
-			IL_00f6: ldstr "console"
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0100: stloc.1
-			IL_0101: ldloc.1
-			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0107: stloc.1
-			IL_0108: ldloc.1
-			IL_0109: ldstr "log"
-			IL_010e: ldstr "silent true connected initially:"
-			IL_0113: ldloc.0
-			IL_0114: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_0119: ldstr "connected"
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0128: pop
-			IL_0129: ldloc.0
-			IL_012a: ldstr ""
-			IL_012f: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stdout
-			IL_0134: ldloc.0
-			IL_0135: ldstr ""
-			IL_013a: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
-			IL_013f: ldloc.0
-			IL_0140: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_0145: ldstr "stdout"
-			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0154: stloc.1
-			IL_0155: ldloc.1
-			IL_0156: ldstr "setEncoding"
-			IL_015b: ldstr "utf8"
-			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0165: pop
-			IL_0166: ldloc.0
-			IL_0167: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_016c: ldstr "stdout"
-			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_017b: stloc.1
-			IL_017c: ldnull
-			IL_017d: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L18C29::__js_call__(object[], object, object)
-			IL_0183: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0188: ldc.i4.2
-			IL_0189: newarr [System.Runtime]System.Object
-			IL_018e: dup
-			IL_018f: ldc.i4.0
-			IL_0190: ldarg.0
-			IL_0191: stelem.ref
-			IL_0192: dup
-			IL_0193: ldc.i4.1
-			IL_0194: ldloc.0
-			IL_0195: stelem.ref
-			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_01a0: ldc.i4.1
-			IL_01a1: conv.r8
-			IL_01a2: ldstr ""
-			IL_01a7: ldc.i4.0
-			IL_01a8: ldc.i4.1
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_01b3: stloc.3
-			IL_01b4: ldloc.1
-			IL_01b5: ldstr "on"
-			IL_01ba: ldstr "data"
-			IL_01bf: ldloc.3
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01c5: pop
-			IL_01c6: ldloc.0
-			IL_01c7: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_01cc: ldstr "stderr"
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01db: stloc.3
-			IL_01dc: ldloc.3
-			IL_01dd: ldstr "setEncoding"
-			IL_01e2: ldstr "utf8"
-			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01ec: pop
-			IL_01ed: ldloc.0
-			IL_01ee: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_01f3: ldstr "stderr"
-			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0202: stloc.3
-			IL_0203: ldnull
-			IL_0204: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L22C29::__js_call__(object[], object, object)
-			IL_020a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_020f: ldc.i4.2
-			IL_0210: newarr [System.Runtime]System.Object
-			IL_0215: dup
-			IL_0216: ldc.i4.0
-			IL_0217: ldarg.0
-			IL_0218: stelem.ref
-			IL_0219: dup
-			IL_021a: ldc.i4.1
-			IL_021b: ldloc.0
-			IL_021c: stelem.ref
-			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0227: ldc.i4.1
-			IL_0228: conv.r8
-			IL_0229: ldstr ""
-			IL_022e: ldc.i4.0
-			IL_022f: ldc.i4.1
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_023a: stloc.1
-			IL_023b: ldloc.3
-			IL_023c: ldstr "on"
-			IL_0241: ldstr "data"
-			IL_0246: ldloc.1
-			IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_024c: pop
-			IL_024d: ldloc.0
-			IL_024e: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0258: stloc.1
-			IL_0259: ldnull
-			IL_025a: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L26C25::__js_call__(object[], object, object)
-			IL_0260: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0265: ldc.i4.2
-			IL_0266: newarr [System.Runtime]System.Object
-			IL_026b: dup
-			IL_026c: ldc.i4.0
-			IL_026d: ldarg.0
-			IL_026e: stelem.ref
-			IL_026f: dup
-			IL_0270: ldc.i4.1
-			IL_0271: ldloc.0
-			IL_0272: stelem.ref
-			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_027d: ldc.i4.1
-			IL_027e: conv.r8
-			IL_027f: ldstr ""
-			IL_0284: ldc.i4.0
-			IL_0285: ldc.i4.1
-			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0290: stloc.3
-			IL_0291: ldloc.1
-			IL_0292: ldstr "on"
-			IL_0297: ldstr "message"
-			IL_029c: ldloc.3
-			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02a2: pop
-			IL_02a3: ldloc.0
-			IL_02a4: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ae: stloc.3
-			IL_02af: ldnull
-			IL_02b0: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L31C23::__js_call__(object[], object, object)
-			IL_02b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_02bb: ldc.i4.2
-			IL_02bc: newarr [System.Runtime]System.Object
-			IL_02c1: dup
-			IL_02c2: ldc.i4.0
-			IL_02c3: ldarg.0
-			IL_02c4: stelem.ref
-			IL_02c5: dup
-			IL_02c6: ldc.i4.1
-			IL_02c7: ldloc.0
-			IL_02c8: stelem.ref
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_02d3: ldc.i4.1
-			IL_02d4: conv.r8
-			IL_02d5: ldstr ""
-			IL_02da: ldc.i4.0
-			IL_02db: ldc.i4.1
-			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_02e6: stloc.1
-			IL_02e7: ldloc.3
-			IL_02e8: ldstr "on"
-			IL_02ed: ldstr "close"
-			IL_02f2: ldloc.1
-			IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02f8: pop
-			IL_02f9: ldnull
-			IL_02fa: ret
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.1
+			IL_0012: ldc.i4.1
+			IL_0013: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0018: dup
+			IL_0019: ldstr "emit-stdio"
+			IL_001e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0023: stloc.2
+			IL_0024: ldloc.1
+			IL_0025: ldstr "fork"
+			IL_002a: ldstr "./Require_ChildProcess_Fork_Silent_Child"
+			IL_002f: ldloc.2
+			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0035: dup
+			IL_0036: ldstr "silent"
+			IL_003b: ldc.i4.1
+			IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0046: stloc.1
+			IL_0047: ldloc.0
+			IL_0048: ldloc.1
+			IL_0049: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_004e: ldstr "console"
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0058: stloc.1
+			IL_0059: ldloc.1
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005f: stloc.1
+			IL_0060: ldloc.0
+			IL_0061: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0066: ldstr "stdout"
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0070: stloc.3
+			IL_0071: ldloc.3
+			IL_0072: ldc.i4.0
+			IL_0073: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0078: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_007d: stloc.s 4
+			IL_007f: ldloc.s 4
+			IL_0081: box [System.Runtime]System.Boolean
+			IL_0086: stloc.s 5
+			IL_0088: ldloc.1
+			IL_0089: ldstr "log"
+			IL_008e: ldstr "silent true stdout piped:"
+			IL_0093: ldloc.s 5
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_009a: pop
+			IL_009b: ldstr "console"
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00a5: stloc.1
+			IL_00a6: ldloc.1
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ac: stloc.1
+			IL_00ad: ldloc.0
+			IL_00ae: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_00b3: ldstr "stderr"
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00bd: stloc.3
+			IL_00be: ldloc.3
+			IL_00bf: ldc.i4.0
+			IL_00c0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_00ca: stloc.s 4
+			IL_00cc: ldloc.s 4
+			IL_00ce: box [System.Runtime]System.Boolean
+			IL_00d3: stloc.s 5
+			IL_00d5: ldloc.1
+			IL_00d6: ldstr "log"
+			IL_00db: ldstr "silent true stderr piped:"
+			IL_00e0: ldloc.s 5
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00e7: pop
+			IL_00e8: ldstr "console"
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00f2: stloc.1
+			IL_00f3: ldloc.1
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f9: stloc.1
+			IL_00fa: ldloc.1
+			IL_00fb: ldstr "log"
+			IL_0100: ldstr "silent true connected initially:"
+			IL_0105: ldloc.0
+			IL_0106: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_010b: ldstr "connected"
+			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_011a: pop
+			IL_011b: ldloc.0
+			IL_011c: ldstr ""
+			IL_0121: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stdout
+			IL_0126: ldloc.0
+			IL_0127: ldstr ""
+			IL_012c: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
+			IL_0131: ldloc.0
+			IL_0132: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0137: ldstr "stdout"
+			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0146: stloc.1
+			IL_0147: ldloc.1
+			IL_0148: ldstr "setEncoding"
+			IL_014d: ldstr "utf8"
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0157: pop
+			IL_0158: ldloc.0
+			IL_0159: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_015e: ldstr "stdout"
+			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016d: stloc.1
+			IL_016e: ldnull
+			IL_016f: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L18C29::__js_call__(object[], object, object)
+			IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_017a: ldc.i4.2
+			IL_017b: newarr [System.Runtime]System.Object
+			IL_0180: dup
+			IL_0181: ldc.i4.0
+			IL_0182: ldarg.0
+			IL_0183: stelem.ref
+			IL_0184: dup
+			IL_0185: ldc.i4.1
+			IL_0186: ldloc.0
+			IL_0187: stelem.ref
+			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0192: ldc.i4.1
+			IL_0193: conv.r8
+			IL_0194: ldstr ""
+			IL_0199: ldc.i4.0
+			IL_019a: ldc.i4.1
+			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_01a5: stloc.3
+			IL_01a6: ldloc.1
+			IL_01a7: ldstr "on"
+			IL_01ac: ldstr "data"
+			IL_01b1: ldloc.3
+			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01b7: pop
+			IL_01b8: ldloc.0
+			IL_01b9: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_01be: ldstr "stderr"
+			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01cd: stloc.3
+			IL_01ce: ldloc.3
+			IL_01cf: ldstr "setEncoding"
+			IL_01d4: ldstr "utf8"
+			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01de: pop
+			IL_01df: ldloc.0
+			IL_01e0: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_01e5: ldstr "stderr"
+			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f4: stloc.3
+			IL_01f5: ldnull
+			IL_01f6: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L22C29::__js_call__(object[], object, object)
+			IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0201: ldc.i4.2
+			IL_0202: newarr [System.Runtime]System.Object
+			IL_0207: dup
+			IL_0208: ldc.i4.0
+			IL_0209: ldarg.0
+			IL_020a: stelem.ref
+			IL_020b: dup
+			IL_020c: ldc.i4.1
+			IL_020d: ldloc.0
+			IL_020e: stelem.ref
+			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0219: ldc.i4.1
+			IL_021a: conv.r8
+			IL_021b: ldstr ""
+			IL_0220: ldc.i4.0
+			IL_0221: ldc.i4.1
+			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_022c: stloc.1
+			IL_022d: ldloc.3
+			IL_022e: ldstr "on"
+			IL_0233: ldstr "data"
+			IL_0238: ldloc.1
+			IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_023e: pop
+			IL_023f: ldloc.0
+			IL_0240: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_024a: stloc.1
+			IL_024b: ldnull
+			IL_024c: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L26C25::__js_call__(object[], object, object)
+			IL_0252: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0257: ldc.i4.2
+			IL_0258: newarr [System.Runtime]System.Object
+			IL_025d: dup
+			IL_025e: ldc.i4.0
+			IL_025f: ldarg.0
+			IL_0260: stelem.ref
+			IL_0261: dup
+			IL_0262: ldc.i4.1
+			IL_0263: ldloc.0
+			IL_0264: stelem.ref
+			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_026f: ldc.i4.1
+			IL_0270: conv.r8
+			IL_0271: ldstr ""
+			IL_0276: ldc.i4.0
+			IL_0277: ldc.i4.1
+			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0282: stloc.3
+			IL_0283: ldloc.1
+			IL_0284: ldstr "on"
+			IL_0289: ldstr "message"
+			IL_028e: ldloc.3
+			IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0294: pop
+			IL_0295: ldloc.0
+			IL_0296: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02a0: stloc.3
+			IL_02a1: ldnull
+			IL_02a2: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L31C23::__js_call__(object[], object, object)
+			IL_02a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_02ad: ldc.i4.2
+			IL_02ae: newarr [System.Runtime]System.Object
+			IL_02b3: dup
+			IL_02b4: ldc.i4.0
+			IL_02b5: ldarg.0
+			IL_02b6: stelem.ref
+			IL_02b7: dup
+			IL_02b8: ldc.i4.1
+			IL_02b9: ldloc.0
+			IL_02ba: stelem.ref
+			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_02c5: ldc.i4.1
+			IL_02c6: conv.r8
+			IL_02c7: ldstr ""
+			IL_02cc: ldc.i4.0
+			IL_02cd: ldc.i4.1
+			IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_02d8: stloc.1
+			IL_02d9: ldloc.3
+			IL_02da: ldstr "on"
+			IL_02df: ldstr "close"
+			IL_02e4: ldloc.1
+			IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02ea: pop
+			IL_02eb: ldnull
+			IL_02ec: ret
 		} // end of method runSilentTrue::__js_call__
 
 	} // end of class runSilentTrue
@@ -799,7 +755,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b10
+					// Method begins at RVA 0x2a8c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -824,9 +780,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x29bc
+				// Method begins at RVA 0x2948
 				// Header size: 12
-				// Code size: 134 (0x86)
+				// Code size: 120 (0x78)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -858,27 +814,21 @@
 				IL_0042: ldelem.ref
 				IL_0043: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope
 				IL_0048: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-				IL_004d: stloc.1
-				IL_004e: ldstr "child"
+				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0052: stloc.1
 				IL_0053: ldloc.1
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0059: stloc.1
-				IL_005a: ldloc.1
-				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0060: stloc.1
-				IL_0061: ldloc.1
-				IL_0062: ldstr "send"
-				IL_0067: ldstr "shutdown"
-				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0071: stloc.1
-				IL_0072: ldloc.0
-				IL_0073: ldstr "log"
-				IL_0078: ldstr "silent false send:"
-				IL_007d: ldloc.1
-				IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0083: pop
-				IL_0084: ldnull
-				IL_0085: ret
+				IL_0054: ldstr "send"
+				IL_0059: ldstr "shutdown"
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0063: stloc.1
+				IL_0064: ldloc.0
+				IL_0065: ldstr "log"
+				IL_006a: ldstr "silent false send:"
+				IL_006f: ldloc.1
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0075: pop
+				IL_0076: ldnull
+				IL_0077: ret
 			} // end of method ArrowFunction_L45C25::__js_call__
 
 		} // end of class ArrowFunction_L45C25
@@ -901,7 +851,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b19
+					// Method begins at RVA 0x2a95
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -925,7 +875,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a50
+				// Method begins at RVA 0x29cc
 				// Header size: 12
 				// Code size: 38 (0x26)
 				.maxstack 8
@@ -965,7 +915,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b07
+				// Method begins at RVA 0x2a83
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -991,9 +941,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2574
+			// Method begins at RVA 0x2568
 			// Header size: 12
-			// Code size: 467 (0x1d3)
+			// Code size: 453 (0x1c5)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope,
@@ -1008,163 +958,157 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::childProcess
-			IL_000c: stloc.1
-			IL_000d: ldstr "childProcess"
-			IL_0012: ldloc.1
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.1
-			IL_0019: ldloc.1
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.1
-			IL_0020: ldc.i4.1
-			IL_0021: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0026: dup
-			IL_0027: ldstr "quiet"
-			IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0031: stloc.2
-			IL_0032: ldloc.1
-			IL_0033: ldstr "fork"
-			IL_0038: ldstr "./Require_ChildProcess_Fork_Silent_Child"
-			IL_003d: ldloc.2
-			IL_003e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0043: dup
-			IL_0044: ldstr "silent"
-			IL_0049: ldc.i4.0
-			IL_004a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0054: stloc.1
-			IL_0055: ldloc.0
-			IL_0056: ldloc.1
-			IL_0057: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_005c: ldstr "console"
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0066: stloc.1
-			IL_0067: ldloc.1
-			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006d: stloc.1
-			IL_006e: ldloc.0
-			IL_006f: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_0074: ldstr "stdout"
-			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_007e: stloc.3
-			IL_007f: ldloc.3
-			IL_0080: ldc.i4.0
-			IL_0081: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0086: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_008b: stloc.s 4
-			IL_008d: ldloc.s 4
-			IL_008f: box [System.Runtime]System.Boolean
-			IL_0094: stloc.s 5
-			IL_0096: ldloc.1
-			IL_0097: ldstr "log"
-			IL_009c: ldstr "silent false stdout null:"
-			IL_00a1: ldloc.s 5
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00a8: pop
-			IL_00a9: ldstr "console"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b3: stloc.1
-			IL_00b4: ldloc.1
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ba: stloc.1
-			IL_00bb: ldloc.0
-			IL_00bc: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_00c1: ldstr "stderr"
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00cb: stloc.3
-			IL_00cc: ldloc.3
-			IL_00cd: ldc.i4.0
-			IL_00ce: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00d8: stloc.s 4
-			IL_00da: ldloc.s 4
-			IL_00dc: box [System.Runtime]System.Boolean
-			IL_00e1: stloc.s 5
-			IL_00e3: ldloc.1
-			IL_00e4: ldstr "log"
-			IL_00e9: ldstr "silent false stderr null:"
-			IL_00ee: ldloc.s 5
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f5: pop
-			IL_00f6: ldstr "console"
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0100: stloc.1
-			IL_0101: ldloc.1
-			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0107: stloc.1
-			IL_0108: ldloc.1
-			IL_0109: ldstr "log"
-			IL_010e: ldstr "silent false connected initially:"
-			IL_0113: ldloc.0
-			IL_0114: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_0119: ldstr "connected"
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0128: pop
-			IL_0129: ldloc.0
-			IL_012a: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0134: stloc.1
-			IL_0135: ldnull
-			IL_0136: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/ArrowFunction_L45C25::__js_call__(object[], object, object)
-			IL_013c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0141: ldc.i4.2
-			IL_0142: newarr [System.Runtime]System.Object
-			IL_0147: dup
-			IL_0148: ldc.i4.0
-			IL_0149: ldarg.0
-			IL_014a: stelem.ref
-			IL_014b: dup
-			IL_014c: ldc.i4.1
-			IL_014d: ldloc.0
-			IL_014e: stelem.ref
-			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0159: ldc.i4.1
-			IL_015a: conv.r8
-			IL_015b: ldstr ""
-			IL_0160: ldc.i4.0
-			IL_0161: ldc.i4.1
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_016c: stloc.3
-			IL_016d: ldloc.1
-			IL_016e: ldstr "on"
-			IL_0173: ldstr "message"
-			IL_0178: ldloc.3
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_017e: pop
-			IL_017f: ldloc.0
-			IL_0180: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018a: stloc.3
-			IL_018b: ldnull
-			IL_018c: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/ArrowFunction_L50C23::__js_call__(object, object)
-			IL_0192: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0197: ldc.i4.1
-			IL_0198: newarr [System.Runtime]System.Object
-			IL_019d: dup
-			IL_019e: ldc.i4.0
-			IL_019f: ldarg.0
-			IL_01a0: stelem.ref
-			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_01ab: ldc.i4.1
-			IL_01ac: conv.r8
-			IL_01ad: ldstr ""
-			IL_01b2: ldc.i4.0
-			IL_01b3: ldc.i4.1
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_01be: stloc.1
-			IL_01bf: ldloc.3
-			IL_01c0: ldstr "on"
-			IL_01c5: ldstr "close"
-			IL_01ca: ldloc.1
-			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01d0: pop
-			IL_01d1: ldnull
-			IL_01d2: ret
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.1
+			IL_0012: ldc.i4.1
+			IL_0013: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0018: dup
+			IL_0019: ldstr "quiet"
+			IL_001e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0023: stloc.2
+			IL_0024: ldloc.1
+			IL_0025: ldstr "fork"
+			IL_002a: ldstr "./Require_ChildProcess_Fork_Silent_Child"
+			IL_002f: ldloc.2
+			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0035: dup
+			IL_0036: ldstr "silent"
+			IL_003b: ldc.i4.0
+			IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0046: stloc.1
+			IL_0047: ldloc.0
+			IL_0048: ldloc.1
+			IL_0049: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_004e: ldstr "console"
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0058: stloc.1
+			IL_0059: ldloc.1
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005f: stloc.1
+			IL_0060: ldloc.0
+			IL_0061: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_0066: ldstr "stdout"
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0070: stloc.3
+			IL_0071: ldloc.3
+			IL_0072: ldc.i4.0
+			IL_0073: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0078: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_007d: stloc.s 4
+			IL_007f: ldloc.s 4
+			IL_0081: box [System.Runtime]System.Boolean
+			IL_0086: stloc.s 5
+			IL_0088: ldloc.1
+			IL_0089: ldstr "log"
+			IL_008e: ldstr "silent false stdout null:"
+			IL_0093: ldloc.s 5
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_009a: pop
+			IL_009b: ldstr "console"
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00a5: stloc.1
+			IL_00a6: ldloc.1
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ac: stloc.1
+			IL_00ad: ldloc.0
+			IL_00ae: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_00b3: ldstr "stderr"
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00bd: stloc.3
+			IL_00be: ldloc.3
+			IL_00bf: ldc.i4.0
+			IL_00c0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00ca: stloc.s 4
+			IL_00cc: ldloc.s 4
+			IL_00ce: box [System.Runtime]System.Boolean
+			IL_00d3: stloc.s 5
+			IL_00d5: ldloc.1
+			IL_00d6: ldstr "log"
+			IL_00db: ldstr "silent false stderr null:"
+			IL_00e0: ldloc.s 5
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00e7: pop
+			IL_00e8: ldstr "console"
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00f2: stloc.1
+			IL_00f3: ldloc.1
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f9: stloc.1
+			IL_00fa: ldloc.1
+			IL_00fb: ldstr "log"
+			IL_0100: ldstr "silent false connected initially:"
+			IL_0105: ldloc.0
+			IL_0106: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_010b: ldstr "connected"
+			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_011a: pop
+			IL_011b: ldloc.0
+			IL_011c: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0126: stloc.1
+			IL_0127: ldnull
+			IL_0128: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/ArrowFunction_L45C25::__js_call__(object[], object, object)
+			IL_012e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0133: ldc.i4.2
+			IL_0134: newarr [System.Runtime]System.Object
+			IL_0139: dup
+			IL_013a: ldc.i4.0
+			IL_013b: ldarg.0
+			IL_013c: stelem.ref
+			IL_013d: dup
+			IL_013e: ldc.i4.1
+			IL_013f: ldloc.0
+			IL_0140: stelem.ref
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_014b: ldc.i4.1
+			IL_014c: conv.r8
+			IL_014d: ldstr ""
+			IL_0152: ldc.i4.0
+			IL_0153: ldc.i4.1
+			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_015e: stloc.3
+			IL_015f: ldloc.1
+			IL_0160: ldstr "on"
+			IL_0165: ldstr "message"
+			IL_016a: ldloc.3
+			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0170: pop
+			IL_0171: ldloc.0
+			IL_0172: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_017c: stloc.3
+			IL_017d: ldnull
+			IL_017e: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/ArrowFunction_L50C23::__js_call__(object, object)
+			IL_0184: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0189: ldc.i4.1
+			IL_018a: newarr [System.Runtime]System.Object
+			IL_018f: dup
+			IL_0190: ldc.i4.0
+			IL_0191: ldarg.0
+			IL_0192: stelem.ref
+			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_019d: ldc.i4.1
+			IL_019e: conv.r8
+			IL_019f: ldstr ""
+			IL_01a4: ldc.i4.0
+			IL_01a5: ldc.i4.1
+			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_01b0: stloc.1
+			IL_01b1: ldloc.3
+			IL_01b2: ldstr "on"
+			IL_01b7: ldstr "close"
+			IL_01bc: ldloc.1
+			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01c2: pop
+			IL_01c3: ldnull
+			IL_01c4: ret
 		} // end of method runSilentFalse::__js_call__
 
 	} // end of class runSilentFalse
@@ -1189,7 +1133,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad1
+				// Method begins at RVA 0x2a4d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1212,7 +1156,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2ac8
+			// Method begins at RVA 0x2a44
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1339,7 +1283,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b3d
+					// Method begins at RVA 0x2ab9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1360,7 +1304,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b34
+				// Method begins at RVA 0x2ab0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1384,7 +1328,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a84
+			// Method begins at RVA 0x2a00
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -1431,7 +1375,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b2b
+				// Method begins at RVA 0x2aa7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1449,7 +1393,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b22
+			// Method begins at RVA 0x2a9e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1617,7 +1561,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b46
+		// Method begins at RVA 0x2ac2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Spawn_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Spawn_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2576
+				// Method begins at RVA 0x2532
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,29 +54,22 @@
 			)
 			// Method begins at RVA 0x23d0
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 22 (0x16)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stdout
-			IL_0006: stloc.0
-			IL_0007: ldstr "stdout"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldarg.2
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001a: stloc.1
-			IL_001b: ldarg.0
-			IL_001c: ldloc.1
-			IL_001d: stfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stdout
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0006: ldarg.2
+			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_000c: stloc.0
+			IL_000d: ldarg.0
+			IL_000e: ldloc.0
+			IL_000f: stfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stdout
+			IL_0014: ldnull
+			IL_0015: ret
 		} // end of method ArrowFunction_L17C25::__js_call__
 
 	} // end of class ArrowFunction_L17C25
@@ -99,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x257f
+				// Method begins at RVA 0x253b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,31 +119,24 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2400
+			// Method begins at RVA 0x23f4
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 22 (0x16)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stderr
-			IL_0006: stloc.0
-			IL_0007: ldstr "stderr"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldarg.2
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001a: stloc.1
-			IL_001b: ldarg.0
-			IL_001c: ldloc.1
-			IL_001d: stfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stderr
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0006: ldarg.2
+			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_000c: stloc.0
+			IL_000d: ldarg.0
+			IL_000e: ldloc.0
+			IL_000f: stfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stderr
+			IL_0014: ldnull
+			IL_0015: ret
 		} // end of method ArrowFunction_L21C25::__js_call__
 
 	} // end of class ArrowFunction_L21C25
@@ -173,7 +159,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2588
+				// Method begins at RVA 0x2544
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -197,7 +183,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2430
+			// Method begins at RVA 0x2418
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -241,7 +227,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2591
+				// Method begins at RVA 0x254d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -268,9 +254,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2464
+			// Method begins at RVA 0x244c
 			// Header size: 12
-			// Code size: 253 (0xfd)
+			// Code size: 209 (0xd1)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -297,75 +283,55 @@
 			IL_0035: stloc.0
 			IL_0036: ldarg.0
 			IL_0037: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stdout
-			IL_003c: stloc.1
-			IL_003d: ldstr "stdout"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0041: stloc.1
 			IL_0042: ldloc.1
-			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0048: stloc.1
-			IL_0049: ldloc.1
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004f: stloc.1
-			IL_0050: ldloc.1
-			IL_0051: ldstr "trim"
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_005b: stloc.1
-			IL_005c: ldloc.0
-			IL_005d: ldstr "log"
-			IL_0062: ldstr "stdout:"
-			IL_0067: ldloc.1
-			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_006d: pop
-			IL_006e: ldstr "console"
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0078: stloc.1
-			IL_0079: ldloc.1
-			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007f: stloc.1
-			IL_0080: ldarg.0
-			IL_0081: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stderr
-			IL_0086: stloc.0
-			IL_0087: ldstr "stderr"
-			IL_008c: ldloc.0
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0092: stloc.0
-			IL_0093: ldloc.0
-			IL_0094: ldstr "length"
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_009e: stloc.0
-			IL_009f: ldloc.1
-			IL_00a0: ldstr "log"
-			IL_00a5: ldstr "stderr length:"
-			IL_00aa: ldloc.0
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00b0: pop
-			IL_00b1: ldstr "console"
-			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00bb: stloc.0
-			IL_00bc: ldloc.0
-			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c2: stloc.0
-			IL_00c3: ldarg.0
-			IL_00c4: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-			IL_00c9: stloc.1
-			IL_00ca: ldstr "child"
-			IL_00cf: ldloc.1
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00d5: stloc.1
-			IL_00d6: ldloc.1
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00dc: stloc.1
-			IL_00dd: ldloc.1
-			IL_00de: ldstr "kill"
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00e8: stloc.1
-			IL_00e9: ldloc.0
-			IL_00ea: ldstr "log"
-			IL_00ef: ldstr "kill after close:"
-			IL_00f4: ldloc.1
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00fa: pop
-			IL_00fb: ldnull
-			IL_00fc: ret
+			IL_0043: ldstr "trim"
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_004d: stloc.1
+			IL_004e: ldloc.0
+			IL_004f: ldstr "log"
+			IL_0054: ldstr "stdout:"
+			IL_0059: ldloc.1
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_005f: pop
+			IL_0060: ldstr "console"
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_006a: stloc.1
+			IL_006b: ldloc.1
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0071: stloc.1
+			IL_0072: ldloc.1
+			IL_0073: ldstr "log"
+			IL_0078: ldstr "stderr length:"
+			IL_007d: ldarg.0
+			IL_007e: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stderr
+			IL_0083: ldstr "length"
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0092: pop
+			IL_0093: ldstr "console"
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_009d: stloc.1
+			IL_009e: ldloc.1
+			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a4: stloc.1
+			IL_00a5: ldarg.0
+			IL_00a6: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b0: stloc.0
+			IL_00b1: ldloc.0
+			IL_00b2: ldstr "kill"
+			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00bc: stloc.0
+			IL_00bd: ldloc.1
+			IL_00be: ldstr "log"
+			IL_00c3: ldstr "kill after close:"
+			IL_00c8: ldloc.0
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00ce: pop
+			IL_00cf: ldnull
+			IL_00d0: ret
 		} // end of method ArrowFunction_L29C19::__js_call__
 
 	} // end of class ArrowFunction_L29C19
@@ -388,7 +354,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x256d
+			// Method begins at RVA 0x2529
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -727,7 +693,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x259a
+		// Method begins at RVA 0x2556
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x420d
+					// Method begins at RVA 0x3f83
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4216
+					// Method begins at RVA 0x3f8c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4204
+				// Method begins at RVA 0x3f7a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -231,7 +231,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x421f
+				// Method begins at RVA 0x3f95
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -259,7 +259,7 @@
 			)
 			// Method begins at RVA 0x2a00
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 40 (0x28)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -267,22 +267,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "createHash"
-			IL_0020: ldc.r8 123
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0033: stloc.0
-			IL_0034: ldloc.0
-			IL_0035: ret
+			IL_000d: ldstr "createHash"
+			IL_0012: ldc.r8 123
+			IL_001b: box [System.Runtime]System.Double
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0025: stloc.0
+			IL_0026: ldloc.0
+			IL_0027: ret
 		} // end of method ArrowFunction_L16C28::__js_call__
 
 	} // end of class ArrowFunction_L16C28
@@ -298,7 +292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4228
+				// Method begins at RVA 0x3f9e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -324,9 +318,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2a44
+			// Method begins at RVA 0x2a34
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -334,21 +328,15 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "createHash"
-			IL_0020: ldstr "sha3"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.0
-			IL_002b: ldloc.0
-			IL_002c: ret
+			IL_000d: ldstr "createHash"
+			IL_0012: ldstr "sha3"
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ret
 		} // end of method ArrowFunction_L17C35::__js_call__
 
 	} // end of class ArrowFunction_L17C35
@@ -364,7 +352,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4231
+				// Method begins at RVA 0x3fa7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -390,9 +378,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2a80
+			// Method begins at RVA 0x2a60
 			// Header size: 12
-			// Code size: 59 (0x3b)
+			// Code size: 45 (0x2d)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -400,23 +388,17 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "createHmac"
-			IL_0020: ldc.r8 123
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: ldstr "key"
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0038: stloc.0
-			IL_0039: ldloc.0
-			IL_003a: ret
+			IL_000d: ldstr "createHmac"
+			IL_0012: ldc.r8 123
+			IL_001b: box [System.Runtime]System.Double
+			IL_0020: ldstr "key"
+			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_002a: stloc.0
+			IL_002b: ldloc.0
+			IL_002c: ret
 		} // end of method ArrowFunction_L18C33::__js_call__
 
 	} // end of class ArrowFunction_L18C33
@@ -432,7 +414,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x423a
+				// Method begins at RVA 0x3fb0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -458,9 +440,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2ac8
+			// Method begins at RVA 0x2a9c
 			// Header size: 12
-			// Code size: 50 (0x32)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -468,22 +450,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "createHmac"
-			IL_0020: ldstr "sha3"
-			IL_0025: ldstr "key"
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_002f: stloc.0
-			IL_0030: ldloc.0
-			IL_0031: ret
+			IL_000d: ldstr "createHmac"
+			IL_0012: ldstr "sha3"
+			IL_0017: ldstr "key"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0021: stloc.0
+			IL_0022: ldloc.0
+			IL_0023: ret
 		} // end of method ArrowFunction_L19C40::__js_call__
 
 	} // end of class ArrowFunction_L19C40
@@ -499,7 +475,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4243
+				// Method begins at RVA 0x3fb9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -525,9 +501,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2b08
+			// Method begins at RVA 0x2acc
 			// Header size: 12
-			// Code size: 51 (0x33)
+			// Code size: 37 (0x25)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -535,23 +511,17 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "createHmac"
-			IL_0020: ldstr "sha256"
-			IL_0025: ldc.i4.0
-			IL_0026: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0030: stloc.0
-			IL_0031: ldloc.0
-			IL_0032: ret
+			IL_000d: ldstr "createHmac"
+			IL_0012: ldstr "sha256"
+			IL_0017: ldc.i4.0
+			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0022: stloc.0
+			IL_0023: ldloc.0
+			IL_0024: ret
 		} // end of method ArrowFunction_L20C27::__js_call__
 
 	} // end of class ArrowFunction_L20C27
@@ -567,7 +537,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x424c
+				// Method begins at RVA 0x3fc2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -593,9 +563,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2b48
+			// Method begins at RVA 0x2b00
 			// Header size: 12
-			// Code size: 59 (0x3b)
+			// Code size: 45 (0x2d)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -603,23 +573,17 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "createHmac"
-			IL_0020: ldstr "sha256"
-			IL_0025: ldc.r8 123
-			IL_002e: box [System.Runtime]System.Double
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0038: stloc.0
-			IL_0039: ldloc.0
-			IL_003a: ret
+			IL_000d: ldstr "createHmac"
+			IL_0012: ldstr "sha256"
+			IL_0017: ldc.r8 123
+			IL_0020: box [System.Runtime]System.Double
+			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_002a: stloc.0
+			IL_002b: ldloc.0
+			IL_002c: ret
 		} // end of method ArrowFunction_L21C29::__js_call__
 
 	} // end of class ArrowFunction_L21C29
@@ -635,7 +599,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4255
+				// Method begins at RVA 0x3fcb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -661,9 +625,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2b90
+			// Method begins at RVA 0x2b3c
 			// Header size: 12
-			// Code size: 96 (0x60)
+			// Code size: 82 (0x52)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -671,40 +635,34 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "pbkdf2Sync"
-			IL_0020: ldc.i4.4
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldstr "password"
-			IL_002d: stelem.ref
-			IL_002e: dup
-			IL_002f: ldc.i4.1
-			IL_0030: ldstr "salt"
-			IL_0035: stelem.ref
-			IL_0036: dup
-			IL_0037: ldc.i4.2
-			IL_0038: ldc.r8 1
-			IL_0041: box [System.Runtime]System.Double
-			IL_0046: stelem.ref
-			IL_0047: dup
-			IL_0048: ldc.i4.3
-			IL_0049: ldc.r8 16
-			IL_0052: box [System.Runtime]System.Double
-			IL_0057: stelem.ref
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_005d: stloc.0
-			IL_005e: ldloc.0
-			IL_005f: ret
+			IL_000d: ldstr "pbkdf2Sync"
+			IL_0012: ldc.i4.4
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldstr "password"
+			IL_001f: stelem.ref
+			IL_0020: dup
+			IL_0021: ldc.i4.1
+			IL_0022: ldstr "salt"
+			IL_0027: stelem.ref
+			IL_0028: dup
+			IL_0029: ldc.i4.2
+			IL_002a: ldc.r8 1
+			IL_0033: box [System.Runtime]System.Double
+			IL_0038: stelem.ref
+			IL_0039: dup
+			IL_003a: ldc.i4.3
+			IL_003b: ldc.r8 16
+			IL_0044: box [System.Runtime]System.Double
+			IL_0049: stelem.ref
+			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_004f: stloc.0
+			IL_0050: ldloc.0
+			IL_0051: ret
 		} // end of method ArrowFunction_L22C35::__js_call__
 
 	} // end of class ArrowFunction_L22C35
@@ -720,7 +678,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x425e
+				// Method begins at RVA 0x3fd4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -746,9 +704,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2bfc
+			// Method begins at RVA 0x2b9c
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 90 (0x5a)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -756,44 +714,38 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "pbkdf2Sync"
-			IL_0020: ldc.i4.5
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldstr "password"
-			IL_002d: stelem.ref
-			IL_002e: dup
-			IL_002f: ldc.i4.1
-			IL_0030: ldstr "salt"
-			IL_0035: stelem.ref
-			IL_0036: dup
-			IL_0037: ldc.i4.2
-			IL_0038: ldc.r8 1
-			IL_0041: box [System.Runtime]System.Double
-			IL_0046: stelem.ref
-			IL_0047: dup
-			IL_0048: ldc.i4.3
-			IL_0049: ldc.r8 16
-			IL_0052: box [System.Runtime]System.Double
-			IL_0057: stelem.ref
-			IL_0058: dup
-			IL_0059: ldc.i4.4
-			IL_005a: ldstr "sha3"
-			IL_005f: stelem.ref
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0065: stloc.0
-			IL_0066: ldloc.0
-			IL_0067: ret
+			IL_000d: ldstr "pbkdf2Sync"
+			IL_0012: ldc.i4.5
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldstr "password"
+			IL_001f: stelem.ref
+			IL_0020: dup
+			IL_0021: ldc.i4.1
+			IL_0022: ldstr "salt"
+			IL_0027: stelem.ref
+			IL_0028: dup
+			IL_0029: ldc.i4.2
+			IL_002a: ldc.r8 1
+			IL_0033: box [System.Runtime]System.Double
+			IL_0038: stelem.ref
+			IL_0039: dup
+			IL_003a: ldc.i4.3
+			IL_003b: ldc.r8 16
+			IL_0044: box [System.Runtime]System.Double
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.4
+			IL_004c: ldstr "sha3"
+			IL_0051: stelem.ref
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0057: stloc.0
+			IL_0058: ldloc.0
+			IL_0059: ret
 		} // end of method ArrowFunction_L23C39::__js_call__
 
 	} // end of class ArrowFunction_L23C39
@@ -809,7 +761,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4267
+				// Method begins at RVA 0x3fdd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -835,9 +787,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2c70
+			// Method begins at RVA 0x2c04
 			// Header size: 12
-			// Code size: 113 (0x71)
+			// Code size: 99 (0x63)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -845,45 +797,39 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "pbkdf2Sync"
-			IL_0020: ldc.i4.5
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldc.r8 123
-			IL_0031: box [System.Runtime]System.Double
-			IL_0036: stelem.ref
-			IL_0037: dup
-			IL_0038: ldc.i4.1
-			IL_0039: ldstr "salt"
-			IL_003e: stelem.ref
-			IL_003f: dup
-			IL_0040: ldc.i4.2
-			IL_0041: ldc.r8 1
-			IL_004a: box [System.Runtime]System.Double
-			IL_004f: stelem.ref
-			IL_0050: dup
-			IL_0051: ldc.i4.3
-			IL_0052: ldc.r8 16
-			IL_005b: box [System.Runtime]System.Double
-			IL_0060: stelem.ref
-			IL_0061: dup
-			IL_0062: ldc.i4.4
-			IL_0063: ldstr "sha256"
-			IL_0068: stelem.ref
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_006e: stloc.0
-			IL_006f: ldloc.0
-			IL_0070: ret
+			IL_000d: ldstr "pbkdf2Sync"
+			IL_0012: ldc.i4.5
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldc.r8 123
+			IL_0023: box [System.Runtime]System.Double
+			IL_0028: stelem.ref
+			IL_0029: dup
+			IL_002a: ldc.i4.1
+			IL_002b: ldstr "salt"
+			IL_0030: stelem.ref
+			IL_0031: dup
+			IL_0032: ldc.i4.2
+			IL_0033: ldc.r8 1
+			IL_003c: box [System.Runtime]System.Double
+			IL_0041: stelem.ref
+			IL_0042: dup
+			IL_0043: ldc.i4.3
+			IL_0044: ldc.r8 16
+			IL_004d: box [System.Runtime]System.Double
+			IL_0052: stelem.ref
+			IL_0053: dup
+			IL_0054: ldc.i4.4
+			IL_0055: ldstr "sha256"
+			IL_005a: stelem.ref
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0060: stloc.0
+			IL_0061: ldloc.0
+			IL_0062: ret
 		} // end of method ArrowFunction_L24C36::__js_call__
 
 	} // end of class ArrowFunction_L24C36
@@ -899,7 +845,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4270
+				// Method begins at RVA 0x3fe6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -925,9 +871,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2cf0
+			// Method begins at RVA 0x2c74
 			// Header size: 12
-			// Code size: 105 (0x69)
+			// Code size: 91 (0x5b)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -935,45 +881,39 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "pbkdf2Sync"
-			IL_0020: ldc.i4.5
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldstr "password"
-			IL_002d: stelem.ref
-			IL_002e: dup
-			IL_002f: ldc.i4.1
-			IL_0030: ldc.i4.0
-			IL_0031: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0036: stelem.ref
-			IL_0037: dup
-			IL_0038: ldc.i4.2
-			IL_0039: ldc.r8 1
-			IL_0042: box [System.Runtime]System.Double
-			IL_0047: stelem.ref
-			IL_0048: dup
-			IL_0049: ldc.i4.3
-			IL_004a: ldc.r8 16
-			IL_0053: box [System.Runtime]System.Double
-			IL_0058: stelem.ref
-			IL_0059: dup
-			IL_005a: ldc.i4.4
-			IL_005b: ldstr "sha256"
-			IL_0060: stelem.ref
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0066: stloc.0
-			IL_0067: ldloc.0
-			IL_0068: ret
+			IL_000d: ldstr "pbkdf2Sync"
+			IL_0012: ldc.i4.5
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldstr "password"
+			IL_001f: stelem.ref
+			IL_0020: dup
+			IL_0021: ldc.i4.1
+			IL_0022: ldc.i4.0
+			IL_0023: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0028: stelem.ref
+			IL_0029: dup
+			IL_002a: ldc.i4.2
+			IL_002b: ldc.r8 1
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: stelem.ref
+			IL_003a: dup
+			IL_003b: ldc.i4.3
+			IL_003c: ldc.r8 16
+			IL_0045: box [System.Runtime]System.Double
+			IL_004a: stelem.ref
+			IL_004b: dup
+			IL_004c: ldc.i4.4
+			IL_004d: ldstr "sha256"
+			IL_0052: stelem.ref
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0058: stloc.0
+			IL_0059: ldloc.0
+			IL_005a: ret
 		} // end of method ArrowFunction_L25C30::__js_call__
 
 	} // end of class ArrowFunction_L25C30
@@ -989,7 +929,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4279
+				// Method begins at RVA 0x3fef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1015,9 +955,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2d68
+			// Method begins at RVA 0x2cdc
 			// Header size: 12
-			// Code size: 95 (0x5f)
+			// Code size: 81 (0x51)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1025,43 +965,37 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "pbkdf2Sync"
-			IL_0020: ldc.i4.5
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldstr "password"
-			IL_002d: stelem.ref
-			IL_002e: dup
-			IL_002f: ldc.i4.1
-			IL_0030: ldstr "salt"
-			IL_0035: stelem.ref
-			IL_0036: dup
-			IL_0037: ldc.i4.2
-			IL_0038: ldstr "1"
-			IL_003d: stelem.ref
-			IL_003e: dup
-			IL_003f: ldc.i4.3
-			IL_0040: ldc.r8 16
-			IL_0049: box [System.Runtime]System.Double
-			IL_004e: stelem.ref
-			IL_004f: dup
-			IL_0050: ldc.i4.4
-			IL_0051: ldstr "sha256"
-			IL_0056: stelem.ref
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_005c: stloc.0
-			IL_005d: ldloc.0
-			IL_005e: ret
+			IL_000d: ldstr "pbkdf2Sync"
+			IL_0012: ldc.i4.5
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldstr "password"
+			IL_001f: stelem.ref
+			IL_0020: dup
+			IL_0021: ldc.i4.1
+			IL_0022: ldstr "salt"
+			IL_0027: stelem.ref
+			IL_0028: dup
+			IL_0029: ldc.i4.2
+			IL_002a: ldstr "1"
+			IL_002f: stelem.ref
+			IL_0030: dup
+			IL_0031: ldc.i4.3
+			IL_0032: ldc.r8 16
+			IL_003b: box [System.Runtime]System.Double
+			IL_0040: stelem.ref
+			IL_0041: dup
+			IL_0042: ldc.i4.4
+			IL_0043: ldstr "sha256"
+			IL_0048: stelem.ref
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_004e: stloc.0
+			IL_004f: ldloc.0
+			IL_0050: ret
 		} // end of method ArrowFunction_L26C36::__js_call__
 
 	} // end of class ArrowFunction_L26C36
@@ -1077,7 +1011,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4282
+				// Method begins at RVA 0x3ff8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1103,9 +1037,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2dd4
+			// Method begins at RVA 0x2d3c
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 90 (0x5a)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1113,44 +1047,38 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "pbkdf2Sync"
-			IL_0020: ldc.i4.5
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldstr "password"
-			IL_002d: stelem.ref
-			IL_002e: dup
-			IL_002f: ldc.i4.1
-			IL_0030: ldstr "salt"
-			IL_0035: stelem.ref
-			IL_0036: dup
-			IL_0037: ldc.i4.2
-			IL_0038: ldc.r8 1.5
-			IL_0041: box [System.Runtime]System.Double
-			IL_0046: stelem.ref
-			IL_0047: dup
-			IL_0048: ldc.i4.3
-			IL_0049: ldc.r8 16
-			IL_0052: box [System.Runtime]System.Double
-			IL_0057: stelem.ref
-			IL_0058: dup
-			IL_0059: ldc.i4.4
-			IL_005a: ldstr "sha256"
-			IL_005f: stelem.ref
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0065: stloc.0
-			IL_0066: ldloc.0
-			IL_0067: ret
+			IL_000d: ldstr "pbkdf2Sync"
+			IL_0012: ldc.i4.5
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldstr "password"
+			IL_001f: stelem.ref
+			IL_0020: dup
+			IL_0021: ldc.i4.1
+			IL_0022: ldstr "salt"
+			IL_0027: stelem.ref
+			IL_0028: dup
+			IL_0029: ldc.i4.2
+			IL_002a: ldc.r8 1.5
+			IL_0033: box [System.Runtime]System.Double
+			IL_0038: stelem.ref
+			IL_0039: dup
+			IL_003a: ldc.i4.3
+			IL_003b: ldc.r8 16
+			IL_0044: box [System.Runtime]System.Double
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.4
+			IL_004c: ldstr "sha256"
+			IL_0051: stelem.ref
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0057: stloc.0
+			IL_0058: ldloc.0
+			IL_0059: ret
 		} // end of method ArrowFunction_L27C37::__js_call__
 
 	} // end of class ArrowFunction_L27C37
@@ -1166,7 +1094,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x428b
+				// Method begins at RVA 0x4001
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1192,9 +1120,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2e48
+			// Method begins at RVA 0x2da4
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 90 (0x5a)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1202,44 +1130,38 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "pbkdf2Sync"
-			IL_0020: ldc.i4.5
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldstr "password"
-			IL_002d: stelem.ref
-			IL_002e: dup
-			IL_002f: ldc.i4.1
-			IL_0030: ldstr "salt"
-			IL_0035: stelem.ref
-			IL_0036: dup
-			IL_0037: ldc.i4.2
-			IL_0038: ldc.r8 0.0
-			IL_0041: box [System.Runtime]System.Double
-			IL_0046: stelem.ref
-			IL_0047: dup
-			IL_0048: ldc.i4.3
-			IL_0049: ldc.r8 16
-			IL_0052: box [System.Runtime]System.Double
-			IL_0057: stelem.ref
-			IL_0058: dup
-			IL_0059: ldc.i4.4
-			IL_005a: ldstr "sha256"
-			IL_005f: stelem.ref
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0065: stloc.0
-			IL_0066: ldloc.0
-			IL_0067: ret
+			IL_000d: ldstr "pbkdf2Sync"
+			IL_0012: ldc.i4.5
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldstr "password"
+			IL_001f: stelem.ref
+			IL_0020: dup
+			IL_0021: ldc.i4.1
+			IL_0022: ldstr "salt"
+			IL_0027: stelem.ref
+			IL_0028: dup
+			IL_0029: ldc.i4.2
+			IL_002a: ldc.r8 0.0
+			IL_0033: box [System.Runtime]System.Double
+			IL_0038: stelem.ref
+			IL_0039: dup
+			IL_003a: ldc.i4.3
+			IL_003b: ldc.r8 16
+			IL_0044: box [System.Runtime]System.Double
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.4
+			IL_004c: ldstr "sha256"
+			IL_0051: stelem.ref
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0057: stloc.0
+			IL_0058: ldloc.0
+			IL_0059: ret
 		} // end of method ArrowFunction_L28C36::__js_call__
 
 	} // end of class ArrowFunction_L28C36
@@ -1255,7 +1177,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4294
+				// Method begins at RVA 0x400a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1281,9 +1203,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2ebc
+			// Method begins at RVA 0x2e0c
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 90 (0x5a)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1291,44 +1213,38 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "pbkdf2Sync"
-			IL_0020: ldc.i4.5
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldstr "password"
-			IL_002d: stelem.ref
-			IL_002e: dup
-			IL_002f: ldc.i4.1
-			IL_0030: ldstr "salt"
-			IL_0035: stelem.ref
-			IL_0036: dup
-			IL_0037: ldc.i4.2
-			IL_0038: ldc.r8 1
-			IL_0041: box [System.Runtime]System.Double
-			IL_0046: stelem.ref
-			IL_0047: dup
-			IL_0048: ldc.i4.3
-			IL_0049: ldc.r8 8.5
-			IL_0052: box [System.Runtime]System.Double
-			IL_0057: stelem.ref
-			IL_0058: dup
-			IL_0059: ldc.i4.4
-			IL_005a: ldstr "sha256"
-			IL_005f: stelem.ref
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0065: stloc.0
-			IL_0066: ldloc.0
-			IL_0067: ret
+			IL_000d: ldstr "pbkdf2Sync"
+			IL_0012: ldc.i4.5
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldstr "password"
+			IL_001f: stelem.ref
+			IL_0020: dup
+			IL_0021: ldc.i4.1
+			IL_0022: ldstr "salt"
+			IL_0027: stelem.ref
+			IL_0028: dup
+			IL_0029: ldc.i4.2
+			IL_002a: ldc.r8 1
+			IL_0033: box [System.Runtime]System.Double
+			IL_0038: stelem.ref
+			IL_0039: dup
+			IL_003a: ldc.i4.3
+			IL_003b: ldc.r8 8.5
+			IL_0044: box [System.Runtime]System.Double
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.4
+			IL_004c: ldstr "sha256"
+			IL_0051: stelem.ref
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0057: stloc.0
+			IL_0058: ldloc.0
+			IL_0059: ret
 		} // end of method ArrowFunction_L29C33::__js_call__
 
 	} // end of class ArrowFunction_L29C33
@@ -1344,7 +1260,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x429d
+				// Method begins at RVA 0x4013
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1370,9 +1286,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2f30
+			// Method begins at RVA 0x2e74
 			// Header size: 12
-			// Code size: 107 (0x6b)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1381,47 +1297,41 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldc.r8 1
-			IL_0023: neg
-			IL_0024: box [System.Runtime]System.Double
-			IL_0029: stloc.1
-			IL_002a: ldloc.0
-			IL_002b: ldstr "pbkdf2Sync"
-			IL_0030: ldc.i4.5
-			IL_0031: newarr [System.Runtime]System.Object
-			IL_0036: dup
-			IL_0037: ldc.i4.0
-			IL_0038: ldstr "password"
-			IL_003d: stelem.ref
-			IL_003e: dup
-			IL_003f: ldc.i4.1
-			IL_0040: ldstr "salt"
-			IL_0045: stelem.ref
-			IL_0046: dup
-			IL_0047: ldc.i4.2
-			IL_0048: ldc.r8 1
-			IL_0051: box [System.Runtime]System.Double
-			IL_0056: stelem.ref
-			IL_0057: dup
-			IL_0058: ldc.i4.3
-			IL_0059: ldloc.1
-			IL_005a: stelem.ref
-			IL_005b: dup
-			IL_005c: ldc.i4.4
-			IL_005d: ldstr "sha256"
-			IL_0062: stelem.ref
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0068: stloc.0
-			IL_0069: ldloc.0
-			IL_006a: ret
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
+			IL_000c: ldc.r8 1
+			IL_0015: neg
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: stloc.1
+			IL_001c: ldloc.0
+			IL_001d: ldstr "pbkdf2Sync"
+			IL_0022: ldc.i4.5
+			IL_0023: newarr [System.Runtime]System.Object
+			IL_0028: dup
+			IL_0029: ldc.i4.0
+			IL_002a: ldstr "password"
+			IL_002f: stelem.ref
+			IL_0030: dup
+			IL_0031: ldc.i4.1
+			IL_0032: ldstr "salt"
+			IL_0037: stelem.ref
+			IL_0038: dup
+			IL_0039: ldc.i4.2
+			IL_003a: ldc.r8 1
+			IL_0043: box [System.Runtime]System.Double
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.3
+			IL_004b: ldloc.1
+			IL_004c: stelem.ref
+			IL_004d: dup
+			IL_004e: ldc.i4.4
+			IL_004f: ldstr "sha256"
+			IL_0054: stelem.ref
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_005a: stloc.0
+			IL_005b: ldloc.0
+			IL_005c: ret
 		} // end of method ArrowFunction_L30C36::__js_call__
 
 	} // end of class ArrowFunction_L30C36
@@ -1437,7 +1347,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x42a6
+				// Method begins at RVA 0x401c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1463,9 +1373,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2fa8
+			// Method begins at RVA 0x2ee0
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1473,21 +1383,15 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "randomBytes"
-			IL_0020: ldstr "4"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.0
-			IL_002b: ldloc.0
-			IL_002c: ret
+			IL_000d: ldstr "randomBytes"
+			IL_0012: ldstr "4"
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ret
 		} // end of method ArrowFunction_L31C30::__js_call__
 
 	} // end of class ArrowFunction_L31C30
@@ -1503,7 +1407,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x42af
+				// Method begins at RVA 0x4025
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1529,9 +1433,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2fe4
+			// Method begins at RVA 0x2f0c
 			// Header size: 12
-			// Code size: 55 (0x37)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1539,23 +1443,17 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: stloc.0
-			IL_0007: ldstr "crypto"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "randomBytes"
-			IL_0020: ldc.r8 1
-			IL_0029: neg
-			IL_002a: box [System.Runtime]System.Double
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0034: stloc.0
-			IL_0035: ldloc.0
-			IL_0036: ret
+			IL_000d: ldstr "randomBytes"
+			IL_0012: ldc.r8 1
+			IL_001b: neg
+			IL_001c: box [System.Runtime]System.Double
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0026: stloc.0
+			IL_0027: ldloc.0
+			IL_0028: ret
 		} // end of method ArrowFunction_L32C34::__js_call__
 
 	} // end of class ArrowFunction_L32C34
@@ -1571,7 +1469,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x42b8
+				// Method begins at RVA 0x402e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1597,9 +1495,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x3028
+			// Method begins at RVA 0x2f44
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1607,21 +1505,15 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-			IL_0006: stloc.0
-			IL_0007: ldstr "hash"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "digest"
-			IL_0020: ldstr "hex"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.0
-			IL_002b: ldloc.0
-			IL_002c: ret
+			IL_000d: ldstr "digest"
+			IL_0012: ldstr "hex"
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ret
 		} // end of method ArrowFunction_L37C26::__js_call__
 
 	} // end of class ArrowFunction_L37C26
@@ -1637,7 +1529,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x42c1
+				// Method begins at RVA 0x4037
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1663,9 +1555,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x3064
+			// Method begins at RVA 0x2f70
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 40 (0x28)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1673,22 +1565,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
-			IL_0006: stloc.0
-			IL_0007: ldstr "hmac"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "update"
-			IL_0020: ldc.r8 123
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0033: stloc.0
-			IL_0034: ldloc.0
-			IL_0035: ret
+			IL_000d: ldstr "update"
+			IL_0012: ldc.r8 123
+			IL_001b: box [System.Runtime]System.Double
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0025: stloc.0
+			IL_0026: ldloc.0
+			IL_0027: ret
 		} // end of method ArrowFunction_L40C30::__js_call__
 
 	} // end of class ArrowFunction_L40C30
@@ -1717,7 +1603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42d3
+					// Method begins at RVA 0x4049
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1737,7 +1623,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42dc
+					// Method begins at RVA 0x4052
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1761,7 +1647,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x42ca
+				// Method begins at RVA 0x4040
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1787,7 +1673,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30a8
+			// Method begins at RVA 0x2fa4
 			// Header size: 12
 			// Code size: 598 (0x256)
 			.maxstack 8
@@ -2058,7 +1944,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42ee
+					// Method begins at RVA 0x4064
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2082,9 +1968,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3c60
+				// Method begins at RVA 0x3a80
 				// Header size: 12
-				// Code size: 64 (0x40)
+				// Code size: 50 (0x32)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2096,25 +1982,19 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: stloc.0
-				IL_000e: ldstr "subtle"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldstr "abc"
-				IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_002b: stloc.1
-				IL_002c: ldloc.0
-				IL_002d: ldstr "digest"
-				IL_0032: ldstr "MD5"
-				IL_0037: ldloc.1
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_003d: stloc.0
-				IL_003e: ldloc.0
-				IL_003f: ret
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
+				IL_0013: ldstr "abc"
+				IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_001d: stloc.1
+				IL_001e: ldloc.0
+				IL_001f: ldstr "digest"
+				IL_0024: ldstr "MD5"
+				IL_0029: ldloc.1
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_002f: stloc.0
+				IL_0030: ldloc.0
+				IL_0031: ret
 			} // end of method ArrowFunction_L56C56::__js_call__
 
 		} // end of class ArrowFunction_L56C56
@@ -2130,7 +2010,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42f7
+					// Method begins at RVA 0x406d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2154,9 +2034,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3cac
+				// Method begins at RVA 0x3ac0
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 135 (0x87)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2170,62 +2050,56 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: stloc.0
-				IL_000e: ldstr "subtle"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldstr "key"
-				IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_002b: stloc.1
-				IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0031: dup
-				IL_0032: ldstr "name"
-				IL_0037: ldstr "HMAC"
-				IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0041: dup
-				IL_0042: ldstr "hash"
-				IL_0047: ldstr "SHA-256"
-				IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0051: stloc.2
-				IL_0052: ldc.i4.5
-				IL_0053: newarr [System.Runtime]System.Object
-				IL_0058: dup
-				IL_0059: ldc.i4.0
-				IL_005a: ldstr "jwk"
-				IL_005f: stelem.ref
-				IL_0060: dup
-				IL_0061: ldc.i4.1
-				IL_0062: ldloc.1
-				IL_0063: stelem.ref
-				IL_0064: dup
-				IL_0065: ldc.i4.2
-				IL_0066: ldloc.2
-				IL_0067: stelem.ref
-				IL_0068: dup
-				IL_0069: ldc.i4.3
-				IL_006a: ldc.i4.0
-				IL_006b: box [System.Runtime]System.Boolean
-				IL_0070: stelem.ref
-				IL_0071: dup
-				IL_0072: ldc.i4.4
-				IL_0073: ldc.i4.1
-				IL_0074: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0079: dup
-				IL_007a: ldstr "sign"
-				IL_007f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0084: stelem.ref
-				IL_0085: stloc.3
-				IL_0086: ldloc.0
-				IL_0087: ldstr "importKey"
-				IL_008c: ldloc.3
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0092: stloc.0
-				IL_0093: ldloc.0
-				IL_0094: ret
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
+				IL_0013: ldstr "key"
+				IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_001d: stloc.1
+				IL_001e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0023: dup
+				IL_0024: ldstr "name"
+				IL_0029: ldstr "HMAC"
+				IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0033: dup
+				IL_0034: ldstr "hash"
+				IL_0039: ldstr "SHA-256"
+				IL_003e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0043: stloc.2
+				IL_0044: ldc.i4.5
+				IL_0045: newarr [System.Runtime]System.Object
+				IL_004a: dup
+				IL_004b: ldc.i4.0
+				IL_004c: ldstr "jwk"
+				IL_0051: stelem.ref
+				IL_0052: dup
+				IL_0053: ldc.i4.1
+				IL_0054: ldloc.1
+				IL_0055: stelem.ref
+				IL_0056: dup
+				IL_0057: ldc.i4.2
+				IL_0058: ldloc.2
+				IL_0059: stelem.ref
+				IL_005a: dup
+				IL_005b: ldc.i4.3
+				IL_005c: ldc.i4.0
+				IL_005d: box [System.Runtime]System.Boolean
+				IL_0062: stelem.ref
+				IL_0063: dup
+				IL_0064: ldc.i4.4
+				IL_0065: ldc.i4.1
+				IL_0066: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_006b: dup
+				IL_006c: ldstr "sign"
+				IL_0071: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0076: stelem.ref
+				IL_0077: stloc.3
+				IL_0078: ldloc.0
+				IL_0079: ldstr "importKey"
+				IL_007e: ldloc.3
+				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0084: stloc.0
+				IL_0085: ldloc.0
+				IL_0086: ret
 			} // end of method ArrowFunction_L57C51::__js_call__
 
 		} // end of class ArrowFunction_L57C51
@@ -2241,7 +2115,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4300
+					// Method begins at RVA 0x4076
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2265,9 +2139,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3d50
+				// Method begins at RVA 0x3b54
 				// Header size: 12
-				// Code size: 140 (0x8c)
+				// Code size: 126 (0x7e)
 				.maxstack 9
 				.locals init (
 					[0] object,
@@ -2279,57 +2153,51 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: stloc.0
-				IL_000e: ldstr "subtle"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0026: dup
-				IL_0027: ldstr "name"
-				IL_002c: ldstr "HMAC"
-				IL_0031: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0036: dup
-				IL_0037: ldstr "hash"
-				IL_003c: ldstr "SHA-256"
-				IL_0041: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0046: stloc.1
-				IL_0047: ldloc.0
-				IL_0048: ldstr "importKey"
-				IL_004d: ldc.i4.5
-				IL_004e: newarr [System.Runtime]System.Object
-				IL_0053: dup
-				IL_0054: ldc.i4.0
-				IL_0055: ldstr "raw"
-				IL_005a: stelem.ref
-				IL_005b: dup
-				IL_005c: ldc.i4.1
-				IL_005d: ldstr "key"
-				IL_0062: stelem.ref
-				IL_0063: dup
-				IL_0064: ldc.i4.2
-				IL_0065: ldloc.1
-				IL_0066: stelem.ref
-				IL_0067: dup
-				IL_0068: ldc.i4.3
-				IL_0069: ldc.i4.0
-				IL_006a: box [System.Runtime]System.Boolean
-				IL_006f: stelem.ref
-				IL_0070: dup
-				IL_0071: ldc.i4.4
-				IL_0072: ldc.i4.1
-				IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0078: dup
-				IL_0079: ldstr "sign"
-				IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0083: stelem.ref
-				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0089: stloc.0
-				IL_008a: ldloc.0
-				IL_008b: ret
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
+				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0018: dup
+				IL_0019: ldstr "name"
+				IL_001e: ldstr "HMAC"
+				IL_0023: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0028: dup
+				IL_0029: ldstr "hash"
+				IL_002e: ldstr "SHA-256"
+				IL_0033: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0038: stloc.1
+				IL_0039: ldloc.0
+				IL_003a: ldstr "importKey"
+				IL_003f: ldc.i4.5
+				IL_0040: newarr [System.Runtime]System.Object
+				IL_0045: dup
+				IL_0046: ldc.i4.0
+				IL_0047: ldstr "raw"
+				IL_004c: stelem.ref
+				IL_004d: dup
+				IL_004e: ldc.i4.1
+				IL_004f: ldstr "key"
+				IL_0054: stelem.ref
+				IL_0055: dup
+				IL_0056: ldc.i4.2
+				IL_0057: ldloc.1
+				IL_0058: stelem.ref
+				IL_0059: dup
+				IL_005a: ldc.i4.3
+				IL_005b: ldc.i4.0
+				IL_005c: box [System.Runtime]System.Boolean
+				IL_0061: stelem.ref
+				IL_0062: dup
+				IL_0063: ldc.i4.4
+				IL_0064: ldc.i4.1
+				IL_0065: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_006a: dup
+				IL_006b: ldstr "sign"
+				IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0075: stelem.ref
+				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_007b: stloc.0
+				IL_007c: ldloc.0
+				IL_007d: ret
 			} // end of method ArrowFunction_L63C53::__js_call__
 
 		} // end of class ArrowFunction_L63C53
@@ -2345,7 +2213,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4309
+					// Method begins at RVA 0x407f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2369,9 +2237,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3de8
+				// Method begins at RVA 0x3be0
 				// Header size: 12
-				// Code size: 138 (0x8a)
+				// Code size: 124 (0x7c)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2385,59 +2253,53 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: stloc.0
-				IL_000e: ldstr "subtle"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldstr "key"
-				IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_002b: stloc.1
-				IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0031: dup
-				IL_0032: ldstr "name"
-				IL_0037: ldstr "HMAC"
-				IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0041: dup
-				IL_0042: ldstr "hash"
-				IL_0047: ldstr "SHA-256"
-				IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0051: stloc.2
-				IL_0052: ldc.i4.5
-				IL_0053: newarr [System.Runtime]System.Object
-				IL_0058: dup
-				IL_0059: ldc.i4.0
-				IL_005a: ldstr "raw"
-				IL_005f: stelem.ref
-				IL_0060: dup
-				IL_0061: ldc.i4.1
-				IL_0062: ldloc.1
-				IL_0063: stelem.ref
-				IL_0064: dup
-				IL_0065: ldc.i4.2
-				IL_0066: ldloc.2
-				IL_0067: stelem.ref
-				IL_0068: dup
-				IL_0069: ldc.i4.3
-				IL_006a: ldc.i4.0
-				IL_006b: box [System.Runtime]System.Boolean
-				IL_0070: stelem.ref
-				IL_0071: dup
-				IL_0072: ldc.i4.4
-				IL_0073: ldc.i4.0
-				IL_0074: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0079: stelem.ref
-				IL_007a: stloc.3
-				IL_007b: ldloc.0
-				IL_007c: ldstr "importKey"
-				IL_0081: ldloc.3
-				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0087: stloc.0
-				IL_0088: ldloc.0
-				IL_0089: ret
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
+				IL_0013: ldstr "key"
+				IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_001d: stloc.1
+				IL_001e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0023: dup
+				IL_0024: ldstr "name"
+				IL_0029: ldstr "HMAC"
+				IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0033: dup
+				IL_0034: ldstr "hash"
+				IL_0039: ldstr "SHA-256"
+				IL_003e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0043: stloc.2
+				IL_0044: ldc.i4.5
+				IL_0045: newarr [System.Runtime]System.Object
+				IL_004a: dup
+				IL_004b: ldc.i4.0
+				IL_004c: ldstr "raw"
+				IL_0051: stelem.ref
+				IL_0052: dup
+				IL_0053: ldc.i4.1
+				IL_0054: ldloc.1
+				IL_0055: stelem.ref
+				IL_0056: dup
+				IL_0057: ldc.i4.2
+				IL_0058: ldloc.2
+				IL_0059: stelem.ref
+				IL_005a: dup
+				IL_005b: ldc.i4.3
+				IL_005c: ldc.i4.0
+				IL_005d: box [System.Runtime]System.Boolean
+				IL_0062: stelem.ref
+				IL_0063: dup
+				IL_0064: ldc.i4.4
+				IL_0065: ldc.i4.0
+				IL_0066: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_006b: stelem.ref
+				IL_006c: stloc.3
+				IL_006d: ldloc.0
+				IL_006e: ldstr "importKey"
+				IL_0073: ldloc.3
+				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0079: stloc.0
+				IL_007a: ldloc.0
+				IL_007b: ret
 			} // end of method ArrowFunction_L69C57::__js_call__
 
 		} // end of class ArrowFunction_L69C57
@@ -2453,7 +2315,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4312
+					// Method begins at RVA 0x4088
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2477,9 +2339,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e80
+				// Method begins at RVA 0x3c68
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 135 (0x87)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2493,62 +2355,56 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: stloc.0
-				IL_000e: ldstr "subtle"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldstr "key"
-				IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_002b: stloc.1
-				IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0031: dup
-				IL_0032: ldstr "name"
-				IL_0037: ldstr "HMAC"
-				IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0041: dup
-				IL_0042: ldstr "hash"
-				IL_0047: ldstr "SHA-256"
-				IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0051: stloc.2
-				IL_0052: ldc.i4.5
-				IL_0053: newarr [System.Runtime]System.Object
-				IL_0058: dup
-				IL_0059: ldc.i4.0
-				IL_005a: ldstr "raw"
-				IL_005f: stelem.ref
-				IL_0060: dup
-				IL_0061: ldc.i4.1
-				IL_0062: ldloc.1
-				IL_0063: stelem.ref
-				IL_0064: dup
-				IL_0065: ldc.i4.2
-				IL_0066: ldloc.2
-				IL_0067: stelem.ref
-				IL_0068: dup
-				IL_0069: ldc.i4.3
-				IL_006a: ldc.i4.0
-				IL_006b: box [System.Runtime]System.Boolean
-				IL_0070: stelem.ref
-				IL_0071: dup
-				IL_0072: ldc.i4.4
-				IL_0073: ldc.i4.1
-				IL_0074: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0079: dup
-				IL_007a: ldstr "SIGN"
-				IL_007f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0084: stelem.ref
-				IL_0085: stloc.3
-				IL_0086: ldloc.0
-				IL_0087: ldstr "importKey"
-				IL_008c: ldloc.3
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0092: stloc.0
-				IL_0093: ldloc.0
-				IL_0094: ret
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
+				IL_0013: ldstr "key"
+				IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_001d: stloc.1
+				IL_001e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0023: dup
+				IL_0024: ldstr "name"
+				IL_0029: ldstr "HMAC"
+				IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0033: dup
+				IL_0034: ldstr "hash"
+				IL_0039: ldstr "SHA-256"
+				IL_003e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0043: stloc.2
+				IL_0044: ldc.i4.5
+				IL_0045: newarr [System.Runtime]System.Object
+				IL_004a: dup
+				IL_004b: ldc.i4.0
+				IL_004c: ldstr "raw"
+				IL_0051: stelem.ref
+				IL_0052: dup
+				IL_0053: ldc.i4.1
+				IL_0054: ldloc.1
+				IL_0055: stelem.ref
+				IL_0056: dup
+				IL_0057: ldc.i4.2
+				IL_0058: ldloc.2
+				IL_0059: stelem.ref
+				IL_005a: dup
+				IL_005b: ldc.i4.3
+				IL_005c: ldc.i4.0
+				IL_005d: box [System.Runtime]System.Boolean
+				IL_0062: stelem.ref
+				IL_0063: dup
+				IL_0064: ldc.i4.4
+				IL_0065: ldc.i4.1
+				IL_0066: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_006b: dup
+				IL_006c: ldstr "SIGN"
+				IL_0071: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0076: stelem.ref
+				IL_0077: stloc.3
+				IL_0078: ldloc.0
+				IL_0079: ldstr "importKey"
+				IL_007e: ldloc.3
+				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0084: stloc.0
+				IL_0085: ldloc.0
+				IL_0086: ret
 			} // end of method ArrowFunction_L75C63::__js_call__
 
 		} // end of class ArrowFunction_L75C63
@@ -2564,7 +2420,401 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x431b
+					// Method begins at RVA 0x4091
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x3cfc
+				// Header size: 12
+				// Code size: 135 (0x87)
+				.maxstack 8
+				.locals init (
+					[0] object,
+					[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+					[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+					[3] object[]
+				)
+
+				IL_0000: ldarg.0
+				IL_0001: ldc.i4.1
+				IL_0002: ldelem.ref
+				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
+				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
+				IL_0013: ldstr "key"
+				IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_001d: stloc.1
+				IL_001e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0023: dup
+				IL_0024: ldstr "name"
+				IL_0029: ldstr "HMAC"
+				IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0033: dup
+				IL_0034: ldstr "hash"
+				IL_0039: ldstr "SHA-256"
+				IL_003e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0043: stloc.2
+				IL_0044: ldc.i4.5
+				IL_0045: newarr [System.Runtime]System.Object
+				IL_004a: dup
+				IL_004b: ldc.i4.0
+				IL_004c: ldstr "raw"
+				IL_0051: stelem.ref
+				IL_0052: dup
+				IL_0053: ldc.i4.1
+				IL_0054: ldloc.1
+				IL_0055: stelem.ref
+				IL_0056: dup
+				IL_0057: ldc.i4.2
+				IL_0058: ldloc.2
+				IL_0059: stelem.ref
+				IL_005a: dup
+				IL_005b: ldc.i4.3
+				IL_005c: ldc.i4.0
+				IL_005d: box [System.Runtime]System.Boolean
+				IL_0062: stelem.ref
+				IL_0063: dup
+				IL_0064: ldc.i4.4
+				IL_0065: ldc.i4.1
+				IL_0066: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_006b: dup
+				IL_006c: ldstr "encrypt"
+				IL_0071: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0076: stelem.ref
+				IL_0077: stloc.3
+				IL_0078: ldloc.0
+				IL_0079: ldstr "importKey"
+				IL_007e: ldloc.3
+				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0084: stloc.0
+				IL_0085: ldloc.0
+				IL_0086: ret
+			} // end of method ArrowFunction_L81C62::__js_call__
+
+		} // end of class ArrowFunction_L81C62
+
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L87C53
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x409a
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x3d90
+				// Header size: 12
+				// Code size: 144 (0x90)
+				.maxstack 8
+				.locals init (
+					[0] object,
+					[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+					[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+					[3] object[]
+				)
+
+				IL_0000: ldarg.0
+				IL_0001: ldc.i4.1
+				IL_0002: ldelem.ref
+				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
+				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
+				IL_0013: ldc.r8 0.0
+				IL_001c: box [System.Runtime]System.Double
+				IL_0021: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+				IL_0026: stloc.1
+				IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_002c: dup
+				IL_002d: ldstr "name"
+				IL_0032: ldstr "HMAC"
+				IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_003c: dup
+				IL_003d: ldstr "hash"
+				IL_0042: ldstr "SHA-256"
+				IL_0047: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_004c: stloc.2
+				IL_004d: ldc.i4.5
+				IL_004e: newarr [System.Runtime]System.Object
+				IL_0053: dup
+				IL_0054: ldc.i4.0
+				IL_0055: ldstr "raw"
+				IL_005a: stelem.ref
+				IL_005b: dup
+				IL_005c: ldc.i4.1
+				IL_005d: ldloc.1
+				IL_005e: stelem.ref
+				IL_005f: dup
+				IL_0060: ldc.i4.2
+				IL_0061: ldloc.2
+				IL_0062: stelem.ref
+				IL_0063: dup
+				IL_0064: ldc.i4.3
+				IL_0065: ldc.i4.0
+				IL_0066: box [System.Runtime]System.Boolean
+				IL_006b: stelem.ref
+				IL_006c: dup
+				IL_006d: ldc.i4.4
+				IL_006e: ldc.i4.1
+				IL_006f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_0074: dup
+				IL_0075: ldstr "sign"
+				IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_007f: stelem.ref
+				IL_0080: stloc.3
+				IL_0081: ldloc.0
+				IL_0082: ldstr "importKey"
+				IL_0087: ldloc.3
+				IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_008d: stloc.0
+				IL_008e: ldloc.0
+				IL_008f: ret
+			} // end of method ArrowFunction_L87C53::__js_call__
+
+		} // end of class ArrowFunction_L87C53
+
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L93C60
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x40a3
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x3e2c
+				// Header size: 12
+				// Code size: 155 (0x9b)
+				.maxstack 8
+				.locals init (
+					[0] object,
+					[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+					[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+					[3] object[]
+				)
+
+				IL_0000: ldarg.0
+				IL_0001: ldc.i4.1
+				IL_0002: ldelem.ref
+				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
+				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
+				IL_0013: ldstr "key"
+				IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_001d: stloc.1
+				IL_001e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0023: dup
+				IL_0024: ldstr "name"
+				IL_0029: ldstr "HMAC"
+				IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0033: dup
+				IL_0034: ldstr "hash"
+				IL_0039: ldstr "SHA-256"
+				IL_003e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0043: dup
+				IL_0044: ldstr "length"
+				IL_0049: ldc.r8 128
+				IL_0052: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+				IL_0057: stloc.2
+				IL_0058: ldc.i4.5
+				IL_0059: newarr [System.Runtime]System.Object
+				IL_005e: dup
+				IL_005f: ldc.i4.0
+				IL_0060: ldstr "raw"
+				IL_0065: stelem.ref
+				IL_0066: dup
+				IL_0067: ldc.i4.1
+				IL_0068: ldloc.1
+				IL_0069: stelem.ref
+				IL_006a: dup
+				IL_006b: ldc.i4.2
+				IL_006c: ldloc.2
+				IL_006d: stelem.ref
+				IL_006e: dup
+				IL_006f: ldc.i4.3
+				IL_0070: ldc.i4.0
+				IL_0071: box [System.Runtime]System.Boolean
+				IL_0076: stelem.ref
+				IL_0077: dup
+				IL_0078: ldc.i4.4
+				IL_0079: ldc.i4.1
+				IL_007a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_007f: dup
+				IL_0080: ldstr "sign"
+				IL_0085: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_008a: stelem.ref
+				IL_008b: stloc.3
+				IL_008c: ldloc.0
+				IL_008d: ldstr "importKey"
+				IL_0092: ldloc.3
+				IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0098: stloc.0
+				IL_0099: ldloc.0
+				IL_009a: ret
+			} // end of method ArrowFunction_L93C60::__js_call__
+
+		} // end of class ArrowFunction_L93C60
+
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L107C52
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x40ac
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x3ed4
+				// Header size: 12
+				// Code size: 65 (0x41)
+				.maxstack 8
+				.locals init (
+					[0] object,
+					[1] object,
+					[2] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
+				)
+
+				IL_0000: ldarg.0
+				IL_0001: ldc.i4.1
+				IL_0002: ldelem.ref
+				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
+				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
+				IL_0013: ldarg.0
+				IL_0014: ldc.i4.1
+				IL_0015: ldelem.ref
+				IL_0016: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
+				IL_001b: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
+				IL_0020: stloc.1
+				IL_0021: ldstr "abc"
+				IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_002b: stloc.2
+				IL_002c: ldloc.0
+				IL_002d: ldstr "sign"
+				IL_0032: ldstr "AES-GCM"
+				IL_0037: ldloc.1
+				IL_0038: ldloc.2
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_003e: stloc.1
+				IL_003f: ldloc.1
+				IL_0040: ret
+			} // end of method ArrowFunction_L107C52::__js_call__
+
+		} // end of class ArrowFunction_L107C52
+
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L108C48
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x40b5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2590,345 +2840,7 @@
 				)
 				// Method begins at RVA 0x3f24
 				// Header size: 12
-				// Code size: 149 (0x95)
-				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-					[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-					[3] object[]
-				)
-
-				IL_0000: ldarg.0
-				IL_0001: ldc.i4.1
-				IL_0002: ldelem.ref
-				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
-				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: stloc.0
-				IL_000e: ldstr "subtle"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldstr "key"
-				IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_002b: stloc.1
-				IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0031: dup
-				IL_0032: ldstr "name"
-				IL_0037: ldstr "HMAC"
-				IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0041: dup
-				IL_0042: ldstr "hash"
-				IL_0047: ldstr "SHA-256"
-				IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0051: stloc.2
-				IL_0052: ldc.i4.5
-				IL_0053: newarr [System.Runtime]System.Object
-				IL_0058: dup
-				IL_0059: ldc.i4.0
-				IL_005a: ldstr "raw"
-				IL_005f: stelem.ref
-				IL_0060: dup
-				IL_0061: ldc.i4.1
-				IL_0062: ldloc.1
-				IL_0063: stelem.ref
-				IL_0064: dup
-				IL_0065: ldc.i4.2
-				IL_0066: ldloc.2
-				IL_0067: stelem.ref
-				IL_0068: dup
-				IL_0069: ldc.i4.3
-				IL_006a: ldc.i4.0
-				IL_006b: box [System.Runtime]System.Boolean
-				IL_0070: stelem.ref
-				IL_0071: dup
-				IL_0072: ldc.i4.4
-				IL_0073: ldc.i4.1
-				IL_0074: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0079: dup
-				IL_007a: ldstr "encrypt"
-				IL_007f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0084: stelem.ref
-				IL_0085: stloc.3
-				IL_0086: ldloc.0
-				IL_0087: ldstr "importKey"
-				IL_008c: ldloc.3
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0092: stloc.0
-				IL_0093: ldloc.0
-				IL_0094: ret
-			} // end of method ArrowFunction_L81C62::__js_call__
-
-		} // end of class ArrowFunction_L81C62
-
-		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L87C53
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested public auto ansi beforefieldinit Scope
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x4324
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Scope::.ctor
-
-			} // end of class Scope
-
-
-			// Methods
-			.method public hidebysig static 
-				object __js_call__ (
-					object[] scopes,
-					object newTarget
-				) cil managed 
-			{
-				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-					01 00 02 00 00 00 00 00
-				)
-				// Method begins at RVA 0x3fc8
-				// Header size: 12
-				// Code size: 158 (0x9e)
-				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-					[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-					[3] object[]
-				)
-
-				IL_0000: ldarg.0
-				IL_0001: ldc.i4.1
-				IL_0002: ldelem.ref
-				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
-				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: stloc.0
-				IL_000e: ldstr "subtle"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldc.r8 0.0
-				IL_002a: box [System.Runtime]System.Double
-				IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-				IL_0034: stloc.1
-				IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_003a: dup
-				IL_003b: ldstr "name"
-				IL_0040: ldstr "HMAC"
-				IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_004a: dup
-				IL_004b: ldstr "hash"
-				IL_0050: ldstr "SHA-256"
-				IL_0055: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_005a: stloc.2
-				IL_005b: ldc.i4.5
-				IL_005c: newarr [System.Runtime]System.Object
-				IL_0061: dup
-				IL_0062: ldc.i4.0
-				IL_0063: ldstr "raw"
-				IL_0068: stelem.ref
-				IL_0069: dup
-				IL_006a: ldc.i4.1
-				IL_006b: ldloc.1
-				IL_006c: stelem.ref
-				IL_006d: dup
-				IL_006e: ldc.i4.2
-				IL_006f: ldloc.2
-				IL_0070: stelem.ref
-				IL_0071: dup
-				IL_0072: ldc.i4.3
-				IL_0073: ldc.i4.0
-				IL_0074: box [System.Runtime]System.Boolean
-				IL_0079: stelem.ref
-				IL_007a: dup
-				IL_007b: ldc.i4.4
-				IL_007c: ldc.i4.1
-				IL_007d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0082: dup
-				IL_0083: ldstr "sign"
-				IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_008d: stelem.ref
-				IL_008e: stloc.3
-				IL_008f: ldloc.0
-				IL_0090: ldstr "importKey"
-				IL_0095: ldloc.3
-				IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_009b: stloc.0
-				IL_009c: ldloc.0
-				IL_009d: ret
-			} // end of method ArrowFunction_L87C53::__js_call__
-
-		} // end of class ArrowFunction_L87C53
-
-		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L93C60
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested public auto ansi beforefieldinit Scope
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x432d
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Scope::.ctor
-
-			} // end of class Scope
-
-
-			// Methods
-			.method public hidebysig static 
-				object __js_call__ (
-					object[] scopes,
-					object newTarget
-				) cil managed 
-			{
-				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-					01 00 02 00 00 00 00 00
-				)
-				// Method begins at RVA 0x4074
-				// Header size: 12
-				// Code size: 169 (0xa9)
-				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-					[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-					[3] object[]
-				)
-
-				IL_0000: ldarg.0
-				IL_0001: ldc.i4.1
-				IL_0002: ldelem.ref
-				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
-				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: stloc.0
-				IL_000e: ldstr "subtle"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldstr "key"
-				IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_002b: stloc.1
-				IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0031: dup
-				IL_0032: ldstr "name"
-				IL_0037: ldstr "HMAC"
-				IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0041: dup
-				IL_0042: ldstr "hash"
-				IL_0047: ldstr "SHA-256"
-				IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0051: dup
-				IL_0052: ldstr "length"
-				IL_0057: ldc.r8 128
-				IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-				IL_0065: stloc.2
-				IL_0066: ldc.i4.5
-				IL_0067: newarr [System.Runtime]System.Object
-				IL_006c: dup
-				IL_006d: ldc.i4.0
-				IL_006e: ldstr "raw"
-				IL_0073: stelem.ref
-				IL_0074: dup
-				IL_0075: ldc.i4.1
-				IL_0076: ldloc.1
-				IL_0077: stelem.ref
-				IL_0078: dup
-				IL_0079: ldc.i4.2
-				IL_007a: ldloc.2
-				IL_007b: stelem.ref
-				IL_007c: dup
-				IL_007d: ldc.i4.3
-				IL_007e: ldc.i4.0
-				IL_007f: box [System.Runtime]System.Boolean
-				IL_0084: stelem.ref
-				IL_0085: dup
-				IL_0086: ldc.i4.4
-				IL_0087: ldc.i4.1
-				IL_0088: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_008d: dup
-				IL_008e: ldstr "sign"
-				IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0098: stelem.ref
-				IL_0099: stloc.3
-				IL_009a: ldloc.0
-				IL_009b: ldstr "importKey"
-				IL_00a0: ldloc.3
-				IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_00a6: stloc.0
-				IL_00a7: ldloc.0
-				IL_00a8: ret
-			} // end of method ArrowFunction_L93C60::__js_call__
-
-		} // end of class ArrowFunction_L93C60
-
-		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L107C52
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested public auto ansi beforefieldinit Scope
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x4336
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Scope::.ctor
-
-			} // end of class Scope
-
-
-			// Methods
-			.method public hidebysig static 
-				object __js_call__ (
-					object[] scopes,
-					object newTarget
-				) cil managed 
-			{
-				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-					01 00 02 00 00 00 00 00
-				)
-				// Method begins at RVA 0x412c
-				// Header size: 12
-				// Code size: 91 (0x5b)
+				// Code size: 65 (0x41)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2941,120 +2853,26 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
 				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: stloc.0
-				IL_000e: ldstr "subtle"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldarg.0
-				IL_0022: ldc.i4.1
-				IL_0023: ldelem.ref
-				IL_0024: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
-				IL_0029: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
-				IL_002e: stloc.1
-				IL_002f: ldstr "verifyOnlyKey"
-				IL_0034: ldloc.1
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003a: stloc.1
-				IL_003b: ldstr "abc"
-				IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_0045: stloc.2
-				IL_0046: ldloc.0
-				IL_0047: ldstr "sign"
-				IL_004c: ldstr "AES-GCM"
-				IL_0051: ldloc.1
-				IL_0052: ldloc.2
-				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_0058: stloc.1
-				IL_0059: ldloc.1
-				IL_005a: ret
-			} // end of method ArrowFunction_L107C52::__js_call__
-
-		} // end of class ArrowFunction_L107C52
-
-		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L108C48
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested public auto ansi beforefieldinit Scope
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x433f
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Scope::.ctor
-
-			} // end of class Scope
-
-
-			// Methods
-			.method public hidebysig static 
-				object __js_call__ (
-					object[] scopes,
-					object newTarget
-				) cil managed 
-			{
-				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-					01 00 02 00 00 00 00 00
-				)
-				// Method begins at RVA 0x4194
-				// Header size: 12
-				// Code size: 91 (0x5b)
-				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] object,
-					[2] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
-				)
-
-				IL_0000: ldarg.0
-				IL_0001: ldc.i4.1
-				IL_0002: ldelem.ref
-				IL_0003: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
-				IL_0008: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-				IL_000d: stloc.0
-				IL_000e: ldstr "subtle"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldarg.0
-				IL_0022: ldc.i4.1
-				IL_0023: ldelem.ref
-				IL_0024: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
-				IL_0029: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
-				IL_002e: stloc.1
-				IL_002f: ldstr "verifyOnlyKey"
-				IL_0034: ldloc.1
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003a: stloc.1
-				IL_003b: ldstr "abc"
-				IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_0045: stloc.2
-				IL_0046: ldloc.0
-				IL_0047: ldstr "sign"
-				IL_004c: ldstr "HMAC"
-				IL_0051: ldloc.1
-				IL_0052: ldloc.2
-				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_0058: stloc.1
-				IL_0059: ldloc.1
-				IL_005a: ret
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
+				IL_0013: ldarg.0
+				IL_0014: ldc.i4.1
+				IL_0015: ldelem.ref
+				IL_0016: castclass Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope
+				IL_001b: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
+				IL_0020: stloc.1
+				IL_0021: ldstr "abc"
+				IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_002b: stloc.2
+				IL_002c: ldloc.0
+				IL_002d: ldstr "sign"
+				IL_0032: ldstr "HMAC"
+				IL_0037: ldloc.1
+				IL_0038: ldloc.2
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_003e: stloc.1
+				IL_003f: ldloc.1
+				IL_0040: ret
 			} // end of method ArrowFunction_L108C48::__js_call__
 
 		} // end of class ArrowFunction_L108C48
@@ -3098,7 +2916,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x42e5
+				// Method begins at RVA 0x405b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3122,17 +2940,16 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x330c
+			// Method begins at RVA 0x3208
 			// Header size: 12
-			// Code size: 2321 (0x911)
+			// Code size: 2101 (0x835)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope,
-				[1] object,
-				[2] object[],
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[1] object[],
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.0
@@ -3165,1086 +2982,968 @@
 			IL_0042: brtrue IL_0053
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.5
+			IL_0048: ldc.i4.4
 			IL_0049: newarr [System.Runtime]System.Object
 			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0053: ldloc.0
 			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0059: ldc.i4.0
-			IL_005a: ble IL_008b
+			IL_005a: ble IL_0086
 
 			IL_005f: ldloc.0
 			IL_0060: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_0065: dup
 			IL_0066: ldc.i4.0
 			IL_0067: ldelem.ref
-			IL_0068: stloc.1
-			IL_0069: dup
-			IL_006a: ldc.i4.1
-			IL_006b: ldelem.ref
-			IL_006c: castclass object[]
+			IL_0068: castclass object[]
+			IL_006d: stloc.1
+			IL_006e: dup
+			IL_006f: ldc.i4.1
+			IL_0070: ldelem.ref
 			IL_0071: stloc.2
 			IL_0072: dup
 			IL_0073: ldc.i4.2
 			IL_0074: ldelem.ref
-			IL_0075: stloc.3
-			IL_0076: dup
-			IL_0077: ldc.i4.3
-			IL_0078: ldelem.ref
-			IL_0079: castclass [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
-			IL_007e: stloc.s 4
-			IL_0080: dup
-			IL_0081: ldc.i4.4
-			IL_0082: ldelem.ref
-			IL_0083: castclass [JavaScriptRuntime]JavaScriptRuntime.JsObject
-			IL_0088: stloc.s 5
-			IL_008a: pop
+			IL_0075: castclass [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
+			IL_007a: stloc.3
+			IL_007b: dup
+			IL_007c: ldc.i4.3
+			IL_007d: ldelem.ref
+			IL_007e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			IL_0083: stloc.s 4
+			IL_0085: pop
 
-			IL_008b: ldloc.0
-			IL_008c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0091: switch (IL_00c6, IL_01ad, IL_0262, IL_0317, IL_03cc, IL_0481, IL_0536, IL_05eb, IL_06a0, IL_076a, IL_0828, IL_08df)
+			IL_0086: ldloc.0
+			IL_0087: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_008c: switch (IL_00c1, IL_0183, IL_0225, IL_02c7, IL_0369, IL_040b, IL_04ad, IL_054f, IL_05f1, IL_06b4, IL_075f, IL_0803)
 
-			IL_00c6: ldarg.0
-			IL_00c7: ldc.i4.1
-			IL_00c8: ldelem.ref
-			IL_00c9: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_00ce: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_00d3: stloc.1
-			IL_00d4: ldstr "crypto"
-			IL_00d9: ldloc.1
-			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00df: stloc.1
-			IL_00e0: ldloc.1
-			IL_00e1: ldstr "webcrypto"
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00eb: stloc.1
-			IL_00ec: ldloc.1
-			IL_00ed: ldstr "subtle"
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f7: stloc.1
-			IL_00f8: ldloc.0
-			IL_00f9: ldloc.1
-			IL_00fa: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-			IL_00ff: ldarg.0
-			IL_0100: ldc.i4.1
-			IL_0101: ldelem.ref
-			IL_0102: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_0107: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_010c: stloc.1
-			IL_010d: ldstr "logPromiseError"
-			IL_0112: ldloc.1
-			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0118: stloc.1
-			IL_0119: ldc.i4.1
-			IL_011a: newarr [System.Runtime]System.Object
-			IL_011f: dup
-			IL_0120: ldc.i4.0
-			IL_0121: ldarg.0
-			IL_0122: ldc.i4.1
-			IL_0123: ldelem.ref
-			IL_0124: stelem.ref
-			IL_0125: stloc.2
-			IL_0126: ldnull
-			IL_0127: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L56C56::__js_call__(object[], object)
-			IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0132: ldc.i4.2
-			IL_0133: newarr [System.Runtime]System.Object
-			IL_0138: dup
-			IL_0139: ldc.i4.0
-			IL_013a: ldarg.0
-			IL_013b: ldc.i4.1
-			IL_013c: ldelem.ref
-			IL_013d: stelem.ref
-			IL_013e: dup
-			IL_013f: ldc.i4.1
-			IL_0140: ldloc.0
-			IL_0141: stelem.ref
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_014c: ldc.i4.0
-			IL_014d: conv.r8
-			IL_014e: ldstr ""
-			IL_0153: ldc.i4.0
-			IL_0154: ldc.i4.1
-			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_015f: stloc.3
-			IL_0160: ldloc.1
-			IL_0161: ldloc.2
-			IL_0162: ldstr "subtle digest unsupported"
-			IL_0167: ldloc.3
-			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_016d: stloc.3
-			IL_016e: ldloc.0
-			IL_016f: ldc.i4.1
-			IL_0170: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0175: ldloc.0
-			IL_0176: ldloc.3
-			IL_0177: ldarg.0
-			IL_0178: ldc.i4.1
-			IL_0179: ldloc.0
-			IL_017a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_017f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0184: ldloc.0
-			IL_0185: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_018a: dup
-			IL_018b: ldc.i4.0
-			IL_018c: ldloc.1
-			IL_018d: stelem.ref
-			IL_018e: dup
-			IL_018f: ldc.i4.1
-			IL_0190: ldloc.2
-			IL_0191: stelem.ref
-			IL_0192: dup
-			IL_0193: ldc.i4.2
-			IL_0194: ldloc.3
+			IL_00c1: ldloc.0
+			IL_00c2: ldarg.0
+			IL_00c3: ldc.i4.1
+			IL_00c4: ldelem.ref
+			IL_00c5: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_00ca: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_00cf: ldstr "webcrypto"
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d9: ldstr "subtle"
+			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e3: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
+			IL_00e8: ldc.i4.1
+			IL_00e9: newarr [System.Runtime]System.Object
+			IL_00ee: dup
+			IL_00ef: ldc.i4.0
+			IL_00f0: ldarg.0
+			IL_00f1: ldc.i4.1
+			IL_00f2: ldelem.ref
+			IL_00f3: stelem.ref
+			IL_00f4: stloc.1
+			IL_00f5: ldnull
+			IL_00f6: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L56C56::__js_call__(object[], object)
+			IL_00fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0101: ldc.i4.2
+			IL_0102: newarr [System.Runtime]System.Object
+			IL_0107: dup
+			IL_0108: ldc.i4.0
+			IL_0109: ldarg.0
+			IL_010a: ldc.i4.1
+			IL_010b: ldelem.ref
+			IL_010c: stelem.ref
+			IL_010d: dup
+			IL_010e: ldc.i4.1
+			IL_010f: ldloc.0
+			IL_0110: stelem.ref
+			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_011b: ldc.i4.0
+			IL_011c: conv.r8
+			IL_011d: ldstr ""
+			IL_0122: ldc.i4.0
+			IL_0123: ldc.i4.1
+			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_012e: stloc.2
+			IL_012f: ldarg.0
+			IL_0130: ldc.i4.1
+			IL_0131: ldelem.ref
+			IL_0132: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_0137: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_013c: ldloc.1
+			IL_013d: ldstr "subtle digest unsupported"
+			IL_0142: ldloc.2
+			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0148: stloc.2
+			IL_0149: ldloc.0
+			IL_014a: ldc.i4.1
+			IL_014b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0150: ldloc.0
+			IL_0151: ldloc.2
+			IL_0152: ldarg.0
+			IL_0153: ldc.i4.1
+			IL_0154: ldloc.0
+			IL_0155: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_015a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_015f: ldloc.0
+			IL_0160: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0165: dup
+			IL_0166: ldc.i4.0
+			IL_0167: ldloc.1
+			IL_0168: stelem.ref
+			IL_0169: dup
+			IL_016a: ldc.i4.1
+			IL_016b: ldloc.2
+			IL_016c: stelem.ref
+			IL_016d: dup
+			IL_016e: ldc.i4.2
+			IL_016f: ldloc.3
+			IL_0170: stelem.ref
+			IL_0171: dup
+			IL_0172: ldc.i4.3
+			IL_0173: ldloc.s 4
+			IL_0175: stelem.ref
+			IL_0176: pop
+			IL_0177: ldloc.0
+			IL_0178: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_017d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0182: ret
+
+			IL_0183: ldloc.0
+			IL_0184: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited1
+			IL_0189: pop
+			IL_018a: ldc.i4.1
+			IL_018b: newarr [System.Runtime]System.Object
+			IL_0190: dup
+			IL_0191: ldc.i4.0
+			IL_0192: ldarg.0
+			IL_0193: ldc.i4.1
+			IL_0194: ldelem.ref
 			IL_0195: stelem.ref
-			IL_0196: dup
-			IL_0197: ldc.i4.3
-			IL_0198: ldloc.s 4
-			IL_019a: stelem.ref
-			IL_019b: dup
-			IL_019c: ldc.i4.4
-			IL_019d: ldloc.s 5
-			IL_019f: stelem.ref
-			IL_01a0: pop
-			IL_01a1: ldloc.0
-			IL_01a2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01a7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01ac: ret
-
-			IL_01ad: ldloc.0
-			IL_01ae: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited1
-			IL_01b3: pop
-			IL_01b4: ldarg.0
-			IL_01b5: ldc.i4.1
-			IL_01b6: ldelem.ref
-			IL_01b7: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_01bc: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_01c1: stloc.3
-			IL_01c2: ldstr "logPromiseError"
-			IL_01c7: ldloc.3
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01cd: stloc.3
-			IL_01ce: ldc.i4.1
-			IL_01cf: newarr [System.Runtime]System.Object
-			IL_01d4: dup
-			IL_01d5: ldc.i4.0
-			IL_01d6: ldarg.0
-			IL_01d7: ldc.i4.1
-			IL_01d8: ldelem.ref
-			IL_01d9: stelem.ref
-			IL_01da: stloc.2
-			IL_01db: ldnull
-			IL_01dc: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L57C51::__js_call__(object[], object)
-			IL_01e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_01e7: ldc.i4.2
-			IL_01e8: newarr [System.Runtime]System.Object
-			IL_01ed: dup
-			IL_01ee: ldc.i4.0
-			IL_01ef: ldarg.0
-			IL_01f0: ldc.i4.1
-			IL_01f1: ldelem.ref
-			IL_01f2: stelem.ref
-			IL_01f3: dup
-			IL_01f4: ldc.i4.1
-			IL_01f5: ldloc.0
-			IL_01f6: stelem.ref
-			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0201: ldc.i4.0
-			IL_0202: conv.r8
-			IL_0203: ldstr ""
+			IL_0196: stloc.1
+			IL_0197: ldnull
+			IL_0198: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L57C51::__js_call__(object[], object)
+			IL_019e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_01a3: ldc.i4.2
+			IL_01a4: newarr [System.Runtime]System.Object
+			IL_01a9: dup
+			IL_01aa: ldc.i4.0
+			IL_01ab: ldarg.0
+			IL_01ac: ldc.i4.1
+			IL_01ad: ldelem.ref
+			IL_01ae: stelem.ref
+			IL_01af: dup
+			IL_01b0: ldc.i4.1
+			IL_01b1: ldloc.0
+			IL_01b2: stelem.ref
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_01bd: ldc.i4.0
+			IL_01be: conv.r8
+			IL_01bf: ldstr ""
+			IL_01c4: ldc.i4.0
+			IL_01c5: ldc.i4.1
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_01d0: stloc.2
+			IL_01d1: ldarg.0
+			IL_01d2: ldc.i4.1
+			IL_01d3: ldelem.ref
+			IL_01d4: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_01d9: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_01de: ldloc.1
+			IL_01df: ldstr "subtle import format"
+			IL_01e4: ldloc.2
+			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01ea: stloc.2
+			IL_01eb: ldloc.0
+			IL_01ec: ldc.i4.2
+			IL_01ed: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01f2: ldloc.0
+			IL_01f3: ldloc.2
+			IL_01f4: ldarg.0
+			IL_01f5: ldc.i4.2
+			IL_01f6: ldloc.0
+			IL_01f7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0201: ldloc.0
+			IL_0202: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0207: dup
 			IL_0208: ldc.i4.0
-			IL_0209: ldc.i4.1
-			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0214: stloc.1
-			IL_0215: ldloc.3
-			IL_0216: ldloc.2
-			IL_0217: ldstr "subtle import format"
-			IL_021c: ldloc.1
-			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0222: stloc.1
-			IL_0223: ldloc.0
-			IL_0224: ldc.i4.2
-			IL_0225: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_022a: ldloc.0
-			IL_022b: ldloc.1
-			IL_022c: ldarg.0
-			IL_022d: ldc.i4.2
-			IL_022e: ldloc.0
-			IL_022f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0234: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0239: ldloc.0
-			IL_023a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_023f: dup
-			IL_0240: ldc.i4.0
-			IL_0241: ldloc.1
-			IL_0242: stelem.ref
-			IL_0243: dup
-			IL_0244: ldc.i4.1
-			IL_0245: ldloc.2
-			IL_0246: stelem.ref
-			IL_0247: dup
-			IL_0248: ldc.i4.2
-			IL_0249: ldloc.3
-			IL_024a: stelem.ref
+			IL_0209: ldloc.1
+			IL_020a: stelem.ref
+			IL_020b: dup
+			IL_020c: ldc.i4.1
+			IL_020d: ldloc.2
+			IL_020e: stelem.ref
+			IL_020f: dup
+			IL_0210: ldc.i4.2
+			IL_0211: ldloc.3
+			IL_0212: stelem.ref
+			IL_0213: dup
+			IL_0214: ldc.i4.3
+			IL_0215: ldloc.s 4
+			IL_0217: stelem.ref
+			IL_0218: pop
+			IL_0219: ldloc.0
+			IL_021a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_021f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0224: ret
+
+			IL_0225: ldloc.0
+			IL_0226: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited2
+			IL_022b: pop
+			IL_022c: ldc.i4.1
+			IL_022d: newarr [System.Runtime]System.Object
+			IL_0232: dup
+			IL_0233: ldc.i4.0
+			IL_0234: ldarg.0
+			IL_0235: ldc.i4.1
+			IL_0236: ldelem.ref
+			IL_0237: stelem.ref
+			IL_0238: stloc.1
+			IL_0239: ldnull
+			IL_023a: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L63C53::__js_call__(object[], object)
+			IL_0240: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0245: ldc.i4.2
+			IL_0246: newarr [System.Runtime]System.Object
 			IL_024b: dup
-			IL_024c: ldc.i4.3
-			IL_024d: ldloc.s 4
-			IL_024f: stelem.ref
-			IL_0250: dup
-			IL_0251: ldc.i4.4
-			IL_0252: ldloc.s 5
+			IL_024c: ldc.i4.0
+			IL_024d: ldarg.0
+			IL_024e: ldc.i4.1
+			IL_024f: ldelem.ref
+			IL_0250: stelem.ref
+			IL_0251: dup
+			IL_0252: ldc.i4.1
+			IL_0253: ldloc.0
 			IL_0254: stelem.ref
-			IL_0255: pop
-			IL_0256: ldloc.0
-			IL_0257: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_025c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0261: ret
+			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_025f: ldc.i4.0
+			IL_0260: conv.r8
+			IL_0261: ldstr ""
+			IL_0266: ldc.i4.0
+			IL_0267: ldc.i4.1
+			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0272: stloc.2
+			IL_0273: ldarg.0
+			IL_0274: ldc.i4.1
+			IL_0275: ldelem.ref
+			IL_0276: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_027b: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_0280: ldloc.1
+			IL_0281: ldstr "subtle import key data"
+			IL_0286: ldloc.2
+			IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_028c: stloc.2
+			IL_028d: ldloc.0
+			IL_028e: ldc.i4.3
+			IL_028f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0294: ldloc.0
+			IL_0295: ldloc.2
+			IL_0296: ldarg.0
+			IL_0297: ldc.i4.3
+			IL_0298: ldloc.0
+			IL_0299: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_029e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02a3: ldloc.0
+			IL_02a4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02a9: dup
+			IL_02aa: ldc.i4.0
+			IL_02ab: ldloc.1
+			IL_02ac: stelem.ref
+			IL_02ad: dup
+			IL_02ae: ldc.i4.1
+			IL_02af: ldloc.2
+			IL_02b0: stelem.ref
+			IL_02b1: dup
+			IL_02b2: ldc.i4.2
+			IL_02b3: ldloc.3
+			IL_02b4: stelem.ref
+			IL_02b5: dup
+			IL_02b6: ldc.i4.3
+			IL_02b7: ldloc.s 4
+			IL_02b9: stelem.ref
+			IL_02ba: pop
+			IL_02bb: ldloc.0
+			IL_02bc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02c1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02c6: ret
 
-			IL_0262: ldloc.0
-			IL_0263: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited2
-			IL_0268: pop
-			IL_0269: ldarg.0
-			IL_026a: ldc.i4.1
-			IL_026b: ldelem.ref
-			IL_026c: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_0271: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_0276: stloc.1
-			IL_0277: ldstr "logPromiseError"
-			IL_027c: ldloc.1
-			IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0282: stloc.1
-			IL_0283: ldc.i4.1
-			IL_0284: newarr [System.Runtime]System.Object
-			IL_0289: dup
-			IL_028a: ldc.i4.0
-			IL_028b: ldarg.0
-			IL_028c: ldc.i4.1
-			IL_028d: ldelem.ref
-			IL_028e: stelem.ref
-			IL_028f: stloc.2
-			IL_0290: ldnull
-			IL_0291: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L63C53::__js_call__(object[], object)
-			IL_0297: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_029c: ldc.i4.2
-			IL_029d: newarr [System.Runtime]System.Object
-			IL_02a2: dup
-			IL_02a3: ldc.i4.0
-			IL_02a4: ldarg.0
-			IL_02a5: ldc.i4.1
-			IL_02a6: ldelem.ref
-			IL_02a7: stelem.ref
-			IL_02a8: dup
-			IL_02a9: ldc.i4.1
-			IL_02aa: ldloc.0
-			IL_02ab: stelem.ref
-			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_02b6: ldc.i4.0
-			IL_02b7: conv.r8
-			IL_02b8: ldstr ""
-			IL_02bd: ldc.i4.0
-			IL_02be: ldc.i4.1
-			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_02c9: stloc.3
-			IL_02ca: ldloc.1
-			IL_02cb: ldloc.2
-			IL_02cc: ldstr "subtle import key data"
-			IL_02d1: ldloc.3
-			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02d7: stloc.3
-			IL_02d8: ldloc.0
-			IL_02d9: ldc.i4.3
-			IL_02da: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02df: ldloc.0
-			IL_02e0: ldloc.3
-			IL_02e1: ldarg.0
-			IL_02e2: ldc.i4.3
-			IL_02e3: ldloc.0
-			IL_02e4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02ee: ldloc.0
-			IL_02ef: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02f4: dup
-			IL_02f5: ldc.i4.0
-			IL_02f6: ldloc.1
-			IL_02f7: stelem.ref
-			IL_02f8: dup
-			IL_02f9: ldc.i4.1
-			IL_02fa: ldloc.2
-			IL_02fb: stelem.ref
-			IL_02fc: dup
-			IL_02fd: ldc.i4.2
-			IL_02fe: ldloc.3
-			IL_02ff: stelem.ref
-			IL_0300: dup
-			IL_0301: ldc.i4.3
-			IL_0302: ldloc.s 4
-			IL_0304: stelem.ref
-			IL_0305: dup
-			IL_0306: ldc.i4.4
-			IL_0307: ldloc.s 5
-			IL_0309: stelem.ref
-			IL_030a: pop
-			IL_030b: ldloc.0
-			IL_030c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0311: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0316: ret
-
-			IL_0317: ldloc.0
-			IL_0318: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited3
-			IL_031d: pop
-			IL_031e: ldarg.0
-			IL_031f: ldc.i4.1
-			IL_0320: ldelem.ref
-			IL_0321: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_0326: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_032b: stloc.3
-			IL_032c: ldstr "logPromiseError"
-			IL_0331: ldloc.3
-			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0337: stloc.3
-			IL_0338: ldc.i4.1
-			IL_0339: newarr [System.Runtime]System.Object
-			IL_033e: dup
-			IL_033f: ldc.i4.0
-			IL_0340: ldarg.0
-			IL_0341: ldc.i4.1
-			IL_0342: ldelem.ref
-			IL_0343: stelem.ref
-			IL_0344: stloc.2
-			IL_0345: ldnull
-			IL_0346: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L69C57::__js_call__(object[], object)
-			IL_034c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0351: ldc.i4.2
-			IL_0352: newarr [System.Runtime]System.Object
+			IL_02c7: ldloc.0
+			IL_02c8: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited3
+			IL_02cd: pop
+			IL_02ce: ldc.i4.1
+			IL_02cf: newarr [System.Runtime]System.Object
+			IL_02d4: dup
+			IL_02d5: ldc.i4.0
+			IL_02d6: ldarg.0
+			IL_02d7: ldc.i4.1
+			IL_02d8: ldelem.ref
+			IL_02d9: stelem.ref
+			IL_02da: stloc.1
+			IL_02db: ldnull
+			IL_02dc: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L69C57::__js_call__(object[], object)
+			IL_02e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_02e7: ldc.i4.2
+			IL_02e8: newarr [System.Runtime]System.Object
+			IL_02ed: dup
+			IL_02ee: ldc.i4.0
+			IL_02ef: ldarg.0
+			IL_02f0: ldc.i4.1
+			IL_02f1: ldelem.ref
+			IL_02f2: stelem.ref
+			IL_02f3: dup
+			IL_02f4: ldc.i4.1
+			IL_02f5: ldloc.0
+			IL_02f6: stelem.ref
+			IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0301: ldc.i4.0
+			IL_0302: conv.r8
+			IL_0303: ldstr ""
+			IL_0308: ldc.i4.0
+			IL_0309: ldc.i4.1
+			IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0314: stloc.2
+			IL_0315: ldarg.0
+			IL_0316: ldc.i4.1
+			IL_0317: ldelem.ref
+			IL_0318: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_031d: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_0322: ldloc.1
+			IL_0323: ldstr "subtle import empty usages"
+			IL_0328: ldloc.2
+			IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_032e: stloc.2
+			IL_032f: ldloc.0
+			IL_0330: ldc.i4.4
+			IL_0331: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0336: ldloc.0
+			IL_0337: ldloc.2
+			IL_0338: ldarg.0
+			IL_0339: ldc.i4.4
+			IL_033a: ldloc.0
+			IL_033b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0340: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0345: ldloc.0
+			IL_0346: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_034b: dup
+			IL_034c: ldc.i4.0
+			IL_034d: ldloc.1
+			IL_034e: stelem.ref
+			IL_034f: dup
+			IL_0350: ldc.i4.1
+			IL_0351: ldloc.2
+			IL_0352: stelem.ref
+			IL_0353: dup
+			IL_0354: ldc.i4.2
+			IL_0355: ldloc.3
+			IL_0356: stelem.ref
 			IL_0357: dup
-			IL_0358: ldc.i4.0
-			IL_0359: ldarg.0
-			IL_035a: ldc.i4.1
-			IL_035b: ldelem.ref
-			IL_035c: stelem.ref
-			IL_035d: dup
-			IL_035e: ldc.i4.1
-			IL_035f: ldloc.0
-			IL_0360: stelem.ref
-			IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_036b: ldc.i4.0
-			IL_036c: conv.r8
-			IL_036d: ldstr ""
-			IL_0372: ldc.i4.0
-			IL_0373: ldc.i4.1
-			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_037e: stloc.1
-			IL_037f: ldloc.3
-			IL_0380: ldloc.2
-			IL_0381: ldstr "subtle import empty usages"
-			IL_0386: ldloc.1
-			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_038c: stloc.1
-			IL_038d: ldloc.0
-			IL_038e: ldc.i4.4
-			IL_038f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0394: ldloc.0
-			IL_0395: ldloc.1
-			IL_0396: ldarg.0
-			IL_0397: ldc.i4.4
-			IL_0398: ldloc.0
-			IL_0399: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_039e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_03a3: ldloc.0
-			IL_03a4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03a9: dup
+			IL_0358: ldc.i4.3
+			IL_0359: ldloc.s 4
+			IL_035b: stelem.ref
+			IL_035c: pop
+			IL_035d: ldloc.0
+			IL_035e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0363: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0368: ret
+
+			IL_0369: ldloc.0
+			IL_036a: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited4
+			IL_036f: pop
+			IL_0370: ldc.i4.1
+			IL_0371: newarr [System.Runtime]System.Object
+			IL_0376: dup
+			IL_0377: ldc.i4.0
+			IL_0378: ldarg.0
+			IL_0379: ldc.i4.1
+			IL_037a: ldelem.ref
+			IL_037b: stelem.ref
+			IL_037c: stloc.1
+			IL_037d: ldnull
+			IL_037e: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L75C63::__js_call__(object[], object)
+			IL_0384: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0389: ldc.i4.2
+			IL_038a: newarr [System.Runtime]System.Object
+			IL_038f: dup
+			IL_0390: ldc.i4.0
+			IL_0391: ldarg.0
+			IL_0392: ldc.i4.1
+			IL_0393: ldelem.ref
+			IL_0394: stelem.ref
+			IL_0395: dup
+			IL_0396: ldc.i4.1
+			IL_0397: ldloc.0
+			IL_0398: stelem.ref
+			IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_03a3: ldc.i4.0
+			IL_03a4: conv.r8
+			IL_03a5: ldstr ""
 			IL_03aa: ldc.i4.0
-			IL_03ab: ldloc.1
-			IL_03ac: stelem.ref
-			IL_03ad: dup
-			IL_03ae: ldc.i4.1
-			IL_03af: ldloc.2
-			IL_03b0: stelem.ref
-			IL_03b1: dup
-			IL_03b2: ldc.i4.2
-			IL_03b3: ldloc.3
-			IL_03b4: stelem.ref
-			IL_03b5: dup
-			IL_03b6: ldc.i4.3
-			IL_03b7: ldloc.s 4
-			IL_03b9: stelem.ref
-			IL_03ba: dup
-			IL_03bb: ldc.i4.4
-			IL_03bc: ldloc.s 5
-			IL_03be: stelem.ref
-			IL_03bf: pop
-			IL_03c0: ldloc.0
-			IL_03c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03c6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03cb: ret
-
-			IL_03cc: ldloc.0
-			IL_03cd: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited4
-			IL_03d2: pop
-			IL_03d3: ldarg.0
-			IL_03d4: ldc.i4.1
-			IL_03d5: ldelem.ref
-			IL_03d6: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_03db: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_03e0: stloc.1
-			IL_03e1: ldstr "logPromiseError"
-			IL_03e6: ldloc.1
-			IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03ec: stloc.1
-			IL_03ed: ldc.i4.1
-			IL_03ee: newarr [System.Runtime]System.Object
-			IL_03f3: dup
-			IL_03f4: ldc.i4.0
-			IL_03f5: ldarg.0
-			IL_03f6: ldc.i4.1
-			IL_03f7: ldelem.ref
+			IL_03ab: ldc.i4.1
+			IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_03b6: stloc.2
+			IL_03b7: ldarg.0
+			IL_03b8: ldc.i4.1
+			IL_03b9: ldelem.ref
+			IL_03ba: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_03bf: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_03c4: ldloc.1
+			IL_03c5: ldstr "subtle import invalid usage enum"
+			IL_03ca: ldloc.2
+			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03d0: stloc.2
+			IL_03d1: ldloc.0
+			IL_03d2: ldc.i4.5
+			IL_03d3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03d8: ldloc.0
+			IL_03d9: ldloc.2
+			IL_03da: ldarg.0
+			IL_03db: ldc.i4.5
+			IL_03dc: ldloc.0
+			IL_03dd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_03e7: ldloc.0
+			IL_03e8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03ed: dup
+			IL_03ee: ldc.i4.0
+			IL_03ef: ldloc.1
+			IL_03f0: stelem.ref
+			IL_03f1: dup
+			IL_03f2: ldc.i4.1
+			IL_03f3: ldloc.2
+			IL_03f4: stelem.ref
+			IL_03f5: dup
+			IL_03f6: ldc.i4.2
+			IL_03f7: ldloc.3
 			IL_03f8: stelem.ref
-			IL_03f9: stloc.2
-			IL_03fa: ldnull
-			IL_03fb: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L75C63::__js_call__(object[], object)
-			IL_0401: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0406: ldc.i4.2
-			IL_0407: newarr [System.Runtime]System.Object
-			IL_040c: dup
-			IL_040d: ldc.i4.0
-			IL_040e: ldarg.0
-			IL_040f: ldc.i4.1
-			IL_0410: ldelem.ref
-			IL_0411: stelem.ref
-			IL_0412: dup
-			IL_0413: ldc.i4.1
-			IL_0414: ldloc.0
-			IL_0415: stelem.ref
-			IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0420: ldc.i4.0
-			IL_0421: conv.r8
-			IL_0422: ldstr ""
-			IL_0427: ldc.i4.0
-			IL_0428: ldc.i4.1
-			IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0433: stloc.3
-			IL_0434: ldloc.1
-			IL_0435: ldloc.2
-			IL_0436: ldstr "subtle import invalid usage enum"
-			IL_043b: ldloc.3
-			IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0441: stloc.3
-			IL_0442: ldloc.0
-			IL_0443: ldc.i4.5
-			IL_0444: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0449: ldloc.0
-			IL_044a: ldloc.3
-			IL_044b: ldarg.0
-			IL_044c: ldc.i4.5
-			IL_044d: ldloc.0
-			IL_044e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0453: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0458: ldloc.0
-			IL_0459: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_045e: dup
-			IL_045f: ldc.i4.0
-			IL_0460: ldloc.1
-			IL_0461: stelem.ref
-			IL_0462: dup
-			IL_0463: ldc.i4.1
-			IL_0464: ldloc.2
-			IL_0465: stelem.ref
-			IL_0466: dup
-			IL_0467: ldc.i4.2
-			IL_0468: ldloc.3
-			IL_0469: stelem.ref
-			IL_046a: dup
-			IL_046b: ldc.i4.3
-			IL_046c: ldloc.s 4
-			IL_046e: stelem.ref
-			IL_046f: dup
-			IL_0470: ldc.i4.4
-			IL_0471: ldloc.s 5
-			IL_0473: stelem.ref
-			IL_0474: pop
-			IL_0475: ldloc.0
-			IL_0476: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_047b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0480: ret
+			IL_03f9: dup
+			IL_03fa: ldc.i4.3
+			IL_03fb: ldloc.s 4
+			IL_03fd: stelem.ref
+			IL_03fe: pop
+			IL_03ff: ldloc.0
+			IL_0400: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0405: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_040a: ret
 
-			IL_0481: ldloc.0
-			IL_0482: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited5
-			IL_0487: pop
-			IL_0488: ldarg.0
-			IL_0489: ldc.i4.1
-			IL_048a: ldelem.ref
-			IL_048b: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_0490: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_0495: stloc.3
-			IL_0496: ldstr "logPromiseError"
-			IL_049b: ldloc.3
-			IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_04a1: stloc.3
-			IL_04a2: ldc.i4.1
-			IL_04a3: newarr [System.Runtime]System.Object
-			IL_04a8: dup
-			IL_04a9: ldc.i4.0
-			IL_04aa: ldarg.0
-			IL_04ab: ldc.i4.1
-			IL_04ac: ldelem.ref
-			IL_04ad: stelem.ref
-			IL_04ae: stloc.2
-			IL_04af: ldnull
-			IL_04b0: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L81C62::__js_call__(object[], object)
-			IL_04b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_04bb: ldc.i4.2
-			IL_04bc: newarr [System.Runtime]System.Object
-			IL_04c1: dup
-			IL_04c2: ldc.i4.0
-			IL_04c3: ldarg.0
-			IL_04c4: ldc.i4.1
-			IL_04c5: ldelem.ref
-			IL_04c6: stelem.ref
-			IL_04c7: dup
-			IL_04c8: ldc.i4.1
-			IL_04c9: ldloc.0
-			IL_04ca: stelem.ref
-			IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_04d5: ldc.i4.0
-			IL_04d6: conv.r8
-			IL_04d7: ldstr ""
-			IL_04dc: ldc.i4.0
-			IL_04dd: ldc.i4.1
-			IL_04de: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_04e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_04e8: stloc.1
-			IL_04e9: ldloc.3
-			IL_04ea: ldloc.2
-			IL_04eb: ldstr "subtle import unsupported usage"
-			IL_04f0: ldloc.1
-			IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04f6: stloc.1
-			IL_04f7: ldloc.0
-			IL_04f8: ldc.i4.6
-			IL_04f9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04fe: ldloc.0
-			IL_04ff: ldloc.1
-			IL_0500: ldarg.0
-			IL_0501: ldc.i4.6
-			IL_0502: ldloc.0
-			IL_0503: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0508: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_050d: ldloc.0
-			IL_050e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0513: dup
-			IL_0514: ldc.i4.0
-			IL_0515: ldloc.1
-			IL_0516: stelem.ref
-			IL_0517: dup
-			IL_0518: ldc.i4.1
-			IL_0519: ldloc.2
-			IL_051a: stelem.ref
-			IL_051b: dup
-			IL_051c: ldc.i4.2
-			IL_051d: ldloc.3
-			IL_051e: stelem.ref
-			IL_051f: dup
-			IL_0520: ldc.i4.3
-			IL_0521: ldloc.s 4
-			IL_0523: stelem.ref
-			IL_0524: dup
-			IL_0525: ldc.i4.4
-			IL_0526: ldloc.s 5
-			IL_0528: stelem.ref
-			IL_0529: pop
-			IL_052a: ldloc.0
-			IL_052b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0530: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0535: ret
+			IL_040b: ldloc.0
+			IL_040c: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited5
+			IL_0411: pop
+			IL_0412: ldc.i4.1
+			IL_0413: newarr [System.Runtime]System.Object
+			IL_0418: dup
+			IL_0419: ldc.i4.0
+			IL_041a: ldarg.0
+			IL_041b: ldc.i4.1
+			IL_041c: ldelem.ref
+			IL_041d: stelem.ref
+			IL_041e: stloc.1
+			IL_041f: ldnull
+			IL_0420: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L81C62::__js_call__(object[], object)
+			IL_0426: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_042b: ldc.i4.2
+			IL_042c: newarr [System.Runtime]System.Object
+			IL_0431: dup
+			IL_0432: ldc.i4.0
+			IL_0433: ldarg.0
+			IL_0434: ldc.i4.1
+			IL_0435: ldelem.ref
+			IL_0436: stelem.ref
+			IL_0437: dup
+			IL_0438: ldc.i4.1
+			IL_0439: ldloc.0
+			IL_043a: stelem.ref
+			IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0445: ldc.i4.0
+			IL_0446: conv.r8
+			IL_0447: ldstr ""
+			IL_044c: ldc.i4.0
+			IL_044d: ldc.i4.1
+			IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0458: stloc.2
+			IL_0459: ldarg.0
+			IL_045a: ldc.i4.1
+			IL_045b: ldelem.ref
+			IL_045c: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_0461: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_0466: ldloc.1
+			IL_0467: ldstr "subtle import unsupported usage"
+			IL_046c: ldloc.2
+			IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0472: stloc.2
+			IL_0473: ldloc.0
+			IL_0474: ldc.i4.6
+			IL_0475: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_047a: ldloc.0
+			IL_047b: ldloc.2
+			IL_047c: ldarg.0
+			IL_047d: ldc.i4.6
+			IL_047e: ldloc.0
+			IL_047f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0484: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0489: ldloc.0
+			IL_048a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_048f: dup
+			IL_0490: ldc.i4.0
+			IL_0491: ldloc.1
+			IL_0492: stelem.ref
+			IL_0493: dup
+			IL_0494: ldc.i4.1
+			IL_0495: ldloc.2
+			IL_0496: stelem.ref
+			IL_0497: dup
+			IL_0498: ldc.i4.2
+			IL_0499: ldloc.3
+			IL_049a: stelem.ref
+			IL_049b: dup
+			IL_049c: ldc.i4.3
+			IL_049d: ldloc.s 4
+			IL_049f: stelem.ref
+			IL_04a0: pop
+			IL_04a1: ldloc.0
+			IL_04a2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04a7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04ac: ret
 
-			IL_0536: ldloc.0
-			IL_0537: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited6
-			IL_053c: pop
-			IL_053d: ldarg.0
-			IL_053e: ldc.i4.1
-			IL_053f: ldelem.ref
-			IL_0540: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_0545: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_054a: stloc.1
-			IL_054b: ldstr "logPromiseError"
-			IL_0550: ldloc.1
-			IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0556: stloc.1
-			IL_0557: ldc.i4.1
-			IL_0558: newarr [System.Runtime]System.Object
-			IL_055d: dup
-			IL_055e: ldc.i4.0
-			IL_055f: ldarg.0
-			IL_0560: ldc.i4.1
-			IL_0561: ldelem.ref
-			IL_0562: stelem.ref
-			IL_0563: stloc.2
-			IL_0564: ldnull
-			IL_0565: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L87C53::__js_call__(object[], object)
-			IL_056b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0570: ldc.i4.2
-			IL_0571: newarr [System.Runtime]System.Object
-			IL_0576: dup
-			IL_0577: ldc.i4.0
-			IL_0578: ldarg.0
-			IL_0579: ldc.i4.1
-			IL_057a: ldelem.ref
-			IL_057b: stelem.ref
-			IL_057c: dup
-			IL_057d: ldc.i4.1
-			IL_057e: ldloc.0
-			IL_057f: stelem.ref
-			IL_0580: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0585: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_058a: ldc.i4.0
-			IL_058b: conv.r8
-			IL_058c: ldstr ""
-			IL_0591: ldc.i4.0
-			IL_0592: ldc.i4.1
-			IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_059d: stloc.3
-			IL_059e: ldloc.1
-			IL_059f: ldloc.2
-			IL_05a0: ldstr "subtle import zero key"
-			IL_05a5: ldloc.3
-			IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05ab: stloc.3
-			IL_05ac: ldloc.0
-			IL_05ad: ldc.i4.7
-			IL_05ae: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05b3: ldloc.0
-			IL_05b4: ldloc.3
-			IL_05b5: ldarg.0
-			IL_05b6: ldc.i4.7
+			IL_04ad: ldloc.0
+			IL_04ae: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited6
+			IL_04b3: pop
+			IL_04b4: ldc.i4.1
+			IL_04b5: newarr [System.Runtime]System.Object
+			IL_04ba: dup
+			IL_04bb: ldc.i4.0
+			IL_04bc: ldarg.0
+			IL_04bd: ldc.i4.1
+			IL_04be: ldelem.ref
+			IL_04bf: stelem.ref
+			IL_04c0: stloc.1
+			IL_04c1: ldnull
+			IL_04c2: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L87C53::__js_call__(object[], object)
+			IL_04c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_04cd: ldc.i4.2
+			IL_04ce: newarr [System.Runtime]System.Object
+			IL_04d3: dup
+			IL_04d4: ldc.i4.0
+			IL_04d5: ldarg.0
+			IL_04d6: ldc.i4.1
+			IL_04d7: ldelem.ref
+			IL_04d8: stelem.ref
+			IL_04d9: dup
+			IL_04da: ldc.i4.1
+			IL_04db: ldloc.0
+			IL_04dc: stelem.ref
+			IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_04e7: ldc.i4.0
+			IL_04e8: conv.r8
+			IL_04e9: ldstr ""
+			IL_04ee: ldc.i4.0
+			IL_04ef: ldc.i4.1
+			IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_04f5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_04fa: stloc.2
+			IL_04fb: ldarg.0
+			IL_04fc: ldc.i4.1
+			IL_04fd: ldelem.ref
+			IL_04fe: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_0503: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_0508: ldloc.1
+			IL_0509: ldstr "subtle import zero key"
+			IL_050e: ldloc.2
+			IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0514: stloc.2
+			IL_0515: ldloc.0
+			IL_0516: ldc.i4.7
+			IL_0517: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_051c: ldloc.0
+			IL_051d: ldloc.2
+			IL_051e: ldarg.0
+			IL_051f: ldc.i4.7
+			IL_0520: ldloc.0
+			IL_0521: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0526: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_052b: ldloc.0
+			IL_052c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0531: dup
+			IL_0532: ldc.i4.0
+			IL_0533: ldloc.1
+			IL_0534: stelem.ref
+			IL_0535: dup
+			IL_0536: ldc.i4.1
+			IL_0537: ldloc.2
+			IL_0538: stelem.ref
+			IL_0539: dup
+			IL_053a: ldc.i4.2
+			IL_053b: ldloc.3
+			IL_053c: stelem.ref
+			IL_053d: dup
+			IL_053e: ldc.i4.3
+			IL_053f: ldloc.s 4
+			IL_0541: stelem.ref
+			IL_0542: pop
+			IL_0543: ldloc.0
+			IL_0544: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0549: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_054e: ret
+
+			IL_054f: ldloc.0
+			IL_0550: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited7
+			IL_0555: pop
+			IL_0556: ldc.i4.1
+			IL_0557: newarr [System.Runtime]System.Object
+			IL_055c: dup
+			IL_055d: ldc.i4.0
+			IL_055e: ldarg.0
+			IL_055f: ldc.i4.1
+			IL_0560: ldelem.ref
+			IL_0561: stelem.ref
+			IL_0562: stloc.1
+			IL_0563: ldnull
+			IL_0564: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L93C60::__js_call__(object[], object)
+			IL_056a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_056f: ldc.i4.2
+			IL_0570: newarr [System.Runtime]System.Object
+			IL_0575: dup
+			IL_0576: ldc.i4.0
+			IL_0577: ldarg.0
+			IL_0578: ldc.i4.1
+			IL_0579: ldelem.ref
+			IL_057a: stelem.ref
+			IL_057b: dup
+			IL_057c: ldc.i4.1
+			IL_057d: ldloc.0
+			IL_057e: stelem.ref
+			IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0589: ldc.i4.0
+			IL_058a: conv.r8
+			IL_058b: ldstr ""
+			IL_0590: ldc.i4.0
+			IL_0591: ldc.i4.1
+			IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_059c: stloc.2
+			IL_059d: ldarg.0
+			IL_059e: ldc.i4.1
+			IL_059f: ldelem.ref
+			IL_05a0: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_05a5: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_05aa: ldloc.1
+			IL_05ab: ldstr "subtle import length mismatch"
+			IL_05b0: ldloc.2
+			IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05b6: stloc.2
 			IL_05b7: ldloc.0
-			IL_05b8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_05b8: ldc.i4.8
+			IL_05b9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05be: ldloc.0
+			IL_05bf: ldloc.2
+			IL_05c0: ldarg.0
+			IL_05c1: ldc.i4.8
 			IL_05c2: ldloc.0
-			IL_05c3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05c8: dup
-			IL_05c9: ldc.i4.0
-			IL_05ca: ldloc.1
-			IL_05cb: stelem.ref
-			IL_05cc: dup
-			IL_05cd: ldc.i4.1
-			IL_05ce: ldloc.2
-			IL_05cf: stelem.ref
-			IL_05d0: dup
-			IL_05d1: ldc.i4.2
-			IL_05d2: ldloc.3
-			IL_05d3: stelem.ref
-			IL_05d4: dup
-			IL_05d5: ldc.i4.3
-			IL_05d6: ldloc.s 4
-			IL_05d8: stelem.ref
-			IL_05d9: dup
-			IL_05da: ldc.i4.4
-			IL_05db: ldloc.s 5
-			IL_05dd: stelem.ref
-			IL_05de: pop
-			IL_05df: ldloc.0
-			IL_05e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05e5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05ea: ret
+			IL_05c3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_05cd: ldloc.0
+			IL_05ce: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05d3: dup
+			IL_05d4: ldc.i4.0
+			IL_05d5: ldloc.1
+			IL_05d6: stelem.ref
+			IL_05d7: dup
+			IL_05d8: ldc.i4.1
+			IL_05d9: ldloc.2
+			IL_05da: stelem.ref
+			IL_05db: dup
+			IL_05dc: ldc.i4.2
+			IL_05dd: ldloc.3
+			IL_05de: stelem.ref
+			IL_05df: dup
+			IL_05e0: ldc.i4.3
+			IL_05e1: ldloc.s 4
+			IL_05e3: stelem.ref
+			IL_05e4: pop
+			IL_05e5: ldloc.0
+			IL_05e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05eb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05f0: ret
 
-			IL_05eb: ldloc.0
-			IL_05ec: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited7
-			IL_05f1: pop
-			IL_05f2: ldarg.0
-			IL_05f3: ldc.i4.1
-			IL_05f4: ldelem.ref
-			IL_05f5: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_05fa: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_05ff: stloc.3
-			IL_0600: ldstr "logPromiseError"
-			IL_0605: ldloc.3
-			IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_060b: stloc.3
-			IL_060c: ldc.i4.1
-			IL_060d: newarr [System.Runtime]System.Object
-			IL_0612: dup
-			IL_0613: ldc.i4.0
-			IL_0614: ldarg.0
-			IL_0615: ldc.i4.1
-			IL_0616: ldelem.ref
-			IL_0617: stelem.ref
-			IL_0618: stloc.2
-			IL_0619: ldnull
-			IL_061a: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L93C60::__js_call__(object[], object)
-			IL_0620: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0625: ldc.i4.2
-			IL_0626: newarr [System.Runtime]System.Object
-			IL_062b: dup
-			IL_062c: ldc.i4.0
-			IL_062d: ldarg.0
-			IL_062e: ldc.i4.1
-			IL_062f: ldelem.ref
-			IL_0630: stelem.ref
-			IL_0631: dup
-			IL_0632: ldc.i4.1
-			IL_0633: ldloc.0
-			IL_0634: stelem.ref
-			IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_063a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_063f: ldc.i4.0
-			IL_0640: conv.r8
-			IL_0641: ldstr ""
-			IL_0646: ldc.i4.0
-			IL_0647: ldc.i4.1
-			IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_064d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0652: stloc.1
-			IL_0653: ldloc.3
-			IL_0654: ldloc.2
-			IL_0655: ldstr "subtle import length mismatch"
-			IL_065a: ldloc.1
-			IL_065b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0660: stloc.1
-			IL_0661: ldloc.0
-			IL_0662: ldc.i4.8
-			IL_0663: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0668: ldloc.0
-			IL_0669: ldloc.1
-			IL_066a: ldarg.0
-			IL_066b: ldc.i4.8
-			IL_066c: ldloc.0
-			IL_066d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0672: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0677: ldloc.0
-			IL_0678: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_067d: dup
-			IL_067e: ldc.i4.0
-			IL_067f: ldloc.1
-			IL_0680: stelem.ref
-			IL_0681: dup
-			IL_0682: ldc.i4.1
-			IL_0683: ldloc.2
-			IL_0684: stelem.ref
-			IL_0685: dup
-			IL_0686: ldc.i4.2
-			IL_0687: ldloc.3
-			IL_0688: stelem.ref
-			IL_0689: dup
-			IL_068a: ldc.i4.3
-			IL_068b: ldloc.s 4
-			IL_068d: stelem.ref
-			IL_068e: dup
-			IL_068f: ldc.i4.4
-			IL_0690: ldloc.s 5
-			IL_0692: stelem.ref
-			IL_0693: pop
-			IL_0694: ldloc.0
-			IL_0695: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_069a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_069f: ret
+			IL_05f1: ldloc.0
+			IL_05f2: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited8
+			IL_05f7: pop
+			IL_05f8: ldloc.0
+			IL_05f9: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
+			IL_05fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0603: stloc.2
+			IL_0604: ldstr "key"
+			IL_0609: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_060e: stloc.3
+			IL_060f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0614: dup
+			IL_0615: ldstr "name"
+			IL_061a: ldstr "HMAC"
+			IL_061f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0624: dup
+			IL_0625: ldstr "hash"
+			IL_062a: ldstr "SHA-256"
+			IL_062f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0634: stloc.s 4
+			IL_0636: ldc.i4.5
+			IL_0637: newarr [System.Runtime]System.Object
+			IL_063c: dup
+			IL_063d: ldc.i4.0
+			IL_063e: ldstr "raw"
+			IL_0643: stelem.ref
+			IL_0644: dup
+			IL_0645: ldc.i4.1
+			IL_0646: ldloc.3
+			IL_0647: stelem.ref
+			IL_0648: dup
+			IL_0649: ldc.i4.2
+			IL_064a: ldloc.s 4
+			IL_064c: stelem.ref
+			IL_064d: dup
+			IL_064e: ldc.i4.3
+			IL_064f: ldc.i4.0
+			IL_0650: box [System.Runtime]System.Boolean
+			IL_0655: stelem.ref
+			IL_0656: dup
+			IL_0657: ldc.i4.4
+			IL_0658: ldc.i4.1
+			IL_0659: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_065e: dup
+			IL_065f: ldstr "verify"
+			IL_0664: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0669: stelem.ref
+			IL_066a: stloc.1
+			IL_066b: ldloc.2
+			IL_066c: ldstr "importKey"
+			IL_0671: ldloc.1
+			IL_0672: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0677: stloc.2
+			IL_0678: ldloc.0
+			IL_0679: ldc.i4.s 9
+			IL_067b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0680: ldloc.0
+			IL_0681: ldloc.2
+			IL_0682: ldarg.0
+			IL_0683: ldc.i4.s 9
+			IL_0685: ldloc.0
+			IL_0686: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_068b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0690: ldloc.0
+			IL_0691: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0696: dup
+			IL_0697: ldc.i4.0
+			IL_0698: ldloc.1
+			IL_0699: stelem.ref
+			IL_069a: dup
+			IL_069b: ldc.i4.1
+			IL_069c: ldloc.2
+			IL_069d: stelem.ref
+			IL_069e: dup
+			IL_069f: ldc.i4.2
+			IL_06a0: ldloc.3
+			IL_06a1: stelem.ref
+			IL_06a2: dup
+			IL_06a3: ldc.i4.3
+			IL_06a4: ldloc.s 4
+			IL_06a6: stelem.ref
+			IL_06a7: pop
+			IL_06a8: ldloc.0
+			IL_06a9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06ae: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06b3: ret
 
-			IL_06a0: ldloc.0
-			IL_06a1: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited8
-			IL_06a6: pop
-			IL_06a7: ldloc.0
-			IL_06a8: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-			IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06b2: stloc.1
-			IL_06b3: ldstr "key"
-			IL_06b8: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_06bd: stloc.s 4
-			IL_06bf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_06c4: dup
-			IL_06c5: ldstr "name"
-			IL_06ca: ldstr "HMAC"
-			IL_06cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06d4: dup
-			IL_06d5: ldstr "hash"
-			IL_06da: ldstr "SHA-256"
-			IL_06df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06e4: stloc.s 5
-			IL_06e6: ldc.i4.5
-			IL_06e7: newarr [System.Runtime]System.Object
-			IL_06ec: dup
-			IL_06ed: ldc.i4.0
-			IL_06ee: ldstr "raw"
-			IL_06f3: stelem.ref
-			IL_06f4: dup
-			IL_06f5: ldc.i4.1
-			IL_06f6: ldloc.s 4
-			IL_06f8: stelem.ref
-			IL_06f9: dup
-			IL_06fa: ldc.i4.2
-			IL_06fb: ldloc.s 5
-			IL_06fd: stelem.ref
-			IL_06fe: dup
-			IL_06ff: ldc.i4.3
-			IL_0700: ldc.i4.0
-			IL_0701: box [System.Runtime]System.Boolean
-			IL_0706: stelem.ref
-			IL_0707: dup
-			IL_0708: ldc.i4.4
-			IL_0709: ldc.i4.1
-			IL_070a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_070f: dup
-			IL_0710: ldstr "verify"
-			IL_0715: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_071a: stelem.ref
-			IL_071b: stloc.2
-			IL_071c: ldloc.1
-			IL_071d: ldstr "importKey"
-			IL_0722: ldloc.2
-			IL_0723: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0728: stloc.1
-			IL_0729: ldloc.0
-			IL_072a: ldc.i4.s 9
-			IL_072c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0731: ldloc.0
-			IL_0732: ldloc.1
-			IL_0733: ldarg.0
-			IL_0734: ldc.i4.s 9
-			IL_0736: ldloc.0
-			IL_0737: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_073c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0741: ldloc.0
-			IL_0742: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0747: dup
-			IL_0748: ldc.i4.0
-			IL_0749: ldloc.1
-			IL_074a: stelem.ref
-			IL_074b: dup
-			IL_074c: ldc.i4.1
-			IL_074d: ldloc.2
-			IL_074e: stelem.ref
-			IL_074f: dup
-			IL_0750: ldc.i4.2
-			IL_0751: ldloc.3
-			IL_0752: stelem.ref
-			IL_0753: dup
-			IL_0754: ldc.i4.3
-			IL_0755: ldloc.s 4
-			IL_0757: stelem.ref
-			IL_0758: dup
-			IL_0759: ldc.i4.4
-			IL_075a: ldloc.s 5
-			IL_075c: stelem.ref
-			IL_075d: pop
-			IL_075e: ldloc.0
-			IL_075f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0764: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0769: ret
+			IL_06b4: ldloc.0
+			IL_06b5: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited9
+			IL_06ba: stloc.2
+			IL_06bb: ldloc.0
+			IL_06bc: ldloc.2
+			IL_06bd: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
+			IL_06c2: ldc.i4.1
+			IL_06c3: newarr [System.Runtime]System.Object
+			IL_06c8: dup
+			IL_06c9: ldc.i4.0
+			IL_06ca: ldarg.0
+			IL_06cb: ldc.i4.1
+			IL_06cc: ldelem.ref
+			IL_06cd: stelem.ref
+			IL_06ce: stloc.1
+			IL_06cf: ldnull
+			IL_06d0: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L107C52::__js_call__(object[], object)
+			IL_06d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_06db: ldc.i4.2
+			IL_06dc: newarr [System.Runtime]System.Object
+			IL_06e1: dup
+			IL_06e2: ldc.i4.0
+			IL_06e3: ldarg.0
+			IL_06e4: ldc.i4.1
+			IL_06e5: ldelem.ref
+			IL_06e6: stelem.ref
+			IL_06e7: dup
+			IL_06e8: ldc.i4.1
+			IL_06e9: ldloc.0
+			IL_06ea: stelem.ref
+			IL_06eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_06f5: ldc.i4.0
+			IL_06f6: conv.r8
+			IL_06f7: ldstr ""
+			IL_06fc: ldc.i4.0
+			IL_06fd: ldc.i4.1
+			IL_06fe: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0703: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0708: stloc.2
+			IL_0709: ldarg.0
+			IL_070a: ldc.i4.1
+			IL_070b: ldelem.ref
+			IL_070c: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_0711: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_0716: ldloc.1
+			IL_0717: ldstr "subtle sign algorithm"
+			IL_071c: ldloc.2
+			IL_071d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0722: stloc.2
+			IL_0723: ldloc.0
+			IL_0724: ldc.i4.s 10
+			IL_0726: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_072b: ldloc.0
+			IL_072c: ldloc.2
+			IL_072d: ldarg.0
+			IL_072e: ldc.i4.s 10
+			IL_0730: ldloc.0
+			IL_0731: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0736: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_073b: ldloc.0
+			IL_073c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0741: dup
+			IL_0742: ldc.i4.0
+			IL_0743: ldloc.1
+			IL_0744: stelem.ref
+			IL_0745: dup
+			IL_0746: ldc.i4.1
+			IL_0747: ldloc.2
+			IL_0748: stelem.ref
+			IL_0749: dup
+			IL_074a: ldc.i4.2
+			IL_074b: ldloc.3
+			IL_074c: stelem.ref
+			IL_074d: dup
+			IL_074e: ldc.i4.3
+			IL_074f: ldloc.s 4
+			IL_0751: stelem.ref
+			IL_0752: pop
+			IL_0753: ldloc.0
+			IL_0754: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0759: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_075e: ret
 
-			IL_076a: ldloc.0
-			IL_076b: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited9
-			IL_0770: stloc.1
-			IL_0771: ldloc.0
-			IL_0772: ldloc.1
-			IL_0773: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
-			IL_0778: ldarg.0
-			IL_0779: ldc.i4.1
-			IL_077a: ldelem.ref
-			IL_077b: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_0780: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_0785: stloc.1
-			IL_0786: ldstr "logPromiseError"
-			IL_078b: ldloc.1
-			IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0791: stloc.1
-			IL_0792: ldc.i4.1
-			IL_0793: newarr [System.Runtime]System.Object
-			IL_0798: dup
+			IL_075f: ldloc.0
+			IL_0760: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited10
+			IL_0765: pop
+			IL_0766: ldc.i4.1
+			IL_0767: newarr [System.Runtime]System.Object
+			IL_076c: dup
+			IL_076d: ldc.i4.0
+			IL_076e: ldarg.0
+			IL_076f: ldc.i4.1
+			IL_0770: ldelem.ref
+			IL_0771: stelem.ref
+			IL_0772: stloc.1
+			IL_0773: ldnull
+			IL_0774: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L108C48::__js_call__(object[], object)
+			IL_077a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_077f: ldc.i4.2
+			IL_0780: newarr [System.Runtime]System.Object
+			IL_0785: dup
+			IL_0786: ldc.i4.0
+			IL_0787: ldarg.0
+			IL_0788: ldc.i4.1
+			IL_0789: ldelem.ref
+			IL_078a: stelem.ref
+			IL_078b: dup
+			IL_078c: ldc.i4.1
+			IL_078d: ldloc.0
+			IL_078e: stelem.ref
+			IL_078f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0794: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 			IL_0799: ldc.i4.0
-			IL_079a: ldarg.0
-			IL_079b: ldc.i4.1
-			IL_079c: ldelem.ref
-			IL_079d: stelem.ref
-			IL_079e: stloc.2
-			IL_079f: ldnull
-			IL_07a0: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L107C52::__js_call__(object[], object)
-			IL_07a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_07ab: ldc.i4.2
-			IL_07ac: newarr [System.Runtime]System.Object
-			IL_07b1: dup
-			IL_07b2: ldc.i4.0
-			IL_07b3: ldarg.0
-			IL_07b4: ldc.i4.1
-			IL_07b5: ldelem.ref
-			IL_07b6: stelem.ref
-			IL_07b7: dup
-			IL_07b8: ldc.i4.1
-			IL_07b9: ldloc.0
-			IL_07ba: stelem.ref
-			IL_07bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_07c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_07c5: ldc.i4.0
-			IL_07c6: conv.r8
-			IL_07c7: ldstr ""
-			IL_07cc: ldc.i4.0
-			IL_07cd: ldc.i4.1
-			IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_07d3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_07d8: stloc.3
-			IL_07d9: ldloc.1
-			IL_07da: ldloc.2
-			IL_07db: ldstr "subtle sign algorithm"
-			IL_07e0: ldloc.3
-			IL_07e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_07e6: stloc.3
-			IL_07e7: ldloc.0
-			IL_07e8: ldc.i4.s 10
-			IL_07ea: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07ef: ldloc.0
-			IL_07f0: ldloc.3
-			IL_07f1: ldarg.0
-			IL_07f2: ldc.i4.s 10
-			IL_07f4: ldloc.0
-			IL_07f5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_07fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_07ff: ldloc.0
-			IL_0800: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0805: dup
-			IL_0806: ldc.i4.0
-			IL_0807: ldloc.1
-			IL_0808: stelem.ref
-			IL_0809: dup
-			IL_080a: ldc.i4.1
-			IL_080b: ldloc.2
-			IL_080c: stelem.ref
-			IL_080d: dup
-			IL_080e: ldc.i4.2
-			IL_080f: ldloc.3
-			IL_0810: stelem.ref
-			IL_0811: dup
-			IL_0812: ldc.i4.3
-			IL_0813: ldloc.s 4
-			IL_0815: stelem.ref
-			IL_0816: dup
-			IL_0817: ldc.i4.4
-			IL_0818: ldloc.s 5
-			IL_081a: stelem.ref
-			IL_081b: pop
-			IL_081c: ldloc.0
-			IL_081d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0822: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0827: ret
+			IL_079a: conv.r8
+			IL_079b: ldstr ""
+			IL_07a0: ldc.i4.0
+			IL_07a1: ldc.i4.1
+			IL_07a2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_07a7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_07ac: stloc.2
+			IL_07ad: ldarg.0
+			IL_07ae: ldc.i4.1
+			IL_07af: ldelem.ref
+			IL_07b0: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_07b5: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_07ba: ldloc.1
+			IL_07bb: ldstr "subtle sign usage"
+			IL_07c0: ldloc.2
+			IL_07c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_07c6: stloc.2
+			IL_07c7: ldloc.0
+			IL_07c8: ldc.i4.s 11
+			IL_07ca: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07cf: ldloc.0
+			IL_07d0: ldloc.2
+			IL_07d1: ldarg.0
+			IL_07d2: ldc.i4.s 11
+			IL_07d4: ldloc.0
+			IL_07d5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_07df: ldloc.0
+			IL_07e0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_07e5: dup
+			IL_07e6: ldc.i4.0
+			IL_07e7: ldloc.1
+			IL_07e8: stelem.ref
+			IL_07e9: dup
+			IL_07ea: ldc.i4.1
+			IL_07eb: ldloc.2
+			IL_07ec: stelem.ref
+			IL_07ed: dup
+			IL_07ee: ldc.i4.2
+			IL_07ef: ldloc.3
+			IL_07f0: stelem.ref
+			IL_07f1: dup
+			IL_07f2: ldc.i4.3
+			IL_07f3: ldloc.s 4
+			IL_07f5: stelem.ref
+			IL_07f6: pop
+			IL_07f7: ldloc.0
+			IL_07f8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07fd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0802: ret
 
-			IL_0828: ldloc.0
-			IL_0829: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited10
-			IL_082e: pop
-			IL_082f: ldarg.0
-			IL_0830: ldc.i4.1
-			IL_0831: ldelem.ref
-			IL_0832: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_0837: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_083c: stloc.3
-			IL_083d: ldstr "logPromiseError"
-			IL_0842: ldloc.3
-			IL_0843: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0848: stloc.3
-			IL_0849: ldc.i4.1
-			IL_084a: newarr [System.Runtime]System.Object
-			IL_084f: dup
-			IL_0850: ldc.i4.0
-			IL_0851: ldarg.0
-			IL_0852: ldc.i4.1
-			IL_0853: ldelem.ref
-			IL_0854: stelem.ref
-			IL_0855: stloc.2
-			IL_0856: ldnull
-			IL_0857: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L108C48::__js_call__(object[], object)
-			IL_085d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0862: ldc.i4.2
-			IL_0863: newarr [System.Runtime]System.Object
-			IL_0868: dup
-			IL_0869: ldc.i4.0
-			IL_086a: ldarg.0
-			IL_086b: ldc.i4.1
-			IL_086c: ldelem.ref
-			IL_086d: stelem.ref
-			IL_086e: dup
-			IL_086f: ldc.i4.1
-			IL_0870: ldloc.0
-			IL_0871: stelem.ref
-			IL_0872: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0877: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_087c: ldc.i4.0
-			IL_087d: conv.r8
-			IL_087e: ldstr ""
-			IL_0883: ldc.i4.0
-			IL_0884: ldc.i4.1
-			IL_0885: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_088a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_088f: stloc.1
-			IL_0890: ldloc.3
-			IL_0891: ldloc.2
-			IL_0892: ldstr "subtle sign usage"
-			IL_0897: ldloc.1
-			IL_0898: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_089d: stloc.1
-			IL_089e: ldloc.0
-			IL_089f: ldc.i4.s 11
-			IL_08a1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08a6: ldloc.0
-			IL_08a7: ldloc.1
-			IL_08a8: ldarg.0
-			IL_08a9: ldc.i4.s 11
-			IL_08ab: ldloc.0
-			IL_08ac: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_08b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_08b6: ldloc.0
-			IL_08b7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_08bc: dup
-			IL_08bd: ldc.i4.0
-			IL_08be: ldloc.1
-			IL_08bf: stelem.ref
-			IL_08c0: dup
-			IL_08c1: ldc.i4.1
-			IL_08c2: ldloc.2
-			IL_08c3: stelem.ref
-			IL_08c4: dup
-			IL_08c5: ldc.i4.2
-			IL_08c6: ldloc.3
-			IL_08c7: stelem.ref
-			IL_08c8: dup
-			IL_08c9: ldc.i4.3
-			IL_08ca: ldloc.s 4
-			IL_08cc: stelem.ref
-			IL_08cd: dup
-			IL_08ce: ldc.i4.4
-			IL_08cf: ldloc.s 5
-			IL_08d1: stelem.ref
-			IL_08d2: pop
-			IL_08d3: ldloc.0
-			IL_08d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08d9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08de: ret
-
-			IL_08df: ldloc.0
-			IL_08e0: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited11
-			IL_08e5: pop
-			IL_08e6: ldloc.0
-			IL_08e7: ldc.i4.m1
-			IL_08e8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08ed: ldloc.0
-			IL_08ee: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_08f8: ldarg.0
-			IL_08f9: ldc.i4.1
-			IL_08fa: newarr [System.Runtime]System.Object
-			IL_08ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0904: pop
-			IL_0905: ldloc.0
-			IL_0906: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_090b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0910: ret
+			IL_0803: ldloc.0
+			IL_0804: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited11
+			IL_0809: pop
+			IL_080a: ldloc.0
+			IL_080b: ldc.i4.m1
+			IL_080c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0811: ldloc.0
+			IL_0812: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0817: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_081c: ldarg.0
+			IL_081d: ldc.i4.1
+			IL_081e: newarr [System.Runtime]System.Object
+			IL_0823: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0828: pop
+			IL_0829: ldloc.0
+			IL_082a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_082f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0834: ret
 		} // end of method runWebCryptoErrors::__js_call__
 
 	} // end of class runWebCryptoErrors
@@ -4260,7 +3959,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4348
+				// Method begins at RVA 0x40be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4283,7 +3982,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3c2c
+			// Method begins at RVA 0x3a4c
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -4335,7 +4034,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x41fb
+			// Method begins at RVA 0x3f71
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5191,7 +4890,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4351
+		// Method begins at RVA 0x40c7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
@@ -69,7 +69,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2cee
+				// Method begins at RVA 0x2cd2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -95,7 +95,7 @@
 			)
 			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 2998 (0xbb6)
+			// Code size: 2972 (0xb9c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_Crypto_WebCrypto_Subtle/run/Scope,
@@ -230,1190 +230,1180 @@
 
 			IL_00e2: ldloc.0
 			IL_00e3: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00e8: switch (IL_0111, IL_01f3, IL_034c, IL_045a, IL_0568, IL_06d9, IL_08c6, IL_0a0b, IL_0b6f)
+			IL_00e8: switch (IL_0111, IL_01d9, IL_0332, IL_0440, IL_054e, IL_06bf, IL_08ac, IL_09f1, IL_0b55)
 
 			IL_0111: ldarg.0
 			IL_0112: ldc.i4.1
 			IL_0113: ldelem.ref
 			IL_0114: castclass Modules.Require_Crypto_WebCrypto_Subtle/Scope
 			IL_0119: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/Scope::crypto
-			IL_011e: stloc.s 8
-			IL_0120: ldstr "crypto"
-			IL_0125: ldloc.s 8
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_012c: stloc.s 8
-			IL_012e: ldloc.s 8
-			IL_0130: ldstr "webcrypto"
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_013a: stloc.s 8
-			IL_013c: ldloc.s 8
-			IL_013e: ldstr "subtle"
-			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0148: stloc.s 8
-			IL_014a: ldloc.s 8
-			IL_014c: stloc.1
-			IL_014d: ldloc.1
-			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0153: stloc.s 8
-			IL_0155: ldstr "abc"
-			IL_015a: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_015f: stloc.s 9
-			IL_0161: ldloc.s 8
-			IL_0163: ldstr "digest"
-			IL_0168: ldstr "SHA-256"
-			IL_016d: ldloc.s 9
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0174: stloc.s 8
-			IL_0176: ldloc.0
-			IL_0177: ldc.i4.1
-			IL_0178: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_017d: ldloc.0
-			IL_017e: ldloc.s 8
-			IL_0180: ldarg.0
-			IL_0181: ldc.i4.1
-			IL_0182: ldloc.0
-			IL_0183: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0188: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_018d: ldloc.0
-			IL_018e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0193: dup
-			IL_0194: ldc.i4.0
-			IL_0195: ldloc.1
-			IL_0196: stelem.ref
-			IL_0197: dup
-			IL_0198: ldc.i4.1
-			IL_0199: ldloc.2
-			IL_019a: stelem.ref
-			IL_019b: dup
-			IL_019c: ldc.i4.2
-			IL_019d: ldloc.3
-			IL_019e: stelem.ref
-			IL_019f: dup
-			IL_01a0: ldc.i4.3
-			IL_01a1: ldloc.s 4
-			IL_01a3: stelem.ref
-			IL_01a4: dup
-			IL_01a5: ldc.i4.4
-			IL_01a6: ldloc.s 5
+			IL_011e: ldstr "webcrypto"
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0128: ldstr "subtle"
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0132: stloc.1
+			IL_0133: ldloc.1
+			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0139: stloc.s 8
+			IL_013b: ldstr "abc"
+			IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0145: stloc.s 9
+			IL_0147: ldloc.s 8
+			IL_0149: ldstr "digest"
+			IL_014e: ldstr "SHA-256"
+			IL_0153: ldloc.s 9
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_015a: stloc.s 8
+			IL_015c: ldloc.0
+			IL_015d: ldc.i4.1
+			IL_015e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0163: ldloc.0
+			IL_0164: ldloc.s 8
+			IL_0166: ldarg.0
+			IL_0167: ldc.i4.1
+			IL_0168: ldloc.0
+			IL_0169: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_016e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0173: ldloc.0
+			IL_0174: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0179: dup
+			IL_017a: ldc.i4.0
+			IL_017b: ldloc.1
+			IL_017c: stelem.ref
+			IL_017d: dup
+			IL_017e: ldc.i4.1
+			IL_017f: ldloc.2
+			IL_0180: stelem.ref
+			IL_0181: dup
+			IL_0182: ldc.i4.2
+			IL_0183: ldloc.3
+			IL_0184: stelem.ref
+			IL_0185: dup
+			IL_0186: ldc.i4.3
+			IL_0187: ldloc.s 4
+			IL_0189: stelem.ref
+			IL_018a: dup
+			IL_018b: ldc.i4.4
+			IL_018c: ldloc.s 5
+			IL_018e: stelem.ref
+			IL_018f: dup
+			IL_0190: ldc.i4.5
+			IL_0191: ldloc.s 6
+			IL_0193: stelem.ref
+			IL_0194: dup
+			IL_0195: ldc.i4.6
+			IL_0196: ldloc.s 7
+			IL_0198: stelem.ref
+			IL_0199: dup
+			IL_019a: ldc.i4.7
+			IL_019b: ldloc.s 8
+			IL_019d: stelem.ref
+			IL_019e: dup
+			IL_019f: ldc.i4.8
+			IL_01a0: ldloc.s 9
+			IL_01a2: stelem.ref
+			IL_01a3: dup
+			IL_01a4: ldc.i4.s 9
+			IL_01a6: ldloc.s 10
 			IL_01a8: stelem.ref
 			IL_01a9: dup
-			IL_01aa: ldc.i4.5
-			IL_01ab: ldloc.s 6
-			IL_01ad: stelem.ref
-			IL_01ae: dup
-			IL_01af: ldc.i4.6
-			IL_01b0: ldloc.s 7
-			IL_01b2: stelem.ref
-			IL_01b3: dup
-			IL_01b4: ldc.i4.7
-			IL_01b5: ldloc.s 8
-			IL_01b7: stelem.ref
-			IL_01b8: dup
-			IL_01b9: ldc.i4.8
-			IL_01ba: ldloc.s 9
-			IL_01bc: stelem.ref
-			IL_01bd: dup
-			IL_01be: ldc.i4.s 9
-			IL_01c0: ldloc.s 10
-			IL_01c2: stelem.ref
-			IL_01c3: dup
-			IL_01c4: ldc.i4.s 10
-			IL_01c6: ldloc.s 11
-			IL_01c8: stelem.ref
-			IL_01c9: dup
-			IL_01ca: ldc.i4.s 11
-			IL_01cc: ldloc.s 12
-			IL_01ce: stelem.ref
-			IL_01cf: dup
-			IL_01d0: ldc.i4.s 12
-			IL_01d2: ldloc.s 13
-			IL_01d4: stelem.ref
-			IL_01d5: dup
-			IL_01d6: ldc.i4.s 13
-			IL_01d8: ldloc.s 14
-			IL_01da: stelem.ref
-			IL_01db: dup
-			IL_01dc: ldc.i4.s 14
-			IL_01de: ldloc.s 15
-			IL_01e0: box [System.Runtime]System.Double
-			IL_01e5: stelem.ref
-			IL_01e6: pop
-			IL_01e7: ldloc.0
-			IL_01e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01f2: ret
+			IL_01aa: ldc.i4.s 10
+			IL_01ac: ldloc.s 11
+			IL_01ae: stelem.ref
+			IL_01af: dup
+			IL_01b0: ldc.i4.s 11
+			IL_01b2: ldloc.s 12
+			IL_01b4: stelem.ref
+			IL_01b5: dup
+			IL_01b6: ldc.i4.s 12
+			IL_01b8: ldloc.s 13
+			IL_01ba: stelem.ref
+			IL_01bb: dup
+			IL_01bc: ldc.i4.s 13
+			IL_01be: ldloc.s 14
+			IL_01c0: stelem.ref
+			IL_01c1: dup
+			IL_01c2: ldc.i4.s 14
+			IL_01c4: ldloc.s 15
+			IL_01c6: box [System.Runtime]System.Double
+			IL_01cb: stelem.ref
+			IL_01cc: pop
+			IL_01cd: ldloc.0
+			IL_01ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01d3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01d8: ret
 
-			IL_01f3: ldloc.0
-			IL_01f4: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited1
+			IL_01d9: ldloc.0
+			IL_01da: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited1
+			IL_01df: stloc.s 8
+			IL_01e1: ldloc.s 8
+			IL_01e3: stloc.2
+			IL_01e4: ldloc.2
+			IL_01e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_01ea: stloc.s 10
+			IL_01ec: ldloc.s 10
+			IL_01ee: stloc.3
+			IL_01ef: ldstr "console"
+			IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_01f9: stloc.s 8
 			IL_01fb: ldloc.s 8
-			IL_01fd: stloc.2
-			IL_01fe: ldloc.2
-			IL_01ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_0204: stloc.s 10
-			IL_0206: ldloc.s 10
-			IL_0208: stloc.3
-			IL_0209: ldstr "console"
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0213: stloc.s 8
-			IL_0215: ldloc.s 8
-			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_021c: stloc.s 8
-			IL_021e: ldloc.s 8
-			IL_0220: ldstr "log"
-			IL_0225: ldstr "digest byteLength:"
-			IL_022a: ldloc.2
-			IL_022b: ldstr "byteLength"
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_023a: pop
-			IL_023b: ldstr "console"
-			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0245: stloc.s 8
-			IL_0247: ldloc.s 8
+			IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0202: stloc.s 8
+			IL_0204: ldloc.s 8
+			IL_0206: ldstr "log"
+			IL_020b: ldstr "digest byteLength:"
+			IL_0210: ldloc.2
+			IL_0211: ldstr "byteLength"
+			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0220: pop
+			IL_0221: ldstr "console"
+			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_022b: stloc.s 8
+			IL_022d: ldloc.s 8
+			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0234: stloc.s 8
+			IL_0236: ldloc.3
+			IL_0237: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_023c: stloc.s 11
+			IL_023e: ldloc.s 11
+			IL_0240: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0245: stloc.s 9
+			IL_0247: ldloc.s 9
 			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_024e: stloc.s 8
-			IL_0250: ldloc.3
-			IL_0251: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0256: stloc.s 11
-			IL_0258: ldloc.s 11
-			IL_025a: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_025f: stloc.s 9
-			IL_0261: ldloc.s 9
-			IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0268: stloc.s 12
-			IL_026a: ldloc.s 12
-			IL_026c: ldstr "toString"
-			IL_0271: ldstr "hex"
-			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_027b: stloc.s 12
-			IL_027d: ldloc.s 8
-			IL_027f: ldstr "log"
-			IL_0284: ldstr "digest hex:"
-			IL_0289: ldloc.s 12
-			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0290: pop
-			IL_0291: ldstr "console"
-			IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_029b: stloc.s 12
-			IL_029d: ldloc.s 12
-			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a4: stloc.s 12
-			IL_02a6: ldloc.1
-			IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ac: stloc.s 8
-			IL_02ae: ldstr "abc"
-			IL_02b3: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_02b8: stloc.s 9
-			IL_02ba: ldloc.s 8
-			IL_02bc: ldstr "digest"
-			IL_02c1: ldstr "SHA-1"
-			IL_02c6: ldloc.s 9
-			IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02cd: stloc.s 8
-			IL_02cf: ldloc.0
-			IL_02d0: ldc.i4.2
-			IL_02d1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02d6: ldloc.0
-			IL_02d7: ldloc.s 8
-			IL_02d9: ldarg.0
-			IL_02da: ldc.i4.2
-			IL_02db: ldloc.0
-			IL_02dc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02e6: ldloc.0
-			IL_02e7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02ec: dup
-			IL_02ed: ldc.i4.0
-			IL_02ee: ldloc.1
-			IL_02ef: stelem.ref
-			IL_02f0: dup
-			IL_02f1: ldc.i4.1
-			IL_02f2: ldloc.2
-			IL_02f3: stelem.ref
-			IL_02f4: dup
-			IL_02f5: ldc.i4.2
-			IL_02f6: ldloc.3
-			IL_02f7: stelem.ref
-			IL_02f8: dup
-			IL_02f9: ldc.i4.3
-			IL_02fa: ldloc.s 4
-			IL_02fc: stelem.ref
-			IL_02fd: dup
-			IL_02fe: ldc.i4.4
-			IL_02ff: ldloc.s 5
+			IL_024e: stloc.s 12
+			IL_0250: ldloc.s 12
+			IL_0252: ldstr "toString"
+			IL_0257: ldstr "hex"
+			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0261: stloc.s 12
+			IL_0263: ldloc.s 8
+			IL_0265: ldstr "log"
+			IL_026a: ldstr "digest hex:"
+			IL_026f: ldloc.s 12
+			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0276: pop
+			IL_0277: ldstr "console"
+			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0281: stloc.s 12
+			IL_0283: ldloc.s 12
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_028a: stloc.s 12
+			IL_028c: ldloc.1
+			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0292: stloc.s 8
+			IL_0294: ldstr "abc"
+			IL_0299: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_029e: stloc.s 9
+			IL_02a0: ldloc.s 8
+			IL_02a2: ldstr "digest"
+			IL_02a7: ldstr "SHA-1"
+			IL_02ac: ldloc.s 9
+			IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02b3: stloc.s 8
+			IL_02b5: ldloc.0
+			IL_02b6: ldc.i4.2
+			IL_02b7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02bc: ldloc.0
+			IL_02bd: ldloc.s 8
+			IL_02bf: ldarg.0
+			IL_02c0: ldc.i4.2
+			IL_02c1: ldloc.0
+			IL_02c2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02cc: ldloc.0
+			IL_02cd: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02d2: dup
+			IL_02d3: ldc.i4.0
+			IL_02d4: ldloc.1
+			IL_02d5: stelem.ref
+			IL_02d6: dup
+			IL_02d7: ldc.i4.1
+			IL_02d8: ldloc.2
+			IL_02d9: stelem.ref
+			IL_02da: dup
+			IL_02db: ldc.i4.2
+			IL_02dc: ldloc.3
+			IL_02dd: stelem.ref
+			IL_02de: dup
+			IL_02df: ldc.i4.3
+			IL_02e0: ldloc.s 4
+			IL_02e2: stelem.ref
+			IL_02e3: dup
+			IL_02e4: ldc.i4.4
+			IL_02e5: ldloc.s 5
+			IL_02e7: stelem.ref
+			IL_02e8: dup
+			IL_02e9: ldc.i4.5
+			IL_02ea: ldloc.s 6
+			IL_02ec: stelem.ref
+			IL_02ed: dup
+			IL_02ee: ldc.i4.6
+			IL_02ef: ldloc.s 7
+			IL_02f1: stelem.ref
+			IL_02f2: dup
+			IL_02f3: ldc.i4.7
+			IL_02f4: ldloc.s 8
+			IL_02f6: stelem.ref
+			IL_02f7: dup
+			IL_02f8: ldc.i4.8
+			IL_02f9: ldloc.s 9
+			IL_02fb: stelem.ref
+			IL_02fc: dup
+			IL_02fd: ldc.i4.s 9
+			IL_02ff: ldloc.s 10
 			IL_0301: stelem.ref
 			IL_0302: dup
-			IL_0303: ldc.i4.5
-			IL_0304: ldloc.s 6
-			IL_0306: stelem.ref
-			IL_0307: dup
-			IL_0308: ldc.i4.6
-			IL_0309: ldloc.s 7
-			IL_030b: stelem.ref
-			IL_030c: dup
-			IL_030d: ldc.i4.7
-			IL_030e: ldloc.s 8
-			IL_0310: stelem.ref
-			IL_0311: dup
-			IL_0312: ldc.i4.8
-			IL_0313: ldloc.s 9
-			IL_0315: stelem.ref
-			IL_0316: dup
-			IL_0317: ldc.i4.s 9
-			IL_0319: ldloc.s 10
-			IL_031b: stelem.ref
-			IL_031c: dup
-			IL_031d: ldc.i4.s 10
-			IL_031f: ldloc.s 11
-			IL_0321: stelem.ref
-			IL_0322: dup
-			IL_0323: ldc.i4.s 11
-			IL_0325: ldloc.s 12
-			IL_0327: stelem.ref
-			IL_0328: dup
-			IL_0329: ldc.i4.s 12
-			IL_032b: ldloc.s 13
-			IL_032d: stelem.ref
-			IL_032e: dup
-			IL_032f: ldc.i4.s 13
-			IL_0331: ldloc.s 14
-			IL_0333: stelem.ref
-			IL_0334: dup
-			IL_0335: ldc.i4.s 14
-			IL_0337: ldloc.s 15
-			IL_0339: box [System.Runtime]System.Double
-			IL_033e: stelem.ref
-			IL_033f: pop
-			IL_0340: ldloc.0
-			IL_0341: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0346: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_034b: ret
+			IL_0303: ldc.i4.s 10
+			IL_0305: ldloc.s 11
+			IL_0307: stelem.ref
+			IL_0308: dup
+			IL_0309: ldc.i4.s 11
+			IL_030b: ldloc.s 12
+			IL_030d: stelem.ref
+			IL_030e: dup
+			IL_030f: ldc.i4.s 12
+			IL_0311: ldloc.s 13
+			IL_0313: stelem.ref
+			IL_0314: dup
+			IL_0315: ldc.i4.s 13
+			IL_0317: ldloc.s 14
+			IL_0319: stelem.ref
+			IL_031a: dup
+			IL_031b: ldc.i4.s 14
+			IL_031d: ldloc.s 15
+			IL_031f: box [System.Runtime]System.Double
+			IL_0324: stelem.ref
+			IL_0325: pop
+			IL_0326: ldloc.0
+			IL_0327: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_032c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0331: ret
 
-			IL_034c: ldloc.0
-			IL_034d: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited2
-			IL_0352: stloc.s 8
-			IL_0354: ldloc.s 8
-			IL_0356: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_035b: stloc.s 10
-			IL_035d: ldloc.s 10
-			IL_035f: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0364: stloc.s 11
-			IL_0366: ldloc.s 11
-			IL_0368: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_036d: stloc.s 9
-			IL_036f: ldloc.s 9
-			IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0376: stloc.s 8
-			IL_0378: ldloc.s 8
-			IL_037a: ldstr "toString"
-			IL_037f: ldstr "hex"
-			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0389: stloc.s 8
-			IL_038b: ldloc.s 12
-			IL_038d: ldstr "log"
-			IL_0392: ldstr "digest sha1 hex:"
-			IL_0397: ldloc.s 8
-			IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_039e: pop
-			IL_039f: ldstr "console"
-			IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03a9: stloc.s 8
-			IL_03ab: ldloc.s 8
-			IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b2: stloc.s 8
-			IL_03b4: ldloc.1
-			IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03ba: stloc.s 12
-			IL_03bc: ldstr "abc"
-			IL_03c1: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_03c6: stloc.s 9
-			IL_03c8: ldloc.s 12
-			IL_03ca: ldstr "digest"
-			IL_03cf: ldstr "SHA-384"
-			IL_03d4: ldloc.s 9
-			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_03db: stloc.s 12
-			IL_03dd: ldloc.0
-			IL_03de: ldc.i4.3
-			IL_03df: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03e4: ldloc.0
-			IL_03e5: ldloc.s 12
-			IL_03e7: ldarg.0
-			IL_03e8: ldc.i4.3
-			IL_03e9: ldloc.0
-			IL_03ea: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_03f4: ldloc.0
-			IL_03f5: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03fa: dup
-			IL_03fb: ldc.i4.0
-			IL_03fc: ldloc.1
-			IL_03fd: stelem.ref
-			IL_03fe: dup
-			IL_03ff: ldc.i4.1
-			IL_0400: ldloc.2
-			IL_0401: stelem.ref
-			IL_0402: dup
-			IL_0403: ldc.i4.2
-			IL_0404: ldloc.3
-			IL_0405: stelem.ref
-			IL_0406: dup
-			IL_0407: ldc.i4.3
-			IL_0408: ldloc.s 4
-			IL_040a: stelem.ref
-			IL_040b: dup
-			IL_040c: ldc.i4.4
-			IL_040d: ldloc.s 5
+			IL_0332: ldloc.0
+			IL_0333: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited2
+			IL_0338: stloc.s 8
+			IL_033a: ldloc.s 8
+			IL_033c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_0341: stloc.s 10
+			IL_0343: ldloc.s 10
+			IL_0345: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_034a: stloc.s 11
+			IL_034c: ldloc.s 11
+			IL_034e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0353: stloc.s 9
+			IL_0355: ldloc.s 9
+			IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_035c: stloc.s 8
+			IL_035e: ldloc.s 8
+			IL_0360: ldstr "toString"
+			IL_0365: ldstr "hex"
+			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_036f: stloc.s 8
+			IL_0371: ldloc.s 12
+			IL_0373: ldstr "log"
+			IL_0378: ldstr "digest sha1 hex:"
+			IL_037d: ldloc.s 8
+			IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0384: pop
+			IL_0385: ldstr "console"
+			IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_038f: stloc.s 8
+			IL_0391: ldloc.s 8
+			IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0398: stloc.s 8
+			IL_039a: ldloc.1
+			IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03a0: stloc.s 12
+			IL_03a2: ldstr "abc"
+			IL_03a7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_03ac: stloc.s 9
+			IL_03ae: ldloc.s 12
+			IL_03b0: ldstr "digest"
+			IL_03b5: ldstr "SHA-384"
+			IL_03ba: ldloc.s 9
+			IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_03c1: stloc.s 12
+			IL_03c3: ldloc.0
+			IL_03c4: ldc.i4.3
+			IL_03c5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03ca: ldloc.0
+			IL_03cb: ldloc.s 12
+			IL_03cd: ldarg.0
+			IL_03ce: ldc.i4.3
+			IL_03cf: ldloc.0
+			IL_03d0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_03da: ldloc.0
+			IL_03db: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03e0: dup
+			IL_03e1: ldc.i4.0
+			IL_03e2: ldloc.1
+			IL_03e3: stelem.ref
+			IL_03e4: dup
+			IL_03e5: ldc.i4.1
+			IL_03e6: ldloc.2
+			IL_03e7: stelem.ref
+			IL_03e8: dup
+			IL_03e9: ldc.i4.2
+			IL_03ea: ldloc.3
+			IL_03eb: stelem.ref
+			IL_03ec: dup
+			IL_03ed: ldc.i4.3
+			IL_03ee: ldloc.s 4
+			IL_03f0: stelem.ref
+			IL_03f1: dup
+			IL_03f2: ldc.i4.4
+			IL_03f3: ldloc.s 5
+			IL_03f5: stelem.ref
+			IL_03f6: dup
+			IL_03f7: ldc.i4.5
+			IL_03f8: ldloc.s 6
+			IL_03fa: stelem.ref
+			IL_03fb: dup
+			IL_03fc: ldc.i4.6
+			IL_03fd: ldloc.s 7
+			IL_03ff: stelem.ref
+			IL_0400: dup
+			IL_0401: ldc.i4.7
+			IL_0402: ldloc.s 8
+			IL_0404: stelem.ref
+			IL_0405: dup
+			IL_0406: ldc.i4.8
+			IL_0407: ldloc.s 9
+			IL_0409: stelem.ref
+			IL_040a: dup
+			IL_040b: ldc.i4.s 9
+			IL_040d: ldloc.s 10
 			IL_040f: stelem.ref
 			IL_0410: dup
-			IL_0411: ldc.i4.5
-			IL_0412: ldloc.s 6
-			IL_0414: stelem.ref
-			IL_0415: dup
-			IL_0416: ldc.i4.6
-			IL_0417: ldloc.s 7
-			IL_0419: stelem.ref
-			IL_041a: dup
-			IL_041b: ldc.i4.7
-			IL_041c: ldloc.s 8
-			IL_041e: stelem.ref
-			IL_041f: dup
-			IL_0420: ldc.i4.8
-			IL_0421: ldloc.s 9
-			IL_0423: stelem.ref
-			IL_0424: dup
-			IL_0425: ldc.i4.s 9
-			IL_0427: ldloc.s 10
-			IL_0429: stelem.ref
-			IL_042a: dup
-			IL_042b: ldc.i4.s 10
-			IL_042d: ldloc.s 11
-			IL_042f: stelem.ref
-			IL_0430: dup
-			IL_0431: ldc.i4.s 11
-			IL_0433: ldloc.s 12
-			IL_0435: stelem.ref
-			IL_0436: dup
-			IL_0437: ldc.i4.s 12
-			IL_0439: ldloc.s 13
-			IL_043b: stelem.ref
-			IL_043c: dup
-			IL_043d: ldc.i4.s 13
-			IL_043f: ldloc.s 14
-			IL_0441: stelem.ref
-			IL_0442: dup
-			IL_0443: ldc.i4.s 14
-			IL_0445: ldloc.s 15
-			IL_0447: box [System.Runtime]System.Double
-			IL_044c: stelem.ref
-			IL_044d: pop
-			IL_044e: ldloc.0
-			IL_044f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0454: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0459: ret
+			IL_0411: ldc.i4.s 10
+			IL_0413: ldloc.s 11
+			IL_0415: stelem.ref
+			IL_0416: dup
+			IL_0417: ldc.i4.s 11
+			IL_0419: ldloc.s 12
+			IL_041b: stelem.ref
+			IL_041c: dup
+			IL_041d: ldc.i4.s 12
+			IL_041f: ldloc.s 13
+			IL_0421: stelem.ref
+			IL_0422: dup
+			IL_0423: ldc.i4.s 13
+			IL_0425: ldloc.s 14
+			IL_0427: stelem.ref
+			IL_0428: dup
+			IL_0429: ldc.i4.s 14
+			IL_042b: ldloc.s 15
+			IL_042d: box [System.Runtime]System.Double
+			IL_0432: stelem.ref
+			IL_0433: pop
+			IL_0434: ldloc.0
+			IL_0435: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_043a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_043f: ret
 
-			IL_045a: ldloc.0
-			IL_045b: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited3
-			IL_0460: stloc.s 12
-			IL_0462: ldloc.s 12
-			IL_0464: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_0469: stloc.s 10
-			IL_046b: ldloc.s 10
-			IL_046d: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0472: stloc.s 11
-			IL_0474: ldloc.s 11
-			IL_0476: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_047b: stloc.s 9
-			IL_047d: ldloc.s 9
-			IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0484: stloc.s 12
-			IL_0486: ldloc.s 12
-			IL_0488: ldstr "toString"
-			IL_048d: ldstr "hex"
-			IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0497: stloc.s 12
-			IL_0499: ldloc.s 8
-			IL_049b: ldstr "log"
-			IL_04a0: ldstr "digest sha384 hex:"
-			IL_04a5: ldloc.s 12
-			IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04ac: pop
-			IL_04ad: ldstr "console"
-			IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04b7: stloc.s 12
-			IL_04b9: ldloc.s 12
-			IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04c0: stloc.s 12
-			IL_04c2: ldloc.1
-			IL_04c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04c8: stloc.s 8
-			IL_04ca: ldstr "abc"
-			IL_04cf: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_04d4: stloc.s 9
-			IL_04d6: ldloc.s 8
-			IL_04d8: ldstr "digest"
-			IL_04dd: ldstr "SHA-512"
-			IL_04e2: ldloc.s 9
-			IL_04e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04e9: stloc.s 8
-			IL_04eb: ldloc.0
-			IL_04ec: ldc.i4.4
-			IL_04ed: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04f2: ldloc.0
-			IL_04f3: ldloc.s 8
-			IL_04f5: ldarg.0
-			IL_04f6: ldc.i4.4
-			IL_04f7: ldloc.0
-			IL_04f8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_04fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0502: ldloc.0
-			IL_0503: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0508: dup
-			IL_0509: ldc.i4.0
-			IL_050a: ldloc.1
-			IL_050b: stelem.ref
-			IL_050c: dup
-			IL_050d: ldc.i4.1
-			IL_050e: ldloc.2
-			IL_050f: stelem.ref
-			IL_0510: dup
-			IL_0511: ldc.i4.2
-			IL_0512: ldloc.3
-			IL_0513: stelem.ref
-			IL_0514: dup
-			IL_0515: ldc.i4.3
-			IL_0516: ldloc.s 4
-			IL_0518: stelem.ref
-			IL_0519: dup
-			IL_051a: ldc.i4.4
-			IL_051b: ldloc.s 5
+			IL_0440: ldloc.0
+			IL_0441: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited3
+			IL_0446: stloc.s 12
+			IL_0448: ldloc.s 12
+			IL_044a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_044f: stloc.s 10
+			IL_0451: ldloc.s 10
+			IL_0453: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0458: stloc.s 11
+			IL_045a: ldloc.s 11
+			IL_045c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0461: stloc.s 9
+			IL_0463: ldloc.s 9
+			IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_046a: stloc.s 12
+			IL_046c: ldloc.s 12
+			IL_046e: ldstr "toString"
+			IL_0473: ldstr "hex"
+			IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_047d: stloc.s 12
+			IL_047f: ldloc.s 8
+			IL_0481: ldstr "log"
+			IL_0486: ldstr "digest sha384 hex:"
+			IL_048b: ldloc.s 12
+			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0492: pop
+			IL_0493: ldstr "console"
+			IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_049d: stloc.s 12
+			IL_049f: ldloc.s 12
+			IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04a6: stloc.s 12
+			IL_04a8: ldloc.1
+			IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04ae: stloc.s 8
+			IL_04b0: ldstr "abc"
+			IL_04b5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_04ba: stloc.s 9
+			IL_04bc: ldloc.s 8
+			IL_04be: ldstr "digest"
+			IL_04c3: ldstr "SHA-512"
+			IL_04c8: ldloc.s 9
+			IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04cf: stloc.s 8
+			IL_04d1: ldloc.0
+			IL_04d2: ldc.i4.4
+			IL_04d3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04d8: ldloc.0
+			IL_04d9: ldloc.s 8
+			IL_04db: ldarg.0
+			IL_04dc: ldc.i4.4
+			IL_04dd: ldloc.0
+			IL_04de: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_04e8: ldloc.0
+			IL_04e9: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_04ee: dup
+			IL_04ef: ldc.i4.0
+			IL_04f0: ldloc.1
+			IL_04f1: stelem.ref
+			IL_04f2: dup
+			IL_04f3: ldc.i4.1
+			IL_04f4: ldloc.2
+			IL_04f5: stelem.ref
+			IL_04f6: dup
+			IL_04f7: ldc.i4.2
+			IL_04f8: ldloc.3
+			IL_04f9: stelem.ref
+			IL_04fa: dup
+			IL_04fb: ldc.i4.3
+			IL_04fc: ldloc.s 4
+			IL_04fe: stelem.ref
+			IL_04ff: dup
+			IL_0500: ldc.i4.4
+			IL_0501: ldloc.s 5
+			IL_0503: stelem.ref
+			IL_0504: dup
+			IL_0505: ldc.i4.5
+			IL_0506: ldloc.s 6
+			IL_0508: stelem.ref
+			IL_0509: dup
+			IL_050a: ldc.i4.6
+			IL_050b: ldloc.s 7
+			IL_050d: stelem.ref
+			IL_050e: dup
+			IL_050f: ldc.i4.7
+			IL_0510: ldloc.s 8
+			IL_0512: stelem.ref
+			IL_0513: dup
+			IL_0514: ldc.i4.8
+			IL_0515: ldloc.s 9
+			IL_0517: stelem.ref
+			IL_0518: dup
+			IL_0519: ldc.i4.s 9
+			IL_051b: ldloc.s 10
 			IL_051d: stelem.ref
 			IL_051e: dup
-			IL_051f: ldc.i4.5
-			IL_0520: ldloc.s 6
-			IL_0522: stelem.ref
-			IL_0523: dup
-			IL_0524: ldc.i4.6
-			IL_0525: ldloc.s 7
-			IL_0527: stelem.ref
-			IL_0528: dup
-			IL_0529: ldc.i4.7
-			IL_052a: ldloc.s 8
-			IL_052c: stelem.ref
-			IL_052d: dup
-			IL_052e: ldc.i4.8
-			IL_052f: ldloc.s 9
-			IL_0531: stelem.ref
-			IL_0532: dup
-			IL_0533: ldc.i4.s 9
-			IL_0535: ldloc.s 10
-			IL_0537: stelem.ref
-			IL_0538: dup
-			IL_0539: ldc.i4.s 10
-			IL_053b: ldloc.s 11
-			IL_053d: stelem.ref
-			IL_053e: dup
-			IL_053f: ldc.i4.s 11
-			IL_0541: ldloc.s 12
-			IL_0543: stelem.ref
-			IL_0544: dup
-			IL_0545: ldc.i4.s 12
-			IL_0547: ldloc.s 13
-			IL_0549: stelem.ref
-			IL_054a: dup
-			IL_054b: ldc.i4.s 13
-			IL_054d: ldloc.s 14
-			IL_054f: stelem.ref
-			IL_0550: dup
-			IL_0551: ldc.i4.s 14
-			IL_0553: ldloc.s 15
-			IL_0555: box [System.Runtime]System.Double
-			IL_055a: stelem.ref
-			IL_055b: pop
-			IL_055c: ldloc.0
-			IL_055d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0562: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0567: ret
+			IL_051f: ldc.i4.s 10
+			IL_0521: ldloc.s 11
+			IL_0523: stelem.ref
+			IL_0524: dup
+			IL_0525: ldc.i4.s 11
+			IL_0527: ldloc.s 12
+			IL_0529: stelem.ref
+			IL_052a: dup
+			IL_052b: ldc.i4.s 12
+			IL_052d: ldloc.s 13
+			IL_052f: stelem.ref
+			IL_0530: dup
+			IL_0531: ldc.i4.s 13
+			IL_0533: ldloc.s 14
+			IL_0535: stelem.ref
+			IL_0536: dup
+			IL_0537: ldc.i4.s 14
+			IL_0539: ldloc.s 15
+			IL_053b: box [System.Runtime]System.Double
+			IL_0540: stelem.ref
+			IL_0541: pop
+			IL_0542: ldloc.0
+			IL_0543: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0548: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_054d: ret
 
-			IL_0568: ldloc.0
-			IL_0569: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited4
-			IL_056e: stloc.s 8
-			IL_0570: ldloc.s 8
-			IL_0572: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_0577: stloc.s 10
-			IL_0579: ldloc.s 10
-			IL_057b: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0580: stloc.s 11
-			IL_0582: ldloc.s 11
-			IL_0584: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0589: stloc.s 9
-			IL_058b: ldloc.s 9
-			IL_058d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0592: stloc.s 8
-			IL_0594: ldloc.s 8
-			IL_0596: ldstr "toString"
-			IL_059b: ldstr "hex"
-			IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05a5: stloc.s 8
-			IL_05a7: ldloc.s 12
-			IL_05a9: ldstr "log"
-			IL_05ae: ldstr "digest sha512 hex:"
-			IL_05b3: ldloc.s 8
-			IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_05ba: pop
-			IL_05bb: ldloc.1
-			IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05c1: stloc.s 8
-			IL_05c3: ldstr "key"
-			IL_05c8: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_05cd: stloc.s 9
-			IL_05cf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05d4: dup
-			IL_05d5: ldstr "name"
-			IL_05da: ldstr "HMAC"
-			IL_05df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05e4: dup
-			IL_05e5: ldstr "hash"
-			IL_05ea: ldstr "SHA-256"
-			IL_05ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05f4: dup
-			IL_05f5: ldstr "length"
-			IL_05fa: ldc.r8 24
-			IL_0603: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0608: stloc.s 13
-			IL_060a: ldc.i4.5
-			IL_060b: newarr [System.Runtime]System.Object
-			IL_0610: dup
-			IL_0611: ldc.i4.0
-			IL_0612: ldstr "raw"
-			IL_0617: stelem.ref
-			IL_0618: dup
-			IL_0619: ldc.i4.1
-			IL_061a: ldloc.s 9
-			IL_061c: stelem.ref
-			IL_061d: dup
-			IL_061e: ldc.i4.2
-			IL_061f: ldloc.s 13
-			IL_0621: stelem.ref
-			IL_0622: dup
-			IL_0623: ldc.i4.3
-			IL_0624: ldc.i4.0
-			IL_0625: box [System.Runtime]System.Boolean
-			IL_062a: stelem.ref
-			IL_062b: dup
-			IL_062c: ldc.i4.4
-			IL_062d: ldc.i4.2
-			IL_062e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0633: dup
-			IL_0634: ldstr "sign"
-			IL_0639: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_063e: dup
-			IL_063f: ldstr "verify"
-			IL_0644: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0649: stelem.ref
-			IL_064a: stloc.s 14
-			IL_064c: ldloc.s 8
-			IL_064e: ldstr "importKey"
-			IL_0653: ldloc.s 14
-			IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_065a: stloc.s 8
-			IL_065c: ldloc.0
-			IL_065d: ldc.i4.5
-			IL_065e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0663: ldloc.0
-			IL_0664: ldloc.s 8
-			IL_0666: ldarg.0
-			IL_0667: ldc.i4.5
-			IL_0668: ldloc.0
-			IL_0669: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_066e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0673: ldloc.0
-			IL_0674: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0679: dup
-			IL_067a: ldc.i4.0
-			IL_067b: ldloc.1
-			IL_067c: stelem.ref
-			IL_067d: dup
-			IL_067e: ldc.i4.1
-			IL_067f: ldloc.2
-			IL_0680: stelem.ref
-			IL_0681: dup
-			IL_0682: ldc.i4.2
-			IL_0683: ldloc.3
-			IL_0684: stelem.ref
-			IL_0685: dup
-			IL_0686: ldc.i4.3
-			IL_0687: ldloc.s 4
-			IL_0689: stelem.ref
-			IL_068a: dup
-			IL_068b: ldc.i4.4
-			IL_068c: ldloc.s 5
+			IL_054e: ldloc.0
+			IL_054f: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited4
+			IL_0554: stloc.s 8
+			IL_0556: ldloc.s 8
+			IL_0558: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_055d: stloc.s 10
+			IL_055f: ldloc.s 10
+			IL_0561: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0566: stloc.s 11
+			IL_0568: ldloc.s 11
+			IL_056a: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_056f: stloc.s 9
+			IL_0571: ldloc.s 9
+			IL_0573: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0578: stloc.s 8
+			IL_057a: ldloc.s 8
+			IL_057c: ldstr "toString"
+			IL_0581: ldstr "hex"
+			IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_058b: stloc.s 8
+			IL_058d: ldloc.s 12
+			IL_058f: ldstr "log"
+			IL_0594: ldstr "digest sha512 hex:"
+			IL_0599: ldloc.s 8
+			IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_05a0: pop
+			IL_05a1: ldloc.1
+			IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05a7: stloc.s 8
+			IL_05a9: ldstr "key"
+			IL_05ae: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_05b3: stloc.s 9
+			IL_05b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05ba: dup
+			IL_05bb: ldstr "name"
+			IL_05c0: ldstr "HMAC"
+			IL_05c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05ca: dup
+			IL_05cb: ldstr "hash"
+			IL_05d0: ldstr "SHA-256"
+			IL_05d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05da: dup
+			IL_05db: ldstr "length"
+			IL_05e0: ldc.r8 24
+			IL_05e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_05ee: stloc.s 13
+			IL_05f0: ldc.i4.5
+			IL_05f1: newarr [System.Runtime]System.Object
+			IL_05f6: dup
+			IL_05f7: ldc.i4.0
+			IL_05f8: ldstr "raw"
+			IL_05fd: stelem.ref
+			IL_05fe: dup
+			IL_05ff: ldc.i4.1
+			IL_0600: ldloc.s 9
+			IL_0602: stelem.ref
+			IL_0603: dup
+			IL_0604: ldc.i4.2
+			IL_0605: ldloc.s 13
+			IL_0607: stelem.ref
+			IL_0608: dup
+			IL_0609: ldc.i4.3
+			IL_060a: ldc.i4.0
+			IL_060b: box [System.Runtime]System.Boolean
+			IL_0610: stelem.ref
+			IL_0611: dup
+			IL_0612: ldc.i4.4
+			IL_0613: ldc.i4.2
+			IL_0614: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0619: dup
+			IL_061a: ldstr "sign"
+			IL_061f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0624: dup
+			IL_0625: ldstr "verify"
+			IL_062a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_062f: stelem.ref
+			IL_0630: stloc.s 14
+			IL_0632: ldloc.s 8
+			IL_0634: ldstr "importKey"
+			IL_0639: ldloc.s 14
+			IL_063b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0640: stloc.s 8
+			IL_0642: ldloc.0
+			IL_0643: ldc.i4.5
+			IL_0644: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0649: ldloc.0
+			IL_064a: ldloc.s 8
+			IL_064c: ldarg.0
+			IL_064d: ldc.i4.5
+			IL_064e: ldloc.0
+			IL_064f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0654: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0659: ldloc.0
+			IL_065a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_065f: dup
+			IL_0660: ldc.i4.0
+			IL_0661: ldloc.1
+			IL_0662: stelem.ref
+			IL_0663: dup
+			IL_0664: ldc.i4.1
+			IL_0665: ldloc.2
+			IL_0666: stelem.ref
+			IL_0667: dup
+			IL_0668: ldc.i4.2
+			IL_0669: ldloc.3
+			IL_066a: stelem.ref
+			IL_066b: dup
+			IL_066c: ldc.i4.3
+			IL_066d: ldloc.s 4
+			IL_066f: stelem.ref
+			IL_0670: dup
+			IL_0671: ldc.i4.4
+			IL_0672: ldloc.s 5
+			IL_0674: stelem.ref
+			IL_0675: dup
+			IL_0676: ldc.i4.5
+			IL_0677: ldloc.s 6
+			IL_0679: stelem.ref
+			IL_067a: dup
+			IL_067b: ldc.i4.6
+			IL_067c: ldloc.s 7
+			IL_067e: stelem.ref
+			IL_067f: dup
+			IL_0680: ldc.i4.7
+			IL_0681: ldloc.s 8
+			IL_0683: stelem.ref
+			IL_0684: dup
+			IL_0685: ldc.i4.8
+			IL_0686: ldloc.s 9
+			IL_0688: stelem.ref
+			IL_0689: dup
+			IL_068a: ldc.i4.s 9
+			IL_068c: ldloc.s 10
 			IL_068e: stelem.ref
 			IL_068f: dup
-			IL_0690: ldc.i4.5
-			IL_0691: ldloc.s 6
-			IL_0693: stelem.ref
-			IL_0694: dup
-			IL_0695: ldc.i4.6
-			IL_0696: ldloc.s 7
-			IL_0698: stelem.ref
-			IL_0699: dup
-			IL_069a: ldc.i4.7
-			IL_069b: ldloc.s 8
-			IL_069d: stelem.ref
-			IL_069e: dup
-			IL_069f: ldc.i4.8
-			IL_06a0: ldloc.s 9
-			IL_06a2: stelem.ref
-			IL_06a3: dup
-			IL_06a4: ldc.i4.s 9
-			IL_06a6: ldloc.s 10
-			IL_06a8: stelem.ref
-			IL_06a9: dup
-			IL_06aa: ldc.i4.s 10
-			IL_06ac: ldloc.s 11
-			IL_06ae: stelem.ref
-			IL_06af: dup
-			IL_06b0: ldc.i4.s 11
-			IL_06b2: ldloc.s 12
-			IL_06b4: stelem.ref
-			IL_06b5: dup
-			IL_06b6: ldc.i4.s 12
-			IL_06b8: ldloc.s 13
-			IL_06ba: stelem.ref
-			IL_06bb: dup
-			IL_06bc: ldc.i4.s 13
-			IL_06be: ldloc.s 14
-			IL_06c0: stelem.ref
-			IL_06c1: dup
-			IL_06c2: ldc.i4.s 14
-			IL_06c4: ldloc.s 15
-			IL_06c6: box [System.Runtime]System.Double
-			IL_06cb: stelem.ref
-			IL_06cc: pop
-			IL_06cd: ldloc.0
-			IL_06ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06d3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06d8: ret
+			IL_0690: ldc.i4.s 10
+			IL_0692: ldloc.s 11
+			IL_0694: stelem.ref
+			IL_0695: dup
+			IL_0696: ldc.i4.s 11
+			IL_0698: ldloc.s 12
+			IL_069a: stelem.ref
+			IL_069b: dup
+			IL_069c: ldc.i4.s 12
+			IL_069e: ldloc.s 13
+			IL_06a0: stelem.ref
+			IL_06a1: dup
+			IL_06a2: ldc.i4.s 13
+			IL_06a4: ldloc.s 14
+			IL_06a6: stelem.ref
+			IL_06a7: dup
+			IL_06a8: ldc.i4.s 14
+			IL_06aa: ldloc.s 15
+			IL_06ac: box [System.Runtime]System.Double
+			IL_06b1: stelem.ref
+			IL_06b2: pop
+			IL_06b3: ldloc.0
+			IL_06b4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06b9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06be: ret
 
-			IL_06d9: ldloc.0
-			IL_06da: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited5
-			IL_06df: stloc.s 8
-			IL_06e1: ldloc.s 8
-			IL_06e3: stloc.s 4
-			IL_06e5: ldstr "console"
-			IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06ef: stloc.s 8
-			IL_06f1: ldloc.s 8
-			IL_06f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06f8: stloc.s 8
-			IL_06fa: ldloc.s 8
-			IL_06fc: ldstr "log"
-			IL_0701: ldstr "key type:"
-			IL_0706: ldloc.s 4
-			IL_0708: ldstr "type"
-			IL_070d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0712: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0717: pop
-			IL_0718: ldstr "console"
-			IL_071d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0722: stloc.s 8
-			IL_0724: ldloc.s 8
-			IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_072b: stloc.s 8
-			IL_072d: ldloc.s 8
-			IL_072f: ldstr "log"
-			IL_0734: ldstr "key algorithm:"
-			IL_0739: ldloc.s 4
-			IL_073b: ldstr "algorithm"
-			IL_0740: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0745: ldstr "name"
-			IL_074a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_074f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0754: pop
-			IL_0755: ldstr "console"
-			IL_075a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_075f: stloc.s 8
-			IL_0761: ldloc.s 8
-			IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0768: stloc.s 8
-			IL_076a: ldloc.s 8
-			IL_076c: ldstr "log"
-			IL_0771: ldstr "key hash:"
-			IL_0776: ldloc.s 4
-			IL_0778: ldstr "algorithm"
-			IL_077d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0782: ldstr "hash"
-			IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_078c: ldstr "name"
-			IL_0791: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0796: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_079b: pop
-			IL_079c: ldstr "console"
-			IL_07a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07a6: stloc.s 8
-			IL_07a8: ldloc.s 8
-			IL_07aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07af: stloc.s 8
-			IL_07b1: ldloc.s 8
-			IL_07b3: ldstr "log"
-			IL_07b8: ldstr "key extractable:"
-			IL_07bd: ldloc.s 4
-			IL_07bf: ldstr "extractable"
-			IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_07ce: pop
-			IL_07cf: ldstr "console"
-			IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07d9: stloc.s 8
-			IL_07db: ldloc.s 8
-			IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07e2: stloc.s 8
-			IL_07e4: ldloc.s 4
-			IL_07e6: ldstr "usages"
-			IL_07eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07f5: stloc.s 12
-			IL_07f7: ldloc.s 12
-			IL_07f9: ldstr "join"
-			IL_07fe: ldstr ","
-			IL_0803: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0808: stloc.s 12
-			IL_080a: ldloc.s 8
-			IL_080c: ldstr "log"
-			IL_0811: ldstr "key usages:"
-			IL_0816: ldloc.s 12
-			IL_0818: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_081d: pop
-			IL_081e: ldloc.1
-			IL_081f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0824: stloc.s 12
-			IL_0826: ldstr "abc"
-			IL_082b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0830: stloc.s 9
-			IL_0832: ldloc.s 12
-			IL_0834: ldstr "sign"
-			IL_0839: ldstr "HMAC"
-			IL_083e: ldloc.s 4
-			IL_0840: ldloc.s 9
-			IL_0842: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0847: stloc.s 12
-			IL_0849: ldloc.0
-			IL_084a: ldc.i4.6
-			IL_084b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0850: ldloc.0
-			IL_0851: ldloc.s 12
-			IL_0853: ldarg.0
-			IL_0854: ldc.i4.6
-			IL_0855: ldloc.0
-			IL_0856: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_085b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0860: ldloc.0
-			IL_0861: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0866: dup
-			IL_0867: ldc.i4.0
-			IL_0868: ldloc.1
-			IL_0869: stelem.ref
-			IL_086a: dup
-			IL_086b: ldc.i4.1
-			IL_086c: ldloc.2
-			IL_086d: stelem.ref
-			IL_086e: dup
-			IL_086f: ldc.i4.2
-			IL_0870: ldloc.3
-			IL_0871: stelem.ref
-			IL_0872: dup
-			IL_0873: ldc.i4.3
-			IL_0874: ldloc.s 4
-			IL_0876: stelem.ref
-			IL_0877: dup
-			IL_0878: ldc.i4.4
-			IL_0879: ldloc.s 5
+			IL_06bf: ldloc.0
+			IL_06c0: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited5
+			IL_06c5: stloc.s 8
+			IL_06c7: ldloc.s 8
+			IL_06c9: stloc.s 4
+			IL_06cb: ldstr "console"
+			IL_06d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06d5: stloc.s 8
+			IL_06d7: ldloc.s 8
+			IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06de: stloc.s 8
+			IL_06e0: ldloc.s 8
+			IL_06e2: ldstr "log"
+			IL_06e7: ldstr "key type:"
+			IL_06ec: ldloc.s 4
+			IL_06ee: ldstr "type"
+			IL_06f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_06fd: pop
+			IL_06fe: ldstr "console"
+			IL_0703: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0708: stloc.s 8
+			IL_070a: ldloc.s 8
+			IL_070c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0711: stloc.s 8
+			IL_0713: ldloc.s 8
+			IL_0715: ldstr "log"
+			IL_071a: ldstr "key algorithm:"
+			IL_071f: ldloc.s 4
+			IL_0721: ldstr "algorithm"
+			IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_072b: ldstr "name"
+			IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0735: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_073a: pop
+			IL_073b: ldstr "console"
+			IL_0740: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0745: stloc.s 8
+			IL_0747: ldloc.s 8
+			IL_0749: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_074e: stloc.s 8
+			IL_0750: ldloc.s 8
+			IL_0752: ldstr "log"
+			IL_0757: ldstr "key hash:"
+			IL_075c: ldloc.s 4
+			IL_075e: ldstr "algorithm"
+			IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0768: ldstr "hash"
+			IL_076d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0772: ldstr "name"
+			IL_0777: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_077c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0781: pop
+			IL_0782: ldstr "console"
+			IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_078c: stloc.s 8
+			IL_078e: ldloc.s 8
+			IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0795: stloc.s 8
+			IL_0797: ldloc.s 8
+			IL_0799: ldstr "log"
+			IL_079e: ldstr "key extractable:"
+			IL_07a3: ldloc.s 4
+			IL_07a5: ldstr "extractable"
+			IL_07aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_07b4: pop
+			IL_07b5: ldstr "console"
+			IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07bf: stloc.s 8
+			IL_07c1: ldloc.s 8
+			IL_07c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07c8: stloc.s 8
+			IL_07ca: ldloc.s 4
+			IL_07cc: ldstr "usages"
+			IL_07d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07db: stloc.s 12
+			IL_07dd: ldloc.s 12
+			IL_07df: ldstr "join"
+			IL_07e4: ldstr ","
+			IL_07e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_07ee: stloc.s 12
+			IL_07f0: ldloc.s 8
+			IL_07f2: ldstr "log"
+			IL_07f7: ldstr "key usages:"
+			IL_07fc: ldloc.s 12
+			IL_07fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0803: pop
+			IL_0804: ldloc.1
+			IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_080a: stloc.s 12
+			IL_080c: ldstr "abc"
+			IL_0811: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0816: stloc.s 9
+			IL_0818: ldloc.s 12
+			IL_081a: ldstr "sign"
+			IL_081f: ldstr "HMAC"
+			IL_0824: ldloc.s 4
+			IL_0826: ldloc.s 9
+			IL_0828: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_082d: stloc.s 12
+			IL_082f: ldloc.0
+			IL_0830: ldc.i4.6
+			IL_0831: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0836: ldloc.0
+			IL_0837: ldloc.s 12
+			IL_0839: ldarg.0
+			IL_083a: ldc.i4.6
+			IL_083b: ldloc.0
+			IL_083c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0841: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0846: ldloc.0
+			IL_0847: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_084c: dup
+			IL_084d: ldc.i4.0
+			IL_084e: ldloc.1
+			IL_084f: stelem.ref
+			IL_0850: dup
+			IL_0851: ldc.i4.1
+			IL_0852: ldloc.2
+			IL_0853: stelem.ref
+			IL_0854: dup
+			IL_0855: ldc.i4.2
+			IL_0856: ldloc.3
+			IL_0857: stelem.ref
+			IL_0858: dup
+			IL_0859: ldc.i4.3
+			IL_085a: ldloc.s 4
+			IL_085c: stelem.ref
+			IL_085d: dup
+			IL_085e: ldc.i4.4
+			IL_085f: ldloc.s 5
+			IL_0861: stelem.ref
+			IL_0862: dup
+			IL_0863: ldc.i4.5
+			IL_0864: ldloc.s 6
+			IL_0866: stelem.ref
+			IL_0867: dup
+			IL_0868: ldc.i4.6
+			IL_0869: ldloc.s 7
+			IL_086b: stelem.ref
+			IL_086c: dup
+			IL_086d: ldc.i4.7
+			IL_086e: ldloc.s 8
+			IL_0870: stelem.ref
+			IL_0871: dup
+			IL_0872: ldc.i4.8
+			IL_0873: ldloc.s 9
+			IL_0875: stelem.ref
+			IL_0876: dup
+			IL_0877: ldc.i4.s 9
+			IL_0879: ldloc.s 10
 			IL_087b: stelem.ref
 			IL_087c: dup
-			IL_087d: ldc.i4.5
-			IL_087e: ldloc.s 6
-			IL_0880: stelem.ref
-			IL_0881: dup
-			IL_0882: ldc.i4.6
-			IL_0883: ldloc.s 7
-			IL_0885: stelem.ref
-			IL_0886: dup
-			IL_0887: ldc.i4.7
-			IL_0888: ldloc.s 8
-			IL_088a: stelem.ref
-			IL_088b: dup
-			IL_088c: ldc.i4.8
-			IL_088d: ldloc.s 9
-			IL_088f: stelem.ref
-			IL_0890: dup
-			IL_0891: ldc.i4.s 9
-			IL_0893: ldloc.s 10
-			IL_0895: stelem.ref
-			IL_0896: dup
-			IL_0897: ldc.i4.s 10
-			IL_0899: ldloc.s 11
-			IL_089b: stelem.ref
-			IL_089c: dup
-			IL_089d: ldc.i4.s 11
-			IL_089f: ldloc.s 12
-			IL_08a1: stelem.ref
-			IL_08a2: dup
-			IL_08a3: ldc.i4.s 12
-			IL_08a5: ldloc.s 13
-			IL_08a7: stelem.ref
-			IL_08a8: dup
-			IL_08a9: ldc.i4.s 13
-			IL_08ab: ldloc.s 14
-			IL_08ad: stelem.ref
-			IL_08ae: dup
-			IL_08af: ldc.i4.s 14
-			IL_08b1: ldloc.s 15
-			IL_08b3: box [System.Runtime]System.Double
-			IL_08b8: stelem.ref
-			IL_08b9: pop
-			IL_08ba: ldloc.0
-			IL_08bb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08c0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08c5: ret
+			IL_087d: ldc.i4.s 10
+			IL_087f: ldloc.s 11
+			IL_0881: stelem.ref
+			IL_0882: dup
+			IL_0883: ldc.i4.s 11
+			IL_0885: ldloc.s 12
+			IL_0887: stelem.ref
+			IL_0888: dup
+			IL_0889: ldc.i4.s 12
+			IL_088b: ldloc.s 13
+			IL_088d: stelem.ref
+			IL_088e: dup
+			IL_088f: ldc.i4.s 13
+			IL_0891: ldloc.s 14
+			IL_0893: stelem.ref
+			IL_0894: dup
+			IL_0895: ldc.i4.s 14
+			IL_0897: ldloc.s 15
+			IL_0899: box [System.Runtime]System.Double
+			IL_089e: stelem.ref
+			IL_089f: pop
+			IL_08a0: ldloc.0
+			IL_08a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08a6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08ab: ret
 
-			IL_08c6: ldloc.0
-			IL_08c7: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited6
-			IL_08cc: stloc.s 12
-			IL_08ce: ldloc.s 12
-			IL_08d0: stloc.s 5
-			IL_08d2: ldloc.s 5
-			IL_08d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_08d9: stloc.s 10
-			IL_08db: ldloc.s 10
-			IL_08dd: stloc.s 6
-			IL_08df: ldstr "console"
-			IL_08e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_08e9: stloc.s 12
-			IL_08eb: ldloc.s 12
-			IL_08ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_08f2: stloc.s 12
-			IL_08f4: ldloc.s 6
-			IL_08f6: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_08fb: stloc.s 11
-			IL_08fd: ldloc.s 11
-			IL_08ff: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0904: stloc.s 9
-			IL_0906: ldloc.s 9
-			IL_0908: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_090d: stloc.s 8
-			IL_090f: ldloc.s 8
-			IL_0911: ldstr "toString"
-			IL_0916: ldstr "hex"
-			IL_091b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0920: stloc.s 8
-			IL_0922: ldloc.s 12
-			IL_0924: ldstr "log"
-			IL_0929: ldstr "signature hex:"
-			IL_092e: ldloc.s 8
-			IL_0930: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0935: pop
-			IL_0936: ldstr "console"
-			IL_093b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0940: stloc.s 8
-			IL_0942: ldloc.s 8
-			IL_0944: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0949: stloc.s 8
-			IL_094b: ldloc.1
-			IL_094c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0951: stloc.s 12
-			IL_0953: ldstr "abc"
-			IL_0958: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_095d: stloc.s 9
-			IL_095f: ldc.i4.4
-			IL_0960: newarr [System.Runtime]System.Object
-			IL_0965: dup
-			IL_0966: ldc.i4.0
-			IL_0967: ldstr "HMAC"
-			IL_096c: stelem.ref
-			IL_096d: dup
-			IL_096e: ldc.i4.1
-			IL_096f: ldloc.s 4
-			IL_0971: stelem.ref
-			IL_0972: dup
-			IL_0973: ldc.i4.2
-			IL_0974: ldloc.s 5
-			IL_0976: stelem.ref
-			IL_0977: dup
-			IL_0978: ldc.i4.3
-			IL_0979: ldloc.s 9
-			IL_097b: stelem.ref
-			IL_097c: stloc.s 14
-			IL_097e: ldloc.s 12
-			IL_0980: ldstr "verify"
-			IL_0985: ldloc.s 14
-			IL_0987: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_098c: stloc.s 12
-			IL_098e: ldloc.0
-			IL_098f: ldc.i4.7
-			IL_0990: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0995: ldloc.0
-			IL_0996: ldloc.s 12
-			IL_0998: ldarg.0
-			IL_0999: ldc.i4.7
-			IL_099a: ldloc.0
-			IL_099b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_09a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_09a5: ldloc.0
-			IL_09a6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_09ab: dup
-			IL_09ac: ldc.i4.0
-			IL_09ad: ldloc.1
-			IL_09ae: stelem.ref
-			IL_09af: dup
-			IL_09b0: ldc.i4.1
-			IL_09b1: ldloc.2
-			IL_09b2: stelem.ref
-			IL_09b3: dup
-			IL_09b4: ldc.i4.2
-			IL_09b5: ldloc.3
-			IL_09b6: stelem.ref
-			IL_09b7: dup
-			IL_09b8: ldc.i4.3
-			IL_09b9: ldloc.s 4
-			IL_09bb: stelem.ref
-			IL_09bc: dup
-			IL_09bd: ldc.i4.4
-			IL_09be: ldloc.s 5
+			IL_08ac: ldloc.0
+			IL_08ad: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited6
+			IL_08b2: stloc.s 12
+			IL_08b4: ldloc.s 12
+			IL_08b6: stloc.s 5
+			IL_08b8: ldloc.s 5
+			IL_08ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_08bf: stloc.s 10
+			IL_08c1: ldloc.s 10
+			IL_08c3: stloc.s 6
+			IL_08c5: ldstr "console"
+			IL_08ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08cf: stloc.s 12
+			IL_08d1: ldloc.s 12
+			IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08d8: stloc.s 12
+			IL_08da: ldloc.s 6
+			IL_08dc: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_08e1: stloc.s 11
+			IL_08e3: ldloc.s 11
+			IL_08e5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_08ea: stloc.s 9
+			IL_08ec: ldloc.s 9
+			IL_08ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08f3: stloc.s 8
+			IL_08f5: ldloc.s 8
+			IL_08f7: ldstr "toString"
+			IL_08fc: ldstr "hex"
+			IL_0901: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0906: stloc.s 8
+			IL_0908: ldloc.s 12
+			IL_090a: ldstr "log"
+			IL_090f: ldstr "signature hex:"
+			IL_0914: ldloc.s 8
+			IL_0916: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_091b: pop
+			IL_091c: ldstr "console"
+			IL_0921: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0926: stloc.s 8
+			IL_0928: ldloc.s 8
+			IL_092a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_092f: stloc.s 8
+			IL_0931: ldloc.1
+			IL_0932: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0937: stloc.s 12
+			IL_0939: ldstr "abc"
+			IL_093e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0943: stloc.s 9
+			IL_0945: ldc.i4.4
+			IL_0946: newarr [System.Runtime]System.Object
+			IL_094b: dup
+			IL_094c: ldc.i4.0
+			IL_094d: ldstr "HMAC"
+			IL_0952: stelem.ref
+			IL_0953: dup
+			IL_0954: ldc.i4.1
+			IL_0955: ldloc.s 4
+			IL_0957: stelem.ref
+			IL_0958: dup
+			IL_0959: ldc.i4.2
+			IL_095a: ldloc.s 5
+			IL_095c: stelem.ref
+			IL_095d: dup
+			IL_095e: ldc.i4.3
+			IL_095f: ldloc.s 9
+			IL_0961: stelem.ref
+			IL_0962: stloc.s 14
+			IL_0964: ldloc.s 12
+			IL_0966: ldstr "verify"
+			IL_096b: ldloc.s 14
+			IL_096d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0972: stloc.s 12
+			IL_0974: ldloc.0
+			IL_0975: ldc.i4.7
+			IL_0976: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_097b: ldloc.0
+			IL_097c: ldloc.s 12
+			IL_097e: ldarg.0
+			IL_097f: ldc.i4.7
+			IL_0980: ldloc.0
+			IL_0981: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0986: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_098b: ldloc.0
+			IL_098c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0991: dup
+			IL_0992: ldc.i4.0
+			IL_0993: ldloc.1
+			IL_0994: stelem.ref
+			IL_0995: dup
+			IL_0996: ldc.i4.1
+			IL_0997: ldloc.2
+			IL_0998: stelem.ref
+			IL_0999: dup
+			IL_099a: ldc.i4.2
+			IL_099b: ldloc.3
+			IL_099c: stelem.ref
+			IL_099d: dup
+			IL_099e: ldc.i4.3
+			IL_099f: ldloc.s 4
+			IL_09a1: stelem.ref
+			IL_09a2: dup
+			IL_09a3: ldc.i4.4
+			IL_09a4: ldloc.s 5
+			IL_09a6: stelem.ref
+			IL_09a7: dup
+			IL_09a8: ldc.i4.5
+			IL_09a9: ldloc.s 6
+			IL_09ab: stelem.ref
+			IL_09ac: dup
+			IL_09ad: ldc.i4.6
+			IL_09ae: ldloc.s 7
+			IL_09b0: stelem.ref
+			IL_09b1: dup
+			IL_09b2: ldc.i4.7
+			IL_09b3: ldloc.s 8
+			IL_09b5: stelem.ref
+			IL_09b6: dup
+			IL_09b7: ldc.i4.8
+			IL_09b8: ldloc.s 9
+			IL_09ba: stelem.ref
+			IL_09bb: dup
+			IL_09bc: ldc.i4.s 9
+			IL_09be: ldloc.s 10
 			IL_09c0: stelem.ref
 			IL_09c1: dup
-			IL_09c2: ldc.i4.5
-			IL_09c3: ldloc.s 6
-			IL_09c5: stelem.ref
-			IL_09c6: dup
-			IL_09c7: ldc.i4.6
-			IL_09c8: ldloc.s 7
-			IL_09ca: stelem.ref
-			IL_09cb: dup
-			IL_09cc: ldc.i4.7
-			IL_09cd: ldloc.s 8
-			IL_09cf: stelem.ref
-			IL_09d0: dup
-			IL_09d1: ldc.i4.8
-			IL_09d2: ldloc.s 9
-			IL_09d4: stelem.ref
-			IL_09d5: dup
-			IL_09d6: ldc.i4.s 9
-			IL_09d8: ldloc.s 10
-			IL_09da: stelem.ref
-			IL_09db: dup
-			IL_09dc: ldc.i4.s 10
-			IL_09de: ldloc.s 11
-			IL_09e0: stelem.ref
-			IL_09e1: dup
-			IL_09e2: ldc.i4.s 11
-			IL_09e4: ldloc.s 12
-			IL_09e6: stelem.ref
-			IL_09e7: dup
-			IL_09e8: ldc.i4.s 12
-			IL_09ea: ldloc.s 13
-			IL_09ec: stelem.ref
-			IL_09ed: dup
-			IL_09ee: ldc.i4.s 13
-			IL_09f0: ldloc.s 14
-			IL_09f2: stelem.ref
-			IL_09f3: dup
-			IL_09f4: ldc.i4.s 14
-			IL_09f6: ldloc.s 15
-			IL_09f8: box [System.Runtime]System.Double
-			IL_09fd: stelem.ref
-			IL_09fe: pop
-			IL_09ff: ldloc.0
-			IL_0a00: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a05: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a0a: ret
+			IL_09c2: ldc.i4.s 10
+			IL_09c4: ldloc.s 11
+			IL_09c6: stelem.ref
+			IL_09c7: dup
+			IL_09c8: ldc.i4.s 11
+			IL_09ca: ldloc.s 12
+			IL_09cc: stelem.ref
+			IL_09cd: dup
+			IL_09ce: ldc.i4.s 12
+			IL_09d0: ldloc.s 13
+			IL_09d2: stelem.ref
+			IL_09d3: dup
+			IL_09d4: ldc.i4.s 13
+			IL_09d6: ldloc.s 14
+			IL_09d8: stelem.ref
+			IL_09d9: dup
+			IL_09da: ldc.i4.s 14
+			IL_09dc: ldloc.s 15
+			IL_09de: box [System.Runtime]System.Double
+			IL_09e3: stelem.ref
+			IL_09e4: pop
+			IL_09e5: ldloc.0
+			IL_09e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09eb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09f0: ret
 
-			IL_0a0b: ldloc.0
-			IL_0a0c: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited7
-			IL_0a11: stloc.s 12
-			IL_0a13: ldloc.s 8
-			IL_0a15: ldstr "log"
-			IL_0a1a: ldstr "verify true:"
-			IL_0a1f: ldloc.s 12
-			IL_0a21: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a26: pop
-			IL_0a27: ldloc.s 6
-			IL_0a29: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0a2e: stloc.s 11
-			IL_0a30: ldloc.s 11
-			IL_0a32: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0a37: stloc.s 9
-			IL_0a39: ldloc.s 9
-			IL_0a3b: stloc.s 7
-			IL_0a3d: ldloc.s 7
-			IL_0a3f: ldc.r8 0.0
-			IL_0a48: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0a4d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0a52: conv.i4
-			IL_0a53: ldc.r8 255
-			IL_0a5c: conv.i4
-			IL_0a5d: xor
-			IL_0a5e: conv.r8
-			IL_0a5f: stloc.s 15
-			IL_0a61: ldloc.s 15
-			IL_0a63: conv.i4
-			IL_0a64: ldc.r8 255
-			IL_0a6d: conv.i4
-			IL_0a6e: and
-			IL_0a6f: conv.r8
-			IL_0a70: stloc.s 15
-			IL_0a72: ldloc.s 7
-			IL_0a74: ldc.r8 0.0
-			IL_0a7d: ldloc.s 15
-			IL_0a7f: ldc.i4.1
-			IL_0a80: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-			IL_0a85: pop
-			IL_0a86: ldstr "console"
-			IL_0a8b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a90: stloc.s 12
-			IL_0a92: ldloc.s 12
-			IL_0a94: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a99: stloc.s 12
-			IL_0a9b: ldloc.1
-			IL_0a9c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0aa1: stloc.s 8
-			IL_0aa3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0aa8: dup
-			IL_0aa9: ldstr "name"
-			IL_0aae: ldstr "HMAC"
-			IL_0ab3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0ab8: stloc.s 13
-			IL_0aba: ldstr "abc"
-			IL_0abf: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0ac4: stloc.s 9
-			IL_0ac6: ldc.i4.4
-			IL_0ac7: newarr [System.Runtime]System.Object
-			IL_0acc: dup
-			IL_0acd: ldc.i4.0
-			IL_0ace: ldloc.s 13
-			IL_0ad0: stelem.ref
-			IL_0ad1: dup
-			IL_0ad2: ldc.i4.1
-			IL_0ad3: ldloc.s 4
-			IL_0ad5: stelem.ref
-			IL_0ad6: dup
-			IL_0ad7: ldc.i4.2
-			IL_0ad8: ldloc.s 7
-			IL_0ada: stelem.ref
-			IL_0adb: dup
-			IL_0adc: ldc.i4.3
-			IL_0add: ldloc.s 9
-			IL_0adf: stelem.ref
-			IL_0ae0: stloc.s 14
-			IL_0ae2: ldloc.s 8
-			IL_0ae4: ldstr "verify"
-			IL_0ae9: ldloc.s 14
-			IL_0aeb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0af0: stloc.s 8
-			IL_0af2: ldloc.0
-			IL_0af3: ldc.i4.8
-			IL_0af4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0af9: ldloc.0
-			IL_0afa: ldloc.s 8
-			IL_0afc: ldarg.0
-			IL_0afd: ldc.i4.8
-			IL_0afe: ldloc.0
-			IL_0aff: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0b04: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0b09: ldloc.0
-			IL_0b0a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0b0f: dup
-			IL_0b10: ldc.i4.0
-			IL_0b11: ldloc.1
-			IL_0b12: stelem.ref
-			IL_0b13: dup
-			IL_0b14: ldc.i4.1
-			IL_0b15: ldloc.2
-			IL_0b16: stelem.ref
-			IL_0b17: dup
-			IL_0b18: ldc.i4.2
-			IL_0b19: ldloc.3
-			IL_0b1a: stelem.ref
-			IL_0b1b: dup
-			IL_0b1c: ldc.i4.3
-			IL_0b1d: ldloc.s 4
-			IL_0b1f: stelem.ref
-			IL_0b20: dup
-			IL_0b21: ldc.i4.4
-			IL_0b22: ldloc.s 5
+			IL_09f1: ldloc.0
+			IL_09f2: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited7
+			IL_09f7: stloc.s 12
+			IL_09f9: ldloc.s 8
+			IL_09fb: ldstr "log"
+			IL_0a00: ldstr "verify true:"
+			IL_0a05: ldloc.s 12
+			IL_0a07: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0a0c: pop
+			IL_0a0d: ldloc.s 6
+			IL_0a0f: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0a14: stloc.s 11
+			IL_0a16: ldloc.s 11
+			IL_0a18: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0a1d: stloc.s 9
+			IL_0a1f: ldloc.s 9
+			IL_0a21: stloc.s 7
+			IL_0a23: ldloc.s 7
+			IL_0a25: ldc.r8 0.0
+			IL_0a2e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0a33: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0a38: conv.i4
+			IL_0a39: ldc.r8 255
+			IL_0a42: conv.i4
+			IL_0a43: xor
+			IL_0a44: conv.r8
+			IL_0a45: stloc.s 15
+			IL_0a47: ldloc.s 15
+			IL_0a49: conv.i4
+			IL_0a4a: ldc.r8 255
+			IL_0a53: conv.i4
+			IL_0a54: and
+			IL_0a55: conv.r8
+			IL_0a56: stloc.s 15
+			IL_0a58: ldloc.s 7
+			IL_0a5a: ldc.r8 0.0
+			IL_0a63: ldloc.s 15
+			IL_0a65: ldc.i4.1
+			IL_0a66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+			IL_0a6b: pop
+			IL_0a6c: ldstr "console"
+			IL_0a71: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a76: stloc.s 12
+			IL_0a78: ldloc.s 12
+			IL_0a7a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a7f: stloc.s 12
+			IL_0a81: ldloc.1
+			IL_0a82: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a87: stloc.s 8
+			IL_0a89: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0a8e: dup
+			IL_0a8f: ldstr "name"
+			IL_0a94: ldstr "HMAC"
+			IL_0a99: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0a9e: stloc.s 13
+			IL_0aa0: ldstr "abc"
+			IL_0aa5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0aaa: stloc.s 9
+			IL_0aac: ldc.i4.4
+			IL_0aad: newarr [System.Runtime]System.Object
+			IL_0ab2: dup
+			IL_0ab3: ldc.i4.0
+			IL_0ab4: ldloc.s 13
+			IL_0ab6: stelem.ref
+			IL_0ab7: dup
+			IL_0ab8: ldc.i4.1
+			IL_0ab9: ldloc.s 4
+			IL_0abb: stelem.ref
+			IL_0abc: dup
+			IL_0abd: ldc.i4.2
+			IL_0abe: ldloc.s 7
+			IL_0ac0: stelem.ref
+			IL_0ac1: dup
+			IL_0ac2: ldc.i4.3
+			IL_0ac3: ldloc.s 9
+			IL_0ac5: stelem.ref
+			IL_0ac6: stloc.s 14
+			IL_0ac8: ldloc.s 8
+			IL_0aca: ldstr "verify"
+			IL_0acf: ldloc.s 14
+			IL_0ad1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0ad6: stloc.s 8
+			IL_0ad8: ldloc.0
+			IL_0ad9: ldc.i4.8
+			IL_0ada: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0adf: ldloc.0
+			IL_0ae0: ldloc.s 8
+			IL_0ae2: ldarg.0
+			IL_0ae3: ldc.i4.8
+			IL_0ae4: ldloc.0
+			IL_0ae5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0aea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0aef: ldloc.0
+			IL_0af0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0af5: dup
+			IL_0af6: ldc.i4.0
+			IL_0af7: ldloc.1
+			IL_0af8: stelem.ref
+			IL_0af9: dup
+			IL_0afa: ldc.i4.1
+			IL_0afb: ldloc.2
+			IL_0afc: stelem.ref
+			IL_0afd: dup
+			IL_0afe: ldc.i4.2
+			IL_0aff: ldloc.3
+			IL_0b00: stelem.ref
+			IL_0b01: dup
+			IL_0b02: ldc.i4.3
+			IL_0b03: ldloc.s 4
+			IL_0b05: stelem.ref
+			IL_0b06: dup
+			IL_0b07: ldc.i4.4
+			IL_0b08: ldloc.s 5
+			IL_0b0a: stelem.ref
+			IL_0b0b: dup
+			IL_0b0c: ldc.i4.5
+			IL_0b0d: ldloc.s 6
+			IL_0b0f: stelem.ref
+			IL_0b10: dup
+			IL_0b11: ldc.i4.6
+			IL_0b12: ldloc.s 7
+			IL_0b14: stelem.ref
+			IL_0b15: dup
+			IL_0b16: ldc.i4.7
+			IL_0b17: ldloc.s 8
+			IL_0b19: stelem.ref
+			IL_0b1a: dup
+			IL_0b1b: ldc.i4.8
+			IL_0b1c: ldloc.s 9
+			IL_0b1e: stelem.ref
+			IL_0b1f: dup
+			IL_0b20: ldc.i4.s 9
+			IL_0b22: ldloc.s 10
 			IL_0b24: stelem.ref
 			IL_0b25: dup
-			IL_0b26: ldc.i4.5
-			IL_0b27: ldloc.s 6
-			IL_0b29: stelem.ref
-			IL_0b2a: dup
-			IL_0b2b: ldc.i4.6
-			IL_0b2c: ldloc.s 7
-			IL_0b2e: stelem.ref
-			IL_0b2f: dup
-			IL_0b30: ldc.i4.7
-			IL_0b31: ldloc.s 8
-			IL_0b33: stelem.ref
-			IL_0b34: dup
-			IL_0b35: ldc.i4.8
-			IL_0b36: ldloc.s 9
-			IL_0b38: stelem.ref
-			IL_0b39: dup
-			IL_0b3a: ldc.i4.s 9
-			IL_0b3c: ldloc.s 10
-			IL_0b3e: stelem.ref
-			IL_0b3f: dup
-			IL_0b40: ldc.i4.s 10
-			IL_0b42: ldloc.s 11
-			IL_0b44: stelem.ref
-			IL_0b45: dup
-			IL_0b46: ldc.i4.s 11
-			IL_0b48: ldloc.s 12
-			IL_0b4a: stelem.ref
-			IL_0b4b: dup
-			IL_0b4c: ldc.i4.s 12
-			IL_0b4e: ldloc.s 13
-			IL_0b50: stelem.ref
-			IL_0b51: dup
-			IL_0b52: ldc.i4.s 13
-			IL_0b54: ldloc.s 14
-			IL_0b56: stelem.ref
-			IL_0b57: dup
-			IL_0b58: ldc.i4.s 14
-			IL_0b5a: ldloc.s 15
-			IL_0b5c: box [System.Runtime]System.Double
-			IL_0b61: stelem.ref
-			IL_0b62: pop
-			IL_0b63: ldloc.0
-			IL_0b64: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0b69: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0b6e: ret
+			IL_0b26: ldc.i4.s 10
+			IL_0b28: ldloc.s 11
+			IL_0b2a: stelem.ref
+			IL_0b2b: dup
+			IL_0b2c: ldc.i4.s 11
+			IL_0b2e: ldloc.s 12
+			IL_0b30: stelem.ref
+			IL_0b31: dup
+			IL_0b32: ldc.i4.s 12
+			IL_0b34: ldloc.s 13
+			IL_0b36: stelem.ref
+			IL_0b37: dup
+			IL_0b38: ldc.i4.s 13
+			IL_0b3a: ldloc.s 14
+			IL_0b3c: stelem.ref
+			IL_0b3d: dup
+			IL_0b3e: ldc.i4.s 14
+			IL_0b40: ldloc.s 15
+			IL_0b42: box [System.Runtime]System.Double
+			IL_0b47: stelem.ref
+			IL_0b48: pop
+			IL_0b49: ldloc.0
+			IL_0b4a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b4f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0b54: ret
 
-			IL_0b6f: ldloc.0
-			IL_0b70: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited8
-			IL_0b75: stloc.s 8
-			IL_0b77: ldloc.s 12
-			IL_0b79: ldstr "log"
-			IL_0b7e: ldstr "verify false:"
-			IL_0b83: ldloc.s 8
-			IL_0b85: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0b8a: pop
-			IL_0b8b: ldloc.0
-			IL_0b8c: ldc.i4.m1
-			IL_0b8d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0b92: ldloc.0
-			IL_0b93: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0b98: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0b9d: ldarg.0
-			IL_0b9e: ldc.i4.1
-			IL_0b9f: newarr [System.Runtime]System.Object
-			IL_0ba4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0ba9: pop
-			IL_0baa: ldloc.0
-			IL_0bab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bb0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bb5: ret
+			IL_0b55: ldloc.0
+			IL_0b56: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited8
+			IL_0b5b: stloc.s 8
+			IL_0b5d: ldloc.s 12
+			IL_0b5f: ldstr "log"
+			IL_0b64: ldstr "verify false:"
+			IL_0b69: ldloc.s 8
+			IL_0b6b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0b70: pop
+			IL_0b71: ldloc.0
+			IL_0b72: ldc.i4.m1
+			IL_0b73: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b78: ldloc.0
+			IL_0b79: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b7e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0b83: ldarg.0
+			IL_0b84: ldc.i4.1
+			IL_0b85: newarr [System.Runtime]System.Object
+			IL_0b8a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0b8f: pop
+			IL_0b90: ldloc.0
+			IL_0b91: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b96: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0b9b: ret
 		} // end of method run::__js_call__
 
 	} // end of class run
@@ -1429,7 +1419,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2cf7
+				// Method begins at RVA 0x2cdb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1452,7 +1442,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cb4
+			// Method begins at RVA 0x2c98
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -1493,7 +1483,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2ce5
+			// Method begins at RVA 0x2cc9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1597,7 +1587,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2d00
+		// Method begins at RVA 0x2ce4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x320e
+				// Method begins at RVA 0x3174
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3229
+						// Method begins at RVA 0x318f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -74,7 +74,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3220
+					// Method begins at RVA 0x3186
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3217
+				// Method begins at RVA 0x317d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			)
 			// Method begins at RVA 0x21d4
 			// Header size: 12
-			// Code size: 1382 (0x566)
+			// Code size: 1346 (0x542)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope,
@@ -249,453 +249,441 @@
 
 			IL_00e1: ldloc.0
 			IL_00e2: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00e7: switch (IL_0100, IL_0377, IL_044b, IL_02ac, IL_043f)
+			IL_00e7: switch (IL_0100, IL_0353, IL_0427, IL_0288, IL_041b)
 
 			IL_0100: ldarg.0
 			IL_0101: ldc.i4.1
 			IL_0102: ldelem.ref
 			IL_0103: castclass Modules.Events_AsyncHelpers_On_Once/Scope
 			IL_0108: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-			IL_010d: stloc.s 12
-			IL_010f: ldstr "EventEmitter"
-			IL_0114: ldloc.s 12
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_011b: stloc.s 12
-			IL_011d: ldloc.s 12
-			IL_011f: ldc.i4.0
-			IL_0120: newarr [System.Runtime]System.Object
-			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_012a: stloc.s 12
-			IL_012c: ldloc.s 12
-			IL_012e: stloc.1
-			IL_012f: ldarg.0
-			IL_0130: ldc.i4.1
-			IL_0131: ldelem.ref
-			IL_0132: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_0137: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_013c: stloc.s 12
-			IL_013e: ldstr "events"
-			IL_0143: ldloc.s 12
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_014a: stloc.s 12
-			IL_014c: ldloc.s 12
-			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0153: stloc.s 12
-			IL_0155: ldloc.s 12
-			IL_0157: ldstr "on"
-			IL_015c: ldloc.1
-			IL_015d: ldstr "tick"
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0167: stloc.s 12
-			IL_0169: ldloc.s 12
-			IL_016b: stloc.2
-			IL_016c: ldloc.1
-			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0172: stloc.s 12
-			IL_0174: ldloc.s 12
-			IL_0176: ldstr "emit"
-			IL_017b: ldstr "tick"
-			IL_0180: ldc.r8 1
-			IL_0189: box [System.Runtime]System.Double
-			IL_018e: ldc.r8 2
-			IL_0197: box [System.Runtime]System.Double
-			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_01a1: pop
-			IL_01a2: ldloc.1
-			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a8: stloc.s 12
-			IL_01aa: ldloc.s 12
-			IL_01ac: ldstr "emit"
-			IL_01b1: ldstr "tick"
-			IL_01b6: ldc.r8 3
-			IL_01bf: box [System.Runtime]System.Double
-			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01c9: pop
-			IL_01ca: ldc.r8 0.0
-			IL_01d3: stloc.3
-			IL_01d4: ldloc.2
-			IL_01d5: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-			IL_01da: stloc.s 4
-			IL_01dc: ldc.i4.0
-			IL_01dd: stloc.s 5
-			IL_01df: ldc.i4.0
-			IL_01e0: stloc.s 6
-			IL_01e2: ldloc.0
-			IL_01e3: ldc.i4.0
-			IL_01e4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01e9: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_01ee: ldloc.0
-			IL_01ef: ldc.i4.0
-			IL_01f0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01f5: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_01fa: ldloc.0
-			IL_01fb: ldc.i4.0
-			IL_01fc: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0201: ldloc.0
-			IL_0202: ldc.i4.0
-			IL_0203: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_010d: ldc.i4.0
+			IL_010e: newarr [System.Runtime]System.Object
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0118: stloc.s 12
+			IL_011a: ldloc.s 12
+			IL_011c: stloc.1
+			IL_011d: ldarg.0
+			IL_011e: ldc.i4.1
+			IL_011f: ldelem.ref
+			IL_0120: castclass Modules.Events_AsyncHelpers_On_Once/Scope
+			IL_0125: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_012f: stloc.s 12
+			IL_0131: ldloc.s 12
+			IL_0133: ldstr "on"
+			IL_0138: ldloc.1
+			IL_0139: ldstr "tick"
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0143: stloc.s 12
+			IL_0145: ldloc.s 12
+			IL_0147: stloc.2
+			IL_0148: ldloc.1
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014e: stloc.s 12
+			IL_0150: ldloc.s 12
+			IL_0152: ldstr "emit"
+			IL_0157: ldstr "tick"
+			IL_015c: ldc.r8 1
+			IL_0165: box [System.Runtime]System.Double
+			IL_016a: ldc.r8 2
+			IL_0173: box [System.Runtime]System.Double
+			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_017d: pop
+			IL_017e: ldloc.1
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0184: stloc.s 12
+			IL_0186: ldloc.s 12
+			IL_0188: ldstr "emit"
+			IL_018d: ldstr "tick"
+			IL_0192: ldc.r8 3
+			IL_019b: box [System.Runtime]System.Double
+			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01a5: pop
+			IL_01a6: ldc.r8 0.0
+			IL_01af: stloc.3
+			IL_01b0: ldloc.2
+			IL_01b1: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+			IL_01b6: stloc.s 4
+			IL_01b8: ldc.i4.0
+			IL_01b9: stloc.s 5
+			IL_01bb: ldc.i4.0
+			IL_01bc: stloc.s 6
+			IL_01be: ldloc.0
+			IL_01bf: ldc.i4.0
+			IL_01c0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01c5: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_01ca: ldloc.0
+			IL_01cb: ldc.i4.0
+			IL_01cc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01d1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_01d6: ldloc.0
+			IL_01d7: ldc.i4.0
+			IL_01d8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_01dd: ldloc.0
+			IL_01de: ldc.i4.0
+			IL_01df: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-			IL_0208: ldloc.s 4
-			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-			IL_020f: stloc.s 12
-			IL_0211: ldloc.0
-			IL_0212: ldc.i4.3
-			IL_0213: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0218: ldloc.0
-			IL_0219: ldloc.s 12
-			IL_021b: ldarg.0
-			IL_021c: ldc.i4.1
-			IL_021d: ldloc.0
-			IL_021e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0223: ldc.i4.1
-			IL_0224: ldstr "_pendingException"
-			IL_0229: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_022e: ldloc.0
-			IL_022f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0234: dup
-			IL_0235: ldc.i4.0
-			IL_0236: ldloc.1
-			IL_0237: stelem.ref
-			IL_0238: dup
-			IL_0239: ldc.i4.1
-			IL_023a: ldloc.2
-			IL_023b: stelem.ref
-			IL_023c: dup
-			IL_023d: ldc.i4.2
-			IL_023e: ldloc.3
-			IL_023f: box [System.Runtime]System.Double
-			IL_0244: stelem.ref
-			IL_0245: dup
-			IL_0246: ldc.i4.3
-			IL_0247: ldloc.s 4
-			IL_0249: stelem.ref
-			IL_024a: dup
-			IL_024b: ldc.i4.4
-			IL_024c: ldloc.s 5
+			IL_01e4: ldloc.s 4
+			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+			IL_01eb: stloc.s 12
+			IL_01ed: ldloc.0
+			IL_01ee: ldc.i4.3
+			IL_01ef: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01f4: ldloc.0
+			IL_01f5: ldloc.s 12
+			IL_01f7: ldarg.0
+			IL_01f8: ldc.i4.1
+			IL_01f9: ldloc.0
+			IL_01fa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01ff: ldc.i4.1
+			IL_0200: ldstr "_pendingException"
+			IL_0205: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_020a: ldloc.0
+			IL_020b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0210: dup
+			IL_0211: ldc.i4.0
+			IL_0212: ldloc.1
+			IL_0213: stelem.ref
+			IL_0214: dup
+			IL_0215: ldc.i4.1
+			IL_0216: ldloc.2
+			IL_0217: stelem.ref
+			IL_0218: dup
+			IL_0219: ldc.i4.2
+			IL_021a: ldloc.3
+			IL_021b: box [System.Runtime]System.Double
+			IL_0220: stelem.ref
+			IL_0221: dup
+			IL_0222: ldc.i4.3
+			IL_0223: ldloc.s 4
+			IL_0225: stelem.ref
+			IL_0226: dup
+			IL_0227: ldc.i4.4
+			IL_0228: ldloc.s 5
+			IL_022a: box [System.Runtime]System.Boolean
+			IL_022f: stelem.ref
+			IL_0230: dup
+			IL_0231: ldc.i4.5
+			IL_0232: ldloc.s 6
+			IL_0234: box [System.Runtime]System.Boolean
+			IL_0239: stelem.ref
+			IL_023a: dup
+			IL_023b: ldc.i4.6
+			IL_023c: ldloc.s 7
+			IL_023e: stelem.ref
+			IL_023f: dup
+			IL_0240: ldc.i4.7
+			IL_0241: ldloc.s 8
+			IL_0243: stelem.ref
+			IL_0244: dup
+			IL_0245: ldc.i4.8
+			IL_0246: ldloc.s 9
+			IL_0248: stelem.ref
+			IL_0249: dup
+			IL_024a: ldc.i4.s 9
+			IL_024c: ldloc.s 10
 			IL_024e: box [System.Runtime]System.Boolean
 			IL_0253: stelem.ref
 			IL_0254: dup
-			IL_0255: ldc.i4.5
-			IL_0256: ldloc.s 6
-			IL_0258: box [System.Runtime]System.Boolean
-			IL_025d: stelem.ref
-			IL_025e: dup
-			IL_025f: ldc.i4.6
-			IL_0260: ldloc.s 7
-			IL_0262: stelem.ref
-			IL_0263: dup
-			IL_0264: ldc.i4.7
-			IL_0265: ldloc.s 8
-			IL_0267: stelem.ref
-			IL_0268: dup
-			IL_0269: ldc.i4.8
-			IL_026a: ldloc.s 9
-			IL_026c: stelem.ref
-			IL_026d: dup
-			IL_026e: ldc.i4.s 9
-			IL_0270: ldloc.s 10
-			IL_0272: box [System.Runtime]System.Boolean
-			IL_0277: stelem.ref
-			IL_0278: dup
-			IL_0279: ldc.i4.s 10
-			IL_027b: ldloc.s 11
-			IL_027d: box [System.Runtime]System.Boolean
-			IL_0282: stelem.ref
-			IL_0283: dup
-			IL_0284: ldc.i4.s 11
-			IL_0286: ldloc.s 12
-			IL_0288: stelem.ref
-			IL_0289: dup
-			IL_028a: ldc.i4.s 12
-			IL_028c: ldloc.s 13
-			IL_028e: box [System.Runtime]System.Boolean
-			IL_0293: stelem.ref
-			IL_0294: dup
-			IL_0295: ldc.i4.s 13
-			IL_0297: ldloc.s 14
-			IL_0299: box [System.Runtime]System.Double
-			IL_029e: stelem.ref
-			IL_029f: pop
-			IL_02a0: ldloc.0
-			IL_02a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02a6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02ab: ret
+			IL_0255: ldc.i4.s 10
+			IL_0257: ldloc.s 11
+			IL_0259: box [System.Runtime]System.Boolean
+			IL_025e: stelem.ref
+			IL_025f: dup
+			IL_0260: ldc.i4.s 11
+			IL_0262: ldloc.s 12
+			IL_0264: stelem.ref
+			IL_0265: dup
+			IL_0266: ldc.i4.s 12
+			IL_0268: ldloc.s 13
+			IL_026a: box [System.Runtime]System.Boolean
+			IL_026f: stelem.ref
+			IL_0270: dup
+			IL_0271: ldc.i4.s 13
+			IL_0273: ldloc.s 14
+			IL_0275: box [System.Runtime]System.Double
+			IL_027a: stelem.ref
+			IL_027b: pop
+			IL_027c: ldloc.0
+			IL_027d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0282: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0287: ret
 
-			IL_02ac: ldloc.0
-			IL_02ad: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope::_awaited1
-			IL_02b2: stloc.s 12
-			IL_02b4: ldloc.s 12
-			IL_02b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_02bb: stloc.s 13
-			IL_02bd: ldloc.s 13
-			IL_02bf: brtrue IL_036f
+			IL_0288: ldloc.0
+			IL_0289: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope::_awaited1
+			IL_028e: stloc.s 12
+			IL_0290: ldloc.s 12
+			IL_0292: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_0297: stloc.s 13
+			IL_0299: ldloc.s 13
+			IL_029b: brtrue IL_034b
 
-			IL_02c4: ldloc.s 12
-			IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_02cb: stloc.s 12
-			IL_02cd: ldloc.s 12
-			IL_02cf: stloc.s 7
-			IL_02d1: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope_ForOf_L14C13/Block_L14C37::.ctor()
-			IL_02d6: stloc.s 8
-			IL_02d8: ldstr "console"
-			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02e2: stloc.s 12
-			IL_02e4: ldloc.s 12
-			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02eb: stloc.s 12
-			IL_02ed: ldloc.s 12
-			IL_02ef: ldstr "log"
-			IL_02f4: ldloc.s 7
-			IL_02f6: ldstr "length"
-			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0305: pop
-			IL_0306: ldstr "console"
-			IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0310: stloc.s 12
-			IL_0312: ldloc.s 12
-			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0319: stloc.s 12
-			IL_031b: ldloc.s 12
-			IL_031d: ldstr "log"
-			IL_0322: ldloc.s 7
-			IL_0324: ldc.r8 0.0
-			IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0337: pop
-			IL_0338: ldloc.3
-			IL_0339: ldc.r8 1
-			IL_0342: add
-			IL_0343: stloc.3
-			IL_0344: ldloc.3
-			IL_0345: stloc.s 14
-			IL_0347: ldloc.s 14
-			IL_0349: ldc.r8 2
-			IL_0352: ceq
-			IL_0354: brfalse IL_0365
+			IL_02a0: ldloc.s 12
+			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_02a7: stloc.s 12
+			IL_02a9: ldloc.s 12
+			IL_02ab: stloc.s 7
+			IL_02ad: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope_ForOf_L14C13/Block_L14C37::.ctor()
+			IL_02b2: stloc.s 8
+			IL_02b4: ldstr "console"
+			IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02be: stloc.s 12
+			IL_02c0: ldloc.s 12
+			IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c7: stloc.s 12
+			IL_02c9: ldloc.s 12
+			IL_02cb: ldstr "log"
+			IL_02d0: ldloc.s 7
+			IL_02d2: ldstr "length"
+			IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02e1: pop
+			IL_02e2: ldstr "console"
+			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02ec: stloc.s 12
+			IL_02ee: ldloc.s 12
+			IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02f5: stloc.s 12
+			IL_02f7: ldloc.s 12
+			IL_02f9: ldstr "log"
+			IL_02fe: ldloc.s 7
+			IL_0300: ldc.r8 0.0
+			IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0313: pop
+			IL_0314: ldloc.3
+			IL_0315: ldc.r8 1
+			IL_031e: add
+			IL_031f: stloc.3
+			IL_0320: ldloc.3
+			IL_0321: stloc.s 14
+			IL_0323: ldloc.s 14
+			IL_0325: ldc.r8 2
+			IL_032e: ceq
+			IL_0330: brfalse IL_0341
 
-			IL_0359: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope_ForOf_L14C13/Block_L14C37/Block_L18C21::.ctor()
-			IL_035e: stloc.s 9
-			IL_0360: br IL_036a
+			IL_0335: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope_ForOf_L14C13/Block_L14C37/Block_L18C21::.ctor()
+			IL_033a: stloc.s 9
+			IL_033c: br IL_0346
 
-			IL_0365: br IL_0208
+			IL_0341: br IL_01e4
 
-			IL_036a: br IL_038a
+			IL_0346: br IL_0366
 
-			IL_036f: ldc.i4.1
-			IL_0370: stloc.s 5
-			IL_0372: br IL_038a
+			IL_034b: ldc.i4.1
+			IL_034c: stloc.s 5
+			IL_034e: br IL_0366
 
-			IL_0377: ldloc.0
-			IL_0378: ldc.i4.1
-			IL_0379: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_037e: ldloc.0
-			IL_037f: ldc.i4.0
-			IL_0380: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0385: br IL_038a
+			IL_0353: ldloc.0
+			IL_0354: ldc.i4.1
+			IL_0355: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_035a: ldloc.0
+			IL_035b: ldc.i4.0
+			IL_035c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0361: br IL_0366
 
-			IL_038a: ldloc.s 5
-			IL_038c: brtrue IL_0446
+			IL_0366: ldloc.s 5
+			IL_0368: brtrue IL_0422
 
-			IL_0391: ldloc.s 6
-			IL_0393: brtrue IL_0446
+			IL_036d: ldloc.s 6
+			IL_036f: brtrue IL_0422
 
-			IL_0398: ldc.i4.1
-			IL_0399: stloc.s 6
-			IL_039b: ldloc.s 4
-			IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-			IL_03a2: stloc.s 12
-			IL_03a4: ldloc.0
-			IL_03a5: ldc.i4.4
-			IL_03a6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03ab: ldloc.0
-			IL_03ac: ldloc.s 12
-			IL_03ae: ldarg.0
-			IL_03af: ldc.i4.2
-			IL_03b0: ldloc.0
-			IL_03b1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03b6: ldc.i4.2
-			IL_03b7: ldstr "_pendingException"
-			IL_03bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_03c1: ldloc.0
-			IL_03c2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03c7: dup
-			IL_03c8: ldc.i4.0
-			IL_03c9: ldloc.1
-			IL_03ca: stelem.ref
-			IL_03cb: dup
-			IL_03cc: ldc.i4.1
-			IL_03cd: ldloc.2
-			IL_03ce: stelem.ref
-			IL_03cf: dup
-			IL_03d0: ldc.i4.2
-			IL_03d1: ldloc.3
-			IL_03d2: box [System.Runtime]System.Double
-			IL_03d7: stelem.ref
-			IL_03d8: dup
-			IL_03d9: ldc.i4.3
-			IL_03da: ldloc.s 4
-			IL_03dc: stelem.ref
-			IL_03dd: dup
-			IL_03de: ldc.i4.4
-			IL_03df: ldloc.s 5
+			IL_0374: ldc.i4.1
+			IL_0375: stloc.s 6
+			IL_0377: ldloc.s 4
+			IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+			IL_037e: stloc.s 12
+			IL_0380: ldloc.0
+			IL_0381: ldc.i4.4
+			IL_0382: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0387: ldloc.0
+			IL_0388: ldloc.s 12
+			IL_038a: ldarg.0
+			IL_038b: ldc.i4.2
+			IL_038c: ldloc.0
+			IL_038d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0392: ldc.i4.2
+			IL_0393: ldstr "_pendingException"
+			IL_0398: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_039d: ldloc.0
+			IL_039e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03a3: dup
+			IL_03a4: ldc.i4.0
+			IL_03a5: ldloc.1
+			IL_03a6: stelem.ref
+			IL_03a7: dup
+			IL_03a8: ldc.i4.1
+			IL_03a9: ldloc.2
+			IL_03aa: stelem.ref
+			IL_03ab: dup
+			IL_03ac: ldc.i4.2
+			IL_03ad: ldloc.3
+			IL_03ae: box [System.Runtime]System.Double
+			IL_03b3: stelem.ref
+			IL_03b4: dup
+			IL_03b5: ldc.i4.3
+			IL_03b6: ldloc.s 4
+			IL_03b8: stelem.ref
+			IL_03b9: dup
+			IL_03ba: ldc.i4.4
+			IL_03bb: ldloc.s 5
+			IL_03bd: box [System.Runtime]System.Boolean
+			IL_03c2: stelem.ref
+			IL_03c3: dup
+			IL_03c4: ldc.i4.5
+			IL_03c5: ldloc.s 6
+			IL_03c7: box [System.Runtime]System.Boolean
+			IL_03cc: stelem.ref
+			IL_03cd: dup
+			IL_03ce: ldc.i4.6
+			IL_03cf: ldloc.s 7
+			IL_03d1: stelem.ref
+			IL_03d2: dup
+			IL_03d3: ldc.i4.7
+			IL_03d4: ldloc.s 8
+			IL_03d6: stelem.ref
+			IL_03d7: dup
+			IL_03d8: ldc.i4.8
+			IL_03d9: ldloc.s 9
+			IL_03db: stelem.ref
+			IL_03dc: dup
+			IL_03dd: ldc.i4.s 9
+			IL_03df: ldloc.s 10
 			IL_03e1: box [System.Runtime]System.Boolean
 			IL_03e6: stelem.ref
 			IL_03e7: dup
-			IL_03e8: ldc.i4.5
-			IL_03e9: ldloc.s 6
-			IL_03eb: box [System.Runtime]System.Boolean
-			IL_03f0: stelem.ref
-			IL_03f1: dup
-			IL_03f2: ldc.i4.6
-			IL_03f3: ldloc.s 7
-			IL_03f5: stelem.ref
-			IL_03f6: dup
-			IL_03f7: ldc.i4.7
-			IL_03f8: ldloc.s 8
-			IL_03fa: stelem.ref
-			IL_03fb: dup
-			IL_03fc: ldc.i4.8
-			IL_03fd: ldloc.s 9
-			IL_03ff: stelem.ref
-			IL_0400: dup
-			IL_0401: ldc.i4.s 9
-			IL_0403: ldloc.s 10
-			IL_0405: box [System.Runtime]System.Boolean
-			IL_040a: stelem.ref
-			IL_040b: dup
-			IL_040c: ldc.i4.s 10
-			IL_040e: ldloc.s 11
-			IL_0410: box [System.Runtime]System.Boolean
-			IL_0415: stelem.ref
-			IL_0416: dup
-			IL_0417: ldc.i4.s 11
-			IL_0419: ldloc.s 12
-			IL_041b: stelem.ref
-			IL_041c: dup
-			IL_041d: ldc.i4.s 12
-			IL_041f: ldloc.s 13
-			IL_0421: box [System.Runtime]System.Boolean
-			IL_0426: stelem.ref
-			IL_0427: dup
-			IL_0428: ldc.i4.s 13
-			IL_042a: ldloc.s 14
-			IL_042c: box [System.Runtime]System.Double
-			IL_0431: stelem.ref
-			IL_0432: pop
-			IL_0433: ldloc.0
-			IL_0434: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0439: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_043e: ret
+			IL_03e8: ldc.i4.s 10
+			IL_03ea: ldloc.s 11
+			IL_03ec: box [System.Runtime]System.Boolean
+			IL_03f1: stelem.ref
+			IL_03f2: dup
+			IL_03f3: ldc.i4.s 11
+			IL_03f5: ldloc.s 12
+			IL_03f7: stelem.ref
+			IL_03f8: dup
+			IL_03f9: ldc.i4.s 12
+			IL_03fb: ldloc.s 13
+			IL_03fd: box [System.Runtime]System.Boolean
+			IL_0402: stelem.ref
+			IL_0403: dup
+			IL_0404: ldc.i4.s 13
+			IL_0406: ldloc.s 14
+			IL_0408: box [System.Runtime]System.Double
+			IL_040d: stelem.ref
+			IL_040e: pop
+			IL_040f: ldloc.0
+			IL_0410: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0415: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_041a: ret
 
-			IL_043f: ldloc.0
-			IL_0440: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope::_awaited2
-			IL_0445: pop
+			IL_041b: ldloc.0
+			IL_041c: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope::_awaited2
+			IL_0421: pop
 
-			IL_0446: br IL_045e
+			IL_0422: br IL_043a
 
-			IL_044b: ldloc.0
-			IL_044c: ldc.i4.1
-			IL_044d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0452: ldloc.0
-			IL_0453: ldc.i4.0
-			IL_0454: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0459: br IL_045e
+			IL_0427: ldloc.0
+			IL_0428: ldc.i4.1
+			IL_0429: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_042e: ldloc.0
+			IL_042f: ldc.i4.0
+			IL_0430: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0435: br IL_043a
 
-			IL_045e: ldloc.0
-			IL_045f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0464: stloc.s 10
-			IL_0466: ldloc.s 10
-			IL_0468: brfalse IL_04a5
+			IL_043a: ldloc.0
+			IL_043b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0440: stloc.s 10
+			IL_0442: ldloc.s 10
+			IL_0444: brfalse IL_0481
 
-			IL_046d: ldloc.0
-			IL_046e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0473: stloc.s 12
+			IL_0449: ldloc.0
+			IL_044a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_044f: stloc.s 12
+			IL_0451: ldloc.0
+			IL_0452: ldc.i4.m1
+			IL_0453: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0458: ldloc.0
+			IL_0459: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_045e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0463: ldarg.0
+			IL_0464: ldc.i4.1
+			IL_0465: newarr [System.Runtime]System.Object
+			IL_046a: dup
+			IL_046b: ldc.i4.0
+			IL_046c: ldloc.s 12
+			IL_046e: stelem.ref
+			IL_046f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0474: pop
 			IL_0475: ldloc.0
-			IL_0476: ldc.i4.m1
-			IL_0477: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_047c: ldloc.0
-			IL_047d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0482: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0487: ldarg.0
-			IL_0488: ldc.i4.1
-			IL_0489: newarr [System.Runtime]System.Object
-			IL_048e: dup
-			IL_048f: ldc.i4.0
-			IL_0490: ldloc.s 12
-			IL_0492: stelem.ref
-			IL_0493: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0498: pop
-			IL_0499: ldloc.0
-			IL_049a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_049f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04a4: ret
+			IL_0476: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_047b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0480: ret
 
-			IL_04a5: ldloc.0
-			IL_04a6: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_04ab: stloc.s 11
-			IL_04ad: ldloc.s 11
-			IL_04af: brfalse IL_04ec
+			IL_0481: ldloc.0
+			IL_0482: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0487: stloc.s 11
+			IL_0489: ldloc.s 11
+			IL_048b: brfalse IL_04c8
 
-			IL_04b4: ldloc.0
-			IL_04b5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_04ba: stloc.s 12
+			IL_0490: ldloc.0
+			IL_0491: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0496: stloc.s 12
+			IL_0498: ldloc.0
+			IL_0499: ldc.i4.m1
+			IL_049a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_049f: ldloc.0
+			IL_04a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_04aa: ldarg.0
+			IL_04ab: ldc.i4.1
+			IL_04ac: newarr [System.Runtime]System.Object
+			IL_04b1: dup
+			IL_04b2: ldc.i4.0
+			IL_04b3: ldloc.s 12
+			IL_04b5: stelem.ref
+			IL_04b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_04bb: pop
 			IL_04bc: ldloc.0
-			IL_04bd: ldc.i4.m1
-			IL_04be: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04c3: ldloc.0
-			IL_04c4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_04ce: ldarg.0
-			IL_04cf: ldc.i4.1
-			IL_04d0: newarr [System.Runtime]System.Object
-			IL_04d5: dup
-			IL_04d6: ldc.i4.0
-			IL_04d7: ldloc.s 12
-			IL_04d9: stelem.ref
-			IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_04df: pop
-			IL_04e0: ldloc.0
-			IL_04e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04e6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04eb: ret
+			IL_04bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04c2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04c7: ret
 
-			IL_04ec: ldloc.1
-			IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04f2: stloc.s 12
-			IL_04f4: ldloc.s 12
-			IL_04f6: ldstr "emit"
-			IL_04fb: ldstr "tick"
-			IL_0500: ldc.r8 99
-			IL_0509: box [System.Runtime]System.Double
-			IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0513: pop
-			IL_0514: ldstr "console"
-			IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_051e: stloc.s 12
-			IL_0520: ldloc.s 12
-			IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0527: stloc.s 12
-			IL_0529: ldloc.s 12
-			IL_052b: ldstr "log"
-			IL_0530: ldstr "break-done"
-			IL_0535: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_053a: pop
-			IL_053b: ldloc.0
-			IL_053c: ldc.i4.m1
-			IL_053d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0542: ldloc.0
-			IL_0543: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0548: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_054d: ldarg.0
-			IL_054e: ldc.i4.1
-			IL_054f: newarr [System.Runtime]System.Object
-			IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0559: pop
-			IL_055a: ldloc.0
-			IL_055b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0560: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0565: ret
+			IL_04c8: ldloc.1
+			IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04ce: stloc.s 12
+			IL_04d0: ldloc.s 12
+			IL_04d2: ldstr "emit"
+			IL_04d7: ldstr "tick"
+			IL_04dc: ldc.r8 99
+			IL_04e5: box [System.Runtime]System.Double
+			IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04ef: pop
+			IL_04f0: ldstr "console"
+			IL_04f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04fa: stloc.s 12
+			IL_04fc: ldloc.s 12
+			IL_04fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0503: stloc.s 12
+			IL_0505: ldloc.s 12
+			IL_0507: ldstr "log"
+			IL_050c: ldstr "break-done"
+			IL_0511: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0516: pop
+			IL_0517: ldloc.0
+			IL_0518: ldc.i4.m1
+			IL_0519: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_051e: ldloc.0
+			IL_051f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0524: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0529: ldarg.0
+			IL_052a: ldc.i4.1
+			IL_052b: newarr [System.Runtime]System.Object
+			IL_0530: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0535: pop
+			IL_0536: ldloc.0
+			IL_0537: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_053c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0541: ret
 		} // end of method runOnBreak::__js_call__
 
 	} // end of class runOnBreak
@@ -728,7 +716,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3244
+						// Method begins at RVA 0x31aa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -752,7 +740,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3256
+							// Method begins at RVA 0x31bc
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -770,7 +758,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x324d
+						// Method begins at RVA 0x31b3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -790,7 +778,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x325f
+						// Method begins at RVA 0x31c5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -814,7 +802,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x323b
+					// Method begins at RVA 0x31a1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -838,9 +826,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2dcc
+				// Method begins at RVA 0x2d44
 				// Header size: 12
-				// Code size: 1069 (0x42d)
+				// Code size: 1051 (0x41b)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope,
@@ -960,7 +948,7 @@
 
 				IL_00d0: ldloc.0
 				IL_00d1: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_00d6: switch (IL_00f3, IL_03b7, IL_0251, IL_030d, IL_01e2, IL_0301)
+				IL_00d6: switch (IL_00f3, IL_03a5, IL_023f, IL_02fb, IL_01d0, IL_02ef)
 
 				IL_00f3: ldloc.0
 				IL_00f4: ldc.i4.0
@@ -973,347 +961,341 @@
 				IL_0107: ldelem.ref
 				IL_0108: castclass Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope
 				IL_010d: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::iterator
-				IL_0112: stloc.s 11
-				IL_0114: ldstr "iterator"
-				IL_0119: ldloc.s 11
-				IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0120: stloc.s 11
-				IL_0122: ldloc.s 11
-				IL_0124: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-				IL_0129: stloc.2
+				IL_0112: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+				IL_0117: stloc.2
+				IL_0118: ldc.i4.0
+				IL_0119: stloc.3
+				IL_011a: ldc.i4.0
+				IL_011b: stloc.s 4
+				IL_011d: ldloc.0
+				IL_011e: ldc.i4.0
+				IL_011f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_0124: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_0129: ldloc.0
 				IL_012a: ldc.i4.0
-				IL_012b: stloc.3
-				IL_012c: ldc.i4.0
-				IL_012d: stloc.s 4
-				IL_012f: ldloc.0
-				IL_0130: ldc.i4.0
-				IL_0131: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_0136: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_013b: ldloc.0
-				IL_013c: ldc.i4.0
-				IL_013d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_0142: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-				IL_0147: ldloc.0
-				IL_0148: ldc.i4.0
-				IL_0149: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-				IL_014e: ldloc.0
-				IL_014f: ldc.i4.0
-				IL_0150: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+				IL_012b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_0130: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+				IL_0135: ldloc.0
+				IL_0136: ldc.i4.0
+				IL_0137: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+				IL_013c: ldloc.0
+				IL_013d: ldc.i4.0
+				IL_013e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-				IL_0155: ldloc.2
-				IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-				IL_015b: stloc.s 11
-				IL_015d: ldloc.0
-				IL_015e: ldc.i4.4
-				IL_015f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_0164: ldloc.0
-				IL_0165: ldloc.s 11
-				IL_0167: ldarg.0
-				IL_0168: ldc.i4.1
-				IL_0169: ldloc.0
-				IL_016a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-				IL_016f: ldc.i4.2
-				IL_0170: ldstr "_pendingException"
-				IL_0175: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-				IL_017a: ldloc.0
-				IL_017b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-				IL_0180: dup
-				IL_0181: ldc.i4.0
-				IL_0182: ldloc.1
-				IL_0183: stelem.ref
-				IL_0184: dup
-				IL_0185: ldc.i4.1
-				IL_0186: ldloc.2
-				IL_0187: stelem.ref
-				IL_0188: dup
-				IL_0189: ldc.i4.2
-				IL_018a: ldloc.3
-				IL_018b: box [System.Runtime]System.Boolean
-				IL_0190: stelem.ref
-				IL_0191: dup
-				IL_0192: ldc.i4.3
-				IL_0193: ldloc.s 4
-				IL_0195: box [System.Runtime]System.Boolean
-				IL_019a: stelem.ref
-				IL_019b: dup
-				IL_019c: ldc.i4.4
-				IL_019d: ldloc.s 5
-				IL_019f: stelem.ref
-				IL_01a0: dup
-				IL_01a1: ldc.i4.5
-				IL_01a2: ldloc.s 6
-				IL_01a4: stelem.ref
-				IL_01a5: dup
-				IL_01a6: ldc.i4.6
-				IL_01a7: ldloc.s 7
-				IL_01a9: box [System.Runtime]System.Boolean
-				IL_01ae: stelem.ref
-				IL_01af: dup
-				IL_01b0: ldc.i4.7
-				IL_01b1: ldloc.s 8
-				IL_01b3: box [System.Runtime]System.Boolean
-				IL_01b8: stelem.ref
-				IL_01b9: dup
-				IL_01ba: ldc.i4.8
-				IL_01bb: ldloc.s 9
-				IL_01bd: stelem.ref
-				IL_01be: dup
-				IL_01bf: ldc.i4.s 9
-				IL_01c1: ldloc.s 10
-				IL_01c3: stelem.ref
-				IL_01c4: dup
-				IL_01c5: ldc.i4.s 10
-				IL_01c7: ldloc.s 11
-				IL_01c9: stelem.ref
-				IL_01ca: dup
-				IL_01cb: ldc.i4.s 11
-				IL_01cd: ldloc.s 12
-				IL_01cf: box [System.Runtime]System.Boolean
-				IL_01d4: stelem.ref
-				IL_01d5: pop
-				IL_01d6: ldloc.0
-				IL_01d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_01dc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-				IL_01e1: ret
+				IL_0143: ldloc.2
+				IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+				IL_0149: stloc.s 11
+				IL_014b: ldloc.0
+				IL_014c: ldc.i4.4
+				IL_014d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_0152: ldloc.0
+				IL_0153: ldloc.s 11
+				IL_0155: ldarg.0
+				IL_0156: ldc.i4.1
+				IL_0157: ldloc.0
+				IL_0158: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+				IL_015d: ldc.i4.2
+				IL_015e: ldstr "_pendingException"
+				IL_0163: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+				IL_0168: ldloc.0
+				IL_0169: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+				IL_016e: dup
+				IL_016f: ldc.i4.0
+				IL_0170: ldloc.1
+				IL_0171: stelem.ref
+				IL_0172: dup
+				IL_0173: ldc.i4.1
+				IL_0174: ldloc.2
+				IL_0175: stelem.ref
+				IL_0176: dup
+				IL_0177: ldc.i4.2
+				IL_0178: ldloc.3
+				IL_0179: box [System.Runtime]System.Boolean
+				IL_017e: stelem.ref
+				IL_017f: dup
+				IL_0180: ldc.i4.3
+				IL_0181: ldloc.s 4
+				IL_0183: box [System.Runtime]System.Boolean
+				IL_0188: stelem.ref
+				IL_0189: dup
+				IL_018a: ldc.i4.4
+				IL_018b: ldloc.s 5
+				IL_018d: stelem.ref
+				IL_018e: dup
+				IL_018f: ldc.i4.5
+				IL_0190: ldloc.s 6
+				IL_0192: stelem.ref
+				IL_0193: dup
+				IL_0194: ldc.i4.6
+				IL_0195: ldloc.s 7
+				IL_0197: box [System.Runtime]System.Boolean
+				IL_019c: stelem.ref
+				IL_019d: dup
+				IL_019e: ldc.i4.7
+				IL_019f: ldloc.s 8
+				IL_01a1: box [System.Runtime]System.Boolean
+				IL_01a6: stelem.ref
+				IL_01a7: dup
+				IL_01a8: ldc.i4.8
+				IL_01a9: ldloc.s 9
+				IL_01ab: stelem.ref
+				IL_01ac: dup
+				IL_01ad: ldc.i4.s 9
+				IL_01af: ldloc.s 10
+				IL_01b1: stelem.ref
+				IL_01b2: dup
+				IL_01b3: ldc.i4.s 10
+				IL_01b5: ldloc.s 11
+				IL_01b7: stelem.ref
+				IL_01b8: dup
+				IL_01b9: ldc.i4.s 11
+				IL_01bb: ldloc.s 12
+				IL_01bd: box [System.Runtime]System.Boolean
+				IL_01c2: stelem.ref
+				IL_01c3: pop
+				IL_01c4: ldloc.0
+				IL_01c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_01ca: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+				IL_01cf: ret
 
-				IL_01e2: ldloc.0
-				IL_01e3: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope::_awaited1
-				IL_01e8: stloc.s 11
-				IL_01ea: ldloc.s 11
-				IL_01ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_01f1: stloc.s 12
-				IL_01f3: ldloc.s 12
-				IL_01f5: brtrue IL_024a
+				IL_01d0: ldloc.0
+				IL_01d1: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope::_awaited1
+				IL_01d6: stloc.s 11
+				IL_01d8: ldloc.s 11
+				IL_01da: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+				IL_01df: stloc.s 12
+				IL_01e1: ldloc.s 12
+				IL_01e3: brtrue IL_0238
 
-				IL_01fa: ldloc.s 11
-				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_0201: stloc.s 11
-				IL_0203: ldloc.s 11
-				IL_0205: stloc.s 5
-				IL_0207: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope/Scope_ForOf_L33C17/Block_L33C41::.ctor()
-				IL_020c: stloc.s 6
-				IL_020e: ldstr "console"
-				IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0218: stloc.s 11
-				IL_021a: ldloc.s 11
-				IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0221: stloc.s 11
-				IL_0223: ldloc.s 11
-				IL_0225: ldstr "log"
-				IL_022a: ldloc.s 5
-				IL_022c: ldc.r8 0.0
-				IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_023f: pop
-				IL_0240: br IL_0155
+				IL_01e8: ldloc.s 11
+				IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+				IL_01ef: stloc.s 11
+				IL_01f1: ldloc.s 11
+				IL_01f3: stloc.s 5
+				IL_01f5: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope/Scope_ForOf_L33C17/Block_L33C41::.ctor()
+				IL_01fa: stloc.s 6
+				IL_01fc: ldstr "console"
+				IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0206: stloc.s 11
+				IL_0208: ldloc.s 11
+				IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_020f: stloc.s 11
+				IL_0211: ldloc.s 11
+				IL_0213: ldstr "log"
+				IL_0218: ldloc.s 5
+				IL_021a: ldc.r8 0.0
+				IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_022d: pop
+				IL_022e: br IL_0143
 
-				IL_0245: br IL_0264
+				IL_0233: br IL_0252
 
-				IL_024a: ldc.i4.1
-				IL_024b: stloc.3
-				IL_024c: br IL_0264
+				IL_0238: ldc.i4.1
+				IL_0239: stloc.3
+				IL_023a: br IL_0252
 
-				IL_0251: ldloc.0
-				IL_0252: ldc.i4.1
-				IL_0253: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-				IL_0258: ldloc.0
-				IL_0259: ldc.i4.0
-				IL_025a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-				IL_025f: br IL_0264
+				IL_023f: ldloc.0
+				IL_0240: ldc.i4.1
+				IL_0241: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+				IL_0246: ldloc.0
+				IL_0247: ldc.i4.0
+				IL_0248: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+				IL_024d: br IL_0252
 
-				IL_0264: ldloc.3
-				IL_0265: brtrue IL_0308
+				IL_0252: ldloc.3
+				IL_0253: brtrue IL_02f6
 
-				IL_026a: ldloc.s 4
-				IL_026c: brtrue IL_0308
+				IL_0258: ldloc.s 4
+				IL_025a: brtrue IL_02f6
 
-				IL_0271: ldc.i4.1
-				IL_0272: stloc.s 4
-				IL_0274: ldloc.2
-				IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-				IL_027a: stloc.s 11
-				IL_027c: ldloc.0
-				IL_027d: ldc.i4.5
-				IL_027e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_0283: ldloc.0
-				IL_0284: ldloc.s 11
-				IL_0286: ldarg.0
-				IL_0287: ldc.i4.2
-				IL_0288: ldloc.0
-				IL_0289: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-				IL_028e: ldc.i4.3
-				IL_028f: ldstr "_pendingException"
-				IL_0294: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-				IL_0299: ldloc.0
-				IL_029a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-				IL_029f: dup
-				IL_02a0: ldc.i4.0
-				IL_02a1: ldloc.1
-				IL_02a2: stelem.ref
-				IL_02a3: dup
-				IL_02a4: ldc.i4.1
-				IL_02a5: ldloc.2
-				IL_02a6: stelem.ref
-				IL_02a7: dup
-				IL_02a8: ldc.i4.2
-				IL_02a9: ldloc.3
-				IL_02aa: box [System.Runtime]System.Boolean
-				IL_02af: stelem.ref
-				IL_02b0: dup
-				IL_02b1: ldc.i4.3
-				IL_02b2: ldloc.s 4
-				IL_02b4: box [System.Runtime]System.Boolean
-				IL_02b9: stelem.ref
-				IL_02ba: dup
-				IL_02bb: ldc.i4.4
-				IL_02bc: ldloc.s 5
-				IL_02be: stelem.ref
-				IL_02bf: dup
-				IL_02c0: ldc.i4.5
-				IL_02c1: ldloc.s 6
-				IL_02c3: stelem.ref
-				IL_02c4: dup
-				IL_02c5: ldc.i4.6
-				IL_02c6: ldloc.s 7
-				IL_02c8: box [System.Runtime]System.Boolean
-				IL_02cd: stelem.ref
-				IL_02ce: dup
-				IL_02cf: ldc.i4.7
-				IL_02d0: ldloc.s 8
-				IL_02d2: box [System.Runtime]System.Boolean
-				IL_02d7: stelem.ref
-				IL_02d8: dup
-				IL_02d9: ldc.i4.8
-				IL_02da: ldloc.s 9
-				IL_02dc: stelem.ref
-				IL_02dd: dup
-				IL_02de: ldc.i4.s 9
-				IL_02e0: ldloc.s 10
-				IL_02e2: stelem.ref
-				IL_02e3: dup
-				IL_02e4: ldc.i4.s 10
-				IL_02e6: ldloc.s 11
-				IL_02e8: stelem.ref
-				IL_02e9: dup
-				IL_02ea: ldc.i4.s 11
-				IL_02ec: ldloc.s 12
-				IL_02ee: box [System.Runtime]System.Boolean
-				IL_02f3: stelem.ref
-				IL_02f4: pop
-				IL_02f5: ldloc.0
-				IL_02f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_02fb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-				IL_0300: ret
+				IL_025f: ldc.i4.1
+				IL_0260: stloc.s 4
+				IL_0262: ldloc.2
+				IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+				IL_0268: stloc.s 11
+				IL_026a: ldloc.0
+				IL_026b: ldc.i4.5
+				IL_026c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_0271: ldloc.0
+				IL_0272: ldloc.s 11
+				IL_0274: ldarg.0
+				IL_0275: ldc.i4.2
+				IL_0276: ldloc.0
+				IL_0277: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+				IL_027c: ldc.i4.3
+				IL_027d: ldstr "_pendingException"
+				IL_0282: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+				IL_0287: ldloc.0
+				IL_0288: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+				IL_028d: dup
+				IL_028e: ldc.i4.0
+				IL_028f: ldloc.1
+				IL_0290: stelem.ref
+				IL_0291: dup
+				IL_0292: ldc.i4.1
+				IL_0293: ldloc.2
+				IL_0294: stelem.ref
+				IL_0295: dup
+				IL_0296: ldc.i4.2
+				IL_0297: ldloc.3
+				IL_0298: box [System.Runtime]System.Boolean
+				IL_029d: stelem.ref
+				IL_029e: dup
+				IL_029f: ldc.i4.3
+				IL_02a0: ldloc.s 4
+				IL_02a2: box [System.Runtime]System.Boolean
+				IL_02a7: stelem.ref
+				IL_02a8: dup
+				IL_02a9: ldc.i4.4
+				IL_02aa: ldloc.s 5
+				IL_02ac: stelem.ref
+				IL_02ad: dup
+				IL_02ae: ldc.i4.5
+				IL_02af: ldloc.s 6
+				IL_02b1: stelem.ref
+				IL_02b2: dup
+				IL_02b3: ldc.i4.6
+				IL_02b4: ldloc.s 7
+				IL_02b6: box [System.Runtime]System.Boolean
+				IL_02bb: stelem.ref
+				IL_02bc: dup
+				IL_02bd: ldc.i4.7
+				IL_02be: ldloc.s 8
+				IL_02c0: box [System.Runtime]System.Boolean
+				IL_02c5: stelem.ref
+				IL_02c6: dup
+				IL_02c7: ldc.i4.8
+				IL_02c8: ldloc.s 9
+				IL_02ca: stelem.ref
+				IL_02cb: dup
+				IL_02cc: ldc.i4.s 9
+				IL_02ce: ldloc.s 10
+				IL_02d0: stelem.ref
+				IL_02d1: dup
+				IL_02d2: ldc.i4.s 10
+				IL_02d4: ldloc.s 11
+				IL_02d6: stelem.ref
+				IL_02d7: dup
+				IL_02d8: ldc.i4.s 11
+				IL_02da: ldloc.s 12
+				IL_02dc: box [System.Runtime]System.Boolean
+				IL_02e1: stelem.ref
+				IL_02e2: pop
+				IL_02e3: ldloc.0
+				IL_02e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_02e9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+				IL_02ee: ret
 
-				IL_0301: ldloc.0
-				IL_0302: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope::_awaited2
-				IL_0307: pop
+				IL_02ef: ldloc.0
+				IL_02f0: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope::_awaited2
+				IL_02f5: pop
 
-				IL_0308: br IL_0320
+				IL_02f6: br IL_030e
 
-				IL_030d: ldloc.0
-				IL_030e: ldc.i4.1
-				IL_030f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-				IL_0314: ldloc.0
-				IL_0315: ldc.i4.0
-				IL_0316: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-				IL_031b: br IL_0320
+				IL_02fb: ldloc.0
+				IL_02fc: ldc.i4.1
+				IL_02fd: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+				IL_0302: ldloc.0
+				IL_0303: ldc.i4.0
+				IL_0304: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+				IL_0309: br IL_030e
 
-				IL_0320: ldloc.0
-				IL_0321: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-				IL_0326: stloc.s 7
-				IL_0328: ldloc.s 7
-				IL_032a: brfalse IL_0344
+				IL_030e: ldloc.0
+				IL_030f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+				IL_0314: stloc.s 7
+				IL_0316: ldloc.s 7
+				IL_0318: brfalse IL_0332
 
-				IL_032f: ldloc.0
-				IL_0330: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_0335: stloc.s 11
-				IL_0337: ldloc.0
-				IL_0338: ldloc.s 11
-				IL_033a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_033f: br IL_03b7
+				IL_031d: ldloc.0
+				IL_031e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_0323: stloc.s 11
+				IL_0325: ldloc.0
+				IL_0326: ldloc.s 11
+				IL_0328: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_032d: br IL_03a5
 
-				IL_0344: ldloc.0
-				IL_0345: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-				IL_034a: stloc.s 8
-				IL_034c: ldloc.s 8
-				IL_034e: brfalse IL_038b
+				IL_0332: ldloc.0
+				IL_0333: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+				IL_0338: stloc.s 8
+				IL_033a: ldloc.s 8
+				IL_033c: brfalse IL_0379
 
-				IL_0353: ldloc.0
-				IL_0354: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-				IL_0359: stloc.s 11
-				IL_035b: ldloc.0
-				IL_035c: ldc.i4.m1
-				IL_035d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_0362: ldloc.0
-				IL_0363: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_0368: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-				IL_036d: ldarg.0
-				IL_036e: ldc.i4.1
-				IL_036f: newarr [System.Runtime]System.Object
-				IL_0374: dup
-				IL_0375: ldc.i4.0
-				IL_0376: ldloc.s 11
-				IL_0378: stelem.ref
-				IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-				IL_037e: pop
-				IL_037f: ldloc.0
-				IL_0380: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_0385: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-				IL_038a: ret
+				IL_0341: ldloc.0
+				IL_0342: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+				IL_0347: stloc.s 11
+				IL_0349: ldloc.0
+				IL_034a: ldc.i4.m1
+				IL_034b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_0350: ldloc.0
+				IL_0351: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_0356: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+				IL_035b: ldarg.0
+				IL_035c: ldc.i4.1
+				IL_035d: newarr [System.Runtime]System.Object
+				IL_0362: dup
+				IL_0363: ldc.i4.0
+				IL_0364: ldloc.s 11
+				IL_0366: stelem.ref
+				IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+				IL_036c: pop
+				IL_036d: ldloc.0
+				IL_036e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_0373: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+				IL_0378: ret
 
-				IL_038b: ldstr "console"
-				IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0395: stloc.s 11
-				IL_0397: ldloc.s 11
-				IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_039e: stloc.s 11
-				IL_03a0: ldloc.s 11
-				IL_03a2: ldstr "log"
-				IL_03a7: ldstr "NO_REJECT"
-				IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_03b1: pop
-				IL_03b2: br IL_0402
+				IL_0379: ldstr "console"
+				IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0383: stloc.s 11
+				IL_0385: ldloc.s 11
+				IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_038c: stloc.s 11
+				IL_038e: ldloc.s 11
+				IL_0390: ldstr "log"
+				IL_0395: ldstr "NO_REJECT"
+				IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_039f: pop
+				IL_03a0: br IL_03f0
 
-				IL_03b7: ldloc.0
-				IL_03b8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_03bd: stloc.s 11
-				IL_03bf: ldloc.0
-				IL_03c0: ldc.i4.0
-				IL_03c1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_03c6: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_03cb: ldloc.s 11
-				IL_03cd: stloc.s 9
-				IL_03cf: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope/Block_L37C16::.ctor()
-				IL_03d4: stloc.s 10
-				IL_03d6: ldstr "console"
-				IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_03e0: stloc.s 11
-				IL_03e2: ldloc.s 11
-				IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03e9: stloc.s 11
-				IL_03eb: ldloc.s 11
-				IL_03ed: ldstr "log"
-				IL_03f2: ldstr "iter-reject"
-				IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_03fc: pop
-				IL_03fd: br IL_0402
+				IL_03a5: ldloc.0
+				IL_03a6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_03ab: stloc.s 11
+				IL_03ad: ldloc.0
+				IL_03ae: ldc.i4.0
+				IL_03af: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_03b4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_03b9: ldloc.s 11
+				IL_03bb: stloc.s 9
+				IL_03bd: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope/Block_L37C16::.ctor()
+				IL_03c2: stloc.s 10
+				IL_03c4: ldstr "console"
+				IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_03ce: stloc.s 11
+				IL_03d0: ldloc.s 11
+				IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03d7: stloc.s 11
+				IL_03d9: ldloc.s 11
+				IL_03db: ldstr "log"
+				IL_03e0: ldstr "iter-reject"
+				IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_03ea: pop
+				IL_03eb: br IL_03f0
 
-				IL_0402: ldloc.0
-				IL_0403: ldc.i4.m1
-				IL_0404: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_0409: ldloc.0
-				IL_040a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_040f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-				IL_0414: ldarg.0
-				IL_0415: ldc.i4.1
-				IL_0416: newarr [System.Runtime]System.Object
-				IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-				IL_0420: pop
-				IL_0421: ldloc.0
-				IL_0422: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_0427: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-				IL_042c: ret
+				IL_03f0: ldloc.0
+				IL_03f1: ldc.i4.m1
+				IL_03f2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_03f7: ldloc.0
+				IL_03f8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_03fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+				IL_0402: ldarg.0
+				IL_0403: ldc.i4.1
+				IL_0404: newarr [System.Runtime]System.Object
+				IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+				IL_040e: pop
+				IL_040f: ldloc.0
+				IL_0410: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_0415: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+				IL_041a: ret
 			} // end of method ArrowFunction_L31C17::__js_call__
 
 		} // end of class ArrowFunction_L31C17
@@ -1334,7 +1316,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3232
+				// Method begins at RVA 0x3198
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1358,9 +1340,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2748
+			// Method begins at RVA 0x2724
 			// Header size: 12
-			// Code size: 468 (0x1d4)
+			// Code size: 440 (0x1b8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope,
@@ -1432,150 +1414,138 @@
 
 			IL_007c: ldloc.0
 			IL_007d: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0082: switch (IL_008f, IL_01a2)
+			IL_0082: switch (IL_008f, IL_0186)
 
 			IL_008f: ldarg.0
 			IL_0090: ldc.i4.1
 			IL_0091: ldelem.ref
 			IL_0092: castclass Modules.Events_AsyncHelpers_On_Once/Scope
 			IL_0097: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-			IL_009c: stloc.3
-			IL_009d: ldstr "EventEmitter"
-			IL_00a2: ldloc.3
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a8: stloc.3
-			IL_00a9: ldloc.3
-			IL_00aa: ldc.i4.0
-			IL_00ab: newarr [System.Runtime]System.Object
-			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_00b5: stloc.3
-			IL_00b6: ldloc.3
-			IL_00b7: stloc.1
-			IL_00b8: ldarg.0
-			IL_00b9: ldc.i4.1
-			IL_00ba: ldelem.ref
-			IL_00bb: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_00c0: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_00c5: stloc.3
-			IL_00c6: ldstr "events"
-			IL_00cb: ldloc.3
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00d1: stloc.3
-			IL_00d2: ldloc.3
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d8: stloc.3
-			IL_00d9: ldloc.3
-			IL_00da: ldstr "on"
-			IL_00df: ldloc.1
-			IL_00e0: ldstr "data"
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00ea: stloc.3
-			IL_00eb: ldloc.0
-			IL_00ec: ldloc.3
-			IL_00ed: stfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::iterator
-			IL_00f2: ldnull
-			IL_00f3: ldftn object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17::__js_call__(object[], object)
-			IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_00fe: ldc.i4.2
-			IL_00ff: newarr [System.Runtime]System.Object
-			IL_0104: dup
-			IL_0105: ldc.i4.0
-			IL_0106: ldarg.0
-			IL_0107: ldc.i4.1
-			IL_0108: ldelem.ref
-			IL_0109: stelem.ref
-			IL_010a: dup
-			IL_010b: ldc.i4.1
-			IL_010c: ldloc.0
-			IL_010d: stelem.ref
-			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0118: ldc.i4.0
-			IL_0119: conv.r8
-			IL_011a: ldstr ""
-			IL_011f: ldc.i4.0
-			IL_0120: ldc.i4.1
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_012b: stloc.3
-			IL_012c: ldc.i4.0
-			IL_012d: newarr [System.Runtime]System.Object
-			IL_0132: stloc.s 4
-			IL_0134: ldloc.3
-			IL_0135: ldc.i4.1
-			IL_0136: newarr [System.Runtime]System.Object
-			IL_013b: dup
-			IL_013c: ldc.i4.0
-			IL_013d: ldarg.0
-			IL_013e: ldc.i4.1
-			IL_013f: ldelem.ref
-			IL_0140: stelem.ref
-			IL_0141: ldloc.s 4
-			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0148: stloc.3
-			IL_0149: ldloc.3
-			IL_014a: stloc.2
-			IL_014b: ldloc.1
-			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0151: stloc.3
-			IL_0152: ldloc.3
-			IL_0153: ldstr "emit"
-			IL_0158: ldstr "error"
-			IL_015d: ldstr "E1"
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0167: pop
-			IL_0168: ldloc.0
-			IL_0169: ldc.i4.1
-			IL_016a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_016f: ldloc.0
-			IL_0170: ldloc.2
-			IL_0171: ldarg.0
-			IL_0172: ldc.i4.1
-			IL_0173: ldloc.0
-			IL_0174: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0179: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_017e: ldloc.0
-			IL_017f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0184: dup
-			IL_0185: ldc.i4.0
-			IL_0186: ldloc.1
-			IL_0187: stelem.ref
-			IL_0188: dup
-			IL_0189: ldc.i4.1
-			IL_018a: ldloc.2
-			IL_018b: stelem.ref
-			IL_018c: dup
-			IL_018d: ldc.i4.2
-			IL_018e: ldloc.3
-			IL_018f: stelem.ref
-			IL_0190: dup
-			IL_0191: ldc.i4.3
-			IL_0192: ldloc.s 4
-			IL_0194: stelem.ref
-			IL_0195: pop
-			IL_0196: ldloc.0
-			IL_0197: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_019c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01a1: ret
+			IL_009c: ldc.i4.0
+			IL_009d: newarr [System.Runtime]System.Object
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_00a7: stloc.3
+			IL_00a8: ldloc.3
+			IL_00a9: stloc.1
+			IL_00aa: ldarg.0
+			IL_00ab: ldc.i4.1
+			IL_00ac: ldelem.ref
+			IL_00ad: castclass Modules.Events_AsyncHelpers_On_Once/Scope
+			IL_00b2: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00bc: stloc.3
+			IL_00bd: ldloc.3
+			IL_00be: ldstr "on"
+			IL_00c3: ldloc.1
+			IL_00c4: ldstr "data"
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00ce: stloc.3
+			IL_00cf: ldloc.0
+			IL_00d0: ldloc.3
+			IL_00d1: stfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::iterator
+			IL_00d6: ldnull
+			IL_00d7: ldftn object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17::__js_call__(object[], object)
+			IL_00dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_00e2: ldc.i4.2
+			IL_00e3: newarr [System.Runtime]System.Object
+			IL_00e8: dup
+			IL_00e9: ldc.i4.0
+			IL_00ea: ldarg.0
+			IL_00eb: ldc.i4.1
+			IL_00ec: ldelem.ref
+			IL_00ed: stelem.ref
+			IL_00ee: dup
+			IL_00ef: ldc.i4.1
+			IL_00f0: ldloc.0
+			IL_00f1: stelem.ref
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00fc: ldc.i4.0
+			IL_00fd: conv.r8
+			IL_00fe: ldstr ""
+			IL_0103: ldc.i4.0
+			IL_0104: ldc.i4.1
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_010f: stloc.3
+			IL_0110: ldc.i4.0
+			IL_0111: newarr [System.Runtime]System.Object
+			IL_0116: stloc.s 4
+			IL_0118: ldloc.3
+			IL_0119: ldc.i4.1
+			IL_011a: newarr [System.Runtime]System.Object
+			IL_011f: dup
+			IL_0120: ldc.i4.0
+			IL_0121: ldarg.0
+			IL_0122: ldc.i4.1
+			IL_0123: ldelem.ref
+			IL_0124: stelem.ref
+			IL_0125: ldloc.s 4
+			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_012c: stloc.3
+			IL_012d: ldloc.3
+			IL_012e: stloc.2
+			IL_012f: ldloc.1
+			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0135: stloc.3
+			IL_0136: ldloc.3
+			IL_0137: ldstr "emit"
+			IL_013c: ldstr "error"
+			IL_0141: ldstr "E1"
+			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_014b: pop
+			IL_014c: ldloc.0
+			IL_014d: ldc.i4.1
+			IL_014e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0153: ldloc.0
+			IL_0154: ldloc.2
+			IL_0155: ldarg.0
+			IL_0156: ldc.i4.1
+			IL_0157: ldloc.0
+			IL_0158: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_015d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0162: ldloc.0
+			IL_0163: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0168: dup
+			IL_0169: ldc.i4.0
+			IL_016a: ldloc.1
+			IL_016b: stelem.ref
+			IL_016c: dup
+			IL_016d: ldc.i4.1
+			IL_016e: ldloc.2
+			IL_016f: stelem.ref
+			IL_0170: dup
+			IL_0171: ldc.i4.2
+			IL_0172: ldloc.3
+			IL_0173: stelem.ref
+			IL_0174: dup
+			IL_0175: ldc.i4.3
+			IL_0176: ldloc.s 4
+			IL_0178: stelem.ref
+			IL_0179: pop
+			IL_017a: ldloc.0
+			IL_017b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0180: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0185: ret
 
-			IL_01a2: ldloc.0
-			IL_01a3: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::_awaited1
-			IL_01a8: pop
-			IL_01a9: ldloc.0
-			IL_01aa: ldc.i4.m1
-			IL_01ab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01b0: ldloc.0
-			IL_01b1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_01bb: ldarg.0
-			IL_01bc: ldc.i4.1
-			IL_01bd: newarr [System.Runtime]System.Object
-			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01c7: pop
-			IL_01c8: ldloc.0
-			IL_01c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ce: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01d3: ret
+			IL_0186: ldloc.0
+			IL_0187: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::_awaited1
+			IL_018c: pop
+			IL_018d: ldloc.0
+			IL_018e: ldc.i4.m1
+			IL_018f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0194: ldloc.0
+			IL_0195: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_019a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_019f: ldarg.0
+			IL_01a0: ldc.i4.1
+			IL_01a1: newarr [System.Runtime]System.Object
+			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01ab: pop
+			IL_01ac: ldloc.0
+			IL_01ad: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01b2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01b7: ret
 		} // end of method runOnErrorReject::__js_call__
 
 	} // end of class runOnErrorReject
@@ -1601,7 +1571,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3268
+				// Method begins at RVA 0x31ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1625,9 +1595,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2928
+			// Method begins at RVA 0x28e8
 			// Header size: 12
-			// Code size: 546 (0x222)
+			// Code size: 510 (0x1fe)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnceResolve/Scope,
@@ -1698,150 +1668,138 @@
 
 			IL_0077: ldloc.0
 			IL_0078: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_007d: switch (IL_008a, IL_015d)
+			IL_007d: switch (IL_008a, IL_0139)
 
 			IL_008a: ldarg.0
 			IL_008b: ldc.i4.1
 			IL_008c: ldelem.ref
 			IL_008d: castclass Modules.Events_AsyncHelpers_On_Once/Scope
 			IL_0092: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-			IL_0097: stloc.s 4
-			IL_0099: ldstr "EventEmitter"
-			IL_009e: ldloc.s 4
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a5: stloc.s 4
-			IL_00a7: ldloc.s 4
-			IL_00a9: ldc.i4.0
-			IL_00aa: newarr [System.Runtime]System.Object
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_00b4: stloc.s 4
-			IL_00b6: ldloc.s 4
-			IL_00b8: stloc.1
-			IL_00b9: ldarg.0
-			IL_00ba: ldc.i4.1
-			IL_00bb: ldelem.ref
-			IL_00bc: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_00c1: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_00c6: stloc.s 4
-			IL_00c8: ldstr "events"
-			IL_00cd: ldloc.s 4
-			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00d4: stloc.s 4
-			IL_00d6: ldloc.s 4
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00dd: stloc.s 4
-			IL_00df: ldloc.s 4
-			IL_00e1: ldstr "once"
-			IL_00e6: ldloc.1
-			IL_00e7: ldstr "ready"
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f1: stloc.s 4
-			IL_00f3: ldloc.s 4
-			IL_00f5: stloc.2
-			IL_00f6: ldloc.1
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fc: stloc.s 4
-			IL_00fe: ldloc.s 4
-			IL_0100: ldstr "emit"
-			IL_0105: ldstr "ready"
-			IL_010a: ldstr "ok"
-			IL_010f: ldc.r8 42
-			IL_0118: box [System.Runtime]System.Double
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0122: pop
-			IL_0123: ldloc.0
-			IL_0124: ldc.i4.1
-			IL_0125: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_012a: ldloc.0
-			IL_012b: ldloc.2
-			IL_012c: ldarg.0
-			IL_012d: ldc.i4.1
-			IL_012e: ldloc.0
-			IL_012f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0134: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0139: ldloc.0
-			IL_013a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_013f: dup
-			IL_0140: ldc.i4.0
-			IL_0141: ldloc.1
-			IL_0142: stelem.ref
-			IL_0143: dup
-			IL_0144: ldc.i4.1
-			IL_0145: ldloc.2
-			IL_0146: stelem.ref
-			IL_0147: dup
-			IL_0148: ldc.i4.2
-			IL_0149: ldloc.3
-			IL_014a: stelem.ref
-			IL_014b: dup
-			IL_014c: ldc.i4.3
-			IL_014d: ldloc.s 4
-			IL_014f: stelem.ref
-			IL_0150: pop
-			IL_0151: ldloc.0
-			IL_0152: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0157: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_015c: ret
+			IL_0097: ldc.i4.0
+			IL_0098: newarr [System.Runtime]System.Object
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_00a2: stloc.s 4
+			IL_00a4: ldloc.s 4
+			IL_00a6: stloc.1
+			IL_00a7: ldarg.0
+			IL_00a8: ldc.i4.1
+			IL_00a9: ldelem.ref
+			IL_00aa: castclass Modules.Events_AsyncHelpers_On_Once/Scope
+			IL_00af: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b9: stloc.s 4
+			IL_00bb: ldloc.s 4
+			IL_00bd: ldstr "once"
+			IL_00c2: ldloc.1
+			IL_00c3: ldstr "ready"
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00cd: stloc.s 4
+			IL_00cf: ldloc.s 4
+			IL_00d1: stloc.2
+			IL_00d2: ldloc.1
+			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d8: stloc.s 4
+			IL_00da: ldloc.s 4
+			IL_00dc: ldstr "emit"
+			IL_00e1: ldstr "ready"
+			IL_00e6: ldstr "ok"
+			IL_00eb: ldc.r8 42
+			IL_00f4: box [System.Runtime]System.Double
+			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_00fe: pop
+			IL_00ff: ldloc.0
+			IL_0100: ldc.i4.1
+			IL_0101: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0106: ldloc.0
+			IL_0107: ldloc.2
+			IL_0108: ldarg.0
+			IL_0109: ldc.i4.1
+			IL_010a: ldloc.0
+			IL_010b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0110: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0115: ldloc.0
+			IL_0116: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_011b: dup
+			IL_011c: ldc.i4.0
+			IL_011d: ldloc.1
+			IL_011e: stelem.ref
+			IL_011f: dup
+			IL_0120: ldc.i4.1
+			IL_0121: ldloc.2
+			IL_0122: stelem.ref
+			IL_0123: dup
+			IL_0124: ldc.i4.2
+			IL_0125: ldloc.3
+			IL_0126: stelem.ref
+			IL_0127: dup
+			IL_0128: ldc.i4.3
+			IL_0129: ldloc.s 4
+			IL_012b: stelem.ref
+			IL_012c: pop
+			IL_012d: ldloc.0
+			IL_012e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0133: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0138: ret
 
-			IL_015d: ldloc.0
-			IL_015e: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceResolve/Scope::_awaited1
-			IL_0163: stloc.s 4
-			IL_0165: ldloc.s 4
-			IL_0167: stloc.3
-			IL_0168: ldstr "console"
-			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0172: stloc.s 4
-			IL_0174: ldloc.s 4
-			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0139: ldloc.0
+			IL_013a: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceResolve/Scope::_awaited1
+			IL_013f: stloc.s 4
+			IL_0141: ldloc.s 4
+			IL_0143: stloc.3
+			IL_0144: ldstr "console"
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_014e: stloc.s 4
+			IL_0150: ldloc.s 4
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0157: stloc.s 4
+			IL_0159: ldloc.s 4
+			IL_015b: ldstr "log"
+			IL_0160: ldloc.3
+			IL_0161: ldstr "length"
+			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0170: pop
+			IL_0171: ldstr "console"
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_017b: stloc.s 4
 			IL_017d: ldloc.s 4
-			IL_017f: ldstr "log"
-			IL_0184: ldloc.3
-			IL_0185: ldstr "length"
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0194: pop
-			IL_0195: ldstr "console"
-			IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_019f: stloc.s 4
-			IL_01a1: ldloc.s 4
-			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a8: stloc.s 4
-			IL_01aa: ldloc.s 4
-			IL_01ac: ldstr "log"
-			IL_01b1: ldloc.3
-			IL_01b2: ldc.r8 0.0
-			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01c5: pop
-			IL_01c6: ldstr "console"
-			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01d0: stloc.s 4
-			IL_01d2: ldloc.s 4
-			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01d9: stloc.s 4
-			IL_01db: ldloc.s 4
-			IL_01dd: ldstr "log"
-			IL_01e2: ldloc.3
-			IL_01e3: ldc.r8 1
-			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01f6: pop
-			IL_01f7: ldloc.0
-			IL_01f8: ldc.i4.m1
-			IL_01f9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01fe: ldloc.0
-			IL_01ff: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0204: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0209: ldarg.0
-			IL_020a: ldc.i4.1
-			IL_020b: newarr [System.Runtime]System.Object
-			IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0215: pop
-			IL_0216: ldloc.0
-			IL_0217: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_021c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0221: ret
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0184: stloc.s 4
+			IL_0186: ldloc.s 4
+			IL_0188: ldstr "log"
+			IL_018d: ldloc.3
+			IL_018e: ldc.r8 0.0
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01a1: pop
+			IL_01a2: ldstr "console"
+			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ac: stloc.s 4
+			IL_01ae: ldloc.s 4
+			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01b5: stloc.s 4
+			IL_01b7: ldloc.s 4
+			IL_01b9: ldstr "log"
+			IL_01be: ldloc.3
+			IL_01bf: ldc.r8 1
+			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01d2: pop
+			IL_01d3: ldloc.0
+			IL_01d4: ldc.i4.m1
+			IL_01d5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01da: ldloc.0
+			IL_01db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_01e5: ldarg.0
+			IL_01e6: ldc.i4.1
+			IL_01e7: newarr [System.Runtime]System.Object
+			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01f1: pop
+			IL_01f2: ldloc.0
+			IL_01f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01f8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01fd: ret
 		} // end of method runOnceResolve::__js_call__
 
 	} // end of class runOnceResolve
@@ -1870,7 +1828,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x327a
+					// Method begins at RVA 0x31e0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1890,7 +1848,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3283
+					// Method begins at RVA 0x31e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1914,7 +1872,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3271
+				// Method begins at RVA 0x31d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1938,9 +1896,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b58
+			// Method begins at RVA 0x2af4
 			// Header size: 12
-			// Code size: 562 (0x232)
+			// Code size: 526 (0x20e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope,
@@ -2023,160 +1981,148 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0091: switch (IL_00a2, IL_01bc, IL_0189)
+			IL_0091: switch (IL_00a2, IL_0198, IL_0165)
 
 			IL_00a2: ldarg.0
 			IL_00a3: ldc.i4.1
 			IL_00a4: ldelem.ref
 			IL_00a5: castclass Modules.Events_AsyncHelpers_On_Once/Scope
 			IL_00aa: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-			IL_00af: stloc.s 6
-			IL_00b1: ldstr "EventEmitter"
-			IL_00b6: ldloc.s 6
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00bd: stloc.s 6
-			IL_00bf: ldloc.s 6
-			IL_00c1: ldc.i4.0
-			IL_00c2: newarr [System.Runtime]System.Object
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_00cc: stloc.s 6
-			IL_00ce: ldloc.s 6
-			IL_00d0: stloc.1
-			IL_00d1: ldarg.0
-			IL_00d2: ldc.i4.1
-			IL_00d3: ldelem.ref
-			IL_00d4: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_00d9: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_00de: stloc.s 6
-			IL_00e0: ldstr "events"
-			IL_00e5: ldloc.s 6
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ec: stloc.s 6
-			IL_00ee: ldloc.s 6
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f5: stloc.s 6
-			IL_00f7: ldloc.s 6
-			IL_00f9: ldstr "once"
-			IL_00fe: ldloc.1
-			IL_00ff: ldstr "ready"
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0109: stloc.s 6
-			IL_010b: ldloc.s 6
-			IL_010d: stloc.2
-			IL_010e: ldloc.1
-			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0114: stloc.s 6
-			IL_0116: ldloc.s 6
-			IL_0118: ldstr "emit"
-			IL_011d: ldstr "error"
-			IL_0122: ldstr "boom"
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_012c: pop
-			IL_012d: ldloc.0
-			IL_012e: ldc.i4.0
-			IL_012f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0134: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0139: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope/Block_L62C6::.ctor()
-			IL_013e: stloc.3
-			IL_013f: ldloc.0
-			IL_0140: ldc.i4.2
-			IL_0141: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0146: ldloc.0
-			IL_0147: ldloc.2
-			IL_0148: ldarg.0
-			IL_0149: ldc.i4.1
-			IL_014a: ldloc.0
-			IL_014b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0150: ldc.i4.1
-			IL_0151: ldstr "_pendingException"
-			IL_0156: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_015b: ldloc.0
-			IL_015c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0161: dup
-			IL_0162: ldc.i4.0
-			IL_0163: ldloc.1
-			IL_0164: stelem.ref
-			IL_0165: dup
-			IL_0166: ldc.i4.1
-			IL_0167: ldloc.2
-			IL_0168: stelem.ref
-			IL_0169: dup
-			IL_016a: ldc.i4.2
-			IL_016b: ldloc.3
-			IL_016c: stelem.ref
-			IL_016d: dup
-			IL_016e: ldc.i4.3
-			IL_016f: ldloc.s 4
-			IL_0171: stelem.ref
-			IL_0172: dup
-			IL_0173: ldc.i4.4
-			IL_0174: ldloc.s 5
-			IL_0176: stelem.ref
-			IL_0177: dup
-			IL_0178: ldc.i4.5
-			IL_0179: ldloc.s 6
-			IL_017b: stelem.ref
-			IL_017c: pop
-			IL_017d: ldloc.0
-			IL_017e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0183: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0188: ret
+			IL_00af: ldc.i4.0
+			IL_00b0: newarr [System.Runtime]System.Object
+			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_00ba: stloc.s 6
+			IL_00bc: ldloc.s 6
+			IL_00be: stloc.1
+			IL_00bf: ldarg.0
+			IL_00c0: ldc.i4.1
+			IL_00c1: ldelem.ref
+			IL_00c2: castclass Modules.Events_AsyncHelpers_On_Once/Scope
+			IL_00c7: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d1: stloc.s 6
+			IL_00d3: ldloc.s 6
+			IL_00d5: ldstr "once"
+			IL_00da: ldloc.1
+			IL_00db: ldstr "ready"
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00e5: stloc.s 6
+			IL_00e7: ldloc.s 6
+			IL_00e9: stloc.2
+			IL_00ea: ldloc.1
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f0: stloc.s 6
+			IL_00f2: ldloc.s 6
+			IL_00f4: ldstr "emit"
+			IL_00f9: ldstr "error"
+			IL_00fe: ldstr "boom"
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0108: pop
+			IL_0109: ldloc.0
+			IL_010a: ldc.i4.0
+			IL_010b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0110: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0115: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope/Block_L62C6::.ctor()
+			IL_011a: stloc.3
+			IL_011b: ldloc.0
+			IL_011c: ldc.i4.2
+			IL_011d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0122: ldloc.0
+			IL_0123: ldloc.2
+			IL_0124: ldarg.0
+			IL_0125: ldc.i4.1
+			IL_0126: ldloc.0
+			IL_0127: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_012c: ldc.i4.1
+			IL_012d: ldstr "_pendingException"
+			IL_0132: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0137: ldloc.0
+			IL_0138: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_013d: dup
+			IL_013e: ldc.i4.0
+			IL_013f: ldloc.1
+			IL_0140: stelem.ref
+			IL_0141: dup
+			IL_0142: ldc.i4.1
+			IL_0143: ldloc.2
+			IL_0144: stelem.ref
+			IL_0145: dup
+			IL_0146: ldc.i4.2
+			IL_0147: ldloc.3
+			IL_0148: stelem.ref
+			IL_0149: dup
+			IL_014a: ldc.i4.3
+			IL_014b: ldloc.s 4
+			IL_014d: stelem.ref
+			IL_014e: dup
+			IL_014f: ldc.i4.4
+			IL_0150: ldloc.s 5
+			IL_0152: stelem.ref
+			IL_0153: dup
+			IL_0154: ldc.i4.5
+			IL_0155: ldloc.s 6
+			IL_0157: stelem.ref
+			IL_0158: pop
+			IL_0159: ldloc.0
+			IL_015a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_015f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0164: ret
 
-			IL_0189: ldloc.0
-			IL_018a: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope::_awaited1
-			IL_018f: pop
-			IL_0190: ldstr "console"
-			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_019a: stloc.s 6
-			IL_019c: ldloc.s 6
-			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a3: stloc.s 6
-			IL_01a5: ldloc.s 6
-			IL_01a7: ldstr "log"
-			IL_01ac: ldstr "NO_REJECT"
-			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01b6: pop
-			IL_01b7: br IL_0207
+			IL_0165: ldloc.0
+			IL_0166: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope::_awaited1
+			IL_016b: pop
+			IL_016c: ldstr "console"
+			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0176: stloc.s 6
+			IL_0178: ldloc.s 6
+			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_017f: stloc.s 6
+			IL_0181: ldloc.s 6
+			IL_0183: ldstr "log"
+			IL_0188: ldstr "NO_REJECT"
+			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0192: pop
+			IL_0193: br IL_01e3
 
-			IL_01bc: ldloc.0
-			IL_01bd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_01c2: stloc.s 6
-			IL_01c4: ldloc.0
-			IL_01c5: ldc.i4.0
-			IL_01c6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01cb: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_01d0: ldloc.s 6
-			IL_01d2: stloc.s 4
-			IL_01d4: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope/Block_L65C14::.ctor()
-			IL_01d9: stloc.s 5
-			IL_01db: ldstr "console"
-			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01e5: stloc.s 6
-			IL_01e7: ldloc.s 6
-			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ee: stloc.s 6
-			IL_01f0: ldloc.s 6
-			IL_01f2: ldstr "log"
-			IL_01f7: ldstr "once-reject"
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0198: ldloc.0
+			IL_0199: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_019e: stloc.s 6
+			IL_01a0: ldloc.0
+			IL_01a1: ldc.i4.0
+			IL_01a2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01a7: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_01ac: ldloc.s 6
+			IL_01ae: stloc.s 4
+			IL_01b0: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope/Block_L65C14::.ctor()
+			IL_01b5: stloc.s 5
+			IL_01b7: ldstr "console"
+			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01c1: stloc.s 6
+			IL_01c3: ldloc.s 6
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ca: stloc.s 6
+			IL_01cc: ldloc.s 6
+			IL_01ce: ldstr "log"
+			IL_01d3: ldstr "once-reject"
+			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01dd: pop
+			IL_01de: br IL_01e3
+
+			IL_01e3: ldloc.0
+			IL_01e4: ldc.i4.m1
+			IL_01e5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01ea: ldloc.0
+			IL_01eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_01f5: ldarg.0
+			IL_01f6: ldc.i4.1
+			IL_01f7: newarr [System.Runtime]System.Object
+			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
 			IL_0201: pop
-			IL_0202: br IL_0207
-
-			IL_0207: ldloc.0
-			IL_0208: ldc.i4.m1
-			IL_0209: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_020e: ldloc.0
-			IL_020f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0214: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0219: ldarg.0
-			IL_021a: ldc.i4.1
-			IL_021b: newarr [System.Runtime]System.Object
-			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0225: pop
-			IL_0226: ldloc.0
-			IL_0227: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_022c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0231: ret
+			IL_0202: ldloc.0
+			IL_0203: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0208: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_020d: ret
 		} // end of method runOnceReject::__js_call__
 
 	} // end of class runOnceReject
@@ -2192,7 +2138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x328c
+				// Method begins at RVA 0x31f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2215,7 +2161,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d98
+			// Method begins at RVA 0x2d10
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -2269,7 +2215,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3205
+			// Method begins at RVA 0x316b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2457,7 +2403,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3295
+		// Method begins at RVA 0x31fb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Complete.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Complete.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a64
+				// Method begins at RVA 0x2a32
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a6d
+				// Method begins at RVA 0x2a3b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a76
+				// Method begins at RVA 0x2a44
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -153,7 +153,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a7f
+				// Method begins at RVA 0x2a4d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -198,7 +198,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a88
+				// Method begins at RVA 0x2a56
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -226,29 +226,22 @@
 			)
 			// Method begins at RVA 0x297c
 			// Header size: 12
-			// Code size: 40 (0x28)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Events_EventEmitter_Complete/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "a"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001e: stloc.1
-			IL_001f: ldarg.0
-			IL_0020: ldloc.1
-			IL_0021: stfld object Modules.Events_EventEmitter_Complete/Scope::order
-			IL_0026: ldnull
-			IL_0027: ret
+			IL_0006: ldstr "a"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0010: stloc.0
+			IL_0011: ldarg.0
+			IL_0012: ldloc.0
+			IL_0013: stfld object Modules.Events_EventEmitter_Complete/Scope::order
+			IL_0018: ldnull
+			IL_0019: ret
 		} // end of method FunctionExpression_L27C21::__js_call__
 
 	} // end of class FunctionExpression_L27C21
@@ -264,7 +257,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a91
+				// Method begins at RVA 0x2a5f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -290,31 +283,24 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x29b0
+			// Method begins at RVA 0x29a4
 			// Header size: 12
-			// Code size: 40 (0x28)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Events_EventEmitter_Complete/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "b"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001e: stloc.1
-			IL_001f: ldarg.0
-			IL_0020: ldloc.1
-			IL_0021: stfld object Modules.Events_EventEmitter_Complete/Scope::order
-			IL_0026: ldnull
-			IL_0027: ret
+			IL_0006: ldstr "b"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0010: stloc.0
+			IL_0011: ldarg.0
+			IL_0012: ldloc.0
+			IL_0013: stfld object Modules.Events_EventEmitter_Complete/Scope::order
+			IL_0018: ldnull
+			IL_0019: ret
 		} // end of method FunctionExpression_L30C34::__js_call__
 
 	} // end of class FunctionExpression_L30C34
@@ -330,7 +316,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a9a
+				// Method begins at RVA 0x2a68
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -356,31 +342,24 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x29e4
+			// Method begins at RVA 0x29cc
 			// Header size: 12
-			// Code size: 40 (0x28)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
-			IL_0006: stloc.0
-			IL_0007: ldstr "prependOnceOrder"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "a"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001e: stloc.1
-			IL_001f: ldarg.0
-			IL_0020: ldloc.1
-			IL_0021: stfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
-			IL_0026: ldnull
-			IL_0027: ret
+			IL_0006: ldstr "a"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0010: stloc.0
+			IL_0011: ldarg.0
+			IL_0012: ldloc.0
+			IL_0013: stfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
+			IL_0018: ldnull
+			IL_0019: ret
 		} // end of method FunctionExpression_L39C20::__js_call__
 
 	} // end of class FunctionExpression_L39C20
@@ -396,7 +375,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa3
+				// Method begins at RVA 0x2a71
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -422,31 +401,24 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2a18
+			// Method begins at RVA 0x29f4
 			// Header size: 12
-			// Code size: 40 (0x28)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
-			IL_0006: stloc.0
-			IL_0007: ldstr "prependOnceOrder"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "b"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001e: stloc.1
-			IL_001f: ldarg.0
-			IL_0020: ldloc.1
-			IL_0021: stfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
-			IL_0026: ldnull
-			IL_0027: ret
+			IL_0006: ldstr "b"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0010: stloc.0
+			IL_0011: ldarg.0
+			IL_0012: ldloc.0
+			IL_0013: stfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
+			IL_0018: ldnull
+			IL_0019: ret
 		} // end of method FunctionExpression_L42C37::__js_call__
 
 	} // end of class FunctionExpression_L42C37
@@ -462,7 +434,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aac
+				// Method begins at RVA 0x2a7a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -485,7 +457,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a4c
+			// Method begins at RVA 0x2a1a
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -507,7 +479,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab5
+				// Method begins at RVA 0x2a83
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -530,7 +502,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a4f
+			// Method begins at RVA 0x2a1d
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -552,7 +524,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2abe
+				// Method begins at RVA 0x2a8c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -575,7 +547,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a52
+			// Method begins at RVA 0x2a20
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -597,7 +569,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac7
+				// Method begins at RVA 0x2a95
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -620,7 +592,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a55
+			// Method begins at RVA 0x2a23
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -642,7 +614,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad0
+				// Method begins at RVA 0x2a9e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -665,7 +637,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a58
+			// Method begins at RVA 0x2a26
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -698,7 +670,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a5b
+			// Method begins at RVA 0x2a29
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1510,7 +1482,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2ad9
+		// Method begins at RVA 0x2aa7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_On_Off_Once.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_On_Off_Once.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2543
+				// Method begins at RVA 0x2529
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,29 +46,22 @@
 			)
 			// Method begins at RVA 0x24c4
 			// Header size: 12
-			// Code size: 44 (0x2c)
+			// Code size: 30 (0x1e)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
-			IL_0006: stloc.0
-			IL_0007: ldstr "sum"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.r8 1
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0022: stloc.1
-			IL_0023: ldarg.0
-			IL_0024: ldloc.1
-			IL_0025: stfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
-			IL_002a: ldnull
-			IL_002b: ret
+			IL_0006: ldc.r8 1
+			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0014: stloc.0
+			IL_0015: ldarg.0
+			IL_0016: ldloc.0
+			IL_0017: stfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
+			IL_001c: ldnull
+			IL_001d: ret
 		} // end of method onData::__js_call__
 
 	} // end of class onData
@@ -84,7 +77,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x254c
+				// Method begins at RVA 0x2532
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -110,31 +103,24 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x24fc
+			// Method begins at RVA 0x24f0
 			// Header size: 12
-			// Code size: 44 (0x2c)
+			// Code size: 30 (0x1e)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::onceTotal
-			IL_0006: stloc.0
-			IL_0007: ldstr "onceTotal"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.r8 1
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0022: stloc.1
-			IL_0023: ldarg.0
-			IL_0024: ldloc.1
-			IL_0025: stfld object Modules.Events_EventEmitter_On_Off_Once/Scope::onceTotal
-			IL_002a: ldnull
-			IL_002b: ret
+			IL_0006: ldc.r8 1
+			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0014: stloc.0
+			IL_0015: ldarg.0
+			IL_0016: ldloc.0
+			IL_0017: stfld object Modules.Events_EventEmitter_On_Off_Once/Scope::onceTotal
+			IL_001c: ldnull
+			IL_001d: ret
 		} // end of method FunctionExpression_L23C21::__js_call__
 
 	} // end of class FunctionExpression_L23C21
@@ -150,7 +136,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2555
+				// Method begins at RVA 0x253b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -173,7 +159,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2534
+			// Method begins at RVA 0x251a
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -195,7 +181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x255e
+				// Method begins at RVA 0x2544
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -218,7 +204,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2537
+			// Method begins at RVA 0x251d
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -247,7 +233,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x253a
+			// Method begins at RVA 0x2520
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -649,7 +635,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2567
+		// Method begins at RVA 0x254d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Append_Rename_Unlink.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Append_Rename_Unlink.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2be2
+					// Method begins at RVA 0x2ad2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2beb
+					// Method begins at RVA 0x2adb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bf4
+					// Method begins at RVA 0x2ae4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -117,7 +117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bd9
+				// Method begins at RVA 0x2ac9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -143,7 +143,7 @@
 			)
 			// Method begins at RVA 0x20e4
 			// Header size: 12
-			// Code size: 2784 (0xae0)
+			// Code size: 2512 (0x9d0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope,
@@ -299,7 +299,7 @@
 
 			IL_00ff: ldloc.0
 			IL_0100: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0105: switch (IL_012e, IL_096b, IL_0a14, IL_08e9, IL_0471, IL_056f, IL_0664, IL_075d, IL_087f)
+			IL_0105: switch (IL_012e, IL_087f, IL_0904, IL_07fd, IL_03ef, IL_04d7, IL_05b6, IL_0699, IL_07a5)
 
 			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_0133: stloc.s 11
@@ -341,1023 +341,929 @@
 			IL_019f: ldelem.ref
 			IL_01a0: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
 			IL_01a5: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
-			IL_01aa: stloc.s 11
-			IL_01ac: ldstr "path"
-			IL_01b1: ldloc.s 11
-			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01b8: stloc.s 11
-			IL_01ba: ldloc.s 11
-			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c1: stloc.s 11
-			IL_01c3: ldarg.0
-			IL_01c4: ldc.i4.1
-			IL_01c5: ldelem.ref
-			IL_01c6: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_01cb: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
-			IL_01d0: stloc.s 16
-			IL_01d2: ldstr "os"
-			IL_01d7: ldloc.s 16
-			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01de: stloc.s 16
-			IL_01e0: ldloc.s 16
-			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e7: stloc.s 16
-			IL_01e9: ldloc.s 16
-			IL_01eb: ldstr "tmpdir"
-			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01f5: stloc.s 16
-			IL_01f7: ldloc.1
-			IL_01f8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01fd: stloc.s 15
-			IL_01ff: ldstr "jroc-fs-append-"
-			IL_0204: ldloc.s 15
-			IL_0206: call string [System.Runtime]System.String::Concat(string, string)
-			IL_020b: stloc.s 15
-			IL_020d: ldloc.s 15
-			IL_020f: ldstr ".txt"
-			IL_0214: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0219: stloc.s 15
-			IL_021b: ldloc.s 11
-			IL_021d: ldstr "join"
-			IL_0222: ldloc.s 16
-			IL_0224: ldloc.s 15
-			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_022b: stloc.s 16
-			IL_022d: ldloc.s 16
-			IL_022f: stloc.2
-			IL_0230: ldarg.0
-			IL_0231: ldc.i4.1
-			IL_0232: ldelem.ref
-			IL_0233: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0238: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
-			IL_023d: stloc.s 16
-			IL_023f: ldstr "path"
-			IL_0244: ldloc.s 16
-			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_024b: stloc.s 16
-			IL_024d: ldloc.s 16
-			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0254: stloc.s 16
-			IL_0256: ldarg.0
-			IL_0257: ldc.i4.1
-			IL_0258: ldelem.ref
-			IL_0259: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_025e: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
-			IL_0263: stloc.s 11
-			IL_0265: ldstr "os"
-			IL_026a: ldloc.s 11
-			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0271: stloc.s 11
-			IL_0273: ldloc.s 11
-			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027a: stloc.s 11
-			IL_027c: ldloc.s 11
-			IL_027e: ldstr "tmpdir"
-			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0288: stloc.s 11
-			IL_028a: ldloc.1
-			IL_028b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0290: stloc.s 15
-			IL_0292: ldstr "jroc-fs-append-"
-			IL_0297: ldloc.s 15
-			IL_0299: call string [System.Runtime]System.String::Concat(string, string)
-			IL_029e: stloc.s 15
-			IL_02a0: ldloc.s 15
-			IL_02a2: ldstr "-renamed.txt"
-			IL_02a7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02ac: stloc.s 15
-			IL_02ae: ldloc.s 16
-			IL_02b0: ldstr "join"
-			IL_02b5: ldloc.s 11
-			IL_02b7: ldloc.s 15
-			IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02be: stloc.s 11
-			IL_02c0: ldloc.s 11
-			IL_02c2: stloc.3
-			IL_02c3: ldloc.0
-			IL_02c4: ldc.i4.0
-			IL_02c5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02ca: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_02cf: ldloc.0
-			IL_02d0: ldc.i4.0
-			IL_02d1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02d6: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_02db: ldloc.0
-			IL_02dc: ldc.i4.0
-			IL_02dd: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02e2: ldloc.0
-			IL_02e3: ldc.i4.0
-			IL_02e4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02e9: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L12C8::.ctor()
-			IL_02ee: stloc.s 4
-			IL_02f0: ldarg.0
-			IL_02f1: ldc.i4.1
-			IL_02f2: ldelem.ref
-			IL_02f3: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_02f8: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_02fd: stloc.s 11
-			IL_02ff: ldstr "fs"
-			IL_0304: ldloc.s 11
-			IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_030b: stloc.s 11
-			IL_030d: ldloc.s 11
-			IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0314: stloc.s 11
-			IL_0316: ldloc.s 11
-			IL_0318: ldstr "rmSync"
-			IL_031d: ldloc.2
-			IL_031e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0323: dup
-			IL_0324: ldstr "force"
-			IL_0329: ldc.i4.1
-			IL_032a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0334: pop
-			IL_0335: ldarg.0
-			IL_0336: ldc.i4.1
-			IL_0337: ldelem.ref
-			IL_0338: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_033d: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0342: stloc.s 11
-			IL_0344: ldstr "fs"
-			IL_0349: ldloc.s 11
-			IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0350: stloc.s 11
-			IL_0352: ldloc.s 11
-			IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0359: stloc.s 11
-			IL_035b: ldloc.s 11
-			IL_035d: ldstr "rmSync"
-			IL_0362: ldloc.3
-			IL_0363: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01af: stloc.s 11
+			IL_01b1: ldarg.0
+			IL_01b2: ldc.i4.1
+			IL_01b3: ldelem.ref
+			IL_01b4: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_01b9: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
+			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c3: stloc.s 16
+			IL_01c5: ldloc.s 16
+			IL_01c7: ldstr "tmpdir"
+			IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01d1: stloc.s 16
+			IL_01d3: ldloc.1
+			IL_01d4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d9: stloc.s 15
+			IL_01db: ldstr "jroc-fs-append-"
+			IL_01e0: ldloc.s 15
+			IL_01e2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e7: stloc.s 15
+			IL_01e9: ldloc.s 15
+			IL_01eb: ldstr ".txt"
+			IL_01f0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f5: stloc.s 15
+			IL_01f7: ldloc.s 11
+			IL_01f9: ldstr "join"
+			IL_01fe: ldloc.s 16
+			IL_0200: ldloc.s 15
+			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0207: stloc.s 16
+			IL_0209: ldloc.s 16
+			IL_020b: stloc.2
+			IL_020c: ldarg.0
+			IL_020d: ldc.i4.1
+			IL_020e: ldelem.ref
+			IL_020f: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0214: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
+			IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021e: stloc.s 16
+			IL_0220: ldarg.0
+			IL_0221: ldc.i4.1
+			IL_0222: ldelem.ref
+			IL_0223: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0228: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
+			IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0232: stloc.s 11
+			IL_0234: ldloc.s 11
+			IL_0236: ldstr "tmpdir"
+			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0240: stloc.s 11
+			IL_0242: ldloc.1
+			IL_0243: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0248: stloc.s 15
+			IL_024a: ldstr "jroc-fs-append-"
+			IL_024f: ldloc.s 15
+			IL_0251: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0256: stloc.s 15
+			IL_0258: ldloc.s 15
+			IL_025a: ldstr "-renamed.txt"
+			IL_025f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0264: stloc.s 15
+			IL_0266: ldloc.s 16
+			IL_0268: ldstr "join"
+			IL_026d: ldloc.s 11
+			IL_026f: ldloc.s 15
+			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0276: stloc.s 11
+			IL_0278: ldloc.s 11
+			IL_027a: stloc.3
+			IL_027b: ldloc.0
+			IL_027c: ldc.i4.0
+			IL_027d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0282: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0287: ldloc.0
+			IL_0288: ldc.i4.0
+			IL_0289: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_028e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0293: ldloc.0
+			IL_0294: ldc.i4.0
+			IL_0295: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_029a: ldloc.0
+			IL_029b: ldc.i4.0
+			IL_029c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02a1: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L12C8::.ctor()
+			IL_02a6: stloc.s 4
+			IL_02a8: ldarg.0
+			IL_02a9: ldc.i4.1
+			IL_02aa: ldelem.ref
+			IL_02ab: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_02b0: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ba: stloc.s 11
+			IL_02bc: ldloc.s 11
+			IL_02be: ldstr "rmSync"
+			IL_02c3: ldloc.2
+			IL_02c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02c9: dup
+			IL_02ca: ldstr "force"
+			IL_02cf: ldc.i4.1
+			IL_02d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02da: pop
+			IL_02db: ldarg.0
+			IL_02dc: ldc.i4.1
+			IL_02dd: ldelem.ref
+			IL_02de: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_02e3: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ed: stloc.s 11
+			IL_02ef: ldloc.s 11
+			IL_02f1: ldstr "rmSync"
+			IL_02f6: ldloc.3
+			IL_02f7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02fc: dup
+			IL_02fd: ldstr "force"
+			IL_0302: ldc.i4.1
+			IL_0303: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_030d: pop
+			IL_030e: ldarg.0
+			IL_030f: ldc.i4.1
+			IL_0310: ldelem.ref
+			IL_0311: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0316: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_031b: ldstr "promises"
+			IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_032a: stloc.s 11
+			IL_032c: ldloc.s 11
+			IL_032e: ldstr "writeFile"
+			IL_0333: ldloc.2
+			IL_0334: ldstr "a"
+			IL_0339: ldstr "utf8"
+			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0343: stloc.s 11
+			IL_0345: ldloc.0
+			IL_0346: ldc.i4.4
+			IL_0347: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_034c: ldloc.0
+			IL_034d: ldloc.s 11
+			IL_034f: ldarg.0
+			IL_0350: ldc.i4.1
+			IL_0351: ldloc.0
+			IL_0352: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0357: ldc.i4.3
+			IL_0358: ldstr "_pendingException"
+			IL_035d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0362: ldloc.0
+			IL_0363: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_0368: dup
-			IL_0369: ldstr "force"
-			IL_036e: ldc.i4.1
-			IL_036f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0379: pop
-			IL_037a: ldarg.0
-			IL_037b: ldc.i4.1
-			IL_037c: ldelem.ref
-			IL_037d: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0382: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0387: stloc.s 11
-			IL_0389: ldstr "fs"
-			IL_038e: ldloc.s 11
-			IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0395: stloc.s 11
-			IL_0397: ldloc.s 11
-			IL_0399: ldstr "promises"
-			IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03a3: stloc.s 11
+			IL_0369: ldc.i4.0
+			IL_036a: ldloc.1
+			IL_036b: stelem.ref
+			IL_036c: dup
+			IL_036d: ldc.i4.1
+			IL_036e: ldloc.2
+			IL_036f: stelem.ref
+			IL_0370: dup
+			IL_0371: ldc.i4.2
+			IL_0372: ldloc.3
+			IL_0373: stelem.ref
+			IL_0374: dup
+			IL_0375: ldc.i4.3
+			IL_0376: ldloc.s 4
+			IL_0378: stelem.ref
+			IL_0379: dup
+			IL_037a: ldc.i4.4
+			IL_037b: ldloc.s 5
+			IL_037d: stelem.ref
+			IL_037e: dup
+			IL_037f: ldc.i4.5
+			IL_0380: ldloc.s 6
+			IL_0382: stelem.ref
+			IL_0383: dup
+			IL_0384: ldc.i4.6
+			IL_0385: ldloc.s 7
+			IL_0387: stelem.ref
+			IL_0388: dup
+			IL_0389: ldc.i4.7
+			IL_038a: ldloc.s 8
+			IL_038c: stelem.ref
+			IL_038d: dup
+			IL_038e: ldc.i4.8
+			IL_038f: ldloc.s 9
+			IL_0391: box [System.Runtime]System.Boolean
+			IL_0396: stelem.ref
+			IL_0397: dup
+			IL_0398: ldc.i4.s 9
+			IL_039a: ldloc.s 10
+			IL_039c: box [System.Runtime]System.Boolean
+			IL_03a1: stelem.ref
+			IL_03a2: dup
+			IL_03a3: ldc.i4.s 10
 			IL_03a5: ldloc.s 11
-			IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03ac: stloc.s 11
-			IL_03ae: ldloc.s 11
-			IL_03b0: ldstr "writeFile"
-			IL_03b5: ldloc.2
-			IL_03b6: ldstr "a"
-			IL_03bb: ldstr "utf8"
-			IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_03c5: stloc.s 11
-			IL_03c7: ldloc.0
-			IL_03c8: ldc.i4.4
-			IL_03c9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03ce: ldloc.0
-			IL_03cf: ldloc.s 11
-			IL_03d1: ldarg.0
-			IL_03d2: ldc.i4.1
-			IL_03d3: ldloc.0
-			IL_03d4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03d9: ldc.i4.3
-			IL_03da: ldstr "_pendingException"
-			IL_03df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_03e4: ldloc.0
-			IL_03e5: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03ea: dup
-			IL_03eb: ldc.i4.0
-			IL_03ec: ldloc.1
-			IL_03ed: stelem.ref
-			IL_03ee: dup
-			IL_03ef: ldc.i4.1
-			IL_03f0: ldloc.2
-			IL_03f1: stelem.ref
-			IL_03f2: dup
-			IL_03f3: ldc.i4.2
-			IL_03f4: ldloc.3
-			IL_03f5: stelem.ref
-			IL_03f6: dup
-			IL_03f7: ldc.i4.3
-			IL_03f8: ldloc.s 4
-			IL_03fa: stelem.ref
-			IL_03fb: dup
-			IL_03fc: ldc.i4.4
-			IL_03fd: ldloc.s 5
-			IL_03ff: stelem.ref
-			IL_0400: dup
-			IL_0401: ldc.i4.5
-			IL_0402: ldloc.s 6
-			IL_0404: stelem.ref
-			IL_0405: dup
-			IL_0406: ldc.i4.6
-			IL_0407: ldloc.s 7
-			IL_0409: stelem.ref
-			IL_040a: dup
-			IL_040b: ldc.i4.7
-			IL_040c: ldloc.s 8
-			IL_040e: stelem.ref
-			IL_040f: dup
-			IL_0410: ldc.i4.8
-			IL_0411: ldloc.s 9
-			IL_0413: box [System.Runtime]System.Boolean
-			IL_0418: stelem.ref
-			IL_0419: dup
-			IL_041a: ldc.i4.s 9
-			IL_041c: ldloc.s 10
-			IL_041e: box [System.Runtime]System.Boolean
-			IL_0423: stelem.ref
-			IL_0424: dup
-			IL_0425: ldc.i4.s 10
-			IL_0427: ldloc.s 11
-			IL_0429: stelem.ref
-			IL_042a: dup
-			IL_042b: ldc.i4.s 11
-			IL_042d: ldloc.s 12
-			IL_042f: stelem.ref
-			IL_0430: dup
-			IL_0431: ldc.i4.s 12
-			IL_0433: ldloc.s 13
-			IL_0435: box [System.Runtime]System.Double
-			IL_043a: stelem.ref
-			IL_043b: dup
-			IL_043c: ldc.i4.s 13
-			IL_043e: ldloc.s 14
-			IL_0440: stelem.ref
-			IL_0441: dup
-			IL_0442: ldc.i4.s 14
-			IL_0444: ldloc.s 15
-			IL_0446: stelem.ref
-			IL_0447: dup
-			IL_0448: ldc.i4.s 15
-			IL_044a: ldloc.s 16
-			IL_044c: stelem.ref
-			IL_044d: dup
-			IL_044e: ldc.i4.s 16
-			IL_0450: ldloc.s 17
-			IL_0452: box [System.Runtime]System.Boolean
+			IL_03a7: stelem.ref
+			IL_03a8: dup
+			IL_03a9: ldc.i4.s 11
+			IL_03ab: ldloc.s 12
+			IL_03ad: stelem.ref
+			IL_03ae: dup
+			IL_03af: ldc.i4.s 12
+			IL_03b1: ldloc.s 13
+			IL_03b3: box [System.Runtime]System.Double
+			IL_03b8: stelem.ref
+			IL_03b9: dup
+			IL_03ba: ldc.i4.s 13
+			IL_03bc: ldloc.s 14
+			IL_03be: stelem.ref
+			IL_03bf: dup
+			IL_03c0: ldc.i4.s 14
+			IL_03c2: ldloc.s 15
+			IL_03c4: stelem.ref
+			IL_03c5: dup
+			IL_03c6: ldc.i4.s 15
+			IL_03c8: ldloc.s 16
+			IL_03ca: stelem.ref
+			IL_03cb: dup
+			IL_03cc: ldc.i4.s 16
+			IL_03ce: ldloc.s 17
+			IL_03d0: box [System.Runtime]System.Boolean
+			IL_03d5: stelem.ref
+			IL_03d6: dup
+			IL_03d7: ldc.i4.s 17
+			IL_03d9: ldloc.s 18
+			IL_03db: stelem.ref
+			IL_03dc: dup
+			IL_03dd: ldc.i4.s 18
+			IL_03df: ldloc.s 19
+			IL_03e1: stelem.ref
+			IL_03e2: pop
+			IL_03e3: ldloc.0
+			IL_03e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03e9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03ee: ret
+
+			IL_03ef: ldloc.0
+			IL_03f0: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited1
+			IL_03f5: pop
+			IL_03f6: ldarg.0
+			IL_03f7: ldc.i4.1
+			IL_03f8: ldelem.ref
+			IL_03f9: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_03fe: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0403: ldstr "promises"
+			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0412: stloc.s 11
+			IL_0414: ldloc.s 11
+			IL_0416: ldstr "appendFile"
+			IL_041b: ldloc.2
+			IL_041c: ldstr "b"
+			IL_0421: ldstr "utf8"
+			IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_042b: stloc.s 11
+			IL_042d: ldloc.0
+			IL_042e: ldc.i4.5
+			IL_042f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0434: ldloc.0
+			IL_0435: ldloc.s 11
+			IL_0437: ldarg.0
+			IL_0438: ldc.i4.2
+			IL_0439: ldloc.0
+			IL_043a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_043f: ldc.i4.3
+			IL_0440: ldstr "_pendingException"
+			IL_0445: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_044a: ldloc.0
+			IL_044b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0450: dup
+			IL_0451: ldc.i4.0
+			IL_0452: ldloc.1
+			IL_0453: stelem.ref
+			IL_0454: dup
+			IL_0455: ldc.i4.1
+			IL_0456: ldloc.2
 			IL_0457: stelem.ref
 			IL_0458: dup
-			IL_0459: ldc.i4.s 17
-			IL_045b: ldloc.s 18
-			IL_045d: stelem.ref
-			IL_045e: dup
-			IL_045f: ldc.i4.s 18
-			IL_0461: ldloc.s 19
-			IL_0463: stelem.ref
-			IL_0464: pop
-			IL_0465: ldloc.0
-			IL_0466: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_046b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0470: ret
+			IL_0459: ldc.i4.2
+			IL_045a: ldloc.3
+			IL_045b: stelem.ref
+			IL_045c: dup
+			IL_045d: ldc.i4.3
+			IL_045e: ldloc.s 4
+			IL_0460: stelem.ref
+			IL_0461: dup
+			IL_0462: ldc.i4.4
+			IL_0463: ldloc.s 5
+			IL_0465: stelem.ref
+			IL_0466: dup
+			IL_0467: ldc.i4.5
+			IL_0468: ldloc.s 6
+			IL_046a: stelem.ref
+			IL_046b: dup
+			IL_046c: ldc.i4.6
+			IL_046d: ldloc.s 7
+			IL_046f: stelem.ref
+			IL_0470: dup
+			IL_0471: ldc.i4.7
+			IL_0472: ldloc.s 8
+			IL_0474: stelem.ref
+			IL_0475: dup
+			IL_0476: ldc.i4.8
+			IL_0477: ldloc.s 9
+			IL_0479: box [System.Runtime]System.Boolean
+			IL_047e: stelem.ref
+			IL_047f: dup
+			IL_0480: ldc.i4.s 9
+			IL_0482: ldloc.s 10
+			IL_0484: box [System.Runtime]System.Boolean
+			IL_0489: stelem.ref
+			IL_048a: dup
+			IL_048b: ldc.i4.s 10
+			IL_048d: ldloc.s 11
+			IL_048f: stelem.ref
+			IL_0490: dup
+			IL_0491: ldc.i4.s 11
+			IL_0493: ldloc.s 12
+			IL_0495: stelem.ref
+			IL_0496: dup
+			IL_0497: ldc.i4.s 12
+			IL_0499: ldloc.s 13
+			IL_049b: box [System.Runtime]System.Double
+			IL_04a0: stelem.ref
+			IL_04a1: dup
+			IL_04a2: ldc.i4.s 13
+			IL_04a4: ldloc.s 14
+			IL_04a6: stelem.ref
+			IL_04a7: dup
+			IL_04a8: ldc.i4.s 14
+			IL_04aa: ldloc.s 15
+			IL_04ac: stelem.ref
+			IL_04ad: dup
+			IL_04ae: ldc.i4.s 15
+			IL_04b0: ldloc.s 16
+			IL_04b2: stelem.ref
+			IL_04b3: dup
+			IL_04b4: ldc.i4.s 16
+			IL_04b6: ldloc.s 17
+			IL_04b8: box [System.Runtime]System.Boolean
+			IL_04bd: stelem.ref
+			IL_04be: dup
+			IL_04bf: ldc.i4.s 17
+			IL_04c1: ldloc.s 18
+			IL_04c3: stelem.ref
+			IL_04c4: dup
+			IL_04c5: ldc.i4.s 18
+			IL_04c7: ldloc.s 19
+			IL_04c9: stelem.ref
+			IL_04ca: pop
+			IL_04cb: ldloc.0
+			IL_04cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04d1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04d6: ret
 
-			IL_0471: ldloc.0
-			IL_0472: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited1
-			IL_0477: pop
-			IL_0478: ldarg.0
-			IL_0479: ldc.i4.1
-			IL_047a: ldelem.ref
-			IL_047b: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0480: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0485: stloc.s 11
-			IL_0487: ldstr "fs"
-			IL_048c: ldloc.s 11
-			IL_048e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0493: stloc.s 11
-			IL_0495: ldloc.s 11
-			IL_0497: ldstr "promises"
-			IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04a1: stloc.s 11
-			IL_04a3: ldloc.s 11
-			IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04aa: stloc.s 11
-			IL_04ac: ldloc.s 11
-			IL_04ae: ldstr "appendFile"
-			IL_04b3: ldloc.2
-			IL_04b4: ldstr "b"
-			IL_04b9: ldstr "utf8"
-			IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_04c3: stloc.s 11
-			IL_04c5: ldloc.0
-			IL_04c6: ldc.i4.5
-			IL_04c7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04cc: ldloc.0
-			IL_04cd: ldloc.s 11
-			IL_04cf: ldarg.0
-			IL_04d0: ldc.i4.2
-			IL_04d1: ldloc.0
-			IL_04d2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_04d7: ldc.i4.3
-			IL_04d8: ldstr "_pendingException"
-			IL_04dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_04e2: ldloc.0
-			IL_04e3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_04e8: dup
-			IL_04e9: ldc.i4.0
-			IL_04ea: ldloc.1
-			IL_04eb: stelem.ref
-			IL_04ec: dup
-			IL_04ed: ldc.i4.1
-			IL_04ee: ldloc.2
-			IL_04ef: stelem.ref
-			IL_04f0: dup
-			IL_04f1: ldc.i4.2
-			IL_04f2: ldloc.3
-			IL_04f3: stelem.ref
-			IL_04f4: dup
-			IL_04f5: ldc.i4.3
-			IL_04f6: ldloc.s 4
-			IL_04f8: stelem.ref
-			IL_04f9: dup
-			IL_04fa: ldc.i4.4
-			IL_04fb: ldloc.s 5
-			IL_04fd: stelem.ref
-			IL_04fe: dup
-			IL_04ff: ldc.i4.5
-			IL_0500: ldloc.s 6
-			IL_0502: stelem.ref
-			IL_0503: dup
-			IL_0504: ldc.i4.6
-			IL_0505: ldloc.s 7
-			IL_0507: stelem.ref
-			IL_0508: dup
-			IL_0509: ldc.i4.7
-			IL_050a: ldloc.s 8
-			IL_050c: stelem.ref
-			IL_050d: dup
-			IL_050e: ldc.i4.8
-			IL_050f: ldloc.s 9
-			IL_0511: box [System.Runtime]System.Boolean
-			IL_0516: stelem.ref
-			IL_0517: dup
-			IL_0518: ldc.i4.s 9
-			IL_051a: ldloc.s 10
-			IL_051c: box [System.Runtime]System.Boolean
-			IL_0521: stelem.ref
-			IL_0522: dup
-			IL_0523: ldc.i4.s 10
-			IL_0525: ldloc.s 11
-			IL_0527: stelem.ref
-			IL_0528: dup
-			IL_0529: ldc.i4.s 11
-			IL_052b: ldloc.s 12
-			IL_052d: stelem.ref
-			IL_052e: dup
-			IL_052f: ldc.i4.s 12
-			IL_0531: ldloc.s 13
-			IL_0533: box [System.Runtime]System.Double
-			IL_0538: stelem.ref
-			IL_0539: dup
-			IL_053a: ldc.i4.s 13
-			IL_053c: ldloc.s 14
-			IL_053e: stelem.ref
-			IL_053f: dup
-			IL_0540: ldc.i4.s 14
-			IL_0542: ldloc.s 15
+			IL_04d7: ldloc.0
+			IL_04d8: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited2
+			IL_04dd: pop
+			IL_04de: ldarg.0
+			IL_04df: ldc.i4.1
+			IL_04e0: ldelem.ref
+			IL_04e1: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_04e6: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_04eb: ldstr "promises"
+			IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04fa: stloc.s 11
+			IL_04fc: ldloc.s 11
+			IL_04fe: ldstr "rename"
+			IL_0503: ldloc.2
+			IL_0504: ldloc.3
+			IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_050a: stloc.s 11
+			IL_050c: ldloc.0
+			IL_050d: ldc.i4.6
+			IL_050e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0513: ldloc.0
+			IL_0514: ldloc.s 11
+			IL_0516: ldarg.0
+			IL_0517: ldc.i4.3
+			IL_0518: ldloc.0
+			IL_0519: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_051e: ldc.i4.3
+			IL_051f: ldstr "_pendingException"
+			IL_0524: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0529: ldloc.0
+			IL_052a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_052f: dup
+			IL_0530: ldc.i4.0
+			IL_0531: ldloc.1
+			IL_0532: stelem.ref
+			IL_0533: dup
+			IL_0534: ldc.i4.1
+			IL_0535: ldloc.2
+			IL_0536: stelem.ref
+			IL_0537: dup
+			IL_0538: ldc.i4.2
+			IL_0539: ldloc.3
+			IL_053a: stelem.ref
+			IL_053b: dup
+			IL_053c: ldc.i4.3
+			IL_053d: ldloc.s 4
+			IL_053f: stelem.ref
+			IL_0540: dup
+			IL_0541: ldc.i4.4
+			IL_0542: ldloc.s 5
 			IL_0544: stelem.ref
 			IL_0545: dup
-			IL_0546: ldc.i4.s 15
-			IL_0548: ldloc.s 16
-			IL_054a: stelem.ref
-			IL_054b: dup
-			IL_054c: ldc.i4.s 16
-			IL_054e: ldloc.s 17
-			IL_0550: box [System.Runtime]System.Boolean
-			IL_0555: stelem.ref
-			IL_0556: dup
-			IL_0557: ldc.i4.s 17
-			IL_0559: ldloc.s 18
-			IL_055b: stelem.ref
-			IL_055c: dup
-			IL_055d: ldc.i4.s 18
-			IL_055f: ldloc.s 19
-			IL_0561: stelem.ref
-			IL_0562: pop
-			IL_0563: ldloc.0
-			IL_0564: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0569: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_056e: ret
+			IL_0546: ldc.i4.5
+			IL_0547: ldloc.s 6
+			IL_0549: stelem.ref
+			IL_054a: dup
+			IL_054b: ldc.i4.6
+			IL_054c: ldloc.s 7
+			IL_054e: stelem.ref
+			IL_054f: dup
+			IL_0550: ldc.i4.7
+			IL_0551: ldloc.s 8
+			IL_0553: stelem.ref
+			IL_0554: dup
+			IL_0555: ldc.i4.8
+			IL_0556: ldloc.s 9
+			IL_0558: box [System.Runtime]System.Boolean
+			IL_055d: stelem.ref
+			IL_055e: dup
+			IL_055f: ldc.i4.s 9
+			IL_0561: ldloc.s 10
+			IL_0563: box [System.Runtime]System.Boolean
+			IL_0568: stelem.ref
+			IL_0569: dup
+			IL_056a: ldc.i4.s 10
+			IL_056c: ldloc.s 11
+			IL_056e: stelem.ref
+			IL_056f: dup
+			IL_0570: ldc.i4.s 11
+			IL_0572: ldloc.s 12
+			IL_0574: stelem.ref
+			IL_0575: dup
+			IL_0576: ldc.i4.s 12
+			IL_0578: ldloc.s 13
+			IL_057a: box [System.Runtime]System.Double
+			IL_057f: stelem.ref
+			IL_0580: dup
+			IL_0581: ldc.i4.s 13
+			IL_0583: ldloc.s 14
+			IL_0585: stelem.ref
+			IL_0586: dup
+			IL_0587: ldc.i4.s 14
+			IL_0589: ldloc.s 15
+			IL_058b: stelem.ref
+			IL_058c: dup
+			IL_058d: ldc.i4.s 15
+			IL_058f: ldloc.s 16
+			IL_0591: stelem.ref
+			IL_0592: dup
+			IL_0593: ldc.i4.s 16
+			IL_0595: ldloc.s 17
+			IL_0597: box [System.Runtime]System.Boolean
+			IL_059c: stelem.ref
+			IL_059d: dup
+			IL_059e: ldc.i4.s 17
+			IL_05a0: ldloc.s 18
+			IL_05a2: stelem.ref
+			IL_05a3: dup
+			IL_05a4: ldc.i4.s 18
+			IL_05a6: ldloc.s 19
+			IL_05a8: stelem.ref
+			IL_05a9: pop
+			IL_05aa: ldloc.0
+			IL_05ab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05b0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05b5: ret
 
-			IL_056f: ldloc.0
-			IL_0570: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited2
-			IL_0575: pop
-			IL_0576: ldarg.0
-			IL_0577: ldc.i4.1
-			IL_0578: ldelem.ref
-			IL_0579: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_057e: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0583: stloc.s 11
-			IL_0585: ldstr "fs"
-			IL_058a: ldloc.s 11
-			IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0591: stloc.s 11
-			IL_0593: ldloc.s 11
-			IL_0595: ldstr "promises"
-			IL_059a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_059f: stloc.s 11
-			IL_05a1: ldloc.s 11
-			IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05a8: stloc.s 11
-			IL_05aa: ldloc.s 11
-			IL_05ac: ldstr "rename"
-			IL_05b1: ldloc.2
-			IL_05b2: ldloc.3
-			IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_05b8: stloc.s 11
-			IL_05ba: ldloc.0
-			IL_05bb: ldc.i4.6
-			IL_05bc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05c1: ldloc.0
-			IL_05c2: ldloc.s 11
-			IL_05c4: ldarg.0
-			IL_05c5: ldc.i4.3
-			IL_05c6: ldloc.0
-			IL_05c7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05cc: ldc.i4.3
-			IL_05cd: ldstr "_pendingException"
-			IL_05d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_05d7: ldloc.0
-			IL_05d8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05dd: dup
-			IL_05de: ldc.i4.0
-			IL_05df: ldloc.1
-			IL_05e0: stelem.ref
-			IL_05e1: dup
-			IL_05e2: ldc.i4.1
-			IL_05e3: ldloc.2
-			IL_05e4: stelem.ref
-			IL_05e5: dup
-			IL_05e6: ldc.i4.2
-			IL_05e7: ldloc.3
-			IL_05e8: stelem.ref
-			IL_05e9: dup
-			IL_05ea: ldc.i4.3
-			IL_05eb: ldloc.s 4
-			IL_05ed: stelem.ref
-			IL_05ee: dup
-			IL_05ef: ldc.i4.4
-			IL_05f0: ldloc.s 5
-			IL_05f2: stelem.ref
-			IL_05f3: dup
-			IL_05f4: ldc.i4.5
-			IL_05f5: ldloc.s 6
-			IL_05f7: stelem.ref
-			IL_05f8: dup
-			IL_05f9: ldc.i4.6
-			IL_05fa: ldloc.s 7
-			IL_05fc: stelem.ref
-			IL_05fd: dup
-			IL_05fe: ldc.i4.7
-			IL_05ff: ldloc.s 8
-			IL_0601: stelem.ref
-			IL_0602: dup
-			IL_0603: ldc.i4.8
-			IL_0604: ldloc.s 9
-			IL_0606: box [System.Runtime]System.Boolean
-			IL_060b: stelem.ref
-			IL_060c: dup
-			IL_060d: ldc.i4.s 9
-			IL_060f: ldloc.s 10
-			IL_0611: box [System.Runtime]System.Boolean
-			IL_0616: stelem.ref
-			IL_0617: dup
-			IL_0618: ldc.i4.s 10
-			IL_061a: ldloc.s 11
-			IL_061c: stelem.ref
-			IL_061d: dup
-			IL_061e: ldc.i4.s 11
-			IL_0620: ldloc.s 12
+			IL_05b6: ldloc.0
+			IL_05b7: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited3
+			IL_05bc: pop
+			IL_05bd: ldarg.0
+			IL_05be: ldc.i4.1
+			IL_05bf: ldelem.ref
+			IL_05c0: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_05c5: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_05ca: ldstr "promises"
+			IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05d9: stloc.s 11
+			IL_05db: ldloc.s 11
+			IL_05dd: ldstr "readFile"
+			IL_05e2: ldloc.3
+			IL_05e3: ldstr "utf8"
+			IL_05e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_05ed: stloc.s 11
+			IL_05ef: ldloc.0
+			IL_05f0: ldc.i4.7
+			IL_05f1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05f6: ldloc.0
+			IL_05f7: ldloc.s 11
+			IL_05f9: ldarg.0
+			IL_05fa: ldc.i4.4
+			IL_05fb: ldloc.0
+			IL_05fc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0601: ldc.i4.3
+			IL_0602: ldstr "_pendingException"
+			IL_0607: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_060c: ldloc.0
+			IL_060d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0612: dup
+			IL_0613: ldc.i4.0
+			IL_0614: ldloc.1
+			IL_0615: stelem.ref
+			IL_0616: dup
+			IL_0617: ldc.i4.1
+			IL_0618: ldloc.2
+			IL_0619: stelem.ref
+			IL_061a: dup
+			IL_061b: ldc.i4.2
+			IL_061c: ldloc.3
+			IL_061d: stelem.ref
+			IL_061e: dup
+			IL_061f: ldc.i4.3
+			IL_0620: ldloc.s 4
 			IL_0622: stelem.ref
 			IL_0623: dup
-			IL_0624: ldc.i4.s 12
-			IL_0626: ldloc.s 13
-			IL_0628: box [System.Runtime]System.Double
-			IL_062d: stelem.ref
-			IL_062e: dup
-			IL_062f: ldc.i4.s 13
-			IL_0631: ldloc.s 14
-			IL_0633: stelem.ref
-			IL_0634: dup
-			IL_0635: ldc.i4.s 14
-			IL_0637: ldloc.s 15
-			IL_0639: stelem.ref
-			IL_063a: dup
-			IL_063b: ldc.i4.s 15
-			IL_063d: ldloc.s 16
-			IL_063f: stelem.ref
-			IL_0640: dup
-			IL_0641: ldc.i4.s 16
-			IL_0643: ldloc.s 17
-			IL_0645: box [System.Runtime]System.Boolean
-			IL_064a: stelem.ref
-			IL_064b: dup
-			IL_064c: ldc.i4.s 17
-			IL_064e: ldloc.s 18
-			IL_0650: stelem.ref
-			IL_0651: dup
-			IL_0652: ldc.i4.s 18
-			IL_0654: ldloc.s 19
-			IL_0656: stelem.ref
-			IL_0657: pop
-			IL_0658: ldloc.0
-			IL_0659: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_065e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0663: ret
+			IL_0624: ldc.i4.4
+			IL_0625: ldloc.s 5
+			IL_0627: stelem.ref
+			IL_0628: dup
+			IL_0629: ldc.i4.5
+			IL_062a: ldloc.s 6
+			IL_062c: stelem.ref
+			IL_062d: dup
+			IL_062e: ldc.i4.6
+			IL_062f: ldloc.s 7
+			IL_0631: stelem.ref
+			IL_0632: dup
+			IL_0633: ldc.i4.7
+			IL_0634: ldloc.s 8
+			IL_0636: stelem.ref
+			IL_0637: dup
+			IL_0638: ldc.i4.8
+			IL_0639: ldloc.s 9
+			IL_063b: box [System.Runtime]System.Boolean
+			IL_0640: stelem.ref
+			IL_0641: dup
+			IL_0642: ldc.i4.s 9
+			IL_0644: ldloc.s 10
+			IL_0646: box [System.Runtime]System.Boolean
+			IL_064b: stelem.ref
+			IL_064c: dup
+			IL_064d: ldc.i4.s 10
+			IL_064f: ldloc.s 11
+			IL_0651: stelem.ref
+			IL_0652: dup
+			IL_0653: ldc.i4.s 11
+			IL_0655: ldloc.s 12
+			IL_0657: stelem.ref
+			IL_0658: dup
+			IL_0659: ldc.i4.s 12
+			IL_065b: ldloc.s 13
+			IL_065d: box [System.Runtime]System.Double
+			IL_0662: stelem.ref
+			IL_0663: dup
+			IL_0664: ldc.i4.s 13
+			IL_0666: ldloc.s 14
+			IL_0668: stelem.ref
+			IL_0669: dup
+			IL_066a: ldc.i4.s 14
+			IL_066c: ldloc.s 15
+			IL_066e: stelem.ref
+			IL_066f: dup
+			IL_0670: ldc.i4.s 15
+			IL_0672: ldloc.s 16
+			IL_0674: stelem.ref
+			IL_0675: dup
+			IL_0676: ldc.i4.s 16
+			IL_0678: ldloc.s 17
+			IL_067a: box [System.Runtime]System.Boolean
+			IL_067f: stelem.ref
+			IL_0680: dup
+			IL_0681: ldc.i4.s 17
+			IL_0683: ldloc.s 18
+			IL_0685: stelem.ref
+			IL_0686: dup
+			IL_0687: ldc.i4.s 18
+			IL_0689: ldloc.s 19
+			IL_068b: stelem.ref
+			IL_068c: pop
+			IL_068d: ldloc.0
+			IL_068e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0693: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0698: ret
 
-			IL_0664: ldloc.0
-			IL_0665: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited3
-			IL_066a: pop
-			IL_066b: ldarg.0
-			IL_066c: ldc.i4.1
-			IL_066d: ldelem.ref
-			IL_066e: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0673: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0678: stloc.s 11
-			IL_067a: ldstr "fs"
-			IL_067f: ldloc.s 11
-			IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0686: stloc.s 11
-			IL_0688: ldloc.s 11
-			IL_068a: ldstr "promises"
-			IL_068f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0694: stloc.s 11
-			IL_0696: ldloc.s 11
-			IL_0698: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_069d: stloc.s 11
-			IL_069f: ldloc.s 11
-			IL_06a1: ldstr "readFile"
-			IL_06a6: ldloc.3
-			IL_06a7: ldstr "utf8"
-			IL_06ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_06b1: stloc.s 11
-			IL_06b3: ldloc.0
-			IL_06b4: ldc.i4.7
-			IL_06b5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06ba: ldloc.0
-			IL_06bb: ldloc.s 11
-			IL_06bd: ldarg.0
-			IL_06be: ldc.i4.4
-			IL_06bf: ldloc.0
-			IL_06c0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_06c5: ldc.i4.3
-			IL_06c6: ldstr "_pendingException"
-			IL_06cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_06d0: ldloc.0
-			IL_06d1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_06d6: dup
-			IL_06d7: ldc.i4.0
-			IL_06d8: ldloc.1
-			IL_06d9: stelem.ref
-			IL_06da: dup
-			IL_06db: ldc.i4.1
-			IL_06dc: ldloc.2
-			IL_06dd: stelem.ref
-			IL_06de: dup
-			IL_06df: ldc.i4.2
-			IL_06e0: ldloc.3
-			IL_06e1: stelem.ref
-			IL_06e2: dup
-			IL_06e3: ldc.i4.3
-			IL_06e4: ldloc.s 4
-			IL_06e6: stelem.ref
-			IL_06e7: dup
-			IL_06e8: ldc.i4.4
-			IL_06e9: ldloc.s 5
-			IL_06eb: stelem.ref
-			IL_06ec: dup
-			IL_06ed: ldc.i4.5
-			IL_06ee: ldloc.s 6
-			IL_06f0: stelem.ref
-			IL_06f1: dup
-			IL_06f2: ldc.i4.6
-			IL_06f3: ldloc.s 7
-			IL_06f5: stelem.ref
-			IL_06f6: dup
-			IL_06f7: ldc.i4.7
-			IL_06f8: ldloc.s 8
-			IL_06fa: stelem.ref
-			IL_06fb: dup
+			IL_0699: ldloc.0
+			IL_069a: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited4
+			IL_069f: stloc.s 11
+			IL_06a1: ldloc.s 11
+			IL_06a3: stloc.s 5
+			IL_06a5: ldstr "console"
+			IL_06aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06af: stloc.s 11
+			IL_06b1: ldloc.s 11
+			IL_06b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06b8: stloc.s 11
+			IL_06ba: ldloc.s 11
+			IL_06bc: ldstr "log"
+			IL_06c1: ldstr "Text:"
+			IL_06c6: ldloc.s 5
+			IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_06cd: pop
+			IL_06ce: ldarg.0
+			IL_06cf: ldc.i4.1
+			IL_06d0: ldelem.ref
+			IL_06d1: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_06d6: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_06db: ldstr "promises"
+			IL_06e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06ea: stloc.s 11
+			IL_06ec: ldloc.s 11
+			IL_06ee: ldstr "unlink"
+			IL_06f3: ldloc.3
+			IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_06f9: stloc.s 11
+			IL_06fb: ldloc.0
 			IL_06fc: ldc.i4.8
-			IL_06fd: ldloc.s 9
-			IL_06ff: box [System.Runtime]System.Boolean
-			IL_0704: stelem.ref
-			IL_0705: dup
-			IL_0706: ldc.i4.s 9
-			IL_0708: ldloc.s 10
-			IL_070a: box [System.Runtime]System.Boolean
-			IL_070f: stelem.ref
-			IL_0710: dup
-			IL_0711: ldc.i4.s 10
-			IL_0713: ldloc.s 11
-			IL_0715: stelem.ref
-			IL_0716: dup
-			IL_0717: ldc.i4.s 11
-			IL_0719: ldloc.s 12
-			IL_071b: stelem.ref
-			IL_071c: dup
-			IL_071d: ldc.i4.s 12
-			IL_071f: ldloc.s 13
-			IL_0721: box [System.Runtime]System.Double
-			IL_0726: stelem.ref
-			IL_0727: dup
-			IL_0728: ldc.i4.s 13
-			IL_072a: ldloc.s 14
-			IL_072c: stelem.ref
-			IL_072d: dup
-			IL_072e: ldc.i4.s 14
-			IL_0730: ldloc.s 15
-			IL_0732: stelem.ref
-			IL_0733: dup
-			IL_0734: ldc.i4.s 15
-			IL_0736: ldloc.s 16
+			IL_06fd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0702: ldloc.0
+			IL_0703: ldloc.s 11
+			IL_0705: ldarg.0
+			IL_0706: ldc.i4.5
+			IL_0707: ldloc.0
+			IL_0708: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_070d: ldc.i4.3
+			IL_070e: ldstr "_pendingException"
+			IL_0713: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0718: ldloc.0
+			IL_0719: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_071e: dup
+			IL_071f: ldc.i4.0
+			IL_0720: ldloc.1
+			IL_0721: stelem.ref
+			IL_0722: dup
+			IL_0723: ldc.i4.1
+			IL_0724: ldloc.2
+			IL_0725: stelem.ref
+			IL_0726: dup
+			IL_0727: ldc.i4.2
+			IL_0728: ldloc.3
+			IL_0729: stelem.ref
+			IL_072a: dup
+			IL_072b: ldc.i4.3
+			IL_072c: ldloc.s 4
+			IL_072e: stelem.ref
+			IL_072f: dup
+			IL_0730: ldc.i4.4
+			IL_0731: ldloc.s 5
+			IL_0733: stelem.ref
+			IL_0734: dup
+			IL_0735: ldc.i4.5
+			IL_0736: ldloc.s 6
 			IL_0738: stelem.ref
 			IL_0739: dup
-			IL_073a: ldc.i4.s 16
-			IL_073c: ldloc.s 17
-			IL_073e: box [System.Runtime]System.Boolean
-			IL_0743: stelem.ref
-			IL_0744: dup
-			IL_0745: ldc.i4.s 17
-			IL_0747: ldloc.s 18
-			IL_0749: stelem.ref
-			IL_074a: dup
-			IL_074b: ldc.i4.s 18
-			IL_074d: ldloc.s 19
-			IL_074f: stelem.ref
-			IL_0750: pop
-			IL_0751: ldloc.0
-			IL_0752: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0757: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_075c: ret
+			IL_073a: ldc.i4.6
+			IL_073b: ldloc.s 7
+			IL_073d: stelem.ref
+			IL_073e: dup
+			IL_073f: ldc.i4.7
+			IL_0740: ldloc.s 8
+			IL_0742: stelem.ref
+			IL_0743: dup
+			IL_0744: ldc.i4.8
+			IL_0745: ldloc.s 9
+			IL_0747: box [System.Runtime]System.Boolean
+			IL_074c: stelem.ref
+			IL_074d: dup
+			IL_074e: ldc.i4.s 9
+			IL_0750: ldloc.s 10
+			IL_0752: box [System.Runtime]System.Boolean
+			IL_0757: stelem.ref
+			IL_0758: dup
+			IL_0759: ldc.i4.s 10
+			IL_075b: ldloc.s 11
+			IL_075d: stelem.ref
+			IL_075e: dup
+			IL_075f: ldc.i4.s 11
+			IL_0761: ldloc.s 12
+			IL_0763: stelem.ref
+			IL_0764: dup
+			IL_0765: ldc.i4.s 12
+			IL_0767: ldloc.s 13
+			IL_0769: box [System.Runtime]System.Double
+			IL_076e: stelem.ref
+			IL_076f: dup
+			IL_0770: ldc.i4.s 13
+			IL_0772: ldloc.s 14
+			IL_0774: stelem.ref
+			IL_0775: dup
+			IL_0776: ldc.i4.s 14
+			IL_0778: ldloc.s 15
+			IL_077a: stelem.ref
+			IL_077b: dup
+			IL_077c: ldc.i4.s 15
+			IL_077e: ldloc.s 16
+			IL_0780: stelem.ref
+			IL_0781: dup
+			IL_0782: ldc.i4.s 16
+			IL_0784: ldloc.s 17
+			IL_0786: box [System.Runtime]System.Boolean
+			IL_078b: stelem.ref
+			IL_078c: dup
+			IL_078d: ldc.i4.s 17
+			IL_078f: ldloc.s 18
+			IL_0791: stelem.ref
+			IL_0792: dup
+			IL_0793: ldc.i4.s 18
+			IL_0795: ldloc.s 19
+			IL_0797: stelem.ref
+			IL_0798: pop
+			IL_0799: ldloc.0
+			IL_079a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_079f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07a4: ret
 
-			IL_075d: ldloc.0
-			IL_075e: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited4
-			IL_0763: stloc.s 11
-			IL_0765: ldloc.s 11
-			IL_0767: stloc.s 5
-			IL_0769: ldstr "console"
-			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0773: stloc.s 11
-			IL_0775: ldloc.s 11
-			IL_0777: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_077c: stloc.s 11
-			IL_077e: ldloc.s 11
-			IL_0780: ldstr "log"
-			IL_0785: ldstr "Text:"
-			IL_078a: ldloc.s 5
-			IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0791: pop
-			IL_0792: ldarg.0
-			IL_0793: ldc.i4.1
-			IL_0794: ldelem.ref
-			IL_0795: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_079a: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_079f: stloc.s 11
-			IL_07a1: ldstr "fs"
-			IL_07a6: ldloc.s 11
-			IL_07a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_07ad: stloc.s 11
-			IL_07af: ldloc.s 11
-			IL_07b1: ldstr "promises"
-			IL_07b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07bb: stloc.s 11
-			IL_07bd: ldloc.s 11
-			IL_07bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07c4: stloc.s 11
-			IL_07c6: ldloc.s 11
-			IL_07c8: ldstr "unlink"
-			IL_07cd: ldloc.3
-			IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_07d3: stloc.s 11
-			IL_07d5: ldloc.0
-			IL_07d6: ldc.i4.8
-			IL_07d7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07dc: ldloc.0
-			IL_07dd: ldloc.s 11
-			IL_07df: ldarg.0
-			IL_07e0: ldc.i4.5
-			IL_07e1: ldloc.0
-			IL_07e2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_07e7: ldc.i4.3
-			IL_07e8: ldstr "_pendingException"
-			IL_07ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_07f2: ldloc.0
-			IL_07f3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_07f8: dup
-			IL_07f9: ldc.i4.0
-			IL_07fa: ldloc.1
-			IL_07fb: stelem.ref
-			IL_07fc: dup
-			IL_07fd: ldc.i4.1
-			IL_07fe: ldloc.2
-			IL_07ff: stelem.ref
-			IL_0800: dup
-			IL_0801: ldc.i4.2
-			IL_0802: ldloc.3
-			IL_0803: stelem.ref
-			IL_0804: dup
-			IL_0805: ldc.i4.3
-			IL_0806: ldloc.s 4
-			IL_0808: stelem.ref
-			IL_0809: dup
-			IL_080a: ldc.i4.4
-			IL_080b: ldloc.s 5
-			IL_080d: stelem.ref
-			IL_080e: dup
-			IL_080f: ldc.i4.5
-			IL_0810: ldloc.s 6
-			IL_0812: stelem.ref
-			IL_0813: dup
-			IL_0814: ldc.i4.6
-			IL_0815: ldloc.s 7
-			IL_0817: stelem.ref
-			IL_0818: dup
-			IL_0819: ldc.i4.7
-			IL_081a: ldloc.s 8
-			IL_081c: stelem.ref
-			IL_081d: dup
-			IL_081e: ldc.i4.8
-			IL_081f: ldloc.s 9
-			IL_0821: box [System.Runtime]System.Boolean
-			IL_0826: stelem.ref
-			IL_0827: dup
-			IL_0828: ldc.i4.s 9
-			IL_082a: ldloc.s 10
-			IL_082c: box [System.Runtime]System.Boolean
-			IL_0831: stelem.ref
-			IL_0832: dup
-			IL_0833: ldc.i4.s 10
-			IL_0835: ldloc.s 11
-			IL_0837: stelem.ref
-			IL_0838: dup
-			IL_0839: ldc.i4.s 11
-			IL_083b: ldloc.s 12
-			IL_083d: stelem.ref
-			IL_083e: dup
-			IL_083f: ldc.i4.s 12
-			IL_0841: ldloc.s 13
-			IL_0843: box [System.Runtime]System.Double
-			IL_0848: stelem.ref
-			IL_0849: dup
-			IL_084a: ldc.i4.s 13
-			IL_084c: ldloc.s 14
-			IL_084e: stelem.ref
-			IL_084f: dup
-			IL_0850: ldc.i4.s 14
-			IL_0852: ldloc.s 15
-			IL_0854: stelem.ref
-			IL_0855: dup
-			IL_0856: ldc.i4.s 15
-			IL_0858: ldloc.s 16
-			IL_085a: stelem.ref
-			IL_085b: dup
-			IL_085c: ldc.i4.s 16
-			IL_085e: ldloc.s 17
-			IL_0860: box [System.Runtime]System.Boolean
-			IL_0865: stelem.ref
-			IL_0866: dup
-			IL_0867: ldc.i4.s 17
-			IL_0869: ldloc.s 18
-			IL_086b: stelem.ref
-			IL_086c: dup
-			IL_086d: ldc.i4.s 18
-			IL_086f: ldloc.s 19
-			IL_0871: stelem.ref
-			IL_0872: pop
-			IL_0873: ldloc.0
-			IL_0874: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0879: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_087e: ret
+			IL_07a5: ldloc.0
+			IL_07a6: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited5
+			IL_07ab: pop
+			IL_07ac: ldstr "console"
+			IL_07b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07b6: stloc.s 11
+			IL_07b8: ldloc.s 11
+			IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07bf: stloc.s 11
+			IL_07c1: ldarg.0
+			IL_07c2: ldc.i4.1
+			IL_07c3: ldelem.ref
+			IL_07c4: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_07c9: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07d3: stloc.s 16
+			IL_07d5: ldloc.s 16
+			IL_07d7: ldstr "existsSync"
+			IL_07dc: ldloc.3
+			IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_07e2: stloc.s 16
+			IL_07e4: ldloc.s 11
+			IL_07e6: ldstr "log"
+			IL_07eb: ldstr "ExistsAfterUnlink:"
+			IL_07f0: ldloc.s 16
+			IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_07f7: pop
+			IL_07f8: br IL_0892
+
+			IL_07fd: ldloc.0
+			IL_07fe: ldc.i4.1
+			IL_07ff: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0804: ldloc.0
+			IL_0805: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_080a: stloc.s 16
+			IL_080c: ldloc.0
+			IL_080d: ldc.i4.0
+			IL_080e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0813: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0818: ldloc.0
+			IL_0819: ldc.i4.0
+			IL_081a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_081f: ldloc.s 16
+			IL_0821: stloc.s 6
+			IL_0823: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L25C18::.ctor()
+			IL_0828: stloc.s 7
+			IL_082a: ldstr "console"
+			IL_082f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0834: stloc.s 16
+			IL_0836: ldloc.s 16
+			IL_0838: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_083d: stloc.s 16
+			IL_083f: ldloc.s 6
+			IL_0841: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0846: stloc.s 17
+			IL_0848: ldloc.s 17
+			IL_084a: brfalse IL_0862
+
+			IL_084f: ldloc.s 6
+			IL_0851: ldstr "message"
+			IL_0856: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_085b: stloc.s 19
+			IL_085d: br IL_0866
+
+			IL_0862: ldloc.s 6
+			IL_0864: stloc.s 19
+
+			IL_0866: ldloc.s 16
+			IL_0868: ldstr "log"
+			IL_086d: ldstr "Error:"
+			IL_0872: ldloc.s 19
+			IL_0874: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0879: pop
+			IL_087a: br IL_0892
 
 			IL_087f: ldloc.0
-			IL_0880: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited5
-			IL_0885: pop
-			IL_0886: ldstr "console"
-			IL_088b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0890: stloc.s 11
-			IL_0892: ldloc.s 11
-			IL_0894: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0899: stloc.s 11
-			IL_089b: ldarg.0
-			IL_089c: ldc.i4.1
-			IL_089d: ldelem.ref
-			IL_089e: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_08a3: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_08a8: stloc.s 16
-			IL_08aa: ldstr "fs"
-			IL_08af: ldloc.s 16
-			IL_08b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_08b6: stloc.s 16
-			IL_08b8: ldloc.s 16
-			IL_08ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_08bf: stloc.s 16
-			IL_08c1: ldloc.s 16
-			IL_08c3: ldstr "existsSync"
-			IL_08c8: ldloc.3
-			IL_08c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_08ce: stloc.s 16
-			IL_08d0: ldloc.s 11
-			IL_08d2: ldstr "log"
-			IL_08d7: ldstr "ExistsAfterUnlink:"
-			IL_08dc: ldloc.s 16
-			IL_08de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_08e3: pop
-			IL_08e4: br IL_097e
+			IL_0880: ldc.i4.1
+			IL_0881: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0886: ldloc.0
+			IL_0887: ldc.i4.0
+			IL_0888: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_088d: br IL_0892
 
-			IL_08e9: ldloc.0
-			IL_08ea: ldc.i4.1
-			IL_08eb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_08f0: ldloc.0
-			IL_08f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_08f6: stloc.s 16
-			IL_08f8: ldloc.0
-			IL_08f9: ldc.i4.0
-			IL_08fa: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_08ff: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0892: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L27C14::.ctor()
+			IL_0897: stloc.s 8
+			IL_0899: ldarg.0
+			IL_089a: ldc.i4.1
+			IL_089b: ldelem.ref
+			IL_089c: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_08a1: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_08a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08ab: stloc.s 16
+			IL_08ad: ldloc.s 16
+			IL_08af: ldstr "rmSync"
+			IL_08b4: ldloc.2
+			IL_08b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_08ba: dup
+			IL_08bb: ldstr "force"
+			IL_08c0: ldc.i4.1
+			IL_08c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_08c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_08cb: pop
+			IL_08cc: ldarg.0
+			IL_08cd: ldc.i4.1
+			IL_08ce: ldelem.ref
+			IL_08cf: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_08d4: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_08d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08de: stloc.s 16
+			IL_08e0: ldloc.s 16
+			IL_08e2: ldstr "rmSync"
+			IL_08e7: ldloc.3
+			IL_08e8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_08ed: dup
+			IL_08ee: ldstr "force"
+			IL_08f3: ldc.i4.1
+			IL_08f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_08f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_08fe: pop
+			IL_08ff: br IL_0917
+
 			IL_0904: ldloc.0
-			IL_0905: ldc.i4.0
+			IL_0905: ldc.i4.1
 			IL_0906: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_090b: ldloc.s 16
-			IL_090d: stloc.s 6
-			IL_090f: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L25C18::.ctor()
-			IL_0914: stloc.s 7
-			IL_0916: ldstr "console"
-			IL_091b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0920: stloc.s 16
-			IL_0922: ldloc.s 16
-			IL_0924: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0929: stloc.s 16
-			IL_092b: ldloc.s 6
-			IL_092d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0932: stloc.s 17
-			IL_0934: ldloc.s 17
-			IL_0936: brfalse IL_094e
+			IL_090b: ldloc.0
+			IL_090c: ldc.i4.0
+			IL_090d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0912: br IL_0917
 
-			IL_093b: ldloc.s 6
-			IL_093d: ldstr "message"
-			IL_0942: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0947: stloc.s 19
-			IL_0949: br IL_0952
+			IL_0917: ldloc.0
+			IL_0918: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_091d: stloc.s 9
+			IL_091f: ldloc.s 9
+			IL_0921: brfalse IL_095e
 
-			IL_094e: ldloc.s 6
-			IL_0950: stloc.s 19
+			IL_0926: ldloc.0
+			IL_0927: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_092c: stloc.s 16
+			IL_092e: ldloc.0
+			IL_092f: ldc.i4.m1
+			IL_0930: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0935: ldloc.0
+			IL_0936: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_093b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0940: ldarg.0
+			IL_0941: ldc.i4.1
+			IL_0942: newarr [System.Runtime]System.Object
+			IL_0947: dup
+			IL_0948: ldc.i4.0
+			IL_0949: ldloc.s 16
+			IL_094b: stelem.ref
+			IL_094c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0951: pop
+			IL_0952: ldloc.0
+			IL_0953: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0958: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_095d: ret
 
-			IL_0952: ldloc.s 16
-			IL_0954: ldstr "log"
-			IL_0959: ldstr "Error:"
-			IL_095e: ldloc.s 19
-			IL_0960: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0965: pop
-			IL_0966: br IL_097e
+			IL_095e: ldloc.0
+			IL_095f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0964: stloc.s 10
+			IL_0966: ldloc.s 10
+			IL_0968: brfalse IL_09a5
 
-			IL_096b: ldloc.0
-			IL_096c: ldc.i4.1
-			IL_096d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0972: ldloc.0
-			IL_0973: ldc.i4.0
-			IL_0974: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0979: br IL_097e
+			IL_096d: ldloc.0
+			IL_096e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0973: stloc.s 16
+			IL_0975: ldloc.0
+			IL_0976: ldc.i4.m1
+			IL_0977: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_097c: ldloc.0
+			IL_097d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0982: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0987: ldarg.0
+			IL_0988: ldc.i4.1
+			IL_0989: newarr [System.Runtime]System.Object
+			IL_098e: dup
+			IL_098f: ldc.i4.0
+			IL_0990: ldloc.s 16
+			IL_0992: stelem.ref
+			IL_0993: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0998: pop
+			IL_0999: ldloc.0
+			IL_099a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_099f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09a4: ret
 
-			IL_097e: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L27C14::.ctor()
-			IL_0983: stloc.s 8
-			IL_0985: ldarg.0
-			IL_0986: ldc.i4.1
-			IL_0987: ldelem.ref
-			IL_0988: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_098d: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0992: stloc.s 16
-			IL_0994: ldstr "fs"
-			IL_0999: ldloc.s 16
-			IL_099b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_09a0: stloc.s 16
-			IL_09a2: ldloc.s 16
-			IL_09a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09a9: stloc.s 16
-			IL_09ab: ldloc.s 16
-			IL_09ad: ldstr "rmSync"
-			IL_09b2: ldloc.2
-			IL_09b3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_09b8: dup
-			IL_09b9: ldstr "force"
-			IL_09be: ldc.i4.1
-			IL_09bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_09c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_09c9: pop
-			IL_09ca: ldarg.0
-			IL_09cb: ldc.i4.1
-			IL_09cc: ldelem.ref
-			IL_09cd: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_09d2: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_09d7: stloc.s 16
-			IL_09d9: ldstr "fs"
-			IL_09de: ldloc.s 16
-			IL_09e0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_09e5: stloc.s 16
-			IL_09e7: ldloc.s 16
-			IL_09e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09ee: stloc.s 16
-			IL_09f0: ldloc.s 16
-			IL_09f2: ldstr "rmSync"
-			IL_09f7: ldloc.3
-			IL_09f8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_09fd: dup
-			IL_09fe: ldstr "force"
-			IL_0a03: ldc.i4.1
-			IL_0a04: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0a09: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a0e: pop
-			IL_0a0f: br IL_0a27
-
-			IL_0a14: ldloc.0
-			IL_0a15: ldc.i4.1
-			IL_0a16: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0a1b: ldloc.0
-			IL_0a1c: ldc.i4.0
-			IL_0a1d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0a22: br IL_0a27
-
-			IL_0a27: ldloc.0
-			IL_0a28: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0a2d: stloc.s 9
-			IL_0a2f: ldloc.s 9
-			IL_0a31: brfalse IL_0a6e
-
-			IL_0a36: ldloc.0
-			IL_0a37: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0a3c: stloc.s 16
-			IL_0a3e: ldloc.0
-			IL_0a3f: ldc.i4.m1
-			IL_0a40: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0a45: ldloc.0
-			IL_0a46: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a4b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0a50: ldarg.0
-			IL_0a51: ldc.i4.1
-			IL_0a52: newarr [System.Runtime]System.Object
-			IL_0a57: dup
-			IL_0a58: ldc.i4.0
-			IL_0a59: ldloc.s 16
-			IL_0a5b: stelem.ref
-			IL_0a5c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0a61: pop
-			IL_0a62: ldloc.0
-			IL_0a63: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a68: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a6d: ret
-
-			IL_0a6e: ldloc.0
-			IL_0a6f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0a74: stloc.s 10
-			IL_0a76: ldloc.s 10
-			IL_0a78: brfalse IL_0ab5
-
-			IL_0a7d: ldloc.0
-			IL_0a7e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0a83: stloc.s 16
-			IL_0a85: ldloc.0
-			IL_0a86: ldc.i4.m1
-			IL_0a87: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0a8c: ldloc.0
-			IL_0a8d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a92: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0a97: ldarg.0
-			IL_0a98: ldc.i4.1
-			IL_0a99: newarr [System.Runtime]System.Object
-			IL_0a9e: dup
-			IL_0a9f: ldc.i4.0
-			IL_0aa0: ldloc.s 16
-			IL_0aa2: stelem.ref
-			IL_0aa3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0aa8: pop
-			IL_0aa9: ldloc.0
-			IL_0aaa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0aaf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0ab4: ret
-
-			IL_0ab5: ldloc.0
-			IL_0ab6: ldc.i4.m1
-			IL_0ab7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0abc: ldloc.0
-			IL_0abd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ac2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0ac7: ldarg.0
-			IL_0ac8: ldc.i4.1
-			IL_0ac9: newarr [System.Runtime]System.Object
-			IL_0ace: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0ad3: pop
-			IL_0ad4: ldloc.0
-			IL_0ad5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ada: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0adf: ret
+			IL_09a5: ldloc.0
+			IL_09a6: ldc.i4.m1
+			IL_09a7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_09ac: ldloc.0
+			IL_09ad: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_09b7: ldarg.0
+			IL_09b8: ldc.i4.1
+			IL_09b9: newarr [System.Runtime]System.Object
+			IL_09be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_09c3: pop
+			IL_09c4: ldloc.0
+			IL_09c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09ca: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09cf: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1379,7 +1285,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2bd0
+			// Method begins at RVA 0x2ac0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1475,7 +1381,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2bfd
+		// Method begins at RVA 0x2aed
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e1e
+					// Method begins at RVA 0x2d9c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e27
+					// Method begins at RVA 0x2da5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e30
+					// Method begins at RVA 0x2dae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -121,7 +121,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e15
+				// Method begins at RVA 0x2d93
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -147,7 +147,7 @@
 			)
 			// Method begins at RVA 0x20e4
 			// Header size: 12
-			// Code size: 3356 (0xd1c)
+			// Code size: 3226 (0xc9a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope,
@@ -342,7 +342,7 @@
 
 			IL_013d: ldloc.0
 			IL_013e: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0143: switch (IL_0170, IL_0bec, IL_0c50, IL_0b6a, IL_043d, IL_05ae, IL_06e5, IL_07f4, IL_08fb, IL_09f3)
+			IL_0143: switch (IL_0170, IL_0b7c, IL_0bce, IL_0afa, IL_03df, IL_0550, IL_0687, IL_0796, IL_089d, IL_0995)
 
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_0175: stloc.s 16
@@ -384,1308 +384,1264 @@
 			IL_01e1: ldelem.ref
 			IL_01e2: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
 			IL_01e7: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::path
-			IL_01ec: stloc.s 16
-			IL_01ee: ldstr "path"
-			IL_01f3: ldloc.s 16
-			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01fa: stloc.s 16
-			IL_01fc: ldloc.s 16
-			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0203: stloc.s 16
-			IL_0205: ldarg.0
-			IL_0206: ldc.i4.1
-			IL_0207: ldelem.ref
-			IL_0208: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_020d: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
-			IL_0212: stloc.s 21
-			IL_0214: ldstr "os"
-			IL_0219: ldloc.s 21
-			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0220: stloc.s 21
-			IL_0222: ldloc.s 21
-			IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0229: stloc.s 21
-			IL_022b: ldloc.s 21
-			IL_022d: ldstr "tmpdir"
-			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0237: stloc.s 21
-			IL_0239: ldloc.1
-			IL_023a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_023f: stloc.s 20
-			IL_0241: ldstr "jroc-fs-open-position-"
-			IL_0246: ldloc.s 20
-			IL_0248: call string [System.Runtime]System.String::Concat(string, string)
-			IL_024d: stloc.s 20
-			IL_024f: ldloc.s 20
-			IL_0251: ldstr ".txt"
-			IL_0256: call string [System.Runtime]System.String::Concat(string, string)
-			IL_025b: stloc.s 20
-			IL_025d: ldloc.s 16
-			IL_025f: ldstr "join"
-			IL_0264: ldloc.s 21
-			IL_0266: ldloc.s 20
-			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_026d: stloc.s 21
-			IL_026f: ldloc.s 21
-			IL_0271: stloc.2
-			IL_0272: ldloc.0
-			IL_0273: ldc.i4.0
-			IL_0274: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0279: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_027e: ldloc.0
-			IL_027f: ldc.i4.0
-			IL_0280: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0285: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_028a: ldloc.0
-			IL_028b: ldc.i4.0
-			IL_028c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0291: ldloc.0
-			IL_0292: ldc.i4.0
-			IL_0293: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0298: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L11C8::.ctor()
-			IL_029d: stloc.3
-			IL_029e: ldarg.0
-			IL_029f: ldc.i4.1
-			IL_02a0: ldelem.ref
-			IL_02a1: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_02a6: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_02ab: stloc.s 21
-			IL_02ad: ldstr "fs"
-			IL_02b2: ldloc.s 21
-			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02b9: stloc.s 21
-			IL_02bb: ldloc.s 21
-			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02c2: stloc.s 21
-			IL_02c4: ldloc.s 21
-			IL_02c6: ldstr "rmSync"
-			IL_02cb: ldloc.2
-			IL_02cc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02d1: dup
-			IL_02d2: ldstr "force"
-			IL_02d7: ldc.i4.1
-			IL_02d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02e2: pop
-			IL_02e3: ldarg.0
-			IL_02e4: ldc.i4.1
-			IL_02e5: ldelem.ref
-			IL_02e6: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_02eb: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_02f0: stloc.s 21
-			IL_02f2: ldstr "fs"
+			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f1: stloc.s 16
+			IL_01f3: ldarg.0
+			IL_01f4: ldc.i4.1
+			IL_01f5: ldelem.ref
+			IL_01f6: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_01fb: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
+			IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0205: stloc.s 21
+			IL_0207: ldloc.s 21
+			IL_0209: ldstr "tmpdir"
+			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0213: stloc.s 21
+			IL_0215: ldloc.1
+			IL_0216: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_021b: stloc.s 20
+			IL_021d: ldstr "jroc-fs-open-position-"
+			IL_0222: ldloc.s 20
+			IL_0224: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0229: stloc.s 20
+			IL_022b: ldloc.s 20
+			IL_022d: ldstr ".txt"
+			IL_0232: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0237: stloc.s 20
+			IL_0239: ldloc.s 16
+			IL_023b: ldstr "join"
+			IL_0240: ldloc.s 21
+			IL_0242: ldloc.s 20
+			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0249: stloc.s 21
+			IL_024b: ldloc.s 21
+			IL_024d: stloc.2
+			IL_024e: ldloc.0
+			IL_024f: ldc.i4.0
+			IL_0250: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0255: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_025a: ldloc.0
+			IL_025b: ldc.i4.0
+			IL_025c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0261: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0266: ldloc.0
+			IL_0267: ldc.i4.0
+			IL_0268: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_026d: ldloc.0
+			IL_026e: ldc.i4.0
+			IL_026f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0274: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L11C8::.ctor()
+			IL_0279: stloc.3
+			IL_027a: ldarg.0
+			IL_027b: ldc.i4.1
+			IL_027c: ldelem.ref
+			IL_027d: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0282: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_028c: stloc.s 21
+			IL_028e: ldloc.s 21
+			IL_0290: ldstr "rmSync"
+			IL_0295: ldloc.2
+			IL_0296: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_029b: dup
+			IL_029c: ldstr "force"
+			IL_02a1: ldc.i4.1
+			IL_02a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02ac: pop
+			IL_02ad: ldarg.0
+			IL_02ae: ldc.i4.1
+			IL_02af: ldelem.ref
+			IL_02b0: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_02b5: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02bf: stloc.s 21
+			IL_02c1: ldloc.s 21
+			IL_02c3: ldstr "writeFileSync"
+			IL_02c8: ldloc.2
+			IL_02c9: ldstr "hello"
+			IL_02ce: ldstr "utf8"
+			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_02d8: pop
+			IL_02d9: ldarg.0
+			IL_02da: ldc.i4.1
+			IL_02db: ldelem.ref
+			IL_02dc: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_02e1: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_02e6: ldstr "promises"
+			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02f5: stloc.s 21
 			IL_02f7: ldloc.s 21
-			IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02fe: stloc.s 21
-			IL_0300: ldloc.s 21
-			IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0307: stloc.s 21
-			IL_0309: ldloc.s 21
-			IL_030b: ldstr "writeFileSync"
-			IL_0310: ldloc.2
-			IL_0311: ldstr "hello"
-			IL_0316: ldstr "utf8"
-			IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0320: pop
-			IL_0321: ldarg.0
-			IL_0322: ldc.i4.1
-			IL_0323: ldelem.ref
-			IL_0324: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0329: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_032e: stloc.s 21
-			IL_0330: ldstr "fs"
-			IL_0335: ldloc.s 21
-			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_033c: stloc.s 21
-			IL_033e: ldloc.s 21
-			IL_0340: ldstr "promises"
-			IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_034a: stloc.s 21
-			IL_034c: ldloc.s 21
-			IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0353: stloc.s 21
-			IL_0355: ldloc.s 21
-			IL_0357: ldstr "open"
-			IL_035c: ldloc.2
-			IL_035d: ldstr "r+"
-			IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0367: stloc.s 21
-			IL_0369: ldloc.0
-			IL_036a: ldc.i4.4
-			IL_036b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0370: ldloc.0
-			IL_0371: ldloc.s 21
-			IL_0373: ldarg.0
-			IL_0374: ldc.i4.1
-			IL_0375: ldloc.0
-			IL_0376: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_037b: ldc.i4.3
-			IL_037c: ldstr "_pendingException"
-			IL_0381: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0386: ldloc.0
-			IL_0387: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02f9: ldstr "open"
+			IL_02fe: ldloc.2
+			IL_02ff: ldstr "r+"
+			IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0309: stloc.s 21
+			IL_030b: ldloc.0
+			IL_030c: ldc.i4.4
+			IL_030d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0312: ldloc.0
+			IL_0313: ldloc.s 21
+			IL_0315: ldarg.0
+			IL_0316: ldc.i4.1
+			IL_0317: ldloc.0
+			IL_0318: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_031d: ldc.i4.3
+			IL_031e: ldstr "_pendingException"
+			IL_0323: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0328: ldloc.0
+			IL_0329: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_032e: dup
+			IL_032f: ldc.i4.0
+			IL_0330: ldloc.1
+			IL_0331: stelem.ref
+			IL_0332: dup
+			IL_0333: ldc.i4.1
+			IL_0334: ldloc.2
+			IL_0335: stelem.ref
+			IL_0336: dup
+			IL_0337: ldc.i4.2
+			IL_0338: ldloc.3
+			IL_0339: stelem.ref
+			IL_033a: dup
+			IL_033b: ldc.i4.3
+			IL_033c: ldloc.s 4
+			IL_033e: stelem.ref
+			IL_033f: dup
+			IL_0340: ldc.i4.4
+			IL_0341: ldloc.s 5
+			IL_0343: stelem.ref
+			IL_0344: dup
+			IL_0345: ldc.i4.5
+			IL_0346: ldloc.s 6
+			IL_0348: stelem.ref
+			IL_0349: dup
+			IL_034a: ldc.i4.6
+			IL_034b: ldloc.s 7
+			IL_034d: stelem.ref
+			IL_034e: dup
+			IL_034f: ldc.i4.7
+			IL_0350: ldloc.s 8
+			IL_0352: stelem.ref
+			IL_0353: dup
+			IL_0354: ldc.i4.8
+			IL_0355: ldloc.s 9
+			IL_0357: stelem.ref
+			IL_0358: dup
+			IL_0359: ldc.i4.s 9
+			IL_035b: ldloc.s 10
+			IL_035d: stelem.ref
+			IL_035e: dup
+			IL_035f: ldc.i4.s 10
+			IL_0361: ldloc.s 11
+			IL_0363: stelem.ref
+			IL_0364: dup
+			IL_0365: ldc.i4.s 11
+			IL_0367: ldloc.s 12
+			IL_0369: stelem.ref
+			IL_036a: dup
+			IL_036b: ldc.i4.s 12
+			IL_036d: ldloc.s 13
+			IL_036f: stelem.ref
+			IL_0370: dup
+			IL_0371: ldc.i4.s 13
+			IL_0373: ldloc.s 14
+			IL_0375: box [System.Runtime]System.Boolean
+			IL_037a: stelem.ref
+			IL_037b: dup
+			IL_037c: ldc.i4.s 14
+			IL_037e: ldloc.s 15
+			IL_0380: box [System.Runtime]System.Boolean
+			IL_0385: stelem.ref
+			IL_0386: dup
+			IL_0387: ldc.i4.s 15
+			IL_0389: ldloc.s 16
+			IL_038b: stelem.ref
 			IL_038c: dup
-			IL_038d: ldc.i4.0
-			IL_038e: ldloc.1
-			IL_038f: stelem.ref
-			IL_0390: dup
-			IL_0391: ldc.i4.1
-			IL_0392: ldloc.2
-			IL_0393: stelem.ref
-			IL_0394: dup
-			IL_0395: ldc.i4.2
-			IL_0396: ldloc.3
-			IL_0397: stelem.ref
-			IL_0398: dup
-			IL_0399: ldc.i4.3
-			IL_039a: ldloc.s 4
+			IL_038d: ldc.i4.s 16
+			IL_038f: ldloc.s 17
+			IL_0391: stelem.ref
+			IL_0392: dup
+			IL_0393: ldc.i4.s 17
+			IL_0395: ldloc.s 18
+			IL_0397: box [System.Runtime]System.Double
 			IL_039c: stelem.ref
 			IL_039d: dup
-			IL_039e: ldc.i4.4
-			IL_039f: ldloc.s 5
-			IL_03a1: stelem.ref
-			IL_03a2: dup
-			IL_03a3: ldc.i4.5
-			IL_03a4: ldloc.s 6
-			IL_03a6: stelem.ref
-			IL_03a7: dup
-			IL_03a8: ldc.i4.6
-			IL_03a9: ldloc.s 7
-			IL_03ab: stelem.ref
-			IL_03ac: dup
-			IL_03ad: ldc.i4.7
-			IL_03ae: ldloc.s 8
-			IL_03b0: stelem.ref
-			IL_03b1: dup
-			IL_03b2: ldc.i4.8
-			IL_03b3: ldloc.s 9
-			IL_03b5: stelem.ref
-			IL_03b6: dup
-			IL_03b7: ldc.i4.s 9
-			IL_03b9: ldloc.s 10
-			IL_03bb: stelem.ref
-			IL_03bc: dup
-			IL_03bd: ldc.i4.s 10
-			IL_03bf: ldloc.s 11
-			IL_03c1: stelem.ref
-			IL_03c2: dup
-			IL_03c3: ldc.i4.s 11
-			IL_03c5: ldloc.s 12
-			IL_03c7: stelem.ref
-			IL_03c8: dup
-			IL_03c9: ldc.i4.s 12
-			IL_03cb: ldloc.s 13
-			IL_03cd: stelem.ref
-			IL_03ce: dup
-			IL_03cf: ldc.i4.s 13
-			IL_03d1: ldloc.s 14
-			IL_03d3: box [System.Runtime]System.Boolean
-			IL_03d8: stelem.ref
-			IL_03d9: dup
-			IL_03da: ldc.i4.s 14
-			IL_03dc: ldloc.s 15
-			IL_03de: box [System.Runtime]System.Boolean
-			IL_03e3: stelem.ref
-			IL_03e4: dup
-			IL_03e5: ldc.i4.s 15
-			IL_03e7: ldloc.s 16
-			IL_03e9: stelem.ref
-			IL_03ea: dup
-			IL_03eb: ldc.i4.s 16
-			IL_03ed: ldloc.s 17
-			IL_03ef: stelem.ref
-			IL_03f0: dup
-			IL_03f1: ldc.i4.s 17
-			IL_03f3: ldloc.s 18
-			IL_03f5: box [System.Runtime]System.Double
-			IL_03fa: stelem.ref
-			IL_03fb: dup
-			IL_03fc: ldc.i4.s 18
-			IL_03fe: ldloc.s 19
-			IL_0400: stelem.ref
-			IL_0401: dup
-			IL_0402: ldc.i4.s 19
-			IL_0404: ldloc.s 20
-			IL_0406: stelem.ref
-			IL_0407: dup
-			IL_0408: ldc.i4.s 20
-			IL_040a: ldloc.s 21
-			IL_040c: stelem.ref
-			IL_040d: dup
-			IL_040e: ldc.i4.s 21
-			IL_0410: ldloc.s 22
-			IL_0412: stelem.ref
-			IL_0413: dup
-			IL_0414: ldc.i4.s 22
-			IL_0416: ldloc.s 23
-			IL_0418: stelem.ref
-			IL_0419: dup
-			IL_041a: ldc.i4.s 23
-			IL_041c: ldloc.s 24
-			IL_041e: box [System.Runtime]System.Boolean
-			IL_0423: stelem.ref
-			IL_0424: dup
-			IL_0425: ldc.i4.s 24
-			IL_0427: ldloc.s 25
-			IL_0429: stelem.ref
-			IL_042a: dup
-			IL_042b: ldc.i4.s 25
-			IL_042d: ldloc.s 26
-			IL_042f: stelem.ref
-			IL_0430: pop
-			IL_0431: ldloc.0
-			IL_0432: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0437: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_043c: ret
+			IL_039e: ldc.i4.s 18
+			IL_03a0: ldloc.s 19
+			IL_03a2: stelem.ref
+			IL_03a3: dup
+			IL_03a4: ldc.i4.s 19
+			IL_03a6: ldloc.s 20
+			IL_03a8: stelem.ref
+			IL_03a9: dup
+			IL_03aa: ldc.i4.s 20
+			IL_03ac: ldloc.s 21
+			IL_03ae: stelem.ref
+			IL_03af: dup
+			IL_03b0: ldc.i4.s 21
+			IL_03b2: ldloc.s 22
+			IL_03b4: stelem.ref
+			IL_03b5: dup
+			IL_03b6: ldc.i4.s 22
+			IL_03b8: ldloc.s 23
+			IL_03ba: stelem.ref
+			IL_03bb: dup
+			IL_03bc: ldc.i4.s 23
+			IL_03be: ldloc.s 24
+			IL_03c0: box [System.Runtime]System.Boolean
+			IL_03c5: stelem.ref
+			IL_03c6: dup
+			IL_03c7: ldc.i4.s 24
+			IL_03c9: ldloc.s 25
+			IL_03cb: stelem.ref
+			IL_03cc: dup
+			IL_03cd: ldc.i4.s 25
+			IL_03cf: ldloc.s 26
+			IL_03d1: stelem.ref
+			IL_03d2: pop
+			IL_03d3: ldloc.0
+			IL_03d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03d9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03de: ret
 
-			IL_043d: ldloc.0
-			IL_043e: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited1
-			IL_0443: stloc.s 21
-			IL_0445: ldloc.s 21
-			IL_0447: stloc.s 4
-			IL_0449: ldc.r8 1
-			IL_0452: box [System.Runtime]System.Double
-			IL_0457: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_045c: stloc.s 22
-			IL_045e: ldloc.s 22
-			IL_0460: stloc.s 5
-			IL_0462: ldc.r8 1
-			IL_046b: box [System.Runtime]System.Double
-			IL_0470: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_0475: stloc.s 22
-			IL_0477: ldloc.s 22
-			IL_0479: stloc.s 6
-			IL_047b: ldloc.s 4
-			IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0482: stloc.s 21
-			IL_0484: ldloc.s 5
-			IL_0486: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_048b: stloc.s 18
-			IL_048d: ldloc.s 18
-			IL_048f: box [System.Runtime]System.Double
-			IL_0494: stloc.s 19
-			IL_0496: ldc.i4.4
-			IL_0497: newarr [System.Runtime]System.Object
-			IL_049c: dup
-			IL_049d: ldc.i4.0
-			IL_049e: ldloc.s 5
-			IL_04a0: stelem.ref
-			IL_04a1: dup
-			IL_04a2: ldc.i4.1
-			IL_04a3: ldc.r8 0.0
-			IL_04ac: box [System.Runtime]System.Double
-			IL_04b1: stelem.ref
-			IL_04b2: dup
-			IL_04b3: ldc.i4.2
-			IL_04b4: ldloc.s 19
-			IL_04b6: stelem.ref
-			IL_04b7: dup
-			IL_04b8: ldc.i4.3
-			IL_04b9: ldc.r8 2
-			IL_04c2: box [System.Runtime]System.Double
-			IL_04c7: stelem.ref
-			IL_04c8: stloc.s 23
-			IL_04ca: ldloc.s 21
-			IL_04cc: ldstr "read"
-			IL_04d1: ldloc.s 23
-			IL_04d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_04d8: stloc.s 21
-			IL_04da: ldloc.0
-			IL_04db: ldc.i4.5
-			IL_04dc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04e1: ldloc.0
-			IL_04e2: ldloc.s 21
-			IL_04e4: ldarg.0
-			IL_04e5: ldc.i4.2
-			IL_04e6: ldloc.0
-			IL_04e7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_04ec: ldc.i4.3
-			IL_04ed: ldstr "_pendingException"
-			IL_04f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_04f7: ldloc.0
-			IL_04f8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03df: ldloc.0
+			IL_03e0: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited1
+			IL_03e5: stloc.s 21
+			IL_03e7: ldloc.s 21
+			IL_03e9: stloc.s 4
+			IL_03eb: ldc.r8 1
+			IL_03f4: box [System.Runtime]System.Double
+			IL_03f9: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_03fe: stloc.s 22
+			IL_0400: ldloc.s 22
+			IL_0402: stloc.s 5
+			IL_0404: ldc.r8 1
+			IL_040d: box [System.Runtime]System.Double
+			IL_0412: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_0417: stloc.s 22
+			IL_0419: ldloc.s 22
+			IL_041b: stloc.s 6
+			IL_041d: ldloc.s 4
+			IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0424: stloc.s 21
+			IL_0426: ldloc.s 5
+			IL_0428: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_042d: stloc.s 18
+			IL_042f: ldloc.s 18
+			IL_0431: box [System.Runtime]System.Double
+			IL_0436: stloc.s 19
+			IL_0438: ldc.i4.4
+			IL_0439: newarr [System.Runtime]System.Object
+			IL_043e: dup
+			IL_043f: ldc.i4.0
+			IL_0440: ldloc.s 5
+			IL_0442: stelem.ref
+			IL_0443: dup
+			IL_0444: ldc.i4.1
+			IL_0445: ldc.r8 0.0
+			IL_044e: box [System.Runtime]System.Double
+			IL_0453: stelem.ref
+			IL_0454: dup
+			IL_0455: ldc.i4.2
+			IL_0456: ldloc.s 19
+			IL_0458: stelem.ref
+			IL_0459: dup
+			IL_045a: ldc.i4.3
+			IL_045b: ldc.r8 2
+			IL_0464: box [System.Runtime]System.Double
+			IL_0469: stelem.ref
+			IL_046a: stloc.s 23
+			IL_046c: ldloc.s 21
+			IL_046e: ldstr "read"
+			IL_0473: ldloc.s 23
+			IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_047a: stloc.s 21
+			IL_047c: ldloc.0
+			IL_047d: ldc.i4.5
+			IL_047e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0483: ldloc.0
+			IL_0484: ldloc.s 21
+			IL_0486: ldarg.0
+			IL_0487: ldc.i4.2
+			IL_0488: ldloc.0
+			IL_0489: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_048e: ldc.i4.3
+			IL_048f: ldstr "_pendingException"
+			IL_0494: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0499: ldloc.0
+			IL_049a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_049f: dup
+			IL_04a0: ldc.i4.0
+			IL_04a1: ldloc.1
+			IL_04a2: stelem.ref
+			IL_04a3: dup
+			IL_04a4: ldc.i4.1
+			IL_04a5: ldloc.2
+			IL_04a6: stelem.ref
+			IL_04a7: dup
+			IL_04a8: ldc.i4.2
+			IL_04a9: ldloc.3
+			IL_04aa: stelem.ref
+			IL_04ab: dup
+			IL_04ac: ldc.i4.3
+			IL_04ad: ldloc.s 4
+			IL_04af: stelem.ref
+			IL_04b0: dup
+			IL_04b1: ldc.i4.4
+			IL_04b2: ldloc.s 5
+			IL_04b4: stelem.ref
+			IL_04b5: dup
+			IL_04b6: ldc.i4.5
+			IL_04b7: ldloc.s 6
+			IL_04b9: stelem.ref
+			IL_04ba: dup
+			IL_04bb: ldc.i4.6
+			IL_04bc: ldloc.s 7
+			IL_04be: stelem.ref
+			IL_04bf: dup
+			IL_04c0: ldc.i4.7
+			IL_04c1: ldloc.s 8
+			IL_04c3: stelem.ref
+			IL_04c4: dup
+			IL_04c5: ldc.i4.8
+			IL_04c6: ldloc.s 9
+			IL_04c8: stelem.ref
+			IL_04c9: dup
+			IL_04ca: ldc.i4.s 9
+			IL_04cc: ldloc.s 10
+			IL_04ce: stelem.ref
+			IL_04cf: dup
+			IL_04d0: ldc.i4.s 10
+			IL_04d2: ldloc.s 11
+			IL_04d4: stelem.ref
+			IL_04d5: dup
+			IL_04d6: ldc.i4.s 11
+			IL_04d8: ldloc.s 12
+			IL_04da: stelem.ref
+			IL_04db: dup
+			IL_04dc: ldc.i4.s 12
+			IL_04de: ldloc.s 13
+			IL_04e0: stelem.ref
+			IL_04e1: dup
+			IL_04e2: ldc.i4.s 13
+			IL_04e4: ldloc.s 14
+			IL_04e6: box [System.Runtime]System.Boolean
+			IL_04eb: stelem.ref
+			IL_04ec: dup
+			IL_04ed: ldc.i4.s 14
+			IL_04ef: ldloc.s 15
+			IL_04f1: box [System.Runtime]System.Boolean
+			IL_04f6: stelem.ref
+			IL_04f7: dup
+			IL_04f8: ldc.i4.s 15
+			IL_04fa: ldloc.s 16
+			IL_04fc: stelem.ref
 			IL_04fd: dup
-			IL_04fe: ldc.i4.0
-			IL_04ff: ldloc.1
-			IL_0500: stelem.ref
-			IL_0501: dup
-			IL_0502: ldc.i4.1
-			IL_0503: ldloc.2
-			IL_0504: stelem.ref
-			IL_0505: dup
-			IL_0506: ldc.i4.2
-			IL_0507: ldloc.3
-			IL_0508: stelem.ref
-			IL_0509: dup
-			IL_050a: ldc.i4.3
-			IL_050b: ldloc.s 4
+			IL_04fe: ldc.i4.s 16
+			IL_0500: ldloc.s 17
+			IL_0502: stelem.ref
+			IL_0503: dup
+			IL_0504: ldc.i4.s 17
+			IL_0506: ldloc.s 18
+			IL_0508: box [System.Runtime]System.Double
 			IL_050d: stelem.ref
 			IL_050e: dup
-			IL_050f: ldc.i4.4
-			IL_0510: ldloc.s 5
-			IL_0512: stelem.ref
-			IL_0513: dup
-			IL_0514: ldc.i4.5
-			IL_0515: ldloc.s 6
-			IL_0517: stelem.ref
-			IL_0518: dup
-			IL_0519: ldc.i4.6
-			IL_051a: ldloc.s 7
-			IL_051c: stelem.ref
-			IL_051d: dup
-			IL_051e: ldc.i4.7
-			IL_051f: ldloc.s 8
-			IL_0521: stelem.ref
-			IL_0522: dup
-			IL_0523: ldc.i4.8
-			IL_0524: ldloc.s 9
-			IL_0526: stelem.ref
-			IL_0527: dup
-			IL_0528: ldc.i4.s 9
-			IL_052a: ldloc.s 10
-			IL_052c: stelem.ref
-			IL_052d: dup
-			IL_052e: ldc.i4.s 10
-			IL_0530: ldloc.s 11
-			IL_0532: stelem.ref
-			IL_0533: dup
-			IL_0534: ldc.i4.s 11
-			IL_0536: ldloc.s 12
-			IL_0538: stelem.ref
-			IL_0539: dup
-			IL_053a: ldc.i4.s 12
-			IL_053c: ldloc.s 13
-			IL_053e: stelem.ref
-			IL_053f: dup
-			IL_0540: ldc.i4.s 13
-			IL_0542: ldloc.s 14
-			IL_0544: box [System.Runtime]System.Boolean
-			IL_0549: stelem.ref
-			IL_054a: dup
-			IL_054b: ldc.i4.s 14
-			IL_054d: ldloc.s 15
-			IL_054f: box [System.Runtime]System.Boolean
-			IL_0554: stelem.ref
-			IL_0555: dup
-			IL_0556: ldc.i4.s 15
-			IL_0558: ldloc.s 16
-			IL_055a: stelem.ref
-			IL_055b: dup
-			IL_055c: ldc.i4.s 16
-			IL_055e: ldloc.s 17
-			IL_0560: stelem.ref
-			IL_0561: dup
-			IL_0562: ldc.i4.s 17
-			IL_0564: ldloc.s 18
-			IL_0566: box [System.Runtime]System.Double
-			IL_056b: stelem.ref
-			IL_056c: dup
-			IL_056d: ldc.i4.s 18
-			IL_056f: ldloc.s 19
-			IL_0571: stelem.ref
-			IL_0572: dup
-			IL_0573: ldc.i4.s 19
-			IL_0575: ldloc.s 20
-			IL_0577: stelem.ref
-			IL_0578: dup
-			IL_0579: ldc.i4.s 20
-			IL_057b: ldloc.s 21
-			IL_057d: stelem.ref
-			IL_057e: dup
-			IL_057f: ldc.i4.s 21
-			IL_0581: ldloc.s 22
-			IL_0583: stelem.ref
-			IL_0584: dup
-			IL_0585: ldc.i4.s 22
-			IL_0587: ldloc.s 23
-			IL_0589: stelem.ref
-			IL_058a: dup
-			IL_058b: ldc.i4.s 23
-			IL_058d: ldloc.s 24
-			IL_058f: box [System.Runtime]System.Boolean
-			IL_0594: stelem.ref
-			IL_0595: dup
-			IL_0596: ldc.i4.s 24
-			IL_0598: ldloc.s 25
-			IL_059a: stelem.ref
-			IL_059b: dup
-			IL_059c: ldc.i4.s 25
-			IL_059e: ldloc.s 26
-			IL_05a0: stelem.ref
-			IL_05a1: pop
-			IL_05a2: ldloc.0
-			IL_05a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05a8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05ad: ret
+			IL_050f: ldc.i4.s 18
+			IL_0511: ldloc.s 19
+			IL_0513: stelem.ref
+			IL_0514: dup
+			IL_0515: ldc.i4.s 19
+			IL_0517: ldloc.s 20
+			IL_0519: stelem.ref
+			IL_051a: dup
+			IL_051b: ldc.i4.s 20
+			IL_051d: ldloc.s 21
+			IL_051f: stelem.ref
+			IL_0520: dup
+			IL_0521: ldc.i4.s 21
+			IL_0523: ldloc.s 22
+			IL_0525: stelem.ref
+			IL_0526: dup
+			IL_0527: ldc.i4.s 22
+			IL_0529: ldloc.s 23
+			IL_052b: stelem.ref
+			IL_052c: dup
+			IL_052d: ldc.i4.s 23
+			IL_052f: ldloc.s 24
+			IL_0531: box [System.Runtime]System.Boolean
+			IL_0536: stelem.ref
+			IL_0537: dup
+			IL_0538: ldc.i4.s 24
+			IL_053a: ldloc.s 25
+			IL_053c: stelem.ref
+			IL_053d: dup
+			IL_053e: ldc.i4.s 25
+			IL_0540: ldloc.s 26
+			IL_0542: stelem.ref
+			IL_0543: pop
+			IL_0544: ldloc.0
+			IL_0545: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_054a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_054f: ret
 
-			IL_05ae: ldloc.0
-			IL_05af: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited2
-			IL_05b4: stloc.s 21
-			IL_05b6: ldloc.s 21
-			IL_05b8: stloc.s 7
-			IL_05ba: ldloc.s 4
-			IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05c1: stloc.s 21
-			IL_05c3: ldloc.s 6
-			IL_05c5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_05ca: stloc.s 18
-			IL_05cc: ldloc.s 18
-			IL_05ce: box [System.Runtime]System.Double
-			IL_05d3: stloc.s 19
-			IL_05d5: ldc.i4.4
-			IL_05d6: newarr [System.Runtime]System.Object
-			IL_05db: dup
-			IL_05dc: ldc.i4.0
-			IL_05dd: ldloc.s 6
-			IL_05df: stelem.ref
-			IL_05e0: dup
-			IL_05e1: ldc.i4.1
-			IL_05e2: ldc.r8 0.0
-			IL_05eb: box [System.Runtime]System.Double
+			IL_0550: ldloc.0
+			IL_0551: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited2
+			IL_0556: stloc.s 21
+			IL_0558: ldloc.s 21
+			IL_055a: stloc.s 7
+			IL_055c: ldloc.s 4
+			IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0563: stloc.s 21
+			IL_0565: ldloc.s 6
+			IL_0567: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_056c: stloc.s 18
+			IL_056e: ldloc.s 18
+			IL_0570: box [System.Runtime]System.Double
+			IL_0575: stloc.s 19
+			IL_0577: ldc.i4.4
+			IL_0578: newarr [System.Runtime]System.Object
+			IL_057d: dup
+			IL_057e: ldc.i4.0
+			IL_057f: ldloc.s 6
+			IL_0581: stelem.ref
+			IL_0582: dup
+			IL_0583: ldc.i4.1
+			IL_0584: ldc.r8 0.0
+			IL_058d: box [System.Runtime]System.Double
+			IL_0592: stelem.ref
+			IL_0593: dup
+			IL_0594: ldc.i4.2
+			IL_0595: ldloc.s 19
+			IL_0597: stelem.ref
+			IL_0598: dup
+			IL_0599: ldc.i4.3
+			IL_059a: ldc.i4.0
+			IL_059b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_05a0: stelem.ref
+			IL_05a1: stloc.s 23
+			IL_05a3: ldloc.s 21
+			IL_05a5: ldstr "read"
+			IL_05aa: ldloc.s 23
+			IL_05ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_05b1: stloc.s 21
+			IL_05b3: ldloc.0
+			IL_05b4: ldc.i4.6
+			IL_05b5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05ba: ldloc.0
+			IL_05bb: ldloc.s 21
+			IL_05bd: ldarg.0
+			IL_05be: ldc.i4.3
+			IL_05bf: ldloc.0
+			IL_05c0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05c5: ldc.i4.3
+			IL_05c6: ldstr "_pendingException"
+			IL_05cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_05d0: ldloc.0
+			IL_05d1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05d6: dup
+			IL_05d7: ldc.i4.0
+			IL_05d8: ldloc.1
+			IL_05d9: stelem.ref
+			IL_05da: dup
+			IL_05db: ldc.i4.1
+			IL_05dc: ldloc.2
+			IL_05dd: stelem.ref
+			IL_05de: dup
+			IL_05df: ldc.i4.2
+			IL_05e0: ldloc.3
+			IL_05e1: stelem.ref
+			IL_05e2: dup
+			IL_05e3: ldc.i4.3
+			IL_05e4: ldloc.s 4
+			IL_05e6: stelem.ref
+			IL_05e7: dup
+			IL_05e8: ldc.i4.4
+			IL_05e9: ldloc.s 5
+			IL_05eb: stelem.ref
+			IL_05ec: dup
+			IL_05ed: ldc.i4.5
+			IL_05ee: ldloc.s 6
 			IL_05f0: stelem.ref
 			IL_05f1: dup
-			IL_05f2: ldc.i4.2
-			IL_05f3: ldloc.s 19
+			IL_05f2: ldc.i4.6
+			IL_05f3: ldloc.s 7
 			IL_05f5: stelem.ref
 			IL_05f6: dup
-			IL_05f7: ldc.i4.3
-			IL_05f8: ldc.i4.0
-			IL_05f9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_05fe: stelem.ref
-			IL_05ff: stloc.s 23
-			IL_0601: ldloc.s 21
-			IL_0603: ldstr "read"
-			IL_0608: ldloc.s 23
-			IL_060a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_060f: stloc.s 21
-			IL_0611: ldloc.0
-			IL_0612: ldc.i4.6
-			IL_0613: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0618: ldloc.0
-			IL_0619: ldloc.s 21
-			IL_061b: ldarg.0
-			IL_061c: ldc.i4.3
-			IL_061d: ldloc.0
-			IL_061e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0623: ldc.i4.3
-			IL_0624: ldstr "_pendingException"
-			IL_0629: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_062e: ldloc.0
-			IL_062f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05f7: ldc.i4.7
+			IL_05f8: ldloc.s 8
+			IL_05fa: stelem.ref
+			IL_05fb: dup
+			IL_05fc: ldc.i4.8
+			IL_05fd: ldloc.s 9
+			IL_05ff: stelem.ref
+			IL_0600: dup
+			IL_0601: ldc.i4.s 9
+			IL_0603: ldloc.s 10
+			IL_0605: stelem.ref
+			IL_0606: dup
+			IL_0607: ldc.i4.s 10
+			IL_0609: ldloc.s 11
+			IL_060b: stelem.ref
+			IL_060c: dup
+			IL_060d: ldc.i4.s 11
+			IL_060f: ldloc.s 12
+			IL_0611: stelem.ref
+			IL_0612: dup
+			IL_0613: ldc.i4.s 12
+			IL_0615: ldloc.s 13
+			IL_0617: stelem.ref
+			IL_0618: dup
+			IL_0619: ldc.i4.s 13
+			IL_061b: ldloc.s 14
+			IL_061d: box [System.Runtime]System.Boolean
+			IL_0622: stelem.ref
+			IL_0623: dup
+			IL_0624: ldc.i4.s 14
+			IL_0626: ldloc.s 15
+			IL_0628: box [System.Runtime]System.Boolean
+			IL_062d: stelem.ref
+			IL_062e: dup
+			IL_062f: ldc.i4.s 15
+			IL_0631: ldloc.s 16
+			IL_0633: stelem.ref
 			IL_0634: dup
-			IL_0635: ldc.i4.0
-			IL_0636: ldloc.1
-			IL_0637: stelem.ref
-			IL_0638: dup
-			IL_0639: ldc.i4.1
-			IL_063a: ldloc.2
-			IL_063b: stelem.ref
-			IL_063c: dup
-			IL_063d: ldc.i4.2
-			IL_063e: ldloc.3
-			IL_063f: stelem.ref
-			IL_0640: dup
-			IL_0641: ldc.i4.3
-			IL_0642: ldloc.s 4
+			IL_0635: ldc.i4.s 16
+			IL_0637: ldloc.s 17
+			IL_0639: stelem.ref
+			IL_063a: dup
+			IL_063b: ldc.i4.s 17
+			IL_063d: ldloc.s 18
+			IL_063f: box [System.Runtime]System.Double
 			IL_0644: stelem.ref
 			IL_0645: dup
-			IL_0646: ldc.i4.4
-			IL_0647: ldloc.s 5
-			IL_0649: stelem.ref
-			IL_064a: dup
-			IL_064b: ldc.i4.5
-			IL_064c: ldloc.s 6
-			IL_064e: stelem.ref
-			IL_064f: dup
-			IL_0650: ldc.i4.6
-			IL_0651: ldloc.s 7
-			IL_0653: stelem.ref
-			IL_0654: dup
-			IL_0655: ldc.i4.7
-			IL_0656: ldloc.s 8
-			IL_0658: stelem.ref
-			IL_0659: dup
-			IL_065a: ldc.i4.8
-			IL_065b: ldloc.s 9
-			IL_065d: stelem.ref
-			IL_065e: dup
-			IL_065f: ldc.i4.s 9
-			IL_0661: ldloc.s 10
-			IL_0663: stelem.ref
-			IL_0664: dup
-			IL_0665: ldc.i4.s 10
-			IL_0667: ldloc.s 11
-			IL_0669: stelem.ref
-			IL_066a: dup
-			IL_066b: ldc.i4.s 11
-			IL_066d: ldloc.s 12
-			IL_066f: stelem.ref
-			IL_0670: dup
-			IL_0671: ldc.i4.s 12
-			IL_0673: ldloc.s 13
-			IL_0675: stelem.ref
-			IL_0676: dup
-			IL_0677: ldc.i4.s 13
-			IL_0679: ldloc.s 14
-			IL_067b: box [System.Runtime]System.Boolean
-			IL_0680: stelem.ref
-			IL_0681: dup
-			IL_0682: ldc.i4.s 14
-			IL_0684: ldloc.s 15
-			IL_0686: box [System.Runtime]System.Boolean
-			IL_068b: stelem.ref
-			IL_068c: dup
-			IL_068d: ldc.i4.s 15
-			IL_068f: ldloc.s 16
-			IL_0691: stelem.ref
-			IL_0692: dup
-			IL_0693: ldc.i4.s 16
-			IL_0695: ldloc.s 17
-			IL_0697: stelem.ref
-			IL_0698: dup
-			IL_0699: ldc.i4.s 17
-			IL_069b: ldloc.s 18
-			IL_069d: box [System.Runtime]System.Double
-			IL_06a2: stelem.ref
-			IL_06a3: dup
-			IL_06a4: ldc.i4.s 18
-			IL_06a6: ldloc.s 19
-			IL_06a8: stelem.ref
-			IL_06a9: dup
-			IL_06aa: ldc.i4.s 19
-			IL_06ac: ldloc.s 20
-			IL_06ae: stelem.ref
-			IL_06af: dup
-			IL_06b0: ldc.i4.s 20
-			IL_06b2: ldloc.s 21
-			IL_06b4: stelem.ref
-			IL_06b5: dup
-			IL_06b6: ldc.i4.s 21
-			IL_06b8: ldloc.s 22
-			IL_06ba: stelem.ref
-			IL_06bb: dup
-			IL_06bc: ldc.i4.s 22
-			IL_06be: ldloc.s 23
-			IL_06c0: stelem.ref
-			IL_06c1: dup
-			IL_06c2: ldc.i4.s 23
-			IL_06c4: ldloc.s 24
-			IL_06c6: box [System.Runtime]System.Boolean
-			IL_06cb: stelem.ref
-			IL_06cc: dup
-			IL_06cd: ldc.i4.s 24
-			IL_06cf: ldloc.s 25
-			IL_06d1: stelem.ref
-			IL_06d2: dup
-			IL_06d3: ldc.i4.s 25
-			IL_06d5: ldloc.s 26
-			IL_06d7: stelem.ref
-			IL_06d8: pop
-			IL_06d9: ldloc.0
-			IL_06da: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06df: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06e4: ret
+			IL_0646: ldc.i4.s 18
+			IL_0648: ldloc.s 19
+			IL_064a: stelem.ref
+			IL_064b: dup
+			IL_064c: ldc.i4.s 19
+			IL_064e: ldloc.s 20
+			IL_0650: stelem.ref
+			IL_0651: dup
+			IL_0652: ldc.i4.s 20
+			IL_0654: ldloc.s 21
+			IL_0656: stelem.ref
+			IL_0657: dup
+			IL_0658: ldc.i4.s 21
+			IL_065a: ldloc.s 22
+			IL_065c: stelem.ref
+			IL_065d: dup
+			IL_065e: ldc.i4.s 22
+			IL_0660: ldloc.s 23
+			IL_0662: stelem.ref
+			IL_0663: dup
+			IL_0664: ldc.i4.s 23
+			IL_0666: ldloc.s 24
+			IL_0668: box [System.Runtime]System.Boolean
+			IL_066d: stelem.ref
+			IL_066e: dup
+			IL_066f: ldc.i4.s 24
+			IL_0671: ldloc.s 25
+			IL_0673: stelem.ref
+			IL_0674: dup
+			IL_0675: ldc.i4.s 25
+			IL_0677: ldloc.s 26
+			IL_0679: stelem.ref
+			IL_067a: pop
+			IL_067b: ldloc.0
+			IL_067c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0681: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0686: ret
 
-			IL_06e5: ldloc.0
-			IL_06e6: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited3
-			IL_06eb: stloc.s 21
-			IL_06ed: ldloc.s 21
-			IL_06ef: stloc.s 8
-			IL_06f1: ldloc.s 4
-			IL_06f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06f8: stloc.s 21
-			IL_06fa: ldloc.s 21
-			IL_06fc: ldstr "write"
-			IL_0701: ldstr "X"
-			IL_0706: ldc.r8 4
-			IL_070f: box [System.Runtime]System.Double
-			IL_0714: ldstr "utf8"
-			IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_071e: stloc.s 21
-			IL_0720: ldloc.0
-			IL_0721: ldc.i4.7
-			IL_0722: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0727: ldloc.0
-			IL_0728: ldloc.s 21
-			IL_072a: ldarg.0
-			IL_072b: ldc.i4.4
-			IL_072c: ldloc.0
-			IL_072d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0732: ldc.i4.3
-			IL_0733: ldstr "_pendingException"
-			IL_0738: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_073d: ldloc.0
-			IL_073e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0687: ldloc.0
+			IL_0688: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited3
+			IL_068d: stloc.s 21
+			IL_068f: ldloc.s 21
+			IL_0691: stloc.s 8
+			IL_0693: ldloc.s 4
+			IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_069a: stloc.s 21
+			IL_069c: ldloc.s 21
+			IL_069e: ldstr "write"
+			IL_06a3: ldstr "X"
+			IL_06a8: ldc.r8 4
+			IL_06b1: box [System.Runtime]System.Double
+			IL_06b6: ldstr "utf8"
+			IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_06c0: stloc.s 21
+			IL_06c2: ldloc.0
+			IL_06c3: ldc.i4.7
+			IL_06c4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06c9: ldloc.0
+			IL_06ca: ldloc.s 21
+			IL_06cc: ldarg.0
+			IL_06cd: ldc.i4.4
+			IL_06ce: ldloc.0
+			IL_06cf: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_06d4: ldc.i4.3
+			IL_06d5: ldstr "_pendingException"
+			IL_06da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_06df: ldloc.0
+			IL_06e0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_06e5: dup
+			IL_06e6: ldc.i4.0
+			IL_06e7: ldloc.1
+			IL_06e8: stelem.ref
+			IL_06e9: dup
+			IL_06ea: ldc.i4.1
+			IL_06eb: ldloc.2
+			IL_06ec: stelem.ref
+			IL_06ed: dup
+			IL_06ee: ldc.i4.2
+			IL_06ef: ldloc.3
+			IL_06f0: stelem.ref
+			IL_06f1: dup
+			IL_06f2: ldc.i4.3
+			IL_06f3: ldloc.s 4
+			IL_06f5: stelem.ref
+			IL_06f6: dup
+			IL_06f7: ldc.i4.4
+			IL_06f8: ldloc.s 5
+			IL_06fa: stelem.ref
+			IL_06fb: dup
+			IL_06fc: ldc.i4.5
+			IL_06fd: ldloc.s 6
+			IL_06ff: stelem.ref
+			IL_0700: dup
+			IL_0701: ldc.i4.6
+			IL_0702: ldloc.s 7
+			IL_0704: stelem.ref
+			IL_0705: dup
+			IL_0706: ldc.i4.7
+			IL_0707: ldloc.s 8
+			IL_0709: stelem.ref
+			IL_070a: dup
+			IL_070b: ldc.i4.8
+			IL_070c: ldloc.s 9
+			IL_070e: stelem.ref
+			IL_070f: dup
+			IL_0710: ldc.i4.s 9
+			IL_0712: ldloc.s 10
+			IL_0714: stelem.ref
+			IL_0715: dup
+			IL_0716: ldc.i4.s 10
+			IL_0718: ldloc.s 11
+			IL_071a: stelem.ref
+			IL_071b: dup
+			IL_071c: ldc.i4.s 11
+			IL_071e: ldloc.s 12
+			IL_0720: stelem.ref
+			IL_0721: dup
+			IL_0722: ldc.i4.s 12
+			IL_0724: ldloc.s 13
+			IL_0726: stelem.ref
+			IL_0727: dup
+			IL_0728: ldc.i4.s 13
+			IL_072a: ldloc.s 14
+			IL_072c: box [System.Runtime]System.Boolean
+			IL_0731: stelem.ref
+			IL_0732: dup
+			IL_0733: ldc.i4.s 14
+			IL_0735: ldloc.s 15
+			IL_0737: box [System.Runtime]System.Boolean
+			IL_073c: stelem.ref
+			IL_073d: dup
+			IL_073e: ldc.i4.s 15
+			IL_0740: ldloc.s 16
+			IL_0742: stelem.ref
 			IL_0743: dup
-			IL_0744: ldc.i4.0
-			IL_0745: ldloc.1
-			IL_0746: stelem.ref
-			IL_0747: dup
-			IL_0748: ldc.i4.1
-			IL_0749: ldloc.2
-			IL_074a: stelem.ref
-			IL_074b: dup
-			IL_074c: ldc.i4.2
-			IL_074d: ldloc.3
-			IL_074e: stelem.ref
-			IL_074f: dup
-			IL_0750: ldc.i4.3
-			IL_0751: ldloc.s 4
+			IL_0744: ldc.i4.s 16
+			IL_0746: ldloc.s 17
+			IL_0748: stelem.ref
+			IL_0749: dup
+			IL_074a: ldc.i4.s 17
+			IL_074c: ldloc.s 18
+			IL_074e: box [System.Runtime]System.Double
 			IL_0753: stelem.ref
 			IL_0754: dup
-			IL_0755: ldc.i4.4
-			IL_0756: ldloc.s 5
-			IL_0758: stelem.ref
-			IL_0759: dup
-			IL_075a: ldc.i4.5
-			IL_075b: ldloc.s 6
-			IL_075d: stelem.ref
-			IL_075e: dup
-			IL_075f: ldc.i4.6
-			IL_0760: ldloc.s 7
-			IL_0762: stelem.ref
-			IL_0763: dup
-			IL_0764: ldc.i4.7
-			IL_0765: ldloc.s 8
-			IL_0767: stelem.ref
-			IL_0768: dup
-			IL_0769: ldc.i4.8
-			IL_076a: ldloc.s 9
-			IL_076c: stelem.ref
-			IL_076d: dup
-			IL_076e: ldc.i4.s 9
-			IL_0770: ldloc.s 10
-			IL_0772: stelem.ref
-			IL_0773: dup
-			IL_0774: ldc.i4.s 10
-			IL_0776: ldloc.s 11
-			IL_0778: stelem.ref
-			IL_0779: dup
-			IL_077a: ldc.i4.s 11
-			IL_077c: ldloc.s 12
-			IL_077e: stelem.ref
-			IL_077f: dup
-			IL_0780: ldc.i4.s 12
-			IL_0782: ldloc.s 13
-			IL_0784: stelem.ref
-			IL_0785: dup
-			IL_0786: ldc.i4.s 13
-			IL_0788: ldloc.s 14
-			IL_078a: box [System.Runtime]System.Boolean
-			IL_078f: stelem.ref
-			IL_0790: dup
-			IL_0791: ldc.i4.s 14
-			IL_0793: ldloc.s 15
-			IL_0795: box [System.Runtime]System.Boolean
-			IL_079a: stelem.ref
-			IL_079b: dup
-			IL_079c: ldc.i4.s 15
-			IL_079e: ldloc.s 16
-			IL_07a0: stelem.ref
-			IL_07a1: dup
-			IL_07a2: ldc.i4.s 16
-			IL_07a4: ldloc.s 17
-			IL_07a6: stelem.ref
-			IL_07a7: dup
-			IL_07a8: ldc.i4.s 17
-			IL_07aa: ldloc.s 18
-			IL_07ac: box [System.Runtime]System.Double
-			IL_07b1: stelem.ref
-			IL_07b2: dup
-			IL_07b3: ldc.i4.s 18
-			IL_07b5: ldloc.s 19
-			IL_07b7: stelem.ref
-			IL_07b8: dup
-			IL_07b9: ldc.i4.s 19
-			IL_07bb: ldloc.s 20
-			IL_07bd: stelem.ref
-			IL_07be: dup
-			IL_07bf: ldc.i4.s 20
-			IL_07c1: ldloc.s 21
-			IL_07c3: stelem.ref
-			IL_07c4: dup
-			IL_07c5: ldc.i4.s 21
-			IL_07c7: ldloc.s 22
-			IL_07c9: stelem.ref
-			IL_07ca: dup
-			IL_07cb: ldc.i4.s 22
-			IL_07cd: ldloc.s 23
-			IL_07cf: stelem.ref
-			IL_07d0: dup
-			IL_07d1: ldc.i4.s 23
-			IL_07d3: ldloc.s 24
-			IL_07d5: box [System.Runtime]System.Boolean
-			IL_07da: stelem.ref
-			IL_07db: dup
-			IL_07dc: ldc.i4.s 24
-			IL_07de: ldloc.s 25
-			IL_07e0: stelem.ref
-			IL_07e1: dup
-			IL_07e2: ldc.i4.s 25
-			IL_07e4: ldloc.s 26
-			IL_07e6: stelem.ref
-			IL_07e7: pop
-			IL_07e8: ldloc.0
-			IL_07e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07ee: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07f3: ret
+			IL_0755: ldc.i4.s 18
+			IL_0757: ldloc.s 19
+			IL_0759: stelem.ref
+			IL_075a: dup
+			IL_075b: ldc.i4.s 19
+			IL_075d: ldloc.s 20
+			IL_075f: stelem.ref
+			IL_0760: dup
+			IL_0761: ldc.i4.s 20
+			IL_0763: ldloc.s 21
+			IL_0765: stelem.ref
+			IL_0766: dup
+			IL_0767: ldc.i4.s 21
+			IL_0769: ldloc.s 22
+			IL_076b: stelem.ref
+			IL_076c: dup
+			IL_076d: ldc.i4.s 22
+			IL_076f: ldloc.s 23
+			IL_0771: stelem.ref
+			IL_0772: dup
+			IL_0773: ldc.i4.s 23
+			IL_0775: ldloc.s 24
+			IL_0777: box [System.Runtime]System.Boolean
+			IL_077c: stelem.ref
+			IL_077d: dup
+			IL_077e: ldc.i4.s 24
+			IL_0780: ldloc.s 25
+			IL_0782: stelem.ref
+			IL_0783: dup
+			IL_0784: ldc.i4.s 25
+			IL_0786: ldloc.s 26
+			IL_0788: stelem.ref
+			IL_0789: pop
+			IL_078a: ldloc.0
+			IL_078b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0790: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0795: ret
 
-			IL_07f4: ldloc.0
-			IL_07f5: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited4
-			IL_07fa: stloc.s 21
-			IL_07fc: ldloc.s 21
-			IL_07fe: stloc.s 9
-			IL_0800: ldloc.s 4
-			IL_0802: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0807: stloc.s 21
-			IL_0809: ldloc.s 21
-			IL_080b: ldstr "write"
-			IL_0810: ldstr "Y"
-			IL_0815: ldc.i4.0
-			IL_0816: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_081b: ldstr "utf8"
-			IL_0820: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0825: stloc.s 21
-			IL_0827: ldloc.0
-			IL_0828: ldc.i4.8
-			IL_0829: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_082e: ldloc.0
-			IL_082f: ldloc.s 21
-			IL_0831: ldarg.0
-			IL_0832: ldc.i4.5
-			IL_0833: ldloc.0
-			IL_0834: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0839: ldc.i4.3
-			IL_083a: ldstr "_pendingException"
-			IL_083f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0844: ldloc.0
-			IL_0845: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0796: ldloc.0
+			IL_0797: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited4
+			IL_079c: stloc.s 21
+			IL_079e: ldloc.s 21
+			IL_07a0: stloc.s 9
+			IL_07a2: ldloc.s 4
+			IL_07a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07a9: stloc.s 21
+			IL_07ab: ldloc.s 21
+			IL_07ad: ldstr "write"
+			IL_07b2: ldstr "Y"
+			IL_07b7: ldc.i4.0
+			IL_07b8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_07bd: ldstr "utf8"
+			IL_07c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_07c7: stloc.s 21
+			IL_07c9: ldloc.0
+			IL_07ca: ldc.i4.8
+			IL_07cb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07d0: ldloc.0
+			IL_07d1: ldloc.s 21
+			IL_07d3: ldarg.0
+			IL_07d4: ldc.i4.5
+			IL_07d5: ldloc.0
+			IL_07d6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07db: ldc.i4.3
+			IL_07dc: ldstr "_pendingException"
+			IL_07e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_07e6: ldloc.0
+			IL_07e7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_07ec: dup
+			IL_07ed: ldc.i4.0
+			IL_07ee: ldloc.1
+			IL_07ef: stelem.ref
+			IL_07f0: dup
+			IL_07f1: ldc.i4.1
+			IL_07f2: ldloc.2
+			IL_07f3: stelem.ref
+			IL_07f4: dup
+			IL_07f5: ldc.i4.2
+			IL_07f6: ldloc.3
+			IL_07f7: stelem.ref
+			IL_07f8: dup
+			IL_07f9: ldc.i4.3
+			IL_07fa: ldloc.s 4
+			IL_07fc: stelem.ref
+			IL_07fd: dup
+			IL_07fe: ldc.i4.4
+			IL_07ff: ldloc.s 5
+			IL_0801: stelem.ref
+			IL_0802: dup
+			IL_0803: ldc.i4.5
+			IL_0804: ldloc.s 6
+			IL_0806: stelem.ref
+			IL_0807: dup
+			IL_0808: ldc.i4.6
+			IL_0809: ldloc.s 7
+			IL_080b: stelem.ref
+			IL_080c: dup
+			IL_080d: ldc.i4.7
+			IL_080e: ldloc.s 8
+			IL_0810: stelem.ref
+			IL_0811: dup
+			IL_0812: ldc.i4.8
+			IL_0813: ldloc.s 9
+			IL_0815: stelem.ref
+			IL_0816: dup
+			IL_0817: ldc.i4.s 9
+			IL_0819: ldloc.s 10
+			IL_081b: stelem.ref
+			IL_081c: dup
+			IL_081d: ldc.i4.s 10
+			IL_081f: ldloc.s 11
+			IL_0821: stelem.ref
+			IL_0822: dup
+			IL_0823: ldc.i4.s 11
+			IL_0825: ldloc.s 12
+			IL_0827: stelem.ref
+			IL_0828: dup
+			IL_0829: ldc.i4.s 12
+			IL_082b: ldloc.s 13
+			IL_082d: stelem.ref
+			IL_082e: dup
+			IL_082f: ldc.i4.s 13
+			IL_0831: ldloc.s 14
+			IL_0833: box [System.Runtime]System.Boolean
+			IL_0838: stelem.ref
+			IL_0839: dup
+			IL_083a: ldc.i4.s 14
+			IL_083c: ldloc.s 15
+			IL_083e: box [System.Runtime]System.Boolean
+			IL_0843: stelem.ref
+			IL_0844: dup
+			IL_0845: ldc.i4.s 15
+			IL_0847: ldloc.s 16
+			IL_0849: stelem.ref
 			IL_084a: dup
-			IL_084b: ldc.i4.0
-			IL_084c: ldloc.1
-			IL_084d: stelem.ref
-			IL_084e: dup
-			IL_084f: ldc.i4.1
-			IL_0850: ldloc.2
-			IL_0851: stelem.ref
-			IL_0852: dup
-			IL_0853: ldc.i4.2
-			IL_0854: ldloc.3
-			IL_0855: stelem.ref
-			IL_0856: dup
-			IL_0857: ldc.i4.3
-			IL_0858: ldloc.s 4
+			IL_084b: ldc.i4.s 16
+			IL_084d: ldloc.s 17
+			IL_084f: stelem.ref
+			IL_0850: dup
+			IL_0851: ldc.i4.s 17
+			IL_0853: ldloc.s 18
+			IL_0855: box [System.Runtime]System.Double
 			IL_085a: stelem.ref
 			IL_085b: dup
-			IL_085c: ldc.i4.4
-			IL_085d: ldloc.s 5
-			IL_085f: stelem.ref
-			IL_0860: dup
-			IL_0861: ldc.i4.5
-			IL_0862: ldloc.s 6
-			IL_0864: stelem.ref
-			IL_0865: dup
-			IL_0866: ldc.i4.6
-			IL_0867: ldloc.s 7
-			IL_0869: stelem.ref
-			IL_086a: dup
-			IL_086b: ldc.i4.7
-			IL_086c: ldloc.s 8
-			IL_086e: stelem.ref
-			IL_086f: dup
-			IL_0870: ldc.i4.8
-			IL_0871: ldloc.s 9
-			IL_0873: stelem.ref
-			IL_0874: dup
-			IL_0875: ldc.i4.s 9
-			IL_0877: ldloc.s 10
-			IL_0879: stelem.ref
-			IL_087a: dup
-			IL_087b: ldc.i4.s 10
-			IL_087d: ldloc.s 11
-			IL_087f: stelem.ref
-			IL_0880: dup
-			IL_0881: ldc.i4.s 11
-			IL_0883: ldloc.s 12
-			IL_0885: stelem.ref
-			IL_0886: dup
-			IL_0887: ldc.i4.s 12
-			IL_0889: ldloc.s 13
-			IL_088b: stelem.ref
-			IL_088c: dup
-			IL_088d: ldc.i4.s 13
-			IL_088f: ldloc.s 14
-			IL_0891: box [System.Runtime]System.Boolean
-			IL_0896: stelem.ref
-			IL_0897: dup
-			IL_0898: ldc.i4.s 14
-			IL_089a: ldloc.s 15
-			IL_089c: box [System.Runtime]System.Boolean
-			IL_08a1: stelem.ref
-			IL_08a2: dup
-			IL_08a3: ldc.i4.s 15
-			IL_08a5: ldloc.s 16
-			IL_08a7: stelem.ref
-			IL_08a8: dup
-			IL_08a9: ldc.i4.s 16
-			IL_08ab: ldloc.s 17
-			IL_08ad: stelem.ref
-			IL_08ae: dup
-			IL_08af: ldc.i4.s 17
-			IL_08b1: ldloc.s 18
-			IL_08b3: box [System.Runtime]System.Double
-			IL_08b8: stelem.ref
-			IL_08b9: dup
-			IL_08ba: ldc.i4.s 18
-			IL_08bc: ldloc.s 19
-			IL_08be: stelem.ref
-			IL_08bf: dup
-			IL_08c0: ldc.i4.s 19
-			IL_08c2: ldloc.s 20
-			IL_08c4: stelem.ref
-			IL_08c5: dup
-			IL_08c6: ldc.i4.s 20
-			IL_08c8: ldloc.s 21
-			IL_08ca: stelem.ref
-			IL_08cb: dup
-			IL_08cc: ldc.i4.s 21
-			IL_08ce: ldloc.s 22
-			IL_08d0: stelem.ref
-			IL_08d1: dup
-			IL_08d2: ldc.i4.s 22
-			IL_08d4: ldloc.s 23
-			IL_08d6: stelem.ref
-			IL_08d7: dup
-			IL_08d8: ldc.i4.s 23
-			IL_08da: ldloc.s 24
-			IL_08dc: box [System.Runtime]System.Boolean
-			IL_08e1: stelem.ref
-			IL_08e2: dup
-			IL_08e3: ldc.i4.s 24
-			IL_08e5: ldloc.s 25
+			IL_085c: ldc.i4.s 18
+			IL_085e: ldloc.s 19
+			IL_0860: stelem.ref
+			IL_0861: dup
+			IL_0862: ldc.i4.s 19
+			IL_0864: ldloc.s 20
+			IL_0866: stelem.ref
+			IL_0867: dup
+			IL_0868: ldc.i4.s 20
+			IL_086a: ldloc.s 21
+			IL_086c: stelem.ref
+			IL_086d: dup
+			IL_086e: ldc.i4.s 21
+			IL_0870: ldloc.s 22
+			IL_0872: stelem.ref
+			IL_0873: dup
+			IL_0874: ldc.i4.s 22
+			IL_0876: ldloc.s 23
+			IL_0878: stelem.ref
+			IL_0879: dup
+			IL_087a: ldc.i4.s 23
+			IL_087c: ldloc.s 24
+			IL_087e: box [System.Runtime]System.Boolean
+			IL_0883: stelem.ref
+			IL_0884: dup
+			IL_0885: ldc.i4.s 24
+			IL_0887: ldloc.s 25
+			IL_0889: stelem.ref
+			IL_088a: dup
+			IL_088b: ldc.i4.s 25
+			IL_088d: ldloc.s 26
+			IL_088f: stelem.ref
+			IL_0890: pop
+			IL_0891: ldloc.0
+			IL_0892: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0897: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_089c: ret
+
+			IL_089d: ldloc.0
+			IL_089e: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited5
+			IL_08a3: stloc.s 21
+			IL_08a5: ldloc.s 21
+			IL_08a7: stloc.s 10
+			IL_08a9: ldloc.s 4
+			IL_08ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08b0: stloc.s 21
+			IL_08b2: ldloc.s 21
+			IL_08b4: ldstr "close"
+			IL_08b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_08be: stloc.s 21
+			IL_08c0: ldloc.0
+			IL_08c1: ldc.i4.s 9
+			IL_08c3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08c8: ldloc.0
+			IL_08c9: ldloc.s 21
+			IL_08cb: ldarg.0
+			IL_08cc: ldc.i4.6
+			IL_08cd: ldloc.0
+			IL_08ce: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_08d3: ldc.i4.3
+			IL_08d4: ldstr "_pendingException"
+			IL_08d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_08de: ldloc.0
+			IL_08df: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08e4: dup
+			IL_08e5: ldc.i4.0
+			IL_08e6: ldloc.1
 			IL_08e7: stelem.ref
 			IL_08e8: dup
-			IL_08e9: ldc.i4.s 25
-			IL_08eb: ldloc.s 26
-			IL_08ed: stelem.ref
-			IL_08ee: pop
-			IL_08ef: ldloc.0
-			IL_08f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08f5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08fa: ret
-
-			IL_08fb: ldloc.0
-			IL_08fc: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited5
-			IL_0901: stloc.s 21
-			IL_0903: ldloc.s 21
-			IL_0905: stloc.s 10
-			IL_0907: ldloc.s 4
-			IL_0909: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_090e: stloc.s 21
-			IL_0910: ldloc.s 21
-			IL_0912: ldstr "close"
-			IL_0917: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_091c: stloc.s 21
-			IL_091e: ldloc.0
-			IL_091f: ldc.i4.s 9
-			IL_0921: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0926: ldloc.0
-			IL_0927: ldloc.s 21
-			IL_0929: ldarg.0
-			IL_092a: ldc.i4.6
-			IL_092b: ldloc.0
-			IL_092c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0931: ldc.i4.3
-			IL_0932: ldstr "_pendingException"
-			IL_0937: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_093c: ldloc.0
-			IL_093d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08e9: ldc.i4.1
+			IL_08ea: ldloc.2
+			IL_08eb: stelem.ref
+			IL_08ec: dup
+			IL_08ed: ldc.i4.2
+			IL_08ee: ldloc.3
+			IL_08ef: stelem.ref
+			IL_08f0: dup
+			IL_08f1: ldc.i4.3
+			IL_08f2: ldloc.s 4
+			IL_08f4: stelem.ref
+			IL_08f5: dup
+			IL_08f6: ldc.i4.4
+			IL_08f7: ldloc.s 5
+			IL_08f9: stelem.ref
+			IL_08fa: dup
+			IL_08fb: ldc.i4.5
+			IL_08fc: ldloc.s 6
+			IL_08fe: stelem.ref
+			IL_08ff: dup
+			IL_0900: ldc.i4.6
+			IL_0901: ldloc.s 7
+			IL_0903: stelem.ref
+			IL_0904: dup
+			IL_0905: ldc.i4.7
+			IL_0906: ldloc.s 8
+			IL_0908: stelem.ref
+			IL_0909: dup
+			IL_090a: ldc.i4.8
+			IL_090b: ldloc.s 9
+			IL_090d: stelem.ref
+			IL_090e: dup
+			IL_090f: ldc.i4.s 9
+			IL_0911: ldloc.s 10
+			IL_0913: stelem.ref
+			IL_0914: dup
+			IL_0915: ldc.i4.s 10
+			IL_0917: ldloc.s 11
+			IL_0919: stelem.ref
+			IL_091a: dup
+			IL_091b: ldc.i4.s 11
+			IL_091d: ldloc.s 12
+			IL_091f: stelem.ref
+			IL_0920: dup
+			IL_0921: ldc.i4.s 12
+			IL_0923: ldloc.s 13
+			IL_0925: stelem.ref
+			IL_0926: dup
+			IL_0927: ldc.i4.s 13
+			IL_0929: ldloc.s 14
+			IL_092b: box [System.Runtime]System.Boolean
+			IL_0930: stelem.ref
+			IL_0931: dup
+			IL_0932: ldc.i4.s 14
+			IL_0934: ldloc.s 15
+			IL_0936: box [System.Runtime]System.Boolean
+			IL_093b: stelem.ref
+			IL_093c: dup
+			IL_093d: ldc.i4.s 15
+			IL_093f: ldloc.s 16
+			IL_0941: stelem.ref
 			IL_0942: dup
-			IL_0943: ldc.i4.0
-			IL_0944: ldloc.1
-			IL_0945: stelem.ref
-			IL_0946: dup
-			IL_0947: ldc.i4.1
-			IL_0948: ldloc.2
-			IL_0949: stelem.ref
-			IL_094a: dup
-			IL_094b: ldc.i4.2
-			IL_094c: ldloc.3
-			IL_094d: stelem.ref
-			IL_094e: dup
-			IL_094f: ldc.i4.3
-			IL_0950: ldloc.s 4
+			IL_0943: ldc.i4.s 16
+			IL_0945: ldloc.s 17
+			IL_0947: stelem.ref
+			IL_0948: dup
+			IL_0949: ldc.i4.s 17
+			IL_094b: ldloc.s 18
+			IL_094d: box [System.Runtime]System.Double
 			IL_0952: stelem.ref
 			IL_0953: dup
-			IL_0954: ldc.i4.4
-			IL_0955: ldloc.s 5
-			IL_0957: stelem.ref
-			IL_0958: dup
-			IL_0959: ldc.i4.5
-			IL_095a: ldloc.s 6
-			IL_095c: stelem.ref
-			IL_095d: dup
-			IL_095e: ldc.i4.6
-			IL_095f: ldloc.s 7
-			IL_0961: stelem.ref
-			IL_0962: dup
-			IL_0963: ldc.i4.7
-			IL_0964: ldloc.s 8
-			IL_0966: stelem.ref
-			IL_0967: dup
-			IL_0968: ldc.i4.8
-			IL_0969: ldloc.s 9
-			IL_096b: stelem.ref
-			IL_096c: dup
-			IL_096d: ldc.i4.s 9
-			IL_096f: ldloc.s 10
-			IL_0971: stelem.ref
-			IL_0972: dup
-			IL_0973: ldc.i4.s 10
-			IL_0975: ldloc.s 11
-			IL_0977: stelem.ref
-			IL_0978: dup
-			IL_0979: ldc.i4.s 11
-			IL_097b: ldloc.s 12
-			IL_097d: stelem.ref
-			IL_097e: dup
-			IL_097f: ldc.i4.s 12
-			IL_0981: ldloc.s 13
-			IL_0983: stelem.ref
-			IL_0984: dup
-			IL_0985: ldc.i4.s 13
-			IL_0987: ldloc.s 14
-			IL_0989: box [System.Runtime]System.Boolean
-			IL_098e: stelem.ref
-			IL_098f: dup
-			IL_0990: ldc.i4.s 14
-			IL_0992: ldloc.s 15
-			IL_0994: box [System.Runtime]System.Boolean
-			IL_0999: stelem.ref
-			IL_099a: dup
-			IL_099b: ldc.i4.s 15
-			IL_099d: ldloc.s 16
-			IL_099f: stelem.ref
-			IL_09a0: dup
-			IL_09a1: ldc.i4.s 16
-			IL_09a3: ldloc.s 17
-			IL_09a5: stelem.ref
-			IL_09a6: dup
-			IL_09a7: ldc.i4.s 17
-			IL_09a9: ldloc.s 18
-			IL_09ab: box [System.Runtime]System.Double
-			IL_09b0: stelem.ref
-			IL_09b1: dup
-			IL_09b2: ldc.i4.s 18
-			IL_09b4: ldloc.s 19
-			IL_09b6: stelem.ref
-			IL_09b7: dup
-			IL_09b8: ldc.i4.s 19
-			IL_09ba: ldloc.s 20
-			IL_09bc: stelem.ref
-			IL_09bd: dup
-			IL_09be: ldc.i4.s 20
-			IL_09c0: ldloc.s 21
-			IL_09c2: stelem.ref
-			IL_09c3: dup
-			IL_09c4: ldc.i4.s 21
-			IL_09c6: ldloc.s 22
-			IL_09c8: stelem.ref
-			IL_09c9: dup
-			IL_09ca: ldc.i4.s 22
-			IL_09cc: ldloc.s 23
-			IL_09ce: stelem.ref
-			IL_09cf: dup
-			IL_09d0: ldc.i4.s 23
-			IL_09d2: ldloc.s 24
-			IL_09d4: box [System.Runtime]System.Boolean
-			IL_09d9: stelem.ref
-			IL_09da: dup
-			IL_09db: ldc.i4.s 24
-			IL_09dd: ldloc.s 25
-			IL_09df: stelem.ref
-			IL_09e0: dup
-			IL_09e1: ldc.i4.s 25
-			IL_09e3: ldloc.s 26
-			IL_09e5: stelem.ref
-			IL_09e6: pop
-			IL_09e7: ldloc.0
-			IL_09e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_09f2: ret
+			IL_0954: ldc.i4.s 18
+			IL_0956: ldloc.s 19
+			IL_0958: stelem.ref
+			IL_0959: dup
+			IL_095a: ldc.i4.s 19
+			IL_095c: ldloc.s 20
+			IL_095e: stelem.ref
+			IL_095f: dup
+			IL_0960: ldc.i4.s 20
+			IL_0962: ldloc.s 21
+			IL_0964: stelem.ref
+			IL_0965: dup
+			IL_0966: ldc.i4.s 21
+			IL_0968: ldloc.s 22
+			IL_096a: stelem.ref
+			IL_096b: dup
+			IL_096c: ldc.i4.s 22
+			IL_096e: ldloc.s 23
+			IL_0970: stelem.ref
+			IL_0971: dup
+			IL_0972: ldc.i4.s 23
+			IL_0974: ldloc.s 24
+			IL_0976: box [System.Runtime]System.Boolean
+			IL_097b: stelem.ref
+			IL_097c: dup
+			IL_097d: ldc.i4.s 24
+			IL_097f: ldloc.s 25
+			IL_0981: stelem.ref
+			IL_0982: dup
+			IL_0983: ldc.i4.s 25
+			IL_0985: ldloc.s 26
+			IL_0987: stelem.ref
+			IL_0988: pop
+			IL_0989: ldloc.0
+			IL_098a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_098f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0994: ret
 
-			IL_09f3: ldloc.0
-			IL_09f4: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited6
-			IL_09f9: pop
-			IL_09fa: ldstr "console"
-			IL_09ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a04: stloc.s 21
-			IL_0a06: ldloc.s 21
-			IL_0a08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a0d: stloc.s 21
-			IL_0a0f: ldloc.s 5
-			IL_0a11: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a16: stloc.s 16
-			IL_0a18: ldloc.s 16
-			IL_0a1a: ldstr "toString"
-			IL_0a1f: ldstr "utf8"
-			IL_0a24: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0a29: stloc.s 16
-			IL_0a2b: ldloc.s 21
-			IL_0a2d: ldstr "log"
-			IL_0a32: ldstr "ExplicitRead:"
-			IL_0a37: ldloc.s 16
-			IL_0a39: ldloc.s 7
-			IL_0a3b: ldstr "bytesRead"
-			IL_0a40: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a45: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0a4a: pop
-			IL_0a4b: ldstr "console"
-			IL_0a50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a55: stloc.s 16
-			IL_0a57: ldloc.s 16
-			IL_0a59: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a5e: stloc.s 16
-			IL_0a60: ldloc.s 6
-			IL_0a62: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a67: stloc.s 21
-			IL_0a69: ldloc.s 21
-			IL_0a6b: ldstr "toString"
-			IL_0a70: ldstr "utf8"
-			IL_0a75: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0a7a: stloc.s 21
-			IL_0a7c: ldloc.s 16
-			IL_0a7e: ldstr "log"
-			IL_0a83: ldstr "ImplicitReadAfterExplicit:"
-			IL_0a88: ldloc.s 21
-			IL_0a8a: ldloc.s 8
-			IL_0a8c: ldstr "bytesRead"
-			IL_0a91: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a96: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0a9b: pop
-			IL_0a9c: ldstr "console"
-			IL_0aa1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0aa6: stloc.s 21
-			IL_0aa8: ldloc.s 21
-			IL_0aaa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0aaf: stloc.s 21
-			IL_0ab1: ldloc.s 21
-			IL_0ab3: ldstr "log"
-			IL_0ab8: ldstr "ExplicitWriteBytes:"
-			IL_0abd: ldloc.s 9
-			IL_0abf: ldstr "bytesWritten"
-			IL_0ac4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ac9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0ace: pop
-			IL_0acf: ldstr "console"
-			IL_0ad4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ad9: stloc.s 21
-			IL_0adb: ldloc.s 21
-			IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0ae2: stloc.s 21
-			IL_0ae4: ldloc.s 21
-			IL_0ae6: ldstr "log"
-			IL_0aeb: ldstr "ImplicitWriteBytes:"
-			IL_0af0: ldloc.s 10
-			IL_0af2: ldstr "bytesWritten"
-			IL_0af7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0afc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0b01: pop
-			IL_0b02: ldstr "console"
-			IL_0b07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b0c: stloc.s 21
-			IL_0b0e: ldloc.s 21
-			IL_0b10: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b15: stloc.s 21
-			IL_0b17: ldarg.0
-			IL_0b18: ldc.i4.1
-			IL_0b19: ldelem.ref
-			IL_0b1a: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0b1f: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0b24: stloc.s 16
-			IL_0b26: ldstr "fs"
-			IL_0b2b: ldloc.s 16
-			IL_0b2d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0b32: stloc.s 16
-			IL_0b34: ldloc.s 16
-			IL_0b36: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b3b: stloc.s 16
-			IL_0b3d: ldloc.s 16
-			IL_0b3f: ldstr "readFileSync"
-			IL_0b44: ldloc.2
-			IL_0b45: ldstr "utf8"
-			IL_0b4a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0b4f: stloc.s 16
-			IL_0b51: ldloc.s 21
-			IL_0b53: ldstr "log"
-			IL_0b58: ldstr "FinalText:"
-			IL_0b5d: ldloc.s 16
-			IL_0b5f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0b64: pop
-			IL_0b65: br IL_0bff
+			IL_0995: ldloc.0
+			IL_0996: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited6
+			IL_099b: pop
+			IL_099c: ldstr "console"
+			IL_09a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09a6: stloc.s 21
+			IL_09a8: ldloc.s 21
+			IL_09aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09af: stloc.s 21
+			IL_09b1: ldloc.s 5
+			IL_09b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09b8: stloc.s 16
+			IL_09ba: ldloc.s 16
+			IL_09bc: ldstr "toString"
+			IL_09c1: ldstr "utf8"
+			IL_09c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_09cb: stloc.s 16
+			IL_09cd: ldloc.s 21
+			IL_09cf: ldstr "log"
+			IL_09d4: ldstr "ExplicitRead:"
+			IL_09d9: ldloc.s 16
+			IL_09db: ldloc.s 7
+			IL_09dd: ldstr "bytesRead"
+			IL_09e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_09ec: pop
+			IL_09ed: ldstr "console"
+			IL_09f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09f7: stloc.s 16
+			IL_09f9: ldloc.s 16
+			IL_09fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a00: stloc.s 16
+			IL_0a02: ldloc.s 6
+			IL_0a04: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a09: stloc.s 21
+			IL_0a0b: ldloc.s 21
+			IL_0a0d: ldstr "toString"
+			IL_0a12: ldstr "utf8"
+			IL_0a17: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0a1c: stloc.s 21
+			IL_0a1e: ldloc.s 16
+			IL_0a20: ldstr "log"
+			IL_0a25: ldstr "ImplicitReadAfterExplicit:"
+			IL_0a2a: ldloc.s 21
+			IL_0a2c: ldloc.s 8
+			IL_0a2e: ldstr "bytesRead"
+			IL_0a33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a38: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0a3d: pop
+			IL_0a3e: ldstr "console"
+			IL_0a43: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a48: stloc.s 21
+			IL_0a4a: ldloc.s 21
+			IL_0a4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a51: stloc.s 21
+			IL_0a53: ldloc.s 21
+			IL_0a55: ldstr "log"
+			IL_0a5a: ldstr "ExplicitWriteBytes:"
+			IL_0a5f: ldloc.s 9
+			IL_0a61: ldstr "bytesWritten"
+			IL_0a66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a6b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0a70: pop
+			IL_0a71: ldstr "console"
+			IL_0a76: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a7b: stloc.s 21
+			IL_0a7d: ldloc.s 21
+			IL_0a7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a84: stloc.s 21
+			IL_0a86: ldloc.s 21
+			IL_0a88: ldstr "log"
+			IL_0a8d: ldstr "ImplicitWriteBytes:"
+			IL_0a92: ldloc.s 10
+			IL_0a94: ldstr "bytesWritten"
+			IL_0a99: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a9e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0aa3: pop
+			IL_0aa4: ldstr "console"
+			IL_0aa9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0aae: stloc.s 21
+			IL_0ab0: ldloc.s 21
+			IL_0ab2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ab7: stloc.s 21
+			IL_0ab9: ldarg.0
+			IL_0aba: ldc.i4.1
+			IL_0abb: ldelem.ref
+			IL_0abc: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0ac1: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0ac6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0acb: stloc.s 16
+			IL_0acd: ldloc.s 16
+			IL_0acf: ldstr "readFileSync"
+			IL_0ad4: ldloc.2
+			IL_0ad5: ldstr "utf8"
+			IL_0ada: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0adf: stloc.s 16
+			IL_0ae1: ldloc.s 21
+			IL_0ae3: ldstr "log"
+			IL_0ae8: ldstr "FinalText:"
+			IL_0aed: ldloc.s 16
+			IL_0aef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0af4: pop
+			IL_0af5: br IL_0b8f
 
-			IL_0b6a: ldloc.0
-			IL_0b6b: ldc.i4.1
-			IL_0b6c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0b71: ldloc.0
-			IL_0b72: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0b77: stloc.s 16
-			IL_0b79: ldloc.0
-			IL_0b7a: ldc.i4.0
-			IL_0b7b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0b80: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0b85: ldloc.0
-			IL_0b86: ldc.i4.0
-			IL_0b87: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0b8c: ldloc.s 16
-			IL_0b8e: stloc.s 11
-			IL_0b90: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L30C18::.ctor()
-			IL_0b95: stloc.s 12
-			IL_0b97: ldstr "console"
-			IL_0b9c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ba1: stloc.s 16
-			IL_0ba3: ldloc.s 16
-			IL_0ba5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0baa: stloc.s 16
-			IL_0bac: ldloc.s 11
-			IL_0bae: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0bb3: stloc.s 24
-			IL_0bb5: ldloc.s 24
-			IL_0bb7: brfalse IL_0bcf
+			IL_0afa: ldloc.0
+			IL_0afb: ldc.i4.1
+			IL_0afc: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b01: ldloc.0
+			IL_0b02: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0b07: stloc.s 16
+			IL_0b09: ldloc.0
+			IL_0b0a: ldc.i4.0
+			IL_0b0b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0b10: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0b15: ldloc.0
+			IL_0b16: ldc.i4.0
+			IL_0b17: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b1c: ldloc.s 16
+			IL_0b1e: stloc.s 11
+			IL_0b20: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L30C18::.ctor()
+			IL_0b25: stloc.s 12
+			IL_0b27: ldstr "console"
+			IL_0b2c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b31: stloc.s 16
+			IL_0b33: ldloc.s 16
+			IL_0b35: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b3a: stloc.s 16
+			IL_0b3c: ldloc.s 11
+			IL_0b3e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0b43: stloc.s 24
+			IL_0b45: ldloc.s 24
+			IL_0b47: brfalse IL_0b5f
 
-			IL_0bbc: ldloc.s 11
-			IL_0bbe: ldstr "message"
-			IL_0bc3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bc8: stloc.s 26
-			IL_0bca: br IL_0bd3
+			IL_0b4c: ldloc.s 11
+			IL_0b4e: ldstr "message"
+			IL_0b53: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b58: stloc.s 26
+			IL_0b5a: br IL_0b63
 
-			IL_0bcf: ldloc.s 11
-			IL_0bd1: stloc.s 26
+			IL_0b5f: ldloc.s 11
+			IL_0b61: stloc.s 26
 
-			IL_0bd3: ldloc.s 16
-			IL_0bd5: ldstr "log"
-			IL_0bda: ldstr "Error:"
-			IL_0bdf: ldloc.s 26
-			IL_0be1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0be6: pop
-			IL_0be7: br IL_0bff
+			IL_0b63: ldloc.s 16
+			IL_0b65: ldstr "log"
+			IL_0b6a: ldstr "Error:"
+			IL_0b6f: ldloc.s 26
+			IL_0b71: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0b76: pop
+			IL_0b77: br IL_0b8f
 
-			IL_0bec: ldloc.0
-			IL_0bed: ldc.i4.1
-			IL_0bee: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0bf3: ldloc.0
-			IL_0bf4: ldc.i4.0
-			IL_0bf5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0bfa: br IL_0bff
+			IL_0b7c: ldloc.0
+			IL_0b7d: ldc.i4.1
+			IL_0b7e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b83: ldloc.0
+			IL_0b84: ldc.i4.0
+			IL_0b85: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0b8a: br IL_0b8f
 
-			IL_0bff: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L32C14::.ctor()
-			IL_0c04: stloc.s 13
-			IL_0c06: ldarg.0
-			IL_0c07: ldc.i4.1
-			IL_0c08: ldelem.ref
-			IL_0c09: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0c0e: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0c13: stloc.s 16
-			IL_0c15: ldstr "fs"
-			IL_0c1a: ldloc.s 16
-			IL_0c1c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0c21: stloc.s 16
-			IL_0c23: ldloc.s 16
-			IL_0c25: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0c2a: stloc.s 16
-			IL_0c2c: ldloc.s 16
-			IL_0c2e: ldstr "rmSync"
-			IL_0c33: ldloc.2
-			IL_0c34: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0c39: dup
-			IL_0c3a: ldstr "force"
-			IL_0c3f: ldc.i4.1
-			IL_0c40: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0c45: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0c4a: pop
-			IL_0c4b: br IL_0c63
+			IL_0b8f: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L32C14::.ctor()
+			IL_0b94: stloc.s 13
+			IL_0b96: ldarg.0
+			IL_0b97: ldc.i4.1
+			IL_0b98: ldelem.ref
+			IL_0b99: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0b9e: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0ba3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ba8: stloc.s 16
+			IL_0baa: ldloc.s 16
+			IL_0bac: ldstr "rmSync"
+			IL_0bb1: ldloc.2
+			IL_0bb2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0bb7: dup
+			IL_0bb8: ldstr "force"
+			IL_0bbd: ldc.i4.1
+			IL_0bbe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0bc3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0bc8: pop
+			IL_0bc9: br IL_0be1
 
-			IL_0c50: ldloc.0
-			IL_0c51: ldc.i4.1
-			IL_0c52: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0c57: ldloc.0
-			IL_0c58: ldc.i4.0
-			IL_0c59: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0c5e: br IL_0c63
+			IL_0bce: ldloc.0
+			IL_0bcf: ldc.i4.1
+			IL_0bd0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0bd5: ldloc.0
+			IL_0bd6: ldc.i4.0
+			IL_0bd7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0bdc: br IL_0be1
 
+			IL_0be1: ldloc.0
+			IL_0be2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0be7: stloc.s 14
+			IL_0be9: ldloc.s 14
+			IL_0beb: brfalse IL_0c28
+
+			IL_0bf0: ldloc.0
+			IL_0bf1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0bf6: stloc.s 16
+			IL_0bf8: ldloc.0
+			IL_0bf9: ldc.i4.m1
+			IL_0bfa: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0bff: ldloc.0
+			IL_0c00: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c05: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0c0a: ldarg.0
+			IL_0c0b: ldc.i4.1
+			IL_0c0c: newarr [System.Runtime]System.Object
+			IL_0c11: dup
+			IL_0c12: ldc.i4.0
+			IL_0c13: ldloc.s 16
+			IL_0c15: stelem.ref
+			IL_0c16: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c1b: pop
+			IL_0c1c: ldloc.0
+			IL_0c1d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c22: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c27: ret
+
+			IL_0c28: ldloc.0
+			IL_0c29: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0c2e: stloc.s 15
+			IL_0c30: ldloc.s 15
+			IL_0c32: brfalse IL_0c6f
+
+			IL_0c37: ldloc.0
+			IL_0c38: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0c3d: stloc.s 16
+			IL_0c3f: ldloc.0
+			IL_0c40: ldc.i4.m1
+			IL_0c41: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c46: ldloc.0
+			IL_0c47: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c4c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0c51: ldarg.0
+			IL_0c52: ldc.i4.1
+			IL_0c53: newarr [System.Runtime]System.Object
+			IL_0c58: dup
+			IL_0c59: ldc.i4.0
+			IL_0c5a: ldloc.s 16
+			IL_0c5c: stelem.ref
+			IL_0c5d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c62: pop
 			IL_0c63: ldloc.0
-			IL_0c64: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0c69: stloc.s 14
-			IL_0c6b: ldloc.s 14
-			IL_0c6d: brfalse IL_0caa
+			IL_0c64: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c69: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c6e: ret
 
-			IL_0c72: ldloc.0
-			IL_0c73: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0c78: stloc.s 16
-			IL_0c7a: ldloc.0
-			IL_0c7b: ldc.i4.m1
-			IL_0c7c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c81: ldloc.0
-			IL_0c82: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c87: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0c8c: ldarg.0
-			IL_0c8d: ldc.i4.1
-			IL_0c8e: newarr [System.Runtime]System.Object
-			IL_0c93: dup
-			IL_0c94: ldc.i4.0
-			IL_0c95: ldloc.s 16
-			IL_0c97: stelem.ref
-			IL_0c98: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c9d: pop
-			IL_0c9e: ldloc.0
-			IL_0c9f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ca4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0ca9: ret
-
-			IL_0caa: ldloc.0
-			IL_0cab: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0cb0: stloc.s 15
-			IL_0cb2: ldloc.s 15
-			IL_0cb4: brfalse IL_0cf1
-
-			IL_0cb9: ldloc.0
-			IL_0cba: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0cbf: stloc.s 16
-			IL_0cc1: ldloc.0
-			IL_0cc2: ldc.i4.m1
-			IL_0cc3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0cc8: ldloc.0
-			IL_0cc9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0cce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0cd3: ldarg.0
-			IL_0cd4: ldc.i4.1
-			IL_0cd5: newarr [System.Runtime]System.Object
-			IL_0cda: dup
-			IL_0cdb: ldc.i4.0
-			IL_0cdc: ldloc.s 16
-			IL_0cde: stelem.ref
-			IL_0cdf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0ce4: pop
-			IL_0ce5: ldloc.0
-			IL_0ce6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ceb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0cf0: ret
-
-			IL_0cf1: ldloc.0
-			IL_0cf2: ldc.i4.m1
-			IL_0cf3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0cf8: ldloc.0
-			IL_0cf9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0cfe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0d03: ldarg.0
-			IL_0d04: ldc.i4.1
-			IL_0d05: newarr [System.Runtime]System.Object
-			IL_0d0a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0d0f: pop
-			IL_0d10: ldloc.0
-			IL_0d11: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0d16: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0d1b: ret
+			IL_0c6f: ldloc.0
+			IL_0c70: ldc.i4.m1
+			IL_0c71: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c76: ldloc.0
+			IL_0c77: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c7c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0c81: ldarg.0
+			IL_0c82: ldc.i4.1
+			IL_0c83: newarr [System.Runtime]System.Object
+			IL_0c88: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c8d: pop
+			IL_0c8e: ldloc.0
+			IL_0c8f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c94: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c99: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1707,7 +1663,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2e0c
+			// Method begins at RVA 0x2d8a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1803,7 +1759,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2e39
+		// Method begins at RVA 0x2db7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_Read_Write_Close.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_Read_Write_Close.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ace
+					// Method begins at RVA 0x2a70
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ad7
+					// Method begins at RVA 0x2a79
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ae0
+					// Method begins at RVA 0x2a82
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -113,7 +113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac5
+				// Method begins at RVA 0x2a67
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -139,7 +139,7 @@
 			)
 			// Method begins at RVA 0x20e4
 			// Header size: 12
-			// Code size: 2508 (0x9cc)
+			// Code size: 2414 (0x96e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope,
@@ -323,7 +323,7 @@
 
 			IL_012c: ldloc.0
 			IL_012d: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0132: switch (IL_0157, IL_089c, IL_0900, IL_081a, IL_03da, IL_04dd, IL_0629, IL_0714)
+			IL_0132: switch (IL_0157, IL_0850, IL_08a2, IL_07ce, IL_038e, IL_0491, IL_05dd, IL_06c8)
 
 			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_015c: stloc.s 13
@@ -365,903 +365,871 @@
 			IL_01c8: ldelem.ref
 			IL_01c9: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
 			IL_01ce: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::path
-			IL_01d3: stloc.s 13
-			IL_01d5: ldstr "path"
-			IL_01da: ldloc.s 13
-			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01e1: stloc.s 13
-			IL_01e3: ldloc.s 13
-			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ea: stloc.s 13
-			IL_01ec: ldarg.0
-			IL_01ed: ldc.i4.1
-			IL_01ee: ldelem.ref
-			IL_01ef: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_01f4: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::os
-			IL_01f9: stloc.s 18
-			IL_01fb: ldstr "os"
-			IL_0200: ldloc.s 18
-			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0207: stloc.s 18
-			IL_0209: ldloc.s 18
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0210: stloc.s 18
-			IL_0212: ldloc.s 18
-			IL_0214: ldstr "tmpdir"
-			IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_021e: stloc.s 18
-			IL_0220: ldloc.1
-			IL_0221: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0226: stloc.s 17
-			IL_0228: ldstr "jroc-fs-open-"
-			IL_022d: ldloc.s 17
-			IL_022f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0234: stloc.s 17
-			IL_0236: ldloc.s 17
-			IL_0238: ldstr ".txt"
-			IL_023d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0242: stloc.s 17
-			IL_0244: ldloc.s 13
-			IL_0246: ldstr "join"
-			IL_024b: ldloc.s 18
-			IL_024d: ldloc.s 17
-			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0254: stloc.s 18
-			IL_0256: ldloc.s 18
-			IL_0258: stloc.2
-			IL_0259: ldloc.0
-			IL_025a: ldc.i4.0
-			IL_025b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0260: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0265: ldloc.0
-			IL_0266: ldc.i4.0
-			IL_0267: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_026c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0271: ldloc.0
-			IL_0272: ldc.i4.0
-			IL_0273: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0278: ldloc.0
-			IL_0279: ldc.i4.0
-			IL_027a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_027f: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L11C8::.ctor()
-			IL_0284: stloc.3
-			IL_0285: ldarg.0
-			IL_0286: ldc.i4.1
-			IL_0287: ldelem.ref
-			IL_0288: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_028d: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_0292: stloc.s 18
-			IL_0294: ldstr "fs"
-			IL_0299: ldloc.s 18
-			IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02a0: stloc.s 18
-			IL_02a2: ldloc.s 18
-			IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a9: stloc.s 18
-			IL_02ab: ldloc.s 18
-			IL_02ad: ldstr "rmSync"
-			IL_02b2: ldloc.2
-			IL_02b3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02b8: dup
-			IL_02b9: ldstr "force"
-			IL_02be: ldc.i4.1
-			IL_02bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02c9: pop
-			IL_02ca: ldarg.0
-			IL_02cb: ldc.i4.1
-			IL_02cc: ldelem.ref
-			IL_02cd: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_02d2: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_02d7: stloc.s 18
-			IL_02d9: ldstr "fs"
-			IL_02de: ldloc.s 18
-			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02e5: stloc.s 18
-			IL_02e7: ldloc.s 18
-			IL_02e9: ldstr "promises"
-			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02f3: stloc.s 18
-			IL_02f5: ldloc.s 18
-			IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02fc: stloc.s 18
-			IL_02fe: ldloc.s 18
-			IL_0300: ldstr "open"
-			IL_0305: ldloc.2
-			IL_0306: ldstr "w+"
-			IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0310: stloc.s 18
-			IL_0312: ldloc.0
-			IL_0313: ldc.i4.4
-			IL_0314: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0319: ldloc.0
-			IL_031a: ldloc.s 18
-			IL_031c: ldarg.0
-			IL_031d: ldc.i4.1
-			IL_031e: ldloc.0
-			IL_031f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0324: ldc.i4.3
-			IL_0325: ldstr "_pendingException"
-			IL_032a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_032f: ldloc.0
-			IL_0330: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01d8: stloc.s 13
+			IL_01da: ldarg.0
+			IL_01db: ldc.i4.1
+			IL_01dc: ldelem.ref
+			IL_01dd: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_01e2: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::os
+			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ec: stloc.s 18
+			IL_01ee: ldloc.s 18
+			IL_01f0: ldstr "tmpdir"
+			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01fa: stloc.s 18
+			IL_01fc: ldloc.1
+			IL_01fd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0202: stloc.s 17
+			IL_0204: ldstr "jroc-fs-open-"
+			IL_0209: ldloc.s 17
+			IL_020b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0210: stloc.s 17
+			IL_0212: ldloc.s 17
+			IL_0214: ldstr ".txt"
+			IL_0219: call string [System.Runtime]System.String::Concat(string, string)
+			IL_021e: stloc.s 17
+			IL_0220: ldloc.s 13
+			IL_0222: ldstr "join"
+			IL_0227: ldloc.s 18
+			IL_0229: ldloc.s 17
+			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0230: stloc.s 18
+			IL_0232: ldloc.s 18
+			IL_0234: stloc.2
+			IL_0235: ldloc.0
+			IL_0236: ldc.i4.0
+			IL_0237: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_023c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0241: ldloc.0
+			IL_0242: ldc.i4.0
+			IL_0243: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0248: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_024d: ldloc.0
+			IL_024e: ldc.i4.0
+			IL_024f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0254: ldloc.0
+			IL_0255: ldc.i4.0
+			IL_0256: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_025b: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L11C8::.ctor()
+			IL_0260: stloc.3
+			IL_0261: ldarg.0
+			IL_0262: ldc.i4.1
+			IL_0263: ldelem.ref
+			IL_0264: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_0269: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0273: stloc.s 18
+			IL_0275: ldloc.s 18
+			IL_0277: ldstr "rmSync"
+			IL_027c: ldloc.2
+			IL_027d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0282: dup
+			IL_0283: ldstr "force"
+			IL_0288: ldc.i4.1
+			IL_0289: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0293: pop
+			IL_0294: ldarg.0
+			IL_0295: ldc.i4.1
+			IL_0296: ldelem.ref
+			IL_0297: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_029c: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_02a1: ldstr "promises"
+			IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02b0: stloc.s 18
+			IL_02b2: ldloc.s 18
+			IL_02b4: ldstr "open"
+			IL_02b9: ldloc.2
+			IL_02ba: ldstr "w+"
+			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02c4: stloc.s 18
+			IL_02c6: ldloc.0
+			IL_02c7: ldc.i4.4
+			IL_02c8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02cd: ldloc.0
+			IL_02ce: ldloc.s 18
+			IL_02d0: ldarg.0
+			IL_02d1: ldc.i4.1
+			IL_02d2: ldloc.0
+			IL_02d3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02d8: ldc.i4.3
+			IL_02d9: ldstr "_pendingException"
+			IL_02de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_02e3: ldloc.0
+			IL_02e4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02e9: dup
+			IL_02ea: ldc.i4.0
+			IL_02eb: ldloc.1
+			IL_02ec: stelem.ref
+			IL_02ed: dup
+			IL_02ee: ldc.i4.1
+			IL_02ef: ldloc.2
+			IL_02f0: stelem.ref
+			IL_02f1: dup
+			IL_02f2: ldc.i4.2
+			IL_02f3: ldloc.3
+			IL_02f4: stelem.ref
+			IL_02f5: dup
+			IL_02f6: ldc.i4.3
+			IL_02f7: ldloc.s 4
+			IL_02f9: stelem.ref
+			IL_02fa: dup
+			IL_02fb: ldc.i4.4
+			IL_02fc: ldloc.s 5
+			IL_02fe: stelem.ref
+			IL_02ff: dup
+			IL_0300: ldc.i4.5
+			IL_0301: ldloc.s 6
+			IL_0303: stelem.ref
+			IL_0304: dup
+			IL_0305: ldc.i4.6
+			IL_0306: ldloc.s 7
+			IL_0308: stelem.ref
+			IL_0309: dup
+			IL_030a: ldc.i4.7
+			IL_030b: ldloc.s 8
+			IL_030d: stelem.ref
+			IL_030e: dup
+			IL_030f: ldc.i4.8
+			IL_0310: ldloc.s 9
+			IL_0312: stelem.ref
+			IL_0313: dup
+			IL_0314: ldc.i4.s 9
+			IL_0316: ldloc.s 10
+			IL_0318: stelem.ref
+			IL_0319: dup
+			IL_031a: ldc.i4.s 10
+			IL_031c: ldloc.s 11
+			IL_031e: box [System.Runtime]System.Boolean
+			IL_0323: stelem.ref
+			IL_0324: dup
+			IL_0325: ldc.i4.s 11
+			IL_0327: ldloc.s 12
+			IL_0329: box [System.Runtime]System.Boolean
+			IL_032e: stelem.ref
+			IL_032f: dup
+			IL_0330: ldc.i4.s 12
+			IL_0332: ldloc.s 13
+			IL_0334: stelem.ref
 			IL_0335: dup
-			IL_0336: ldc.i4.0
-			IL_0337: ldloc.1
-			IL_0338: stelem.ref
-			IL_0339: dup
-			IL_033a: ldc.i4.1
-			IL_033b: ldloc.2
-			IL_033c: stelem.ref
-			IL_033d: dup
-			IL_033e: ldc.i4.2
-			IL_033f: ldloc.3
-			IL_0340: stelem.ref
-			IL_0341: dup
-			IL_0342: ldc.i4.3
-			IL_0343: ldloc.s 4
+			IL_0336: ldc.i4.s 13
+			IL_0338: ldloc.s 14
+			IL_033a: stelem.ref
+			IL_033b: dup
+			IL_033c: ldc.i4.s 14
+			IL_033e: ldloc.s 15
+			IL_0340: box [System.Runtime]System.Double
 			IL_0345: stelem.ref
 			IL_0346: dup
-			IL_0347: ldc.i4.4
-			IL_0348: ldloc.s 5
-			IL_034a: stelem.ref
-			IL_034b: dup
-			IL_034c: ldc.i4.5
-			IL_034d: ldloc.s 6
-			IL_034f: stelem.ref
-			IL_0350: dup
-			IL_0351: ldc.i4.6
-			IL_0352: ldloc.s 7
-			IL_0354: stelem.ref
-			IL_0355: dup
-			IL_0356: ldc.i4.7
-			IL_0357: ldloc.s 8
-			IL_0359: stelem.ref
-			IL_035a: dup
-			IL_035b: ldc.i4.8
-			IL_035c: ldloc.s 9
-			IL_035e: stelem.ref
-			IL_035f: dup
-			IL_0360: ldc.i4.s 9
-			IL_0362: ldloc.s 10
-			IL_0364: stelem.ref
-			IL_0365: dup
-			IL_0366: ldc.i4.s 10
-			IL_0368: ldloc.s 11
-			IL_036a: box [System.Runtime]System.Boolean
-			IL_036f: stelem.ref
-			IL_0370: dup
-			IL_0371: ldc.i4.s 11
-			IL_0373: ldloc.s 12
-			IL_0375: box [System.Runtime]System.Boolean
+			IL_0347: ldc.i4.s 15
+			IL_0349: ldloc.s 16
+			IL_034b: stelem.ref
+			IL_034c: dup
+			IL_034d: ldc.i4.s 16
+			IL_034f: ldloc.s 17
+			IL_0351: stelem.ref
+			IL_0352: dup
+			IL_0353: ldc.i4.s 17
+			IL_0355: ldloc.s 18
+			IL_0357: stelem.ref
+			IL_0358: dup
+			IL_0359: ldc.i4.s 18
+			IL_035b: ldloc.s 19
+			IL_035d: stelem.ref
+			IL_035e: dup
+			IL_035f: ldc.i4.s 19
+			IL_0361: ldloc.s 20
+			IL_0363: stelem.ref
+			IL_0364: dup
+			IL_0365: ldc.i4.s 20
+			IL_0367: ldloc.s 21
+			IL_0369: box [System.Runtime]System.Boolean
+			IL_036e: stelem.ref
+			IL_036f: dup
+			IL_0370: ldc.i4.s 21
+			IL_0372: ldloc.s 22
+			IL_0374: stelem.ref
+			IL_0375: dup
+			IL_0376: ldc.i4.s 22
+			IL_0378: ldloc.s 23
 			IL_037a: stelem.ref
 			IL_037b: dup
-			IL_037c: ldc.i4.s 12
-			IL_037e: ldloc.s 13
+			IL_037c: ldc.i4.s 23
+			IL_037e: ldloc.s 24
 			IL_0380: stelem.ref
-			IL_0381: dup
-			IL_0382: ldc.i4.s 13
-			IL_0384: ldloc.s 14
-			IL_0386: stelem.ref
-			IL_0387: dup
-			IL_0388: ldc.i4.s 14
-			IL_038a: ldloc.s 15
-			IL_038c: box [System.Runtime]System.Double
-			IL_0391: stelem.ref
-			IL_0392: dup
-			IL_0393: ldc.i4.s 15
-			IL_0395: ldloc.s 16
-			IL_0397: stelem.ref
-			IL_0398: dup
-			IL_0399: ldc.i4.s 16
-			IL_039b: ldloc.s 17
-			IL_039d: stelem.ref
-			IL_039e: dup
-			IL_039f: ldc.i4.s 17
-			IL_03a1: ldloc.s 18
-			IL_03a3: stelem.ref
-			IL_03a4: dup
-			IL_03a5: ldc.i4.s 18
-			IL_03a7: ldloc.s 19
-			IL_03a9: stelem.ref
-			IL_03aa: dup
-			IL_03ab: ldc.i4.s 19
-			IL_03ad: ldloc.s 20
-			IL_03af: stelem.ref
-			IL_03b0: dup
-			IL_03b1: ldc.i4.s 20
-			IL_03b3: ldloc.s 21
-			IL_03b5: box [System.Runtime]System.Boolean
-			IL_03ba: stelem.ref
-			IL_03bb: dup
-			IL_03bc: ldc.i4.s 21
-			IL_03be: ldloc.s 22
-			IL_03c0: stelem.ref
-			IL_03c1: dup
-			IL_03c2: ldc.i4.s 22
-			IL_03c4: ldloc.s 23
-			IL_03c6: stelem.ref
-			IL_03c7: dup
-			IL_03c8: ldc.i4.s 23
-			IL_03ca: ldloc.s 24
-			IL_03cc: stelem.ref
-			IL_03cd: pop
-			IL_03ce: ldloc.0
-			IL_03cf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03d4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03d9: ret
+			IL_0381: pop
+			IL_0382: ldloc.0
+			IL_0383: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0388: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_038d: ret
 
-			IL_03da: ldloc.0
-			IL_03db: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited1
-			IL_03e0: stloc.s 18
-			IL_03e2: ldloc.s 18
-			IL_03e4: stloc.s 4
-			IL_03e6: ldloc.s 4
-			IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03ed: stloc.s 18
-			IL_03ef: ldloc.s 18
-			IL_03f1: ldstr "write"
-			IL_03f6: ldstr "hello"
-			IL_03fb: ldc.r8 0.0
-			IL_0404: box [System.Runtime]System.Double
-			IL_0409: ldstr "utf8"
-			IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0413: stloc.s 18
-			IL_0415: ldloc.0
-			IL_0416: ldc.i4.5
-			IL_0417: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_041c: ldloc.0
-			IL_041d: ldloc.s 18
-			IL_041f: ldarg.0
-			IL_0420: ldc.i4.2
-			IL_0421: ldloc.0
-			IL_0422: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0427: ldc.i4.3
-			IL_0428: ldstr "_pendingException"
-			IL_042d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0432: ldloc.0
-			IL_0433: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_038e: ldloc.0
+			IL_038f: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited1
+			IL_0394: stloc.s 18
+			IL_0396: ldloc.s 18
+			IL_0398: stloc.s 4
+			IL_039a: ldloc.s 4
+			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03a1: stloc.s 18
+			IL_03a3: ldloc.s 18
+			IL_03a5: ldstr "write"
+			IL_03aa: ldstr "hello"
+			IL_03af: ldc.r8 0.0
+			IL_03b8: box [System.Runtime]System.Double
+			IL_03bd: ldstr "utf8"
+			IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_03c7: stloc.s 18
+			IL_03c9: ldloc.0
+			IL_03ca: ldc.i4.5
+			IL_03cb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03d0: ldloc.0
+			IL_03d1: ldloc.s 18
+			IL_03d3: ldarg.0
+			IL_03d4: ldc.i4.2
+			IL_03d5: ldloc.0
+			IL_03d6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03db: ldc.i4.3
+			IL_03dc: ldstr "_pendingException"
+			IL_03e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_03e6: ldloc.0
+			IL_03e7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03ec: dup
+			IL_03ed: ldc.i4.0
+			IL_03ee: ldloc.1
+			IL_03ef: stelem.ref
+			IL_03f0: dup
+			IL_03f1: ldc.i4.1
+			IL_03f2: ldloc.2
+			IL_03f3: stelem.ref
+			IL_03f4: dup
+			IL_03f5: ldc.i4.2
+			IL_03f6: ldloc.3
+			IL_03f7: stelem.ref
+			IL_03f8: dup
+			IL_03f9: ldc.i4.3
+			IL_03fa: ldloc.s 4
+			IL_03fc: stelem.ref
+			IL_03fd: dup
+			IL_03fe: ldc.i4.4
+			IL_03ff: ldloc.s 5
+			IL_0401: stelem.ref
+			IL_0402: dup
+			IL_0403: ldc.i4.5
+			IL_0404: ldloc.s 6
+			IL_0406: stelem.ref
+			IL_0407: dup
+			IL_0408: ldc.i4.6
+			IL_0409: ldloc.s 7
+			IL_040b: stelem.ref
+			IL_040c: dup
+			IL_040d: ldc.i4.7
+			IL_040e: ldloc.s 8
+			IL_0410: stelem.ref
+			IL_0411: dup
+			IL_0412: ldc.i4.8
+			IL_0413: ldloc.s 9
+			IL_0415: stelem.ref
+			IL_0416: dup
+			IL_0417: ldc.i4.s 9
+			IL_0419: ldloc.s 10
+			IL_041b: stelem.ref
+			IL_041c: dup
+			IL_041d: ldc.i4.s 10
+			IL_041f: ldloc.s 11
+			IL_0421: box [System.Runtime]System.Boolean
+			IL_0426: stelem.ref
+			IL_0427: dup
+			IL_0428: ldc.i4.s 11
+			IL_042a: ldloc.s 12
+			IL_042c: box [System.Runtime]System.Boolean
+			IL_0431: stelem.ref
+			IL_0432: dup
+			IL_0433: ldc.i4.s 12
+			IL_0435: ldloc.s 13
+			IL_0437: stelem.ref
 			IL_0438: dup
-			IL_0439: ldc.i4.0
-			IL_043a: ldloc.1
-			IL_043b: stelem.ref
-			IL_043c: dup
-			IL_043d: ldc.i4.1
-			IL_043e: ldloc.2
-			IL_043f: stelem.ref
-			IL_0440: dup
-			IL_0441: ldc.i4.2
-			IL_0442: ldloc.3
-			IL_0443: stelem.ref
-			IL_0444: dup
-			IL_0445: ldc.i4.3
-			IL_0446: ldloc.s 4
+			IL_0439: ldc.i4.s 13
+			IL_043b: ldloc.s 14
+			IL_043d: stelem.ref
+			IL_043e: dup
+			IL_043f: ldc.i4.s 14
+			IL_0441: ldloc.s 15
+			IL_0443: box [System.Runtime]System.Double
 			IL_0448: stelem.ref
 			IL_0449: dup
-			IL_044a: ldc.i4.4
-			IL_044b: ldloc.s 5
-			IL_044d: stelem.ref
-			IL_044e: dup
-			IL_044f: ldc.i4.5
-			IL_0450: ldloc.s 6
-			IL_0452: stelem.ref
-			IL_0453: dup
-			IL_0454: ldc.i4.6
-			IL_0455: ldloc.s 7
-			IL_0457: stelem.ref
-			IL_0458: dup
-			IL_0459: ldc.i4.7
-			IL_045a: ldloc.s 8
-			IL_045c: stelem.ref
-			IL_045d: dup
-			IL_045e: ldc.i4.8
-			IL_045f: ldloc.s 9
-			IL_0461: stelem.ref
-			IL_0462: dup
-			IL_0463: ldc.i4.s 9
-			IL_0465: ldloc.s 10
-			IL_0467: stelem.ref
-			IL_0468: dup
-			IL_0469: ldc.i4.s 10
-			IL_046b: ldloc.s 11
-			IL_046d: box [System.Runtime]System.Boolean
-			IL_0472: stelem.ref
-			IL_0473: dup
-			IL_0474: ldc.i4.s 11
-			IL_0476: ldloc.s 12
-			IL_0478: box [System.Runtime]System.Boolean
+			IL_044a: ldc.i4.s 15
+			IL_044c: ldloc.s 16
+			IL_044e: stelem.ref
+			IL_044f: dup
+			IL_0450: ldc.i4.s 16
+			IL_0452: ldloc.s 17
+			IL_0454: stelem.ref
+			IL_0455: dup
+			IL_0456: ldc.i4.s 17
+			IL_0458: ldloc.s 18
+			IL_045a: stelem.ref
+			IL_045b: dup
+			IL_045c: ldc.i4.s 18
+			IL_045e: ldloc.s 19
+			IL_0460: stelem.ref
+			IL_0461: dup
+			IL_0462: ldc.i4.s 19
+			IL_0464: ldloc.s 20
+			IL_0466: stelem.ref
+			IL_0467: dup
+			IL_0468: ldc.i4.s 20
+			IL_046a: ldloc.s 21
+			IL_046c: box [System.Runtime]System.Boolean
+			IL_0471: stelem.ref
+			IL_0472: dup
+			IL_0473: ldc.i4.s 21
+			IL_0475: ldloc.s 22
+			IL_0477: stelem.ref
+			IL_0478: dup
+			IL_0479: ldc.i4.s 22
+			IL_047b: ldloc.s 23
 			IL_047d: stelem.ref
 			IL_047e: dup
-			IL_047f: ldc.i4.s 12
-			IL_0481: ldloc.s 13
+			IL_047f: ldc.i4.s 23
+			IL_0481: ldloc.s 24
 			IL_0483: stelem.ref
-			IL_0484: dup
-			IL_0485: ldc.i4.s 13
-			IL_0487: ldloc.s 14
-			IL_0489: stelem.ref
-			IL_048a: dup
-			IL_048b: ldc.i4.s 14
-			IL_048d: ldloc.s 15
-			IL_048f: box [System.Runtime]System.Double
-			IL_0494: stelem.ref
-			IL_0495: dup
-			IL_0496: ldc.i4.s 15
-			IL_0498: ldloc.s 16
-			IL_049a: stelem.ref
-			IL_049b: dup
-			IL_049c: ldc.i4.s 16
-			IL_049e: ldloc.s 17
-			IL_04a0: stelem.ref
-			IL_04a1: dup
-			IL_04a2: ldc.i4.s 17
-			IL_04a4: ldloc.s 18
-			IL_04a6: stelem.ref
-			IL_04a7: dup
-			IL_04a8: ldc.i4.s 18
-			IL_04aa: ldloc.s 19
-			IL_04ac: stelem.ref
-			IL_04ad: dup
-			IL_04ae: ldc.i4.s 19
-			IL_04b0: ldloc.s 20
-			IL_04b2: stelem.ref
-			IL_04b3: dup
-			IL_04b4: ldc.i4.s 20
-			IL_04b6: ldloc.s 21
-			IL_04b8: box [System.Runtime]System.Boolean
-			IL_04bd: stelem.ref
-			IL_04be: dup
-			IL_04bf: ldc.i4.s 21
-			IL_04c1: ldloc.s 22
-			IL_04c3: stelem.ref
-			IL_04c4: dup
-			IL_04c5: ldc.i4.s 22
-			IL_04c7: ldloc.s 23
-			IL_04c9: stelem.ref
-			IL_04ca: dup
-			IL_04cb: ldc.i4.s 23
-			IL_04cd: ldloc.s 24
-			IL_04cf: stelem.ref
-			IL_04d0: pop
-			IL_04d1: ldloc.0
-			IL_04d2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04d7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04dc: ret
+			IL_0484: pop
+			IL_0485: ldloc.0
+			IL_0486: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_048b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0490: ret
 
-			IL_04dd: ldloc.0
-			IL_04de: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited2
-			IL_04e3: stloc.s 18
-			IL_04e5: ldloc.s 18
-			IL_04e7: stloc.s 5
-			IL_04e9: ldc.r8 5
-			IL_04f2: box [System.Runtime]System.Double
-			IL_04f7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_04fc: stloc.s 19
-			IL_04fe: ldloc.s 19
-			IL_0500: stloc.s 6
-			IL_0502: ldloc.s 4
-			IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0509: stloc.s 18
-			IL_050b: ldloc.s 6
-			IL_050d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_0512: stloc.s 15
-			IL_0514: ldloc.s 15
-			IL_0516: box [System.Runtime]System.Double
-			IL_051b: stloc.s 16
-			IL_051d: ldc.i4.4
-			IL_051e: newarr [System.Runtime]System.Object
-			IL_0523: dup
-			IL_0524: ldc.i4.0
-			IL_0525: ldloc.s 6
-			IL_0527: stelem.ref
-			IL_0528: dup
-			IL_0529: ldc.i4.1
-			IL_052a: ldc.r8 0.0
-			IL_0533: box [System.Runtime]System.Double
-			IL_0538: stelem.ref
-			IL_0539: dup
-			IL_053a: ldc.i4.2
-			IL_053b: ldloc.s 16
-			IL_053d: stelem.ref
-			IL_053e: dup
-			IL_053f: ldc.i4.3
-			IL_0540: ldc.r8 0.0
-			IL_0549: box [System.Runtime]System.Double
-			IL_054e: stelem.ref
-			IL_054f: stloc.s 20
-			IL_0551: ldloc.s 18
-			IL_0553: ldstr "read"
-			IL_0558: ldloc.s 20
-			IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_055f: stloc.s 18
-			IL_0561: ldloc.0
-			IL_0562: ldc.i4.6
-			IL_0563: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0568: ldloc.0
-			IL_0569: ldloc.s 18
-			IL_056b: ldarg.0
-			IL_056c: ldc.i4.3
-			IL_056d: ldloc.0
-			IL_056e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0573: ldc.i4.3
-			IL_0574: ldstr "_pendingException"
-			IL_0579: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_057e: ldloc.0
-			IL_057f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0491: ldloc.0
+			IL_0492: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited2
+			IL_0497: stloc.s 18
+			IL_0499: ldloc.s 18
+			IL_049b: stloc.s 5
+			IL_049d: ldc.r8 5
+			IL_04a6: box [System.Runtime]System.Double
+			IL_04ab: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_04b0: stloc.s 19
+			IL_04b2: ldloc.s 19
+			IL_04b4: stloc.s 6
+			IL_04b6: ldloc.s 4
+			IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04bd: stloc.s 18
+			IL_04bf: ldloc.s 6
+			IL_04c1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_04c6: stloc.s 15
+			IL_04c8: ldloc.s 15
+			IL_04ca: box [System.Runtime]System.Double
+			IL_04cf: stloc.s 16
+			IL_04d1: ldc.i4.4
+			IL_04d2: newarr [System.Runtime]System.Object
+			IL_04d7: dup
+			IL_04d8: ldc.i4.0
+			IL_04d9: ldloc.s 6
+			IL_04db: stelem.ref
+			IL_04dc: dup
+			IL_04dd: ldc.i4.1
+			IL_04de: ldc.r8 0.0
+			IL_04e7: box [System.Runtime]System.Double
+			IL_04ec: stelem.ref
+			IL_04ed: dup
+			IL_04ee: ldc.i4.2
+			IL_04ef: ldloc.s 16
+			IL_04f1: stelem.ref
+			IL_04f2: dup
+			IL_04f3: ldc.i4.3
+			IL_04f4: ldc.r8 0.0
+			IL_04fd: box [System.Runtime]System.Double
+			IL_0502: stelem.ref
+			IL_0503: stloc.s 20
+			IL_0505: ldloc.s 18
+			IL_0507: ldstr "read"
+			IL_050c: ldloc.s 20
+			IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0513: stloc.s 18
+			IL_0515: ldloc.0
+			IL_0516: ldc.i4.6
+			IL_0517: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_051c: ldloc.0
+			IL_051d: ldloc.s 18
+			IL_051f: ldarg.0
+			IL_0520: ldc.i4.3
+			IL_0521: ldloc.0
+			IL_0522: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0527: ldc.i4.3
+			IL_0528: ldstr "_pendingException"
+			IL_052d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0532: ldloc.0
+			IL_0533: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0538: dup
+			IL_0539: ldc.i4.0
+			IL_053a: ldloc.1
+			IL_053b: stelem.ref
+			IL_053c: dup
+			IL_053d: ldc.i4.1
+			IL_053e: ldloc.2
+			IL_053f: stelem.ref
+			IL_0540: dup
+			IL_0541: ldc.i4.2
+			IL_0542: ldloc.3
+			IL_0543: stelem.ref
+			IL_0544: dup
+			IL_0545: ldc.i4.3
+			IL_0546: ldloc.s 4
+			IL_0548: stelem.ref
+			IL_0549: dup
+			IL_054a: ldc.i4.4
+			IL_054b: ldloc.s 5
+			IL_054d: stelem.ref
+			IL_054e: dup
+			IL_054f: ldc.i4.5
+			IL_0550: ldloc.s 6
+			IL_0552: stelem.ref
+			IL_0553: dup
+			IL_0554: ldc.i4.6
+			IL_0555: ldloc.s 7
+			IL_0557: stelem.ref
+			IL_0558: dup
+			IL_0559: ldc.i4.7
+			IL_055a: ldloc.s 8
+			IL_055c: stelem.ref
+			IL_055d: dup
+			IL_055e: ldc.i4.8
+			IL_055f: ldloc.s 9
+			IL_0561: stelem.ref
+			IL_0562: dup
+			IL_0563: ldc.i4.s 9
+			IL_0565: ldloc.s 10
+			IL_0567: stelem.ref
+			IL_0568: dup
+			IL_0569: ldc.i4.s 10
+			IL_056b: ldloc.s 11
+			IL_056d: box [System.Runtime]System.Boolean
+			IL_0572: stelem.ref
+			IL_0573: dup
+			IL_0574: ldc.i4.s 11
+			IL_0576: ldloc.s 12
+			IL_0578: box [System.Runtime]System.Boolean
+			IL_057d: stelem.ref
+			IL_057e: dup
+			IL_057f: ldc.i4.s 12
+			IL_0581: ldloc.s 13
+			IL_0583: stelem.ref
 			IL_0584: dup
-			IL_0585: ldc.i4.0
-			IL_0586: ldloc.1
-			IL_0587: stelem.ref
-			IL_0588: dup
-			IL_0589: ldc.i4.1
-			IL_058a: ldloc.2
-			IL_058b: stelem.ref
-			IL_058c: dup
-			IL_058d: ldc.i4.2
-			IL_058e: ldloc.3
-			IL_058f: stelem.ref
-			IL_0590: dup
-			IL_0591: ldc.i4.3
-			IL_0592: ldloc.s 4
+			IL_0585: ldc.i4.s 13
+			IL_0587: ldloc.s 14
+			IL_0589: stelem.ref
+			IL_058a: dup
+			IL_058b: ldc.i4.s 14
+			IL_058d: ldloc.s 15
+			IL_058f: box [System.Runtime]System.Double
 			IL_0594: stelem.ref
 			IL_0595: dup
-			IL_0596: ldc.i4.4
-			IL_0597: ldloc.s 5
-			IL_0599: stelem.ref
-			IL_059a: dup
-			IL_059b: ldc.i4.5
-			IL_059c: ldloc.s 6
-			IL_059e: stelem.ref
-			IL_059f: dup
-			IL_05a0: ldc.i4.6
-			IL_05a1: ldloc.s 7
-			IL_05a3: stelem.ref
-			IL_05a4: dup
-			IL_05a5: ldc.i4.7
-			IL_05a6: ldloc.s 8
-			IL_05a8: stelem.ref
-			IL_05a9: dup
-			IL_05aa: ldc.i4.8
-			IL_05ab: ldloc.s 9
-			IL_05ad: stelem.ref
-			IL_05ae: dup
-			IL_05af: ldc.i4.s 9
-			IL_05b1: ldloc.s 10
-			IL_05b3: stelem.ref
-			IL_05b4: dup
-			IL_05b5: ldc.i4.s 10
-			IL_05b7: ldloc.s 11
-			IL_05b9: box [System.Runtime]System.Boolean
-			IL_05be: stelem.ref
-			IL_05bf: dup
-			IL_05c0: ldc.i4.s 11
-			IL_05c2: ldloc.s 12
-			IL_05c4: box [System.Runtime]System.Boolean
+			IL_0596: ldc.i4.s 15
+			IL_0598: ldloc.s 16
+			IL_059a: stelem.ref
+			IL_059b: dup
+			IL_059c: ldc.i4.s 16
+			IL_059e: ldloc.s 17
+			IL_05a0: stelem.ref
+			IL_05a1: dup
+			IL_05a2: ldc.i4.s 17
+			IL_05a4: ldloc.s 18
+			IL_05a6: stelem.ref
+			IL_05a7: dup
+			IL_05a8: ldc.i4.s 18
+			IL_05aa: ldloc.s 19
+			IL_05ac: stelem.ref
+			IL_05ad: dup
+			IL_05ae: ldc.i4.s 19
+			IL_05b0: ldloc.s 20
+			IL_05b2: stelem.ref
+			IL_05b3: dup
+			IL_05b4: ldc.i4.s 20
+			IL_05b6: ldloc.s 21
+			IL_05b8: box [System.Runtime]System.Boolean
+			IL_05bd: stelem.ref
+			IL_05be: dup
+			IL_05bf: ldc.i4.s 21
+			IL_05c1: ldloc.s 22
+			IL_05c3: stelem.ref
+			IL_05c4: dup
+			IL_05c5: ldc.i4.s 22
+			IL_05c7: ldloc.s 23
 			IL_05c9: stelem.ref
 			IL_05ca: dup
-			IL_05cb: ldc.i4.s 12
-			IL_05cd: ldloc.s 13
+			IL_05cb: ldc.i4.s 23
+			IL_05cd: ldloc.s 24
 			IL_05cf: stelem.ref
-			IL_05d0: dup
-			IL_05d1: ldc.i4.s 13
-			IL_05d3: ldloc.s 14
-			IL_05d5: stelem.ref
-			IL_05d6: dup
-			IL_05d7: ldc.i4.s 14
-			IL_05d9: ldloc.s 15
-			IL_05db: box [System.Runtime]System.Double
-			IL_05e0: stelem.ref
-			IL_05e1: dup
-			IL_05e2: ldc.i4.s 15
-			IL_05e4: ldloc.s 16
-			IL_05e6: stelem.ref
-			IL_05e7: dup
-			IL_05e8: ldc.i4.s 16
-			IL_05ea: ldloc.s 17
-			IL_05ec: stelem.ref
-			IL_05ed: dup
-			IL_05ee: ldc.i4.s 17
-			IL_05f0: ldloc.s 18
-			IL_05f2: stelem.ref
-			IL_05f3: dup
-			IL_05f4: ldc.i4.s 18
-			IL_05f6: ldloc.s 19
-			IL_05f8: stelem.ref
-			IL_05f9: dup
-			IL_05fa: ldc.i4.s 19
-			IL_05fc: ldloc.s 20
-			IL_05fe: stelem.ref
-			IL_05ff: dup
-			IL_0600: ldc.i4.s 20
-			IL_0602: ldloc.s 21
-			IL_0604: box [System.Runtime]System.Boolean
-			IL_0609: stelem.ref
-			IL_060a: dup
-			IL_060b: ldc.i4.s 21
-			IL_060d: ldloc.s 22
-			IL_060f: stelem.ref
-			IL_0610: dup
-			IL_0611: ldc.i4.s 22
-			IL_0613: ldloc.s 23
-			IL_0615: stelem.ref
-			IL_0616: dup
-			IL_0617: ldc.i4.s 23
-			IL_0619: ldloc.s 24
-			IL_061b: stelem.ref
-			IL_061c: pop
-			IL_061d: ldloc.0
-			IL_061e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0623: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0628: ret
+			IL_05d0: pop
+			IL_05d1: ldloc.0
+			IL_05d2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05d7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05dc: ret
 
-			IL_0629: ldloc.0
-			IL_062a: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited3
-			IL_062f: stloc.s 18
-			IL_0631: ldloc.s 18
-			IL_0633: stloc.s 7
-			IL_0635: ldloc.s 4
-			IL_0637: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_063c: stloc.s 18
-			IL_063e: ldloc.s 18
-			IL_0640: ldstr "close"
-			IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_064a: stloc.s 18
-			IL_064c: ldloc.0
-			IL_064d: ldc.i4.7
-			IL_064e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0653: ldloc.0
-			IL_0654: ldloc.s 18
-			IL_0656: ldarg.0
-			IL_0657: ldc.i4.4
-			IL_0658: ldloc.0
-			IL_0659: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_065e: ldc.i4.3
-			IL_065f: ldstr "_pendingException"
-			IL_0664: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0669: ldloc.0
-			IL_066a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05dd: ldloc.0
+			IL_05de: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited3
+			IL_05e3: stloc.s 18
+			IL_05e5: ldloc.s 18
+			IL_05e7: stloc.s 7
+			IL_05e9: ldloc.s 4
+			IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05f0: stloc.s 18
+			IL_05f2: ldloc.s 18
+			IL_05f4: ldstr "close"
+			IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_05fe: stloc.s 18
+			IL_0600: ldloc.0
+			IL_0601: ldc.i4.7
+			IL_0602: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0607: ldloc.0
+			IL_0608: ldloc.s 18
+			IL_060a: ldarg.0
+			IL_060b: ldc.i4.4
+			IL_060c: ldloc.0
+			IL_060d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0612: ldc.i4.3
+			IL_0613: ldstr "_pendingException"
+			IL_0618: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_061d: ldloc.0
+			IL_061e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0623: dup
+			IL_0624: ldc.i4.0
+			IL_0625: ldloc.1
+			IL_0626: stelem.ref
+			IL_0627: dup
+			IL_0628: ldc.i4.1
+			IL_0629: ldloc.2
+			IL_062a: stelem.ref
+			IL_062b: dup
+			IL_062c: ldc.i4.2
+			IL_062d: ldloc.3
+			IL_062e: stelem.ref
+			IL_062f: dup
+			IL_0630: ldc.i4.3
+			IL_0631: ldloc.s 4
+			IL_0633: stelem.ref
+			IL_0634: dup
+			IL_0635: ldc.i4.4
+			IL_0636: ldloc.s 5
+			IL_0638: stelem.ref
+			IL_0639: dup
+			IL_063a: ldc.i4.5
+			IL_063b: ldloc.s 6
+			IL_063d: stelem.ref
+			IL_063e: dup
+			IL_063f: ldc.i4.6
+			IL_0640: ldloc.s 7
+			IL_0642: stelem.ref
+			IL_0643: dup
+			IL_0644: ldc.i4.7
+			IL_0645: ldloc.s 8
+			IL_0647: stelem.ref
+			IL_0648: dup
+			IL_0649: ldc.i4.8
+			IL_064a: ldloc.s 9
+			IL_064c: stelem.ref
+			IL_064d: dup
+			IL_064e: ldc.i4.s 9
+			IL_0650: ldloc.s 10
+			IL_0652: stelem.ref
+			IL_0653: dup
+			IL_0654: ldc.i4.s 10
+			IL_0656: ldloc.s 11
+			IL_0658: box [System.Runtime]System.Boolean
+			IL_065d: stelem.ref
+			IL_065e: dup
+			IL_065f: ldc.i4.s 11
+			IL_0661: ldloc.s 12
+			IL_0663: box [System.Runtime]System.Boolean
+			IL_0668: stelem.ref
+			IL_0669: dup
+			IL_066a: ldc.i4.s 12
+			IL_066c: ldloc.s 13
+			IL_066e: stelem.ref
 			IL_066f: dup
-			IL_0670: ldc.i4.0
-			IL_0671: ldloc.1
-			IL_0672: stelem.ref
-			IL_0673: dup
-			IL_0674: ldc.i4.1
-			IL_0675: ldloc.2
-			IL_0676: stelem.ref
-			IL_0677: dup
-			IL_0678: ldc.i4.2
-			IL_0679: ldloc.3
-			IL_067a: stelem.ref
-			IL_067b: dup
-			IL_067c: ldc.i4.3
-			IL_067d: ldloc.s 4
+			IL_0670: ldc.i4.s 13
+			IL_0672: ldloc.s 14
+			IL_0674: stelem.ref
+			IL_0675: dup
+			IL_0676: ldc.i4.s 14
+			IL_0678: ldloc.s 15
+			IL_067a: box [System.Runtime]System.Double
 			IL_067f: stelem.ref
 			IL_0680: dup
-			IL_0681: ldc.i4.4
-			IL_0682: ldloc.s 5
-			IL_0684: stelem.ref
-			IL_0685: dup
-			IL_0686: ldc.i4.5
-			IL_0687: ldloc.s 6
-			IL_0689: stelem.ref
-			IL_068a: dup
-			IL_068b: ldc.i4.6
-			IL_068c: ldloc.s 7
-			IL_068e: stelem.ref
-			IL_068f: dup
-			IL_0690: ldc.i4.7
-			IL_0691: ldloc.s 8
-			IL_0693: stelem.ref
-			IL_0694: dup
-			IL_0695: ldc.i4.8
-			IL_0696: ldloc.s 9
-			IL_0698: stelem.ref
-			IL_0699: dup
-			IL_069a: ldc.i4.s 9
-			IL_069c: ldloc.s 10
-			IL_069e: stelem.ref
-			IL_069f: dup
-			IL_06a0: ldc.i4.s 10
-			IL_06a2: ldloc.s 11
-			IL_06a4: box [System.Runtime]System.Boolean
-			IL_06a9: stelem.ref
-			IL_06aa: dup
-			IL_06ab: ldc.i4.s 11
-			IL_06ad: ldloc.s 12
-			IL_06af: box [System.Runtime]System.Boolean
+			IL_0681: ldc.i4.s 15
+			IL_0683: ldloc.s 16
+			IL_0685: stelem.ref
+			IL_0686: dup
+			IL_0687: ldc.i4.s 16
+			IL_0689: ldloc.s 17
+			IL_068b: stelem.ref
+			IL_068c: dup
+			IL_068d: ldc.i4.s 17
+			IL_068f: ldloc.s 18
+			IL_0691: stelem.ref
+			IL_0692: dup
+			IL_0693: ldc.i4.s 18
+			IL_0695: ldloc.s 19
+			IL_0697: stelem.ref
+			IL_0698: dup
+			IL_0699: ldc.i4.s 19
+			IL_069b: ldloc.s 20
+			IL_069d: stelem.ref
+			IL_069e: dup
+			IL_069f: ldc.i4.s 20
+			IL_06a1: ldloc.s 21
+			IL_06a3: box [System.Runtime]System.Boolean
+			IL_06a8: stelem.ref
+			IL_06a9: dup
+			IL_06aa: ldc.i4.s 21
+			IL_06ac: ldloc.s 22
+			IL_06ae: stelem.ref
+			IL_06af: dup
+			IL_06b0: ldc.i4.s 22
+			IL_06b2: ldloc.s 23
 			IL_06b4: stelem.ref
 			IL_06b5: dup
-			IL_06b6: ldc.i4.s 12
-			IL_06b8: ldloc.s 13
+			IL_06b6: ldc.i4.s 23
+			IL_06b8: ldloc.s 24
 			IL_06ba: stelem.ref
-			IL_06bb: dup
-			IL_06bc: ldc.i4.s 13
-			IL_06be: ldloc.s 14
-			IL_06c0: stelem.ref
-			IL_06c1: dup
-			IL_06c2: ldc.i4.s 14
-			IL_06c4: ldloc.s 15
-			IL_06c6: box [System.Runtime]System.Double
-			IL_06cb: stelem.ref
-			IL_06cc: dup
-			IL_06cd: ldc.i4.s 15
-			IL_06cf: ldloc.s 16
-			IL_06d1: stelem.ref
-			IL_06d2: dup
-			IL_06d3: ldc.i4.s 16
-			IL_06d5: ldloc.s 17
-			IL_06d7: stelem.ref
-			IL_06d8: dup
-			IL_06d9: ldc.i4.s 17
+			IL_06bb: pop
+			IL_06bc: ldloc.0
+			IL_06bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06c2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06c7: ret
+
+			IL_06c8: ldloc.0
+			IL_06c9: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited4
+			IL_06ce: pop
+			IL_06cf: ldstr "console"
+			IL_06d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06d9: stloc.s 18
 			IL_06db: ldloc.s 18
-			IL_06dd: stelem.ref
-			IL_06de: dup
-			IL_06df: ldc.i4.s 18
-			IL_06e1: ldloc.s 19
-			IL_06e3: stelem.ref
-			IL_06e4: dup
-			IL_06e5: ldc.i4.s 19
-			IL_06e7: ldloc.s 20
-			IL_06e9: stelem.ref
-			IL_06ea: dup
-			IL_06eb: ldc.i4.s 20
-			IL_06ed: ldloc.s 21
-			IL_06ef: box [System.Runtime]System.Boolean
-			IL_06f4: stelem.ref
-			IL_06f5: dup
-			IL_06f6: ldc.i4.s 21
-			IL_06f8: ldloc.s 22
-			IL_06fa: stelem.ref
-			IL_06fb: dup
-			IL_06fc: ldc.i4.s 22
-			IL_06fe: ldloc.s 23
-			IL_0700: stelem.ref
-			IL_0701: dup
-			IL_0702: ldc.i4.s 23
-			IL_0704: ldloc.s 24
-			IL_0706: stelem.ref
-			IL_0707: pop
-			IL_0708: ldloc.0
-			IL_0709: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_070e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0713: ret
+			IL_06dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06e2: stloc.s 18
+			IL_06e4: ldloc.s 4
+			IL_06e6: ldstr "fd"
+			IL_06eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06f0: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_06f5: ldstr "number"
+			IL_06fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_06ff: stloc.s 21
+			IL_0701: ldloc.s 21
+			IL_0703: box [System.Runtime]System.Boolean
+			IL_0708: stloc.s 22
+			IL_070a: ldloc.s 18
+			IL_070c: ldstr "log"
+			IL_0711: ldstr "FDIsNumber:"
+			IL_0716: ldloc.s 22
+			IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_071d: pop
+			IL_071e: ldstr "console"
+			IL_0723: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0728: stloc.s 18
+			IL_072a: ldloc.s 18
+			IL_072c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0731: stloc.s 18
+			IL_0733: ldloc.s 18
+			IL_0735: ldstr "log"
+			IL_073a: ldstr "BytesWritten:"
+			IL_073f: ldloc.s 5
+			IL_0741: ldstr "bytesWritten"
+			IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0750: pop
+			IL_0751: ldstr "console"
+			IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_075b: stloc.s 18
+			IL_075d: ldloc.s 18
+			IL_075f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0764: stloc.s 18
+			IL_0766: ldloc.s 18
+			IL_0768: ldstr "log"
+			IL_076d: ldstr "BytesRead:"
+			IL_0772: ldloc.s 7
+			IL_0774: ldstr "bytesRead"
+			IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_077e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0783: pop
+			IL_0784: ldstr "console"
+			IL_0789: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_078e: stloc.s 18
+			IL_0790: ldloc.s 18
+			IL_0792: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0797: stloc.s 18
+			IL_0799: ldloc.s 6
+			IL_079b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07a0: stloc.s 13
+			IL_07a2: ldloc.s 13
+			IL_07a4: ldstr "toString"
+			IL_07a9: ldstr "utf8"
+			IL_07ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_07b3: stloc.s 13
+			IL_07b5: ldloc.s 18
+			IL_07b7: ldstr "log"
+			IL_07bc: ldstr "BufferText:"
+			IL_07c1: ldloc.s 13
+			IL_07c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_07c8: pop
+			IL_07c9: br IL_0863
 
-			IL_0714: ldloc.0
-			IL_0715: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited4
-			IL_071a: pop
-			IL_071b: ldstr "console"
-			IL_0720: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0725: stloc.s 18
-			IL_0727: ldloc.s 18
-			IL_0729: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_072e: stloc.s 18
-			IL_0730: ldloc.s 4
-			IL_0732: ldstr "fd"
-			IL_0737: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_073c: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_0741: ldstr "number"
-			IL_0746: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_074b: stloc.s 21
-			IL_074d: ldloc.s 21
-			IL_074f: box [System.Runtime]System.Boolean
-			IL_0754: stloc.s 22
-			IL_0756: ldloc.s 18
-			IL_0758: ldstr "log"
-			IL_075d: ldstr "FDIsNumber:"
-			IL_0762: ldloc.s 22
-			IL_0764: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0769: pop
-			IL_076a: ldstr "console"
-			IL_076f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0774: stloc.s 18
-			IL_0776: ldloc.s 18
-			IL_0778: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_077d: stloc.s 18
-			IL_077f: ldloc.s 18
-			IL_0781: ldstr "log"
-			IL_0786: ldstr "BytesWritten:"
-			IL_078b: ldloc.s 5
-			IL_078d: ldstr "bytesWritten"
-			IL_0792: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0797: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_079c: pop
-			IL_079d: ldstr "console"
-			IL_07a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07a7: stloc.s 18
-			IL_07a9: ldloc.s 18
-			IL_07ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07b0: stloc.s 18
-			IL_07b2: ldloc.s 18
-			IL_07b4: ldstr "log"
-			IL_07b9: ldstr "BytesRead:"
-			IL_07be: ldloc.s 7
-			IL_07c0: ldstr "bytesRead"
-			IL_07c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_07cf: pop
-			IL_07d0: ldstr "console"
-			IL_07d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07da: stloc.s 18
-			IL_07dc: ldloc.s 18
-			IL_07de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07e3: stloc.s 18
-			IL_07e5: ldloc.s 6
-			IL_07e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07ec: stloc.s 13
-			IL_07ee: ldloc.s 13
-			IL_07f0: ldstr "toString"
-			IL_07f5: ldstr "utf8"
-			IL_07fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_07ff: stloc.s 13
-			IL_0801: ldloc.s 18
-			IL_0803: ldstr "log"
-			IL_0808: ldstr "BufferText:"
-			IL_080d: ldloc.s 13
-			IL_080f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0814: pop
-			IL_0815: br IL_08af
+			IL_07ce: ldloc.0
+			IL_07cf: ldc.i4.1
+			IL_07d0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_07d5: ldloc.0
+			IL_07d6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_07db: stloc.s 13
+			IL_07dd: ldloc.0
+			IL_07de: ldc.i4.0
+			IL_07df: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_07e4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_07e9: ldloc.0
+			IL_07ea: ldc.i4.0
+			IL_07eb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_07f0: ldloc.s 13
+			IL_07f2: stloc.s 8
+			IL_07f4: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L25C18::.ctor()
+			IL_07f9: stloc.s 9
+			IL_07fb: ldstr "console"
+			IL_0800: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0805: stloc.s 13
+			IL_0807: ldloc.s 13
+			IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_080e: stloc.s 13
+			IL_0810: ldloc.s 8
+			IL_0812: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0817: stloc.s 21
+			IL_0819: ldloc.s 21
+			IL_081b: brfalse IL_0833
 
-			IL_081a: ldloc.0
-			IL_081b: ldc.i4.1
-			IL_081c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0821: ldloc.0
-			IL_0822: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0827: stloc.s 13
-			IL_0829: ldloc.0
-			IL_082a: ldc.i4.0
-			IL_082b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0830: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0835: ldloc.0
-			IL_0836: ldc.i4.0
-			IL_0837: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_083c: ldloc.s 13
-			IL_083e: stloc.s 8
-			IL_0840: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L25C18::.ctor()
-			IL_0845: stloc.s 9
-			IL_0847: ldstr "console"
-			IL_084c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0851: stloc.s 13
-			IL_0853: ldloc.s 13
-			IL_0855: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_085a: stloc.s 13
-			IL_085c: ldloc.s 8
-			IL_085e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0863: stloc.s 21
-			IL_0865: ldloc.s 21
-			IL_0867: brfalse IL_087f
+			IL_0820: ldloc.s 8
+			IL_0822: ldstr "message"
+			IL_0827: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_082c: stloc.s 24
+			IL_082e: br IL_0837
 
-			IL_086c: ldloc.s 8
-			IL_086e: ldstr "message"
-			IL_0873: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0878: stloc.s 24
-			IL_087a: br IL_0883
+			IL_0833: ldloc.s 8
+			IL_0835: stloc.s 24
 
-			IL_087f: ldloc.s 8
-			IL_0881: stloc.s 24
+			IL_0837: ldloc.s 13
+			IL_0839: ldstr "log"
+			IL_083e: ldstr "Error:"
+			IL_0843: ldloc.s 24
+			IL_0845: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_084a: pop
+			IL_084b: br IL_0863
 
-			IL_0883: ldloc.s 13
-			IL_0885: ldstr "log"
-			IL_088a: ldstr "Error:"
-			IL_088f: ldloc.s 24
-			IL_0891: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0896: pop
-			IL_0897: br IL_08af
+			IL_0850: ldloc.0
+			IL_0851: ldc.i4.1
+			IL_0852: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0857: ldloc.0
+			IL_0858: ldc.i4.0
+			IL_0859: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_085e: br IL_0863
 
-			IL_089c: ldloc.0
-			IL_089d: ldc.i4.1
-			IL_089e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_08a3: ldloc.0
-			IL_08a4: ldc.i4.0
-			IL_08a5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_08aa: br IL_08af
+			IL_0863: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L27C14::.ctor()
+			IL_0868: stloc.s 10
+			IL_086a: ldarg.0
+			IL_086b: ldc.i4.1
+			IL_086c: ldelem.ref
+			IL_086d: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_0872: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_0877: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_087c: stloc.s 13
+			IL_087e: ldloc.s 13
+			IL_0880: ldstr "rmSync"
+			IL_0885: ldloc.2
+			IL_0886: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_088b: dup
+			IL_088c: ldstr "force"
+			IL_0891: ldc.i4.1
+			IL_0892: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0897: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_089c: pop
+			IL_089d: br IL_08b5
 
-			IL_08af: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L27C14::.ctor()
-			IL_08b4: stloc.s 10
-			IL_08b6: ldarg.0
-			IL_08b7: ldc.i4.1
-			IL_08b8: ldelem.ref
-			IL_08b9: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_08be: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_08c3: stloc.s 13
-			IL_08c5: ldstr "fs"
-			IL_08ca: ldloc.s 13
-			IL_08cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_08d1: stloc.s 13
-			IL_08d3: ldloc.s 13
-			IL_08d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_08da: stloc.s 13
-			IL_08dc: ldloc.s 13
-			IL_08de: ldstr "rmSync"
-			IL_08e3: ldloc.2
-			IL_08e4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_08e9: dup
-			IL_08ea: ldstr "force"
-			IL_08ef: ldc.i4.1
-			IL_08f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_08f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_08fa: pop
-			IL_08fb: br IL_0913
+			IL_08a2: ldloc.0
+			IL_08a3: ldc.i4.1
+			IL_08a4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_08a9: ldloc.0
+			IL_08aa: ldc.i4.0
+			IL_08ab: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_08b0: br IL_08b5
 
-			IL_0900: ldloc.0
-			IL_0901: ldc.i4.1
-			IL_0902: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0907: ldloc.0
-			IL_0908: ldc.i4.0
-			IL_0909: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_090e: br IL_0913
+			IL_08b5: ldloc.0
+			IL_08b6: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_08bb: stloc.s 11
+			IL_08bd: ldloc.s 11
+			IL_08bf: brfalse IL_08fc
 
+			IL_08c4: ldloc.0
+			IL_08c5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_08ca: stloc.s 13
+			IL_08cc: ldloc.0
+			IL_08cd: ldc.i4.m1
+			IL_08ce: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08d3: ldloc.0
+			IL_08d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_08de: ldarg.0
+			IL_08df: ldc.i4.1
+			IL_08e0: newarr [System.Runtime]System.Object
+			IL_08e5: dup
+			IL_08e6: ldc.i4.0
+			IL_08e7: ldloc.s 13
+			IL_08e9: stelem.ref
+			IL_08ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_08ef: pop
+			IL_08f0: ldloc.0
+			IL_08f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08f6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08fb: ret
+
+			IL_08fc: ldloc.0
+			IL_08fd: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0902: stloc.s 12
+			IL_0904: ldloc.s 12
+			IL_0906: brfalse IL_0943
+
+			IL_090b: ldloc.0
+			IL_090c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0911: stloc.s 13
 			IL_0913: ldloc.0
-			IL_0914: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0919: stloc.s 11
-			IL_091b: ldloc.s 11
-			IL_091d: brfalse IL_095a
+			IL_0914: ldc.i4.m1
+			IL_0915: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_091a: ldloc.0
+			IL_091b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0920: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0925: ldarg.0
+			IL_0926: ldc.i4.1
+			IL_0927: newarr [System.Runtime]System.Object
+			IL_092c: dup
+			IL_092d: ldc.i4.0
+			IL_092e: ldloc.s 13
+			IL_0930: stelem.ref
+			IL_0931: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0936: pop
+			IL_0937: ldloc.0
+			IL_0938: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_093d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0942: ret
 
-			IL_0922: ldloc.0
-			IL_0923: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0928: stloc.s 13
-			IL_092a: ldloc.0
-			IL_092b: ldc.i4.m1
-			IL_092c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0931: ldloc.0
-			IL_0932: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0937: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_093c: ldarg.0
-			IL_093d: ldc.i4.1
-			IL_093e: newarr [System.Runtime]System.Object
-			IL_0943: dup
-			IL_0944: ldc.i4.0
-			IL_0945: ldloc.s 13
-			IL_0947: stelem.ref
-			IL_0948: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_094d: pop
-			IL_094e: ldloc.0
-			IL_094f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0954: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0959: ret
-
-			IL_095a: ldloc.0
-			IL_095b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0960: stloc.s 12
-			IL_0962: ldloc.s 12
-			IL_0964: brfalse IL_09a1
-
-			IL_0969: ldloc.0
-			IL_096a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_096f: stloc.s 13
-			IL_0971: ldloc.0
-			IL_0972: ldc.i4.m1
-			IL_0973: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0978: ldloc.0
-			IL_0979: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_097e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0983: ldarg.0
-			IL_0984: ldc.i4.1
-			IL_0985: newarr [System.Runtime]System.Object
-			IL_098a: dup
-			IL_098b: ldc.i4.0
-			IL_098c: ldloc.s 13
-			IL_098e: stelem.ref
-			IL_098f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0994: pop
-			IL_0995: ldloc.0
-			IL_0996: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_099b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_09a0: ret
-
-			IL_09a1: ldloc.0
-			IL_09a2: ldc.i4.m1
-			IL_09a3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_09a8: ldloc.0
-			IL_09a9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_09b3: ldarg.0
-			IL_09b4: ldc.i4.1
-			IL_09b5: newarr [System.Runtime]System.Object
-			IL_09ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_09bf: pop
-			IL_09c0: ldloc.0
-			IL_09c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09c6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_09cb: ret
+			IL_0943: ldloc.0
+			IL_0944: ldc.i4.m1
+			IL_0945: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_094a: ldloc.0
+			IL_094b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0950: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0955: ldarg.0
+			IL_0956: ldc.i4.1
+			IL_0957: newarr [System.Runtime]System.Object
+			IL_095c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0961: pop
+			IL_0962: ldloc.0
+			IL_0963: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0968: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_096d: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1283,7 +1251,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2abc
+			// Method begins at RVA 0x2a5e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1379,7 +1347,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2ae9
+		// Method begins at RVA 0x2a8b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Buffer.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Buffer.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e9
+				// Method begins at RVA 0x22b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,15 +54,12 @@
 			)
 			// Method begins at RVA 0x21dc
 			// Header size: 12
-			// Code size: 186 (0xba)
+			// Code size: 140 (0x8c)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] bool,
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate,
-				[4] object[],
-				[5] object
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -99,40 +96,20 @@
 			IL_005f: pop
 			IL_0060: ldarg.0
 			IL_0061: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Buffer/Scope::require
-			IL_0066: stloc.3
-			IL_0067: ldstr "require"
-			IL_006c: ldloc.3
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0072: stloc.0
-			IL_0073: ldc.i4.1
-			IL_0074: newarr [System.Runtime]System.Object
-			IL_0079: dup
-			IL_007a: ldc.i4.0
-			IL_007b: ldarg.0
-			IL_007c: stelem.ref
-			IL_007d: stloc.s 4
-			IL_007f: ldloc.0
-			IL_0080: ldloc.s 4
-			IL_0082: ldstr "fs"
-			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_008c: stloc.0
-			IL_008d: ldloc.0
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0093: stloc.0
-			IL_0094: ldarg.0
-			IL_0095: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
-			IL_009a: stloc.s 5
-			IL_009c: ldstr "testFile"
-			IL_00a1: ldloc.s 5
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a8: stloc.s 5
-			IL_00aa: ldloc.0
-			IL_00ab: ldstr "rmSync"
-			IL_00b0: ldloc.s 5
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00b7: pop
-			IL_00b8: ldnull
-			IL_00b9: ret
+			IL_0066: ldstr "fs"
+			IL_006b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0070: stloc.0
+			IL_0071: ldloc.0
+			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0077: stloc.0
+			IL_0078: ldloc.0
+			IL_0079: ldstr "rmSync"
+			IL_007e: ldarg.0
+			IL_007f: ldfld object Modules.FSPromises_ReadFile_Buffer/Scope::testFile
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0089: pop
+			IL_008a: ldnull
+			IL_008b: ret
 		} // end of method ArrowFunction_L8C28::__js_call__
 
 	} // end of class ArrowFunction_L8C28
@@ -155,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f2
+				// Method begins at RVA 0x22c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -179,7 +156,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a4
+			// Method begins at RVA 0x2274
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -223,7 +200,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e0
+			// Method begins at RVA 0x22b0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -404,7 +381,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22fb
+		// Method begins at RVA 0x22cb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Utf8.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ad
+				// Method begins at RVA 0x2285
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,13 +54,10 @@
 			)
 			// Method begins at RVA 0x21e4
 			// Header size: 12
-			// Code size: 120 (0x78)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate,
-				[2] object[],
-				[3] object
+				[0] object
 			)
 
 			IL_0000: ldstr "console"
@@ -77,40 +74,20 @@
 			IL_0023: pop
 			IL_0024: ldarg.0
 			IL_0025: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_ReadFile_Utf8/Scope::require
-			IL_002a: stloc.1
-			IL_002b: ldstr "require"
-			IL_0030: ldloc.1
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldc.i4.1
-			IL_0038: newarr [System.Runtime]System.Object
-			IL_003d: dup
-			IL_003e: ldc.i4.0
-			IL_003f: ldarg.0
-			IL_0040: stelem.ref
-			IL_0041: stloc.2
-			IL_0042: ldloc.0
-			IL_0043: ldloc.2
-			IL_0044: ldstr "fs"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_004e: stloc.0
-			IL_004f: ldloc.0
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0055: stloc.0
-			IL_0056: ldarg.0
-			IL_0057: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
-			IL_005c: stloc.3
-			IL_005d: ldstr "testFile"
-			IL_0062: ldloc.3
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0068: stloc.3
-			IL_0069: ldloc.0
-			IL_006a: ldstr "rmSync"
-			IL_006f: ldloc.3
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0075: pop
-			IL_0076: ldnull
-			IL_0077: ret
+			IL_002a: ldstr "fs"
+			IL_002f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0034: stloc.0
+			IL_0035: ldloc.0
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003b: stloc.0
+			IL_003c: ldloc.0
+			IL_003d: ldstr "rmSync"
+			IL_0042: ldarg.0
+			IL_0043: ldfld object Modules.FSPromises_ReadFile_Utf8/Scope::testFile
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method ArrowFunction_L8C36::__js_call__
 
 	} // end of class ArrowFunction_L8C36
@@ -133,7 +110,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b6
+				// Method begins at RVA 0x228e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -157,7 +134,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2268
+			// Method begins at RVA 0x2240
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -201,7 +178,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22a4
+			// Method begins at RVA 0x227c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -385,7 +362,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22bf
+		// Method begins at RVA 0x2297
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_MissingDir_Rejects.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_MissingDir_Rejects.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2228
+				// Method begins at RVA 0x222d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -84,7 +84,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2231
+				// Method begins at RVA 0x2236
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -110,12 +110,13 @@
 			)
 			// Method begins at RVA 0x21c4
 			// Header size: 12
-			// Code size: 79 (0x4f)
+			// Code size: 84 (0x54)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] string,
-				[2] object
+				[2] object,
+				[3] bool
 			)
 
 			IL_0000: ldstr "console"
@@ -133,18 +134,19 @@
 			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0029: stloc.2
 			IL_002a: ldloc.2
-			IL_002b: ldstr "startsWith"
+			IL_002b: castclass [System.Runtime]System.String
 			IL_0030: ldstr "ENOENT:"
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003a: stloc.2
+			IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+			IL_003a: stloc.3
 			IL_003b: ldloc.0
 			IL_003c: ldstr "log"
 			IL_0041: ldstr "Is ENOENT:"
-			IL_0046: ldloc.2
-			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004c: pop
-			IL_004d: ldnull
-			IL_004e: ret
+			IL_0046: ldloc.3
+			IL_0047: box [System.Runtime]System.Boolean
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0051: pop
+			IL_0052: ldnull
+			IL_0053: ret
 		} // end of method ArrowFunction_L12C12::__js_call__
 
 	} // end of class ArrowFunction_L12C12
@@ -156,7 +158,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x221f
+			// Method begins at RVA 0x2224
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -314,7 +316,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x223a
+		// Method begins at RVA 0x223f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_Names.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_Names.verified.txt
@@ -28,7 +28,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x247b
+					// Method begins at RVA 0x245f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -52,7 +52,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x243c
+				// Method begins at RVA 0x2420
 				// Header size: 12
 				// Code size: 33 (0x21)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2472
+				// Method begins at RVA 0x2456
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -190,7 +190,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2484
+				// Method begins at RVA 0x2468
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -253,7 +253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x248d
+				// Method begins at RVA 0x2471
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -281,7 +281,7 @@
 			)
 			// Method begins at RVA 0x23d4
 			// Header size: 12
-			// Code size: 89 (0x59)
+			// Code size: 63 (0x3f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -290,37 +290,27 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-			IL_0006: stloc.0
-			IL_0007: ldstr "syncFs"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+			IL_0012: stloc.1
 			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldarg.0
-			IL_001b: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-			IL_0020: stloc.1
-			IL_0021: ldstr "dir"
-			IL_0026: ldloc.1
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_002c: stloc.1
-			IL_002d: ldloc.0
-			IL_002e: ldstr "rmSync"
-			IL_0033: ldloc.1
-			IL_0034: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0039: dup
-			IL_003a: ldstr "recursive"
-			IL_003f: ldc.i4.1
-			IL_0040: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0045: dup
-			IL_0046: ldstr "force"
-			IL_004b: ldc.i4.1
-			IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0056: pop
-			IL_0057: ldnull
-			IL_0058: ret
+			IL_0014: ldstr "rmSync"
+			IL_0019: ldloc.1
+			IL_001a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001f: dup
+			IL_0020: ldstr "recursive"
+			IL_0025: ldc.i4.1
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_002b: dup
+			IL_002c: ldstr "force"
+			IL_0031: ldc.i4.1
+			IL_0032: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_003c: pop
+			IL_003d: ldnull
+			IL_003e: ret
 		} // end of method ArrowFunction_L21C14::__js_call__
 
 	} // end of class ArrowFunction_L21C14
@@ -341,7 +331,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2469
+			// Method begins at RVA 0x244d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -626,7 +616,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2496
+		// Method begins at RVA 0x247a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_WithFileTypes.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_WithFileTypes.verified.txt
@@ -28,7 +28,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24d3
+					// Method begins at RVA 0x24b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -52,7 +52,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2434
+				// Method begins at RVA 0x2418
 				// Header size: 12
 				// Code size: 81 (0x51)
 				.maxstack 8
@@ -116,7 +116,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24dc
+					// Method begins at RVA 0x24c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -140,7 +140,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2494
+				// Method begins at RVA 0x2478
 				// Header size: 12
 				// Code size: 33 (0x21)
 				.maxstack 8
@@ -179,7 +179,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ca
+				// Method begins at RVA 0x24ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -293,7 +293,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24e5
+				// Method begins at RVA 0x24c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -356,7 +356,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ee
+				// Method begins at RVA 0x24d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -384,7 +384,7 @@
 			)
 			// Method begins at RVA 0x23cc
 			// Header size: 12
-			// Code size: 89 (0x59)
+			// Code size: 63 (0x3f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -393,37 +393,27 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-			IL_0006: stloc.0
-			IL_0007: ldstr "syncFs"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+			IL_0012: stloc.1
 			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldarg.0
-			IL_001b: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-			IL_0020: stloc.1
-			IL_0021: ldstr "dir"
-			IL_0026: ldloc.1
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_002c: stloc.1
-			IL_002d: ldloc.0
-			IL_002e: ldstr "rmSync"
-			IL_0033: ldloc.1
-			IL_0034: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0039: dup
-			IL_003a: ldstr "recursive"
-			IL_003f: ldc.i4.1
-			IL_0040: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0045: dup
-			IL_0046: ldstr "force"
-			IL_004b: ldc.i4.1
-			IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0056: pop
-			IL_0057: ldnull
-			IL_0058: ret
+			IL_0014: ldstr "rmSync"
+			IL_0019: ldloc.1
+			IL_001a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001f: dup
+			IL_0020: ldstr "recursive"
+			IL_0025: ldc.i4.1
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_002b: dup
+			IL_002c: ldstr "force"
+			IL_0031: ldc.i4.1
+			IL_0032: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_003c: pop
+			IL_003d: ldnull
+			IL_003e: ret
 		} // end of method ArrowFunction_L21C14::__js_call__
 
 	} // end of class ArrowFunction_L21C14
@@ -444,7 +434,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24c1
+			// Method begins at RVA 0x24a5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -713,7 +703,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24f7
+		// Method begins at RVA 0x24db
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Realpath.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Realpath.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2301
+				// Method begins at RVA 0x22d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,13 +54,11 @@
 			)
 			// Method begins at RVA 0x21dc
 			// Header size: 12
-			// Code size: 211 (0xd3)
+			// Code size: 171 (0xab)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate,
-				[3] object[]
+				[1] object
 			)
 
 			IL_0000: ldstr "console"
@@ -103,40 +101,20 @@
 			IL_007e: pop
 			IL_007f: ldarg.0
 			IL_0080: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Realpath/Scope::require
-			IL_0085: stloc.2
-			IL_0086: ldstr "require"
-			IL_008b: ldloc.2
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0091: stloc.1
-			IL_0092: ldc.i4.1
-			IL_0093: newarr [System.Runtime]System.Object
-			IL_0098: dup
-			IL_0099: ldc.i4.0
-			IL_009a: ldarg.0
-			IL_009b: stelem.ref
-			IL_009c: stloc.3
-			IL_009d: ldloc.1
-			IL_009e: ldloc.3
-			IL_009f: ldstr "fs"
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00a9: stloc.1
-			IL_00aa: ldloc.1
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b0: stloc.1
-			IL_00b1: ldarg.0
-			IL_00b2: ldfld object Modules.FSPromises_Realpath/Scope::testFile
-			IL_00b7: stloc.0
-			IL_00b8: ldstr "testFile"
-			IL_00bd: ldloc.0
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c3: stloc.0
-			IL_00c4: ldloc.1
-			IL_00c5: ldstr "rmSync"
-			IL_00ca: ldloc.0
-			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00d0: pop
-			IL_00d1: ldnull
-			IL_00d2: ret
+			IL_0085: ldstr "fs"
+			IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_008f: stloc.1
+			IL_0090: ldloc.1
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0096: stloc.1
+			IL_0097: ldloc.1
+			IL_0098: ldstr "rmSync"
+			IL_009d: ldarg.0
+			IL_009e: ldfld object Modules.FSPromises_Realpath/Scope::testFile
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00a8: pop
+			IL_00a9: ldnull
+			IL_00aa: ret
 		} // end of method ArrowFunction_L8C28::__js_call__
 
 	} // end of class ArrowFunction_L8C28
@@ -159,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230a
+				// Method begins at RVA 0x22e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -183,7 +161,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22bc
+			// Method begins at RVA 0x2294
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -227,7 +205,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22f8
+			// Method begins at RVA 0x22d0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -408,7 +386,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2313
+		// Method begins at RVA 0x22eb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Rename_ExistingDirectory_Rejects.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Rename_ExistingDirectory_Rejects.verified.txt
@@ -41,7 +41,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2982
+						// Method begins at RVA 0x2882
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -61,7 +61,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x298b
+						// Method begins at RVA 0x288b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -79,7 +79,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2979
+					// Method begins at RVA 0x2879
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -99,7 +99,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2994
+					// Method begins at RVA 0x2894
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -127,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2970
+				// Method begins at RVA 0x2870
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -153,7 +153,7 @@
 			)
 			// Method begins at RVA 0x20e4
 			// Header size: 12
-			// Code size: 2167 (0x877)
+			// Code size: 1911 (0x777)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope,
@@ -326,7 +326,7 @@
 
 			IL_011b: ldloc.0
 			IL_011c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0121: switch (IL_013a, IL_073b, IL_07ab, IL_057c, IL_0544)
+			IL_0121: switch (IL_013a, IL_064d, IL_06ab, IL_04c4, IL_048c)
 
 			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_013f: stloc.s 13
@@ -368,640 +368,554 @@
 			IL_01ab: ldelem.ref
 			IL_01ac: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
 			IL_01b1: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_01b6: stloc.s 13
-			IL_01b8: ldstr "path"
-			IL_01bd: ldloc.s 13
-			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01c4: stloc.s 13
-			IL_01c6: ldloc.s 13
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01cd: stloc.s 13
-			IL_01cf: ldarg.0
-			IL_01d0: ldc.i4.1
-			IL_01d1: ldelem.ref
-			IL_01d2: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_01d7: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
-			IL_01dc: stloc.s 18
-			IL_01de: ldstr "os"
-			IL_01e3: ldloc.s 18
-			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01ea: stloc.s 18
-			IL_01ec: ldloc.s 18
-			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f3: stloc.s 18
-			IL_01f5: ldloc.s 18
-			IL_01f7: ldstr "tmpdir"
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0201: stloc.s 18
-			IL_0203: ldloc.1
-			IL_0204: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0209: stloc.s 17
-			IL_020b: ldstr "jroc-fs-rename-existing-dir-"
-			IL_0210: ldloc.s 17
-			IL_0212: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0217: stloc.s 17
-			IL_0219: ldloc.s 13
-			IL_021b: ldstr "join"
-			IL_0220: ldloc.s 18
-			IL_0222: ldloc.s 17
-			IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0229: stloc.s 18
-			IL_022b: ldloc.s 18
-			IL_022d: stloc.2
-			IL_022e: ldarg.0
-			IL_022f: ldc.i4.1
-			IL_0230: ldelem.ref
-			IL_0231: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0236: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_023b: stloc.s 18
-			IL_023d: ldstr "path"
-			IL_0242: ldloc.s 18
-			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0249: stloc.s 18
-			IL_024b: ldloc.s 18
-			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0252: stloc.s 18
-			IL_0254: ldloc.s 18
-			IL_0256: ldstr "join"
-			IL_025b: ldloc.2
-			IL_025c: ldstr "source"
-			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0266: stloc.s 18
-			IL_0268: ldloc.s 18
-			IL_026a: stloc.3
-			IL_026b: ldarg.0
-			IL_026c: ldc.i4.1
-			IL_026d: ldelem.ref
-			IL_026e: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0273: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_0278: stloc.s 18
-			IL_027a: ldstr "path"
-			IL_027f: ldloc.s 18
-			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0286: stloc.s 18
-			IL_0288: ldloc.s 18
-			IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_028f: stloc.s 18
-			IL_0291: ldloc.s 18
-			IL_0293: ldstr "join"
-			IL_0298: ldloc.2
-			IL_0299: ldstr "destination"
-			IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02a3: stloc.s 18
-			IL_02a5: ldloc.s 18
-			IL_02a7: stloc.s 4
-			IL_02a9: ldarg.0
-			IL_02aa: ldc.i4.1
-			IL_02ab: ldelem.ref
-			IL_02ac: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_02b1: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_02b6: stloc.s 18
-			IL_02b8: ldstr "path"
-			IL_02bd: ldloc.s 18
-			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_02c4: stloc.s 18
-			IL_02c6: ldloc.s 18
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01bb: stloc.s 13
+			IL_01bd: ldarg.0
+			IL_01be: ldc.i4.1
+			IL_01bf: ldelem.ref
+			IL_01c0: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_01c5: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
+			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01cf: stloc.s 18
+			IL_01d1: ldloc.s 18
+			IL_01d3: ldstr "tmpdir"
+			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01dd: stloc.s 18
+			IL_01df: ldloc.1
+			IL_01e0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01e5: stloc.s 17
+			IL_01e7: ldstr "jroc-fs-rename-existing-dir-"
+			IL_01ec: ldloc.s 17
+			IL_01ee: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f3: stloc.s 17
+			IL_01f5: ldloc.s 13
+			IL_01f7: ldstr "join"
+			IL_01fc: ldloc.s 18
+			IL_01fe: ldloc.s 17
+			IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0205: stloc.s 18
+			IL_0207: ldloc.s 18
+			IL_0209: stloc.2
+			IL_020a: ldarg.0
+			IL_020b: ldc.i4.1
+			IL_020c: ldelem.ref
+			IL_020d: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0212: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021c: stloc.s 18
+			IL_021e: ldloc.s 18
+			IL_0220: ldstr "join"
+			IL_0225: ldloc.2
+			IL_0226: ldstr "source"
+			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0230: stloc.s 18
+			IL_0232: ldloc.s 18
+			IL_0234: stloc.3
+			IL_0235: ldarg.0
+			IL_0236: ldc.i4.1
+			IL_0237: ldelem.ref
+			IL_0238: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_023d: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0247: stloc.s 18
+			IL_0249: ldloc.s 18
+			IL_024b: ldstr "join"
+			IL_0250: ldloc.2
+			IL_0251: ldstr "destination"
+			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_025b: stloc.s 18
+			IL_025d: ldloc.s 18
+			IL_025f: stloc.s 4
+			IL_0261: ldarg.0
+			IL_0262: ldc.i4.1
+			IL_0263: ldelem.ref
+			IL_0264: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0269: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0273: stloc.s 18
+			IL_0275: ldloc.s 18
+			IL_0277: ldstr "join"
+			IL_027c: ldloc.s 4
+			IL_027e: ldstr "keep.txt"
+			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0288: stloc.s 18
+			IL_028a: ldloc.s 18
+			IL_028c: stloc.s 5
+			IL_028e: ldloc.0
+			IL_028f: ldc.i4.0
+			IL_0290: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0295: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_029a: ldloc.0
+			IL_029b: ldc.i4.0
+			IL_029c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02a1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_02a6: ldloc.0
+			IL_02a7: ldc.i4.0
+			IL_02a8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02ad: ldloc.0
+			IL_02ae: ldc.i4.0
+			IL_02af: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02b4: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8::.ctor()
+			IL_02b9: stloc.s 6
+			IL_02bb: ldarg.0
+			IL_02bc: ldc.i4.1
+			IL_02bd: ldelem.ref
+			IL_02be: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_02c3: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
 			IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_02cd: stloc.s 18
 			IL_02cf: ldloc.s 18
-			IL_02d1: ldstr "join"
-			IL_02d6: ldloc.s 4
-			IL_02d8: ldstr "keep.txt"
-			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02e2: stloc.s 18
-			IL_02e4: ldloc.s 18
-			IL_02e6: stloc.s 5
-			IL_02e8: ldloc.0
-			IL_02e9: ldc.i4.0
-			IL_02ea: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02ef: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_02f4: ldloc.0
-			IL_02f5: ldc.i4.0
-			IL_02f6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02fb: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0300: ldloc.0
-			IL_0301: ldc.i4.0
-			IL_0302: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0307: ldloc.0
-			IL_0308: ldc.i4.0
-			IL_0309: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_030e: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8::.ctor()
-			IL_0313: stloc.s 6
-			IL_0315: ldarg.0
-			IL_0316: ldc.i4.1
-			IL_0317: ldelem.ref
-			IL_0318: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_031d: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0322: stloc.s 18
-			IL_0324: ldstr "fs"
-			IL_0329: ldloc.s 18
-			IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0330: stloc.s 18
-			IL_0332: ldloc.s 18
-			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0339: stloc.s 18
-			IL_033b: ldloc.s 18
-			IL_033d: ldstr "rmSync"
-			IL_0342: ldloc.2
-			IL_0343: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0348: dup
-			IL_0349: ldstr "recursive"
-			IL_034e: ldc.i4.1
-			IL_034f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0354: dup
-			IL_0355: ldstr "force"
-			IL_035a: ldc.i4.1
-			IL_035b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0365: pop
-			IL_0366: ldarg.0
-			IL_0367: ldc.i4.1
-			IL_0368: ldelem.ref
-			IL_0369: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_036e: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_02d1: ldstr "rmSync"
+			IL_02d6: ldloc.2
+			IL_02d7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02dc: dup
+			IL_02dd: ldstr "recursive"
+			IL_02e2: ldc.i4.1
+			IL_02e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02e8: dup
+			IL_02e9: ldstr "force"
+			IL_02ee: ldc.i4.1
+			IL_02ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02f9: pop
+			IL_02fa: ldarg.0
+			IL_02fb: ldc.i4.1
+			IL_02fc: ldelem.ref
+			IL_02fd: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0302: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_030c: stloc.s 18
+			IL_030e: ldloc.s 18
+			IL_0310: ldstr "mkdirSync"
+			IL_0315: ldloc.3
+			IL_0316: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_031b: dup
+			IL_031c: ldstr "recursive"
+			IL_0321: ldc.i4.1
+			IL_0322: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_032c: pop
+			IL_032d: ldarg.0
+			IL_032e: ldc.i4.1
+			IL_032f: ldelem.ref
+			IL_0330: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0335: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_033f: stloc.s 18
+			IL_0341: ldloc.s 18
+			IL_0343: ldstr "mkdirSync"
+			IL_0348: ldloc.s 4
+			IL_034a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_034f: dup
+			IL_0350: ldstr "recursive"
+			IL_0355: ldc.i4.1
+			IL_0356: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0360: pop
+			IL_0361: ldarg.0
+			IL_0362: ldc.i4.1
+			IL_0363: ldelem.ref
+			IL_0364: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0369: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0373: stloc.s 18
-			IL_0375: ldstr "fs"
-			IL_037a: ldloc.s 18
-			IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0381: stloc.s 18
-			IL_0383: ldloc.s 18
-			IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_038a: stloc.s 18
-			IL_038c: ldloc.s 18
-			IL_038e: ldstr "mkdirSync"
-			IL_0393: ldloc.3
-			IL_0394: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0399: dup
-			IL_039a: ldstr "recursive"
-			IL_039f: ldc.i4.1
-			IL_03a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_03aa: pop
-			IL_03ab: ldarg.0
-			IL_03ac: ldc.i4.1
-			IL_03ad: ldelem.ref
-			IL_03ae: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_03b3: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_03b8: stloc.s 18
-			IL_03ba: ldstr "fs"
+			IL_0375: ldloc.s 18
+			IL_0377: ldstr "writeFileSync"
+			IL_037c: ldloc.s 5
+			IL_037e: ldstr "keep"
+			IL_0383: ldstr "utf8"
+			IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_038d: pop
+			IL_038e: ldloc.0
+			IL_038f: ldc.i4.0
+			IL_0390: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0395: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_039a: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8/Block_L20C12::.ctor()
+			IL_039f: stloc.s 7
+			IL_03a1: ldarg.0
+			IL_03a2: ldc.i4.1
+			IL_03a3: ldelem.ref
+			IL_03a4: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_03a9: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_03ae: ldstr "promises"
+			IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03bd: stloc.s 18
 			IL_03bf: ldloc.s 18
-			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03c6: stloc.s 18
-			IL_03c8: ldloc.s 18
-			IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03cf: stloc.s 18
-			IL_03d1: ldloc.s 18
-			IL_03d3: ldstr "mkdirSync"
-			IL_03d8: ldloc.s 4
-			IL_03da: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03df: dup
-			IL_03e0: ldstr "recursive"
-			IL_03e5: ldc.i4.1
-			IL_03e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_03f0: pop
-			IL_03f1: ldarg.0
-			IL_03f2: ldc.i4.1
-			IL_03f3: ldelem.ref
-			IL_03f4: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_03f9: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_03fe: stloc.s 18
-			IL_0400: ldstr "fs"
-			IL_0405: ldloc.s 18
-			IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_040c: stloc.s 18
-			IL_040e: ldloc.s 18
-			IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0415: stloc.s 18
-			IL_0417: ldloc.s 18
-			IL_0419: ldstr "writeFileSync"
-			IL_041e: ldloc.s 5
-			IL_0420: ldstr "keep"
-			IL_0425: ldstr "utf8"
-			IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_042f: pop
-			IL_0430: ldloc.0
-			IL_0431: ldc.i4.0
-			IL_0432: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0437: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_043c: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8/Block_L20C12::.ctor()
-			IL_0441: stloc.s 7
-			IL_0443: ldarg.0
-			IL_0444: ldc.i4.1
-			IL_0445: ldelem.ref
-			IL_0446: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_044b: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0450: stloc.s 18
-			IL_0452: ldstr "fs"
-			IL_0457: ldloc.s 18
-			IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_045e: stloc.s 18
-			IL_0460: ldloc.s 18
-			IL_0462: ldstr "promises"
-			IL_0467: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_046c: stloc.s 18
-			IL_046e: ldloc.s 18
-			IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0475: stloc.s 18
-			IL_0477: ldloc.s 18
-			IL_0479: ldstr "rename"
-			IL_047e: ldloc.3
-			IL_047f: ldloc.s 4
-			IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0486: stloc.s 18
-			IL_0488: ldloc.0
-			IL_0489: ldc.i4.4
-			IL_048a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_048f: ldloc.0
-			IL_0490: ldloc.s 18
-			IL_0492: ldarg.0
-			IL_0493: ldc.i4.1
-			IL_0494: ldloc.0
-			IL_0495: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_049a: ldc.i4.3
-			IL_049b: ldstr "_pendingException"
-			IL_04a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_04a5: ldloc.0
-			IL_04a6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_04ab: dup
-			IL_04ac: ldc.i4.0
-			IL_04ad: ldloc.1
-			IL_04ae: stelem.ref
-			IL_04af: dup
-			IL_04b0: ldc.i4.1
-			IL_04b1: ldloc.2
-			IL_04b2: stelem.ref
-			IL_04b3: dup
-			IL_04b4: ldc.i4.2
-			IL_04b5: ldloc.3
-			IL_04b6: stelem.ref
-			IL_04b7: dup
-			IL_04b8: ldc.i4.3
-			IL_04b9: ldloc.s 4
-			IL_04bb: stelem.ref
-			IL_04bc: dup
-			IL_04bd: ldc.i4.4
-			IL_04be: ldloc.s 5
-			IL_04c0: stelem.ref
-			IL_04c1: dup
-			IL_04c2: ldc.i4.5
-			IL_04c3: ldloc.s 6
-			IL_04c5: stelem.ref
-			IL_04c6: dup
-			IL_04c7: ldc.i4.6
-			IL_04c8: ldloc.s 7
-			IL_04ca: stelem.ref
-			IL_04cb: dup
-			IL_04cc: ldc.i4.7
-			IL_04cd: ldloc.s 8
-			IL_04cf: stelem.ref
-			IL_04d0: dup
-			IL_04d1: ldc.i4.8
-			IL_04d2: ldloc.s 9
-			IL_04d4: stelem.ref
-			IL_04d5: dup
-			IL_04d6: ldc.i4.s 9
-			IL_04d8: ldloc.s 10
-			IL_04da: stelem.ref
-			IL_04db: dup
-			IL_04dc: ldc.i4.s 10
-			IL_04de: ldloc.s 11
-			IL_04e0: box [System.Runtime]System.Boolean
-			IL_04e5: stelem.ref
-			IL_04e6: dup
-			IL_04e7: ldc.i4.s 11
-			IL_04e9: ldloc.s 12
-			IL_04eb: box [System.Runtime]System.Boolean
-			IL_04f0: stelem.ref
-			IL_04f1: dup
-			IL_04f2: ldc.i4.s 12
-			IL_04f4: ldloc.s 13
-			IL_04f6: stelem.ref
-			IL_04f7: dup
-			IL_04f8: ldc.i4.s 13
-			IL_04fa: ldloc.s 14
-			IL_04fc: stelem.ref
-			IL_04fd: dup
-			IL_04fe: ldc.i4.s 14
-			IL_0500: ldloc.s 15
-			IL_0502: box [System.Runtime]System.Double
-			IL_0507: stelem.ref
-			IL_0508: dup
-			IL_0509: ldc.i4.s 15
-			IL_050b: ldloc.s 16
-			IL_050d: stelem.ref
-			IL_050e: dup
-			IL_050f: ldc.i4.s 16
-			IL_0511: ldloc.s 17
-			IL_0513: stelem.ref
-			IL_0514: dup
-			IL_0515: ldc.i4.s 17
-			IL_0517: ldloc.s 18
-			IL_0519: stelem.ref
-			IL_051a: dup
-			IL_051b: ldc.i4.s 18
-			IL_051d: ldloc.s 19
-			IL_051f: stelem.ref
-			IL_0520: dup
-			IL_0521: ldc.i4.s 19
-			IL_0523: ldloc.s 20
-			IL_0525: box [System.Runtime]System.Boolean
-			IL_052a: stelem.ref
-			IL_052b: dup
-			IL_052c: ldc.i4.s 20
-			IL_052e: ldloc.s 21
-			IL_0530: stelem.ref
-			IL_0531: dup
-			IL_0532: ldc.i4.s 21
-			IL_0534: ldloc.s 22
-			IL_0536: stelem.ref
-			IL_0537: pop
-			IL_0538: ldloc.0
-			IL_0539: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_053e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0543: ret
+			IL_03c1: ldstr "rename"
+			IL_03c6: ldloc.3
+			IL_03c7: ldloc.s 4
+			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_03ce: stloc.s 18
+			IL_03d0: ldloc.0
+			IL_03d1: ldc.i4.4
+			IL_03d2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03d7: ldloc.0
+			IL_03d8: ldloc.s 18
+			IL_03da: ldarg.0
+			IL_03db: ldc.i4.1
+			IL_03dc: ldloc.0
+			IL_03dd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03e2: ldc.i4.3
+			IL_03e3: ldstr "_pendingException"
+			IL_03e8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_03ed: ldloc.0
+			IL_03ee: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03f3: dup
+			IL_03f4: ldc.i4.0
+			IL_03f5: ldloc.1
+			IL_03f6: stelem.ref
+			IL_03f7: dup
+			IL_03f8: ldc.i4.1
+			IL_03f9: ldloc.2
+			IL_03fa: stelem.ref
+			IL_03fb: dup
+			IL_03fc: ldc.i4.2
+			IL_03fd: ldloc.3
+			IL_03fe: stelem.ref
+			IL_03ff: dup
+			IL_0400: ldc.i4.3
+			IL_0401: ldloc.s 4
+			IL_0403: stelem.ref
+			IL_0404: dup
+			IL_0405: ldc.i4.4
+			IL_0406: ldloc.s 5
+			IL_0408: stelem.ref
+			IL_0409: dup
+			IL_040a: ldc.i4.5
+			IL_040b: ldloc.s 6
+			IL_040d: stelem.ref
+			IL_040e: dup
+			IL_040f: ldc.i4.6
+			IL_0410: ldloc.s 7
+			IL_0412: stelem.ref
+			IL_0413: dup
+			IL_0414: ldc.i4.7
+			IL_0415: ldloc.s 8
+			IL_0417: stelem.ref
+			IL_0418: dup
+			IL_0419: ldc.i4.8
+			IL_041a: ldloc.s 9
+			IL_041c: stelem.ref
+			IL_041d: dup
+			IL_041e: ldc.i4.s 9
+			IL_0420: ldloc.s 10
+			IL_0422: stelem.ref
+			IL_0423: dup
+			IL_0424: ldc.i4.s 10
+			IL_0426: ldloc.s 11
+			IL_0428: box [System.Runtime]System.Boolean
+			IL_042d: stelem.ref
+			IL_042e: dup
+			IL_042f: ldc.i4.s 11
+			IL_0431: ldloc.s 12
+			IL_0433: box [System.Runtime]System.Boolean
+			IL_0438: stelem.ref
+			IL_0439: dup
+			IL_043a: ldc.i4.s 12
+			IL_043c: ldloc.s 13
+			IL_043e: stelem.ref
+			IL_043f: dup
+			IL_0440: ldc.i4.s 13
+			IL_0442: ldloc.s 14
+			IL_0444: stelem.ref
+			IL_0445: dup
+			IL_0446: ldc.i4.s 14
+			IL_0448: ldloc.s 15
+			IL_044a: box [System.Runtime]System.Double
+			IL_044f: stelem.ref
+			IL_0450: dup
+			IL_0451: ldc.i4.s 15
+			IL_0453: ldloc.s 16
+			IL_0455: stelem.ref
+			IL_0456: dup
+			IL_0457: ldc.i4.s 16
+			IL_0459: ldloc.s 17
+			IL_045b: stelem.ref
+			IL_045c: dup
+			IL_045d: ldc.i4.s 17
+			IL_045f: ldloc.s 18
+			IL_0461: stelem.ref
+			IL_0462: dup
+			IL_0463: ldc.i4.s 18
+			IL_0465: ldloc.s 19
+			IL_0467: stelem.ref
+			IL_0468: dup
+			IL_0469: ldc.i4.s 19
+			IL_046b: ldloc.s 20
+			IL_046d: box [System.Runtime]System.Boolean
+			IL_0472: stelem.ref
+			IL_0473: dup
+			IL_0474: ldc.i4.s 20
+			IL_0476: ldloc.s 21
+			IL_0478: stelem.ref
+			IL_0479: dup
+			IL_047a: ldc.i4.s 21
+			IL_047c: ldloc.s 22
+			IL_047e: stelem.ref
+			IL_047f: pop
+			IL_0480: ldloc.0
+			IL_0481: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0486: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_048b: ret
 
-			IL_0544: ldloc.0
-			IL_0545: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope::_awaited1
-			IL_054a: pop
-			IL_054b: ldstr "console"
-			IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0555: stloc.s 18
-			IL_0557: ldloc.s 18
-			IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_055e: stloc.s 18
-			IL_0560: ldloc.s 18
-			IL_0562: ldstr "log"
-			IL_0567: ldstr "RenameResult:"
-			IL_056c: ldstr "success"
-			IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0576: pop
-			IL_0577: br IL_061a
+			IL_048c: ldloc.0
+			IL_048d: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope::_awaited1
+			IL_0492: pop
+			IL_0493: ldstr "console"
+			IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_049d: stloc.s 18
+			IL_049f: ldloc.s 18
+			IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04a6: stloc.s 18
+			IL_04a8: ldloc.s 18
+			IL_04aa: ldstr "log"
+			IL_04af: ldstr "RenameResult:"
+			IL_04b4: ldstr "success"
+			IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04be: pop
+			IL_04bf: br IL_0562
 
-			IL_057c: ldloc.0
-			IL_057d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0582: stloc.s 18
-			IL_0584: ldloc.0
-			IL_0585: ldc.i4.0
-			IL_0586: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_058b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0590: ldloc.s 18
-			IL_0592: stloc.s 8
-			IL_0594: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8/Block_L23C22::.ctor()
-			IL_0599: stloc.s 9
-			IL_059b: ldstr "console"
-			IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05a5: stloc.s 18
-			IL_05a7: ldloc.s 18
-			IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05ae: stloc.s 18
-			IL_05b0: ldstr "^EPERM: "
-			IL_05b5: ldstr ""
-			IL_05ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_05bf: stloc.s 19
-			IL_05c1: ldloc.s 19
-			IL_05c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05c8: stloc.s 13
-			IL_05ca: ldloc.s 8
-			IL_05cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05d1: stloc.s 20
-			IL_05d3: ldloc.s 20
-			IL_05d5: brfalse IL_05ed
+			IL_04c4: ldloc.0
+			IL_04c5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_04ca: stloc.s 18
+			IL_04cc: ldloc.0
+			IL_04cd: ldc.i4.0
+			IL_04ce: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04d3: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_04d8: ldloc.s 18
+			IL_04da: stloc.s 8
+			IL_04dc: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8/Block_L23C22::.ctor()
+			IL_04e1: stloc.s 9
+			IL_04e3: ldstr "console"
+			IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04ed: stloc.s 18
+			IL_04ef: ldloc.s 18
+			IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04f6: stloc.s 18
+			IL_04f8: ldstr "^EPERM: "
+			IL_04fd: ldstr ""
+			IL_0502: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0507: stloc.s 19
+			IL_0509: ldloc.s 19
+			IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0510: stloc.s 13
+			IL_0512: ldloc.s 8
+			IL_0514: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0519: stloc.s 20
+			IL_051b: ldloc.s 20
+			IL_051d: brfalse IL_0535
 
-			IL_05da: ldloc.s 8
-			IL_05dc: ldstr "message"
-			IL_05e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05e6: stloc.s 22
-			IL_05e8: br IL_05f1
+			IL_0522: ldloc.s 8
+			IL_0524: ldstr "message"
+			IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_052e: stloc.s 22
+			IL_0530: br IL_0539
 
-			IL_05ed: ldloc.s 8
-			IL_05ef: stloc.s 22
+			IL_0535: ldloc.s 8
+			IL_0537: stloc.s 22
 
-			IL_05f1: ldloc.s 13
-			IL_05f3: ldstr "test"
-			IL_05f8: ldloc.s 22
-			IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05ff: stloc.s 13
-			IL_0601: ldloc.s 18
-			IL_0603: ldstr "log"
-			IL_0608: ldstr "RenameStartsWithEPERM:"
-			IL_060d: ldloc.s 13
-			IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0614: pop
-			IL_0615: br IL_061a
+			IL_0539: ldloc.s 13
+			IL_053b: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			IL_0540: ldloc.s 22
+			IL_0542: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0547: stloc.s 13
+			IL_0549: ldloc.s 18
+			IL_054b: ldstr "log"
+			IL_0550: ldstr "RenameStartsWithEPERM:"
+			IL_0555: ldloc.s 13
+			IL_0557: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_055c: pop
+			IL_055d: br IL_0562
 
-			IL_061a: ldstr "console"
-			IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0624: stloc.s 13
-			IL_0626: ldloc.s 13
-			IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_062d: stloc.s 13
-			IL_062f: ldarg.0
-			IL_0630: ldc.i4.1
-			IL_0631: ldelem.ref
-			IL_0632: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0637: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_063c: stloc.s 18
-			IL_063e: ldstr "fs"
-			IL_0643: ldloc.s 18
-			IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_064a: stloc.s 18
-			IL_064c: ldloc.s 18
-			IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0653: stloc.s 18
-			IL_0655: ldloc.s 18
-			IL_0657: ldstr "existsSync"
-			IL_065c: ldloc.3
-			IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0662: stloc.s 18
-			IL_0664: ldloc.s 13
-			IL_0666: ldstr "log"
-			IL_066b: ldstr "SourceExists:"
-			IL_0670: ldloc.s 18
-			IL_0672: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0677: pop
-			IL_0678: ldstr "console"
-			IL_067d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0682: stloc.s 18
-			IL_0684: ldloc.s 18
-			IL_0686: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_068b: stloc.s 18
-			IL_068d: ldarg.0
+			IL_0562: ldstr "console"
+			IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_056c: stloc.s 13
+			IL_056e: ldloc.s 13
+			IL_0570: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0575: stloc.s 13
+			IL_0577: ldarg.0
+			IL_0578: ldc.i4.1
+			IL_0579: ldelem.ref
+			IL_057a: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_057f: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0589: stloc.s 18
+			IL_058b: ldloc.s 18
+			IL_058d: ldstr "existsSync"
+			IL_0592: ldloc.3
+			IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0598: stloc.s 18
+			IL_059a: ldloc.s 13
+			IL_059c: ldstr "log"
+			IL_05a1: ldstr "SourceExists:"
+			IL_05a6: ldloc.s 18
+			IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_05ad: pop
+			IL_05ae: ldstr "console"
+			IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05b8: stloc.s 18
+			IL_05ba: ldloc.s 18
+			IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05c1: stloc.s 18
+			IL_05c3: ldarg.0
+			IL_05c4: ldc.i4.1
+			IL_05c5: ldelem.ref
+			IL_05c6: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_05cb: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_05d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05d5: stloc.s 13
+			IL_05d7: ldloc.s 13
+			IL_05d9: ldstr "existsSync"
+			IL_05de: ldloc.s 4
+			IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05e5: stloc.s 13
+			IL_05e7: ldloc.s 18
+			IL_05e9: ldstr "log"
+			IL_05ee: ldstr "DestinationExists:"
+			IL_05f3: ldloc.s 13
+			IL_05f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_05fa: pop
+			IL_05fb: ldstr "console"
+			IL_0600: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0605: stloc.s 13
+			IL_0607: ldloc.s 13
+			IL_0609: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_060e: stloc.s 13
+			IL_0610: ldarg.0
+			IL_0611: ldc.i4.1
+			IL_0612: ldelem.ref
+			IL_0613: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0618: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0622: stloc.s 18
+			IL_0624: ldloc.s 18
+			IL_0626: ldstr "existsSync"
+			IL_062b: ldloc.s 5
+			IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0632: stloc.s 18
+			IL_0634: ldloc.s 13
+			IL_0636: ldstr "log"
+			IL_063b: ldstr "SentinelExists:"
+			IL_0640: ldloc.s 18
+			IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0647: pop
+			IL_0648: br IL_0660
+
+			IL_064d: ldloc.0
+			IL_064e: ldc.i4.1
+			IL_064f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0654: ldloc.0
+			IL_0655: ldc.i4.0
+			IL_0656: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_065b: br IL_0660
+
+			IL_0660: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L30C14::.ctor()
+			IL_0665: stloc.s 10
+			IL_0667: ldarg.0
+			IL_0668: ldc.i4.1
+			IL_0669: ldelem.ref
+			IL_066a: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_066f: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0679: stloc.s 18
+			IL_067b: ldloc.s 18
+			IL_067d: ldstr "rmSync"
+			IL_0682: ldloc.2
+			IL_0683: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0688: dup
+			IL_0689: ldstr "recursive"
 			IL_068e: ldc.i4.1
-			IL_068f: ldelem.ref
-			IL_0690: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0695: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_069a: stloc.s 13
-			IL_069c: ldstr "fs"
-			IL_06a1: ldloc.s 13
-			IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_06a8: stloc.s 13
-			IL_06aa: ldloc.s 13
-			IL_06ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06b1: stloc.s 13
-			IL_06b3: ldloc.s 13
-			IL_06b5: ldstr "existsSync"
-			IL_06ba: ldloc.s 4
-			IL_06bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_06c1: stloc.s 13
-			IL_06c3: ldloc.s 18
-			IL_06c5: ldstr "log"
-			IL_06ca: ldstr "DestinationExists:"
-			IL_06cf: ldloc.s 13
-			IL_06d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_06d6: pop
-			IL_06d7: ldstr "console"
-			IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06e1: stloc.s 13
-			IL_06e3: ldloc.s 13
-			IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06ea: stloc.s 13
-			IL_06ec: ldarg.0
-			IL_06ed: ldc.i4.1
-			IL_06ee: ldelem.ref
-			IL_06ef: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_06f4: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_06f9: stloc.s 18
-			IL_06fb: ldstr "fs"
-			IL_0700: ldloc.s 18
-			IL_0702: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0707: stloc.s 18
-			IL_0709: ldloc.s 18
-			IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0710: stloc.s 18
-			IL_0712: ldloc.s 18
-			IL_0714: ldstr "existsSync"
-			IL_0719: ldloc.s 5
-			IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0720: stloc.s 18
-			IL_0722: ldloc.s 13
-			IL_0724: ldstr "log"
-			IL_0729: ldstr "SentinelExists:"
-			IL_072e: ldloc.s 18
-			IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0735: pop
-			IL_0736: br IL_074e
+			IL_068f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0694: dup
+			IL_0695: ldstr "force"
+			IL_069a: ldc.i4.1
+			IL_069b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_06a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_06a5: pop
+			IL_06a6: br IL_06be
 
-			IL_073b: ldloc.0
-			IL_073c: ldc.i4.1
-			IL_073d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0742: ldloc.0
-			IL_0743: ldc.i4.0
-			IL_0744: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0749: br IL_074e
+			IL_06ab: ldloc.0
+			IL_06ac: ldc.i4.1
+			IL_06ad: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_06b2: ldloc.0
+			IL_06b3: ldc.i4.0
+			IL_06b4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_06b9: br IL_06be
 
-			IL_074e: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L30C14::.ctor()
-			IL_0753: stloc.s 10
-			IL_0755: ldarg.0
-			IL_0756: ldc.i4.1
-			IL_0757: ldelem.ref
-			IL_0758: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_075d: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0762: stloc.s 18
-			IL_0764: ldstr "fs"
-			IL_0769: ldloc.s 18
-			IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0770: stloc.s 18
-			IL_0772: ldloc.s 18
-			IL_0774: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0779: stloc.s 18
-			IL_077b: ldloc.s 18
-			IL_077d: ldstr "rmSync"
-			IL_0782: ldloc.2
-			IL_0783: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0788: dup
-			IL_0789: ldstr "recursive"
-			IL_078e: ldc.i4.1
-			IL_078f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0794: dup
-			IL_0795: ldstr "force"
-			IL_079a: ldc.i4.1
-			IL_079b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_07a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_07a5: pop
-			IL_07a6: br IL_07be
+			IL_06be: ldloc.0
+			IL_06bf: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_06c4: stloc.s 11
+			IL_06c6: ldloc.s 11
+			IL_06c8: brfalse IL_0705
 
-			IL_07ab: ldloc.0
-			IL_07ac: ldc.i4.1
-			IL_07ad: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_07b2: ldloc.0
-			IL_07b3: ldc.i4.0
-			IL_07b4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_07b9: br IL_07be
+			IL_06cd: ldloc.0
+			IL_06ce: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_06d3: stloc.s 18
+			IL_06d5: ldloc.0
+			IL_06d6: ldc.i4.m1
+			IL_06d7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06dc: ldloc.0
+			IL_06dd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_06e7: ldarg.0
+			IL_06e8: ldc.i4.1
+			IL_06e9: newarr [System.Runtime]System.Object
+			IL_06ee: dup
+			IL_06ef: ldc.i4.0
+			IL_06f0: ldloc.s 18
+			IL_06f2: stelem.ref
+			IL_06f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06f8: pop
+			IL_06f9: ldloc.0
+			IL_06fa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06ff: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0704: ret
 
-			IL_07be: ldloc.0
-			IL_07bf: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_07c4: stloc.s 11
-			IL_07c6: ldloc.s 11
-			IL_07c8: brfalse IL_0805
+			IL_0705: ldloc.0
+			IL_0706: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_070b: stloc.s 12
+			IL_070d: ldloc.s 12
+			IL_070f: brfalse IL_074c
 
-			IL_07cd: ldloc.0
-			IL_07ce: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07d3: stloc.s 18
-			IL_07d5: ldloc.0
-			IL_07d6: ldc.i4.m1
-			IL_07d7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07dc: ldloc.0
-			IL_07dd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_07e7: ldarg.0
-			IL_07e8: ldc.i4.1
-			IL_07e9: newarr [System.Runtime]System.Object
-			IL_07ee: dup
-			IL_07ef: ldc.i4.0
-			IL_07f0: ldloc.s 18
-			IL_07f2: stelem.ref
-			IL_07f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_07f8: pop
-			IL_07f9: ldloc.0
-			IL_07fa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07ff: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0804: ret
+			IL_0714: ldloc.0
+			IL_0715: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_071a: stloc.s 18
+			IL_071c: ldloc.0
+			IL_071d: ldc.i4.m1
+			IL_071e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0723: ldloc.0
+			IL_0724: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0729: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_072e: ldarg.0
+			IL_072f: ldc.i4.1
+			IL_0730: newarr [System.Runtime]System.Object
+			IL_0735: dup
+			IL_0736: ldc.i4.0
+			IL_0737: ldloc.s 18
+			IL_0739: stelem.ref
+			IL_073a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_073f: pop
+			IL_0740: ldloc.0
+			IL_0741: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0746: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_074b: ret
 
-			IL_0805: ldloc.0
-			IL_0806: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_080b: stloc.s 12
-			IL_080d: ldloc.s 12
-			IL_080f: brfalse IL_084c
-
-			IL_0814: ldloc.0
-			IL_0815: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_081a: stloc.s 18
-			IL_081c: ldloc.0
-			IL_081d: ldc.i4.m1
-			IL_081e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0823: ldloc.0
-			IL_0824: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0829: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_082e: ldarg.0
-			IL_082f: ldc.i4.1
-			IL_0830: newarr [System.Runtime]System.Object
-			IL_0835: dup
-			IL_0836: ldc.i4.0
-			IL_0837: ldloc.s 18
-			IL_0839: stelem.ref
-			IL_083a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_083f: pop
-			IL_0840: ldloc.0
-			IL_0841: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0846: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_084b: ret
-
-			IL_084c: ldloc.0
-			IL_084d: ldc.i4.m1
-			IL_084e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0853: ldloc.0
-			IL_0854: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0859: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_085e: ldarg.0
-			IL_085f: ldc.i4.1
-			IL_0860: newarr [System.Runtime]System.Object
-			IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_086a: pop
-			IL_086b: ldloc.0
-			IL_086c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0871: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0876: ret
+			IL_074c: ldloc.0
+			IL_074d: ldc.i4.m1
+			IL_074e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0753: ldloc.0
+			IL_0754: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0759: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_075e: ldarg.0
+			IL_075f: ldc.i4.1
+			IL_0760: newarr [System.Runtime]System.Object
+			IL_0765: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_076a: pop
+			IL_076b: ldloc.0
+			IL_076c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0771: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0776: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1023,7 +937,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2967
+			// Method begins at RVA 0x2867
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1119,7 +1033,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x299d
+		// Method begins at RVA 0x289d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_FileSize.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_FileSize.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c1
+				// Method begins at RVA 0x2299
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,13 +54,10 @@
 			)
 			// Method begins at RVA 0x21ec
 			// Header size: 12
-			// Code size: 130 (0x82)
+			// Code size: 90 (0x5a)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate,
-				[2] object[],
-				[3] object
+				[0] object
 			)
 
 			IL_0000: ldstr "console"
@@ -79,40 +76,20 @@
 			IL_002d: pop
 			IL_002e: ldarg.0
 			IL_002f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_Stat_FileSize/Scope::require
-			IL_0034: stloc.1
-			IL_0035: ldstr "require"
-			IL_003a: ldloc.1
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0040: stloc.0
-			IL_0041: ldc.i4.1
-			IL_0042: newarr [System.Runtime]System.Object
-			IL_0047: dup
-			IL_0048: ldc.i4.0
-			IL_0049: ldarg.0
-			IL_004a: stelem.ref
-			IL_004b: stloc.2
-			IL_004c: ldloc.0
-			IL_004d: ldloc.2
-			IL_004e: ldstr "fs"
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0058: stloc.0
-			IL_0059: ldloc.0
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005f: stloc.0
-			IL_0060: ldarg.0
-			IL_0061: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
-			IL_0066: stloc.3
-			IL_0067: ldstr "testFile"
-			IL_006c: ldloc.3
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0072: stloc.3
-			IL_0073: ldloc.0
-			IL_0074: ldstr "rmSync"
-			IL_0079: ldloc.3
-			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_007f: pop
-			IL_0080: ldnull
-			IL_0081: ret
+			IL_0034: ldstr "fs"
+			IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_003e: stloc.0
+			IL_003f: ldloc.0
+			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0045: stloc.0
+			IL_0046: ldloc.0
+			IL_0047: ldstr "rmSync"
+			IL_004c: ldarg.0
+			IL_004d: ldfld object Modules.FSPromises_Stat_FileSize/Scope::testFile
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0057: pop
+			IL_0058: ldnull
+			IL_0059: ret
 		} // end of method ArrowFunction_L9C24::__js_call__
 
 	} // end of class ArrowFunction_L9C24
@@ -135,7 +112,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ca
+				// Method begins at RVA 0x22a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -159,7 +136,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x227c
+			// Method begins at RVA 0x2254
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -203,7 +180,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22b8
+			// Method begins at RVA 0x2290
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -387,7 +364,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22d3
+		// Method begins at RVA 0x22ab
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_RichMetadata.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_RichMetadata.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x298b
+				// Method begins at RVA 0x28a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,11 +54,10 @@
 			)
 			// Method begins at RVA 0x23e0
 			// Header size: 12
-			// Code size: 67 (0x43)
+			// Code size: 39 (0x27)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
@@ -66,28 +65,16 @@
 			IL_0002: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
 			IL_0007: ldarg.0
 			IL_0008: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fs
-			IL_000d: stloc.0
-			IL_000e: ldstr "fs"
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0012: stloc.0
 			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0020: stloc.0
-			IL_0021: ldarg.0
-			IL_0022: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-			IL_0027: stloc.1
-			IL_0028: ldstr "dir"
-			IL_002d: ldloc.1
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0033: stloc.1
-			IL_0034: ldloc.0
-			IL_0035: ldstr "stat"
-			IL_003a: ldloc.1
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0040: stloc.1
-			IL_0041: ldloc.1
-			IL_0042: ret
+			IL_0014: ldstr "stat"
+			IL_0019: ldarg.0
+			IL_001a: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0024: stloc.0
+			IL_0025: ldloc.0
+			IL_0026: ret
 		} // end of method ArrowFunction_L18C20::__js_call__
 
 	} // end of class ArrowFunction_L18C20
@@ -110,7 +97,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2994
+				// Method begins at RVA 0x28aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -137,20 +124,19 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2430
+			// Method begins at RVA 0x2414
 			// Header size: 12
-			// Code size: 1094 (0x446)
+			// Code size: 946 (0x3b2)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] float64,
-				[3] bool,
+				[1] float64,
+				[2] bool,
+				[3] object,
 				[4] object,
 				[5] object,
 				[6] object,
-				[7] object,
-				[8] object
+				[7] object
 			)
 
 			IL_0000: ldstr "console"
@@ -159,382 +145,302 @@
 			IL_000b: ldloc.0
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
-			IL_0012: ldarg.0
-			IL_0013: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
-			IL_0018: stloc.1
-			IL_0019: ldstr "fileStats"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: ldloc.1
-			IL_0026: ldstr "size"
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0030: stloc.1
-			IL_0031: ldloc.0
-			IL_0032: ldstr "log"
-			IL_0037: ldstr "FileSize:"
-			IL_003c: ldloc.1
-			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0042: pop
-			IL_0043: ldstr "console"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_004d: stloc.1
-			IL_004e: ldloc.1
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0054: stloc.1
-			IL_0055: ldarg.0
-			IL_0056: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
-			IL_005b: stloc.0
-			IL_005c: ldstr "fileStats"
-			IL_0061: ldloc.0
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0067: stloc.0
-			IL_0068: ldloc.0
-			IL_0069: ldstr "mode"
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0073: stloc.0
-			IL_0074: ldloc.0
-			IL_0075: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_007a: stloc.2
-			IL_007b: ldloc.2
-			IL_007c: conv.i4
-			IL_007d: ldc.r8 32768
-			IL_0086: conv.i4
-			IL_0087: and
-			IL_0088: conv.r8
-			IL_0089: stloc.2
-			IL_008a: ldloc.2
-			IL_008b: ldc.r8 32768
-			IL_0094: ceq
-			IL_0096: stloc.3
-			IL_0097: ldloc.3
-			IL_0098: box [System.Runtime]System.Boolean
-			IL_009d: stloc.s 4
-			IL_009f: ldloc.1
-			IL_00a0: ldstr "log"
-			IL_00a5: ldstr "FileModeHasRegularBit:"
-			IL_00aa: ldloc.s 4
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00b1: pop
-			IL_00b2: ldstr "console"
-			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00bc: stloc.1
-			IL_00bd: ldloc.1
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c3: stloc.1
-			IL_00c4: ldarg.0
-			IL_00c5: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
-			IL_00ca: stloc.0
-			IL_00cb: ldstr "fileStats"
-			IL_00d0: ldloc.0
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00d6: stloc.0
-			IL_00d7: ldloc.0
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00dd: stloc.0
-			IL_00de: ldloc.0
-			IL_00df: ldstr "isFile"
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00e9: stloc.0
-			IL_00ea: ldloc.1
-			IL_00eb: ldstr "log"
-			IL_00f0: ldstr "FileIsFile:"
-			IL_00f5: ldloc.0
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00fb: pop
-			IL_00fc: ldstr "console"
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0106: stloc.0
-			IL_0107: ldloc.0
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010d: stloc.0
-			IL_010e: ldarg.0
-			IL_010f: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
-			IL_0114: stloc.1
-			IL_0115: ldstr "fileStats"
-			IL_011a: ldloc.1
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0120: stloc.1
-			IL_0121: ldloc.1
-			IL_0122: ldstr "birthtimeMs"
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_012c: stloc.1
-			IL_012d: ldloc.1
-			IL_012e: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_0133: ldstr "number"
-			IL_0138: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_013d: stloc.3
-			IL_013e: ldloc.3
-			IL_013f: box [System.Runtime]System.Boolean
-			IL_0144: stloc.s 4
+			IL_0012: ldloc.0
+			IL_0013: ldstr "log"
+			IL_0018: ldstr "FileSize:"
+			IL_001d: ldarg.0
+			IL_001e: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
+			IL_0023: ldstr "size"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0032: pop
+			IL_0033: ldstr "console"
+			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_003d: stloc.0
+			IL_003e: ldloc.0
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0044: stloc.0
+			IL_0045: ldarg.0
+			IL_0046: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
+			IL_004b: ldstr "mode"
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_005a: conv.i4
+			IL_005b: ldc.r8 32768
+			IL_0064: conv.i4
+			IL_0065: and
+			IL_0066: conv.r8
+			IL_0067: stloc.1
+			IL_0068: ldloc.1
+			IL_0069: ldc.r8 32768
+			IL_0072: ceq
+			IL_0074: stloc.2
+			IL_0075: ldloc.2
+			IL_0076: box [System.Runtime]System.Boolean
+			IL_007b: stloc.3
+			IL_007c: ldloc.0
+			IL_007d: ldstr "log"
+			IL_0082: ldstr "FileModeHasRegularBit:"
+			IL_0087: ldloc.3
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_008d: pop
+			IL_008e: ldstr "console"
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0098: stloc.0
+			IL_0099: ldloc.0
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009f: stloc.0
+			IL_00a0: ldarg.0
+			IL_00a1: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ab: stloc.s 4
+			IL_00ad: ldloc.s 4
+			IL_00af: ldstr "isFile"
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00b9: stloc.s 4
+			IL_00bb: ldloc.0
+			IL_00bc: ldstr "log"
+			IL_00c1: ldstr "FileIsFile:"
+			IL_00c6: ldloc.s 4
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00cd: pop
+			IL_00ce: ldstr "console"
+			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00d8: stloc.s 4
+			IL_00da: ldloc.s 4
+			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e1: stloc.s 4
+			IL_00e3: ldarg.0
+			IL_00e4: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
+			IL_00e9: ldstr "birthtimeMs"
+			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f3: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_00f8: ldstr "number"
+			IL_00fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0102: stloc.2
+			IL_0103: ldloc.2
+			IL_0104: box [System.Runtime]System.Boolean
+			IL_0109: stloc.3
+			IL_010a: ldloc.3
+			IL_010b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0110: stloc.2
+			IL_0111: ldloc.2
+			IL_0112: brfalse IL_0143
+
+			IL_0117: ldarg.0
+			IL_0118: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
+			IL_011d: ldstr "birthtimeMs"
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0127: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_012c: ldc.r8 0.0
+			IL_0135: cgt
+			IL_0137: box [System.Runtime]System.Boolean
+			IL_013c: stloc.s 6
+			IL_013e: br IL_0146
+
+			IL_0143: ldloc.3
+			IL_0144: stloc.s 6
+
 			IL_0146: ldloc.s 4
-			IL_0148: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_014d: stloc.3
-			IL_014e: ldloc.3
-			IL_014f: brfalse IL_0198
-
-			IL_0154: ldarg.0
-			IL_0155: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
-			IL_015a: stloc.1
-			IL_015b: ldstr "fileStats"
-			IL_0160: ldloc.1
-			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0166: stloc.1
-			IL_0167: ldloc.1
-			IL_0168: ldstr "birthtimeMs"
-			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0172: stloc.1
-			IL_0173: ldloc.1
-			IL_0174: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0179: stloc.2
-			IL_017a: ldloc.2
-			IL_017b: ldc.r8 0.0
-			IL_0184: cgt
-			IL_0186: stloc.3
-			IL_0187: ldloc.3
-			IL_0188: box [System.Runtime]System.Boolean
-			IL_018d: stloc.s 5
-			IL_018f: ldloc.s 5
-			IL_0191: stloc.s 7
-			IL_0193: br IL_019c
-
-			IL_0198: ldloc.s 4
-			IL_019a: stloc.s 7
-
-			IL_019c: ldloc.0
-			IL_019d: ldstr "log"
-			IL_01a2: ldstr "FileHasBirthtimeMs:"
-			IL_01a7: ldloc.s 7
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01ae: pop
-			IL_01af: ldstr "console"
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01b9: stloc.0
-			IL_01ba: ldloc.0
-			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c0: stloc.0
-			IL_01c1: ldarg.0
-			IL_01c2: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
-			IL_01c7: stloc.1
-			IL_01c8: ldstr "fileStats"
-			IL_01cd: ldloc.1
-			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01d3: stloc.1
-			IL_01d4: ldloc.1
-			IL_01d5: ldstr "birthtime"
-			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01df: stloc.1
-			IL_01e0: ldloc.1
-			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e6: stloc.1
-			IL_01e7: ldloc.1
-			IL_01e8: ldstr "toISOString"
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01f2: stloc.1
-			IL_01f3: ldloc.1
-			IL_01f4: ldstr "length"
-			IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01fe: stloc.1
-			IL_01ff: ldloc.0
-			IL_0200: ldstr "log"
-			IL_0205: ldstr "FileBirthtimeIsoLength:"
-			IL_020a: ldloc.1
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0210: pop
-			IL_0211: ldstr "console"
-			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_021b: stloc.1
-			IL_021c: ldloc.1
-			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0148: ldstr "log"
+			IL_014d: ldstr "FileHasBirthtimeMs:"
+			IL_0152: ldloc.s 6
+			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0159: pop
+			IL_015a: ldstr "console"
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0164: stloc.s 4
+			IL_0166: ldloc.s 4
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016d: stloc.s 4
+			IL_016f: ldarg.0
+			IL_0170: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
+			IL_0175: ldstr "birthtime"
+			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0184: stloc.0
+			IL_0185: ldloc.0
+			IL_0186: ldstr "toISOString"
+			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0190: stloc.0
+			IL_0191: ldloc.0
+			IL_0192: ldstr "length"
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_019c: stloc.0
+			IL_019d: ldloc.s 4
+			IL_019f: ldstr "log"
+			IL_01a4: ldstr "FileBirthtimeIsoLength:"
+			IL_01a9: ldloc.0
+			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01af: pop
+			IL_01b0: ldstr "console"
+			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ba: stloc.0
+			IL_01bb: ldloc.0
+			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c1: stloc.0
+			IL_01c2: ldarg.0
+			IL_01c3: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
+			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01cd: stloc.s 4
+			IL_01cf: ldloc.s 4
+			IL_01d1: ldstr "isCharacterDevice"
+			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01db: stloc.s 4
+			IL_01dd: ldloc.0
+			IL_01de: ldstr "log"
+			IL_01e3: ldstr "FileIsCharacterDevice:"
+			IL_01e8: ldloc.s 4
+			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01ef: pop
+			IL_01f0: ldstr "console"
+			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01fa: stloc.s 4
+			IL_01fc: ldloc.s 4
+			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0203: stloc.s 4
+			IL_0205: ldarg.2
+			IL_0206: ldstr "mode"
+			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0210: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0215: conv.i4
+			IL_0216: ldc.r8 16384
+			IL_021f: conv.i4
+			IL_0220: and
+			IL_0221: conv.r8
 			IL_0222: stloc.1
-			IL_0223: ldarg.0
-			IL_0224: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
-			IL_0229: stloc.0
-			IL_022a: ldstr "fileStats"
-			IL_022f: ldloc.0
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0235: stloc.0
-			IL_0236: ldloc.0
-			IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_023c: stloc.0
-			IL_023d: ldloc.0
-			IL_023e: ldstr "isCharacterDevice"
-			IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0248: stloc.0
-			IL_0249: ldloc.1
-			IL_024a: ldstr "log"
-			IL_024f: ldstr "FileIsCharacterDevice:"
-			IL_0254: ldloc.0
-			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_025a: pop
-			IL_025b: ldstr "console"
-			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0223: ldloc.1
+			IL_0224: ldc.r8 16384
+			IL_022d: ceq
+			IL_022f: stloc.2
+			IL_0230: ldloc.2
+			IL_0231: box [System.Runtime]System.Boolean
+			IL_0236: stloc.3
+			IL_0237: ldloc.s 4
+			IL_0239: ldstr "log"
+			IL_023e: ldstr "DirModeHasDirectoryBit:"
+			IL_0243: ldloc.3
+			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0249: pop
+			IL_024a: ldstr "console"
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0254: stloc.s 4
+			IL_0256: ldloc.s 4
+			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_025d: stloc.s 4
+			IL_025f: ldarg.2
+			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0265: stloc.0
 			IL_0266: ldloc.0
-			IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_026c: stloc.0
-			IL_026d: ldarg.2
-			IL_026e: ldstr "mode"
-			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0278: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_027d: conv.i4
-			IL_027e: ldc.r8 16384
-			IL_0287: conv.i4
-			IL_0288: and
-			IL_0289: conv.r8
-			IL_028a: stloc.2
-			IL_028b: ldloc.2
-			IL_028c: ldc.r8 16384
-			IL_0295: ceq
-			IL_0297: stloc.3
-			IL_0298: ldloc.3
-			IL_0299: box [System.Runtime]System.Boolean
-			IL_029e: stloc.s 4
-			IL_02a0: ldloc.0
-			IL_02a1: ldstr "log"
-			IL_02a6: ldstr "DirModeHasDirectoryBit:"
-			IL_02ab: ldloc.s 4
-			IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02b2: pop
-			IL_02b3: ldstr "console"
-			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02bd: stloc.0
-			IL_02be: ldloc.0
-			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02c4: stloc.0
-			IL_02c5: ldarg.2
-			IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02cb: stloc.1
-			IL_02cc: ldloc.1
-			IL_02cd: ldstr "isDirectory"
-			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_02d7: stloc.1
-			IL_02d8: ldloc.0
-			IL_02d9: ldstr "log"
-			IL_02de: ldstr "DirIsDirectory:"
-			IL_02e3: ldloc.1
-			IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02e9: pop
-			IL_02ea: ldstr "console"
-			IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02f4: stloc.1
-			IL_02f5: ldloc.1
-			IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02fb: stloc.1
-			IL_02fc: ldarg.2
-			IL_02fd: ldstr "ctimeMs"
-			IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0307: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_030c: ldstr "number"
-			IL_0311: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0316: stloc.3
-			IL_0317: ldloc.3
-			IL_0318: box [System.Runtime]System.Boolean
-			IL_031d: stloc.s 4
-			IL_031f: ldloc.s 4
-			IL_0321: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0326: stloc.3
-			IL_0327: ldloc.3
-			IL_0328: brfalse IL_0354
+			IL_0267: ldstr "isDirectory"
+			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0271: stloc.0
+			IL_0272: ldloc.s 4
+			IL_0274: ldstr "log"
+			IL_0279: ldstr "DirIsDirectory:"
+			IL_027e: ldloc.0
+			IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0284: pop
+			IL_0285: ldstr "console"
+			IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_028f: stloc.0
+			IL_0290: ldloc.0
+			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0296: stloc.0
+			IL_0297: ldarg.2
+			IL_0298: ldstr "ctimeMs"
+			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02a2: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_02a7: ldstr "number"
+			IL_02ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_02b1: stloc.2
+			IL_02b2: ldloc.2
+			IL_02b3: box [System.Runtime]System.Boolean
+			IL_02b8: stloc.3
+			IL_02b9: ldloc.3
+			IL_02ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02bf: stloc.2
+			IL_02c0: ldloc.2
+			IL_02c1: brfalse IL_02ed
 
-			IL_032d: ldarg.2
-			IL_032e: ldstr "ctimeMs"
-			IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0338: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_033d: ldc.r8 0.0
-			IL_0346: cgt
-			IL_0348: box [System.Runtime]System.Boolean
-			IL_034d: stloc.s 8
-			IL_034f: br IL_0358
+			IL_02c6: ldarg.2
+			IL_02c7: ldstr "ctimeMs"
+			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_02d6: ldc.r8 0.0
+			IL_02df: cgt
+			IL_02e1: box [System.Runtime]System.Boolean
+			IL_02e6: stloc.s 7
+			IL_02e8: br IL_02f0
 
-			IL_0354: ldloc.s 4
-			IL_0356: stloc.s 8
+			IL_02ed: ldloc.3
+			IL_02ee: stloc.s 7
 
-			IL_0358: ldloc.1
-			IL_0359: ldstr "log"
-			IL_035e: ldstr "DirHasCtimeMs:"
-			IL_0363: ldloc.s 8
-			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_036a: pop
-			IL_036b: ldstr "console"
-			IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0375: stloc.1
-			IL_0376: ldloc.1
+			IL_02f0: ldloc.0
+			IL_02f1: ldstr "log"
+			IL_02f6: ldstr "DirHasCtimeMs:"
+			IL_02fb: ldloc.s 7
+			IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0302: pop
+			IL_0303: ldstr "console"
+			IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_030d: stloc.0
+			IL_030e: ldloc.0
+			IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0314: stloc.0
+			IL_0315: ldarg.2
+			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_031b: stloc.s 4
+			IL_031d: ldloc.s 4
+			IL_031f: ldstr "isFIFO"
+			IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0329: stloc.s 4
+			IL_032b: ldloc.0
+			IL_032c: ldstr "log"
+			IL_0331: ldstr "DirIsFIFO:"
+			IL_0336: ldloc.s 4
+			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_033d: pop
+			IL_033e: ldarg.0
+			IL_033f: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+			IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0349: stloc.s 4
+			IL_034b: ldarg.0
+			IL_034c: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
+			IL_0351: stloc.0
+			IL_0352: ldloc.s 4
+			IL_0354: ldstr "rmSync"
+			IL_0359: ldloc.0
+			IL_035a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_035f: dup
+			IL_0360: ldstr "force"
+			IL_0365: ldc.i4.1
+			IL_0366: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0370: pop
+			IL_0371: ldarg.0
+			IL_0372: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
 			IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_037c: stloc.1
-			IL_037d: ldarg.2
-			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0383: stloc.0
-			IL_0384: ldloc.0
-			IL_0385: ldstr "isFIFO"
-			IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_038f: stloc.0
-			IL_0390: ldloc.1
-			IL_0391: ldstr "log"
-			IL_0396: ldstr "DirIsFIFO:"
-			IL_039b: ldloc.0
-			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_03a1: pop
-			IL_03a2: ldarg.0
-			IL_03a3: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_03a8: stloc.0
-			IL_03a9: ldstr "syncFs"
-			IL_03ae: ldloc.0
-			IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03b4: stloc.0
-			IL_03b5: ldloc.0
-			IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03bb: stloc.0
-			IL_03bc: ldarg.0
-			IL_03bd: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-			IL_03c2: stloc.1
-			IL_03c3: ldstr "file"
-			IL_03c8: ldloc.1
-			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03ce: stloc.1
-			IL_03cf: ldloc.0
-			IL_03d0: ldstr "rmSync"
-			IL_03d5: ldloc.1
-			IL_03d6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03db: dup
-			IL_03dc: ldstr "force"
-			IL_03e1: ldc.i4.1
-			IL_03e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_03ec: pop
-			IL_03ed: ldarg.0
-			IL_03ee: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_03f3: stloc.1
-			IL_03f4: ldstr "syncFs"
-			IL_03f9: ldloc.1
-			IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_03ff: stloc.1
-			IL_0400: ldloc.1
-			IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0406: stloc.1
-			IL_0407: ldarg.0
-			IL_0408: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-			IL_040d: stloc.0
-			IL_040e: ldstr "dir"
-			IL_0413: ldloc.0
-			IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0419: stloc.0
-			IL_041a: ldloc.1
-			IL_041b: ldstr "rmSync"
-			IL_0420: ldloc.0
-			IL_0421: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0426: dup
-			IL_0427: ldstr "force"
-			IL_042c: ldc.i4.1
-			IL_042d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0432: dup
-			IL_0433: ldstr "recursive"
-			IL_0438: ldc.i4.1
-			IL_0439: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0443: pop
-			IL_0444: ldnull
-			IL_0445: ret
+			IL_037c: stloc.0
+			IL_037d: ldarg.0
+			IL_037e: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+			IL_0383: stloc.s 4
+			IL_0385: ldloc.0
+			IL_0386: ldstr "rmSync"
+			IL_038b: ldloc.s 4
+			IL_038d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0392: dup
+			IL_0393: ldstr "force"
+			IL_0398: ldc.i4.1
+			IL_0399: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_039e: dup
+			IL_039f: ldstr "recursive"
+			IL_03a4: ldc.i4.1
+			IL_03a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_03af: pop
+			IL_03b0: ldnull
+			IL_03b1: ret
 		} // end of method ArrowFunction_L21C9::__js_call__
 
 	} // end of class ArrowFunction_L21C9
@@ -557,7 +463,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x299d
+				// Method begins at RVA 0x28b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -584,9 +490,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2884
+			// Method begins at RVA 0x27d4
 			// Header size: 12
-			// Code size: 242 (0xf2)
+			// Code size: 184 (0xb8)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -625,64 +531,44 @@
 			IL_0043: pop
 			IL_0044: ldarg.0
 			IL_0045: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_004a: stloc.0
-			IL_004b: ldstr "syncFs"
-			IL_0050: ldloc.0
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0056: stloc.0
-			IL_0057: ldloc.0
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005d: stloc.0
-			IL_005e: ldarg.0
-			IL_005f: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-			IL_0064: stloc.s 4
-			IL_0066: ldstr "file"
-			IL_006b: ldloc.s 4
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0072: stloc.s 4
-			IL_0074: ldloc.0
-			IL_0075: ldstr "rmSync"
-			IL_007a: ldloc.s 4
-			IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0081: dup
-			IL_0082: ldstr "force"
-			IL_0087: ldc.i4.1
-			IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0092: pop
-			IL_0093: ldarg.0
-			IL_0094: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_0099: stloc.s 4
-			IL_009b: ldstr "syncFs"
-			IL_00a0: ldloc.s 4
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a7: stloc.s 4
-			IL_00a9: ldloc.s 4
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b0: stloc.s 4
-			IL_00b2: ldarg.0
-			IL_00b3: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-			IL_00b8: stloc.0
-			IL_00b9: ldstr "dir"
-			IL_00be: ldloc.0
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c4: stloc.0
-			IL_00c5: ldloc.s 4
-			IL_00c7: ldstr "rmSync"
-			IL_00cc: ldloc.0
-			IL_00cd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00d2: dup
-			IL_00d3: ldstr "force"
-			IL_00d8: ldc.i4.1
-			IL_00d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00de: dup
-			IL_00df: ldstr "recursive"
-			IL_00e4: ldc.i4.1
-			IL_00e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00ef: pop
-			IL_00f0: ldnull
-			IL_00f1: ret
+			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_004f: stloc.0
+			IL_0050: ldarg.0
+			IL_0051: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
+			IL_0056: stloc.s 4
+			IL_0058: ldloc.0
+			IL_0059: ldstr "rmSync"
+			IL_005e: ldloc.s 4
+			IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0065: dup
+			IL_0066: ldstr "force"
+			IL_006b: ldc.i4.1
+			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0076: pop
+			IL_0077: ldarg.0
+			IL_0078: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0082: stloc.s 4
+			IL_0084: ldarg.0
+			IL_0085: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+			IL_008a: stloc.0
+			IL_008b: ldloc.s 4
+			IL_008d: ldstr "rmSync"
+			IL_0092: ldloc.0
+			IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0098: dup
+			IL_0099: ldstr "force"
+			IL_009e: ldc.i4.1
+			IL_009f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00a4: dup
+			IL_00a5: ldstr "recursive"
+			IL_00aa: ldc.i4.1
+			IL_00ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00b5: pop
+			IL_00b6: ldnull
+			IL_00b7: ret
 		} // end of method ArrowFunction_L36C10::__js_call__
 
 	} // end of class ArrowFunction_L36C10
@@ -709,7 +595,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2982
+			// Method begins at RVA 0x2898
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1068,7 +954,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29a6
+		// Method begins at RVA 0x28bc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_WriteFile_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_WriteFile_Utf8.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e5
+				// Method begins at RVA 0x2285
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,101 +46,61 @@
 			)
 			// Method begins at RVA 0x21b0
 			// Header size: 12
-			// Code size: 225 (0xe1)
+			// Code size: 131 (0x83)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate,
-				[2] object,
-				[3] object[],
-				[4] object
+				[1] object,
+				[2] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_WriteFile_Utf8/Scope::require
-			IL_0006: stloc.1
-			IL_0007: ldstr "require"
-			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.2
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.3
-			IL_001e: ldloc.2
-			IL_001f: ldloc.3
-			IL_0020: ldstr "fs"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_002a: stloc.2
-			IL_002b: ldloc.2
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0031: stloc.2
-			IL_0032: ldarg.0
-			IL_0033: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
-			IL_0038: stloc.s 4
-			IL_003a: ldstr "testFile"
-			IL_003f: ldloc.s 4
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0046: stloc.s 4
-			IL_0048: ldloc.2
-			IL_0049: ldstr "readFileSync"
-			IL_004e: ldloc.s 4
-			IL_0050: ldstr "utf8"
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_005a: stloc.s 4
-			IL_005c: ldloc.s 4
-			IL_005e: stloc.0
-			IL_005f: ldstr "console"
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0069: stloc.s 4
-			IL_006b: ldloc.s 4
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0072: stloc.s 4
-			IL_0074: ldloc.s 4
-			IL_0076: ldstr "log"
-			IL_007b: ldstr "Written content:"
-			IL_0080: ldloc.0
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0086: pop
-			IL_0087: ldarg.0
-			IL_0088: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_WriteFile_Utf8/Scope::require
-			IL_008d: stloc.1
-			IL_008e: ldstr "require"
-			IL_0093: ldloc.1
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0099: stloc.s 4
-			IL_009b: ldc.i4.1
-			IL_009c: newarr [System.Runtime]System.Object
-			IL_00a1: dup
-			IL_00a2: ldc.i4.0
-			IL_00a3: ldarg.0
-			IL_00a4: stelem.ref
-			IL_00a5: stloc.3
-			IL_00a6: ldloc.s 4
-			IL_00a8: ldloc.3
-			IL_00a9: ldstr "fs"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00b3: stloc.s 4
-			IL_00b5: ldloc.s 4
-			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00bc: stloc.s 4
-			IL_00be: ldarg.0
-			IL_00bf: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
-			IL_00c4: stloc.2
-			IL_00c5: ldstr "testFile"
-			IL_00ca: ldloc.2
-			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00d0: stloc.2
-			IL_00d1: ldloc.s 4
-			IL_00d3: ldstr "rmSync"
-			IL_00d8: ldloc.2
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00de: pop
-			IL_00df: ldnull
-			IL_00e0: ret
+			IL_0006: ldstr "fs"
+			IL_000b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0010: stloc.1
+			IL_0011: ldloc.1
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0017: stloc.1
+			IL_0018: ldarg.0
+			IL_0019: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
+			IL_001e: stloc.2
+			IL_001f: ldloc.1
+			IL_0020: ldstr "readFileSync"
+			IL_0025: ldloc.2
+			IL_0026: ldstr "utf8"
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0030: stloc.2
+			IL_0031: ldloc.2
+			IL_0032: stloc.0
+			IL_0033: ldstr "console"
+			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_003d: stloc.2
+			IL_003e: ldloc.2
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0044: stloc.2
+			IL_0045: ldloc.2
+			IL_0046: ldstr "log"
+			IL_004b: ldstr "Written content:"
+			IL_0050: ldloc.0
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0056: pop
+			IL_0057: ldarg.0
+			IL_0058: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.FSPromises_WriteFile_Utf8/Scope::require
+			IL_005d: ldstr "fs"
+			IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+			IL_0067: stloc.2
+			IL_0068: ldloc.2
+			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006e: stloc.2
+			IL_006f: ldloc.2
+			IL_0070: ldstr "rmSync"
+			IL_0075: ldarg.0
+			IL_0076: ldfld object Modules.FSPromises_WriteFile_Utf8/Scope::testFile
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0080: pop
+			IL_0081: ldnull
+			IL_0082: ret
 		} // end of method ArrowFunction_L7C63::__js_call__
 
 	} // end of class ArrowFunction_L7C63
@@ -163,7 +123,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ee
+				// Method begins at RVA 0x228e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -187,7 +147,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a0
+			// Method begins at RVA 0x2240
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -231,7 +191,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22dc
+			// Method begins at RVA 0x227c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -398,7 +358,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22f7
+		// Method begins at RVA 0x2297
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_Append_Rename_Unlink_Callback.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_Append_Rename_Unlink_Callback.verified.txt
@@ -34,7 +34,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x26b3
+							// Method begins at RVA 0x25ff
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -55,7 +55,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26aa
+						// Method begins at RVA 0x25f6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -80,16 +80,15 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x250c
+					// Method begins at RVA 0x24a8
 					// Header size: 12
-					// Code size: 357 (0x165)
+					// Code size: 277 (0x115)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/ArrowFunction_L28C28/Scope/Block_L29C27,
 						[1] bool,
 						[2] object,
-						[3] object,
-						[4] object
+						[3] object
 					)
 
 					IL_0000: ldarg.2
@@ -123,104 +122,74 @@
 					IL_004e: ldloc.2
 					IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0054: stloc.2
-					IL_0055: ldarg.0
-					IL_0056: ldc.i4.2
-					IL_0057: ldelem.ref
-					IL_0058: castclass Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope
-					IL_005d: ldfld object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope::text
-					IL_0062: stloc.3
-					IL_0063: ldstr "text"
-					IL_0068: ldloc.3
-					IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_006e: stloc.3
-					IL_006f: ldloc.2
-					IL_0070: ldstr "log"
-					IL_0075: ldstr "RenamedText:"
-					IL_007a: ldloc.3
-					IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0080: pop
-					IL_0081: ldstr "console"
-					IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_008b: stloc.3
-					IL_008c: ldloc.3
-					IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0092: stloc.3
-					IL_0093: ldarg.0
-					IL_0094: ldc.i4.0
-					IL_0095: ldelem.ref
-					IL_0096: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-					IL_009b: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-					IL_00a0: stloc.2
-					IL_00a1: ldstr "fs"
-					IL_00a6: ldloc.2
-					IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_00ac: stloc.2
-					IL_00ad: ldloc.2
-					IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_00b3: stloc.2
-					IL_00b4: ldarg.0
-					IL_00b5: ldc.i4.0
-					IL_00b6: ldelem.ref
-					IL_00b7: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-					IL_00bc: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-					IL_00c1: stloc.s 4
-					IL_00c3: ldstr "source"
-					IL_00c8: ldloc.s 4
-					IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_00cf: stloc.s 4
-					IL_00d1: ldloc.2
-					IL_00d2: ldstr "existsSync"
-					IL_00d7: ldloc.s 4
-					IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00de: stloc.s 4
-					IL_00e0: ldloc.3
-					IL_00e1: ldstr "log"
-					IL_00e6: ldstr "SourceExists:"
-					IL_00eb: ldloc.s 4
-					IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_00f2: pop
-					IL_00f3: ldstr "console"
-					IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_00fd: stloc.s 4
-					IL_00ff: ldloc.s 4
-					IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0106: stloc.s 4
-					IL_0108: ldarg.0
-					IL_0109: ldc.i4.0
-					IL_010a: ldelem.ref
-					IL_010b: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-					IL_0110: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-					IL_0115: stloc.3
-					IL_0116: ldstr "fs"
-					IL_011b: ldloc.3
-					IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0121: stloc.3
-					IL_0122: ldloc.3
-					IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0128: stloc.3
-					IL_0129: ldarg.0
-					IL_012a: ldc.i4.0
-					IL_012b: ldelem.ref
-					IL_012c: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-					IL_0131: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-					IL_0136: stloc.2
-					IL_0137: ldstr "renamed"
-					IL_013c: ldloc.2
-					IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0142: stloc.2
-					IL_0143: ldloc.3
-					IL_0144: ldstr "existsSync"
-					IL_0149: ldloc.2
-					IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_014f: stloc.2
-					IL_0150: ldloc.s 4
-					IL_0152: ldstr "log"
-					IL_0157: ldstr "RenamedExists:"
-					IL_015c: ldloc.2
-					IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0162: pop
-					IL_0163: ldnull
-					IL_0164: ret
+					IL_0055: ldloc.2
+					IL_0056: ldstr "log"
+					IL_005b: ldstr "RenamedText:"
+					IL_0060: ldarg.0
+					IL_0061: ldc.i4.2
+					IL_0062: ldelem.ref
+					IL_0063: castclass Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope
+					IL_0068: ldfld object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope::text
+					IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0072: pop
+					IL_0073: ldstr "console"
+					IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+					IL_007d: stloc.2
+					IL_007e: ldloc.2
+					IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0084: stloc.2
+					IL_0085: ldarg.0
+					IL_0086: ldc.i4.0
+					IL_0087: ldelem.ref
+					IL_0088: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+					IL_008d: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+					IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0097: stloc.3
+					IL_0098: ldloc.3
+					IL_0099: ldstr "existsSync"
+					IL_009e: ldarg.0
+					IL_009f: ldc.i4.0
+					IL_00a0: ldelem.ref
+					IL_00a1: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+					IL_00a6: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
+					IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_00b0: stloc.3
+					IL_00b1: ldloc.2
+					IL_00b2: ldstr "log"
+					IL_00b7: ldstr "SourceExists:"
+					IL_00bc: ldloc.3
+					IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_00c2: pop
+					IL_00c3: ldstr "console"
+					IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+					IL_00cd: stloc.3
+					IL_00ce: ldloc.3
+					IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_00d4: stloc.3
+					IL_00d5: ldarg.0
+					IL_00d6: ldc.i4.0
+					IL_00d7: ldelem.ref
+					IL_00d8: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+					IL_00dd: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+					IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_00e7: stloc.2
+					IL_00e8: ldloc.2
+					IL_00e9: ldstr "existsSync"
+					IL_00ee: ldarg.0
+					IL_00ef: ldc.i4.0
+					IL_00f0: ldelem.ref
+					IL_00f1: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+					IL_00f6: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+					IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0100: stloc.2
+					IL_0101: ldloc.3
+					IL_0102: ldstr "log"
+					IL_0107: ldstr "RenamedExists:"
+					IL_010c: ldloc.2
+					IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0112: pop
+					IL_0113: ldnull
+					IL_0114: ret
 				} // end of method ArrowFunction_L28C28::__js_call__
 
 			} // end of class ArrowFunction_L28C28
@@ -241,7 +210,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26a1
+						// Method begins at RVA 0x25ed
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -263,7 +232,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2698
+					// Method begins at RVA 0x25e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -288,9 +257,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23c8
+				// Method begins at RVA 0x23a0
 				// Header size: 12
-				// Code size: 310 (0x136)
+				// Code size: 252 (0xfc)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope,
@@ -333,95 +302,75 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
 				IL_0051: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-				IL_0056: stloc.3
-				IL_0057: ldstr "fs"
-				IL_005c: ldloc.3
-				IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0062: stloc.3
-				IL_0063: ldloc.3
-				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0069: stloc.3
-				IL_006a: ldarg.0
-				IL_006b: ldc.i4.0
-				IL_006c: ldelem.ref
-				IL_006d: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-				IL_0072: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-				IL_0077: stloc.s 4
-				IL_0079: ldstr "renamed"
-				IL_007e: ldloc.s 4
-				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0085: stloc.s 4
-				IL_0087: ldloc.3
-				IL_0088: ldstr "readFileSync"
-				IL_008d: ldloc.s 4
-				IL_008f: ldstr "utf8"
-				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_005b: stloc.3
+				IL_005c: ldarg.0
+				IL_005d: ldc.i4.0
+				IL_005e: ldelem.ref
+				IL_005f: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+				IL_0064: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+				IL_0069: stloc.s 4
+				IL_006b: ldloc.3
+				IL_006c: ldstr "readFileSync"
+				IL_0071: ldloc.s 4
+				IL_0073: ldstr "utf8"
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_007d: stloc.s 4
+				IL_007f: ldloc.0
+				IL_0080: ldloc.s 4
+				IL_0082: stfld object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope::text
+				IL_0087: ldarg.0
+				IL_0088: ldc.i4.0
+				IL_0089: ldelem.ref
+				IL_008a: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+				IL_008f: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0099: stloc.s 4
-				IL_009b: ldloc.0
-				IL_009c: ldloc.s 4
-				IL_009e: stfld object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope::text
-				IL_00a3: ldarg.0
-				IL_00a4: ldc.i4.0
-				IL_00a5: ldelem.ref
-				IL_00a6: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-				IL_00ab: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-				IL_00b0: stloc.s 4
-				IL_00b2: ldstr "fs"
-				IL_00b7: ldloc.s 4
-				IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00be: stloc.s 4
-				IL_00c0: ldloc.s 4
-				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00c7: stloc.s 4
-				IL_00c9: ldarg.0
-				IL_00ca: ldc.i4.0
-				IL_00cb: ldelem.ref
-				IL_00cc: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-				IL_00d1: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-				IL_00d6: stloc.3
-				IL_00d7: ldstr "renamed"
-				IL_00dc: ldloc.3
-				IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00e2: stloc.3
-				IL_00e3: ldnull
-				IL_00e4: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/ArrowFunction_L28C28::__js_call__(object[], object, object)
-				IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_00ef: ldc.i4.3
-				IL_00f0: newarr [System.Runtime]System.Object
-				IL_00f5: dup
-				IL_00f6: ldc.i4.0
-				IL_00f7: ldarg.0
-				IL_00f8: ldc.i4.0
-				IL_00f9: ldelem.ref
-				IL_00fa: stelem.ref
-				IL_00fb: dup
-				IL_00fc: ldc.i4.1
-				IL_00fd: ldarg.0
-				IL_00fe: ldc.i4.1
-				IL_00ff: ldelem.ref
-				IL_0100: stelem.ref
-				IL_0101: dup
-				IL_0102: ldc.i4.2
-				IL_0103: ldloc.0
-				IL_0104: stelem.ref
-				IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_010f: ldc.i4.1
-				IL_0110: conv.r8
-				IL_0111: ldstr ""
-				IL_0116: ldc.i4.0
-				IL_0117: ldc.i4.1
-				IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-				IL_0122: stloc.s 5
-				IL_0124: ldloc.s 4
-				IL_0126: ldstr "unlink"
-				IL_012b: ldloc.3
-				IL_012c: ldloc.s 5
-				IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0133: pop
-				IL_0134: ldnull
-				IL_0135: ret
+				IL_009b: ldarg.0
+				IL_009c: ldc.i4.0
+				IL_009d: ldelem.ref
+				IL_009e: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+				IL_00a3: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+				IL_00a8: stloc.3
+				IL_00a9: ldnull
+				IL_00aa: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/ArrowFunction_L28C28::__js_call__(object[], object, object)
+				IL_00b0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_00b5: ldc.i4.3
+				IL_00b6: newarr [System.Runtime]System.Object
+				IL_00bb: dup
+				IL_00bc: ldc.i4.0
+				IL_00bd: ldarg.0
+				IL_00be: ldc.i4.0
+				IL_00bf: ldelem.ref
+				IL_00c0: stelem.ref
+				IL_00c1: dup
+				IL_00c2: ldc.i4.1
+				IL_00c3: ldarg.0
+				IL_00c4: ldc.i4.1
+				IL_00c5: ldelem.ref
+				IL_00c6: stelem.ref
+				IL_00c7: dup
+				IL_00c8: ldc.i4.2
+				IL_00c9: ldloc.0
+				IL_00ca: stelem.ref
+				IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_00d5: ldc.i4.1
+				IL_00d6: conv.r8
+				IL_00d7: ldstr ""
+				IL_00dc: ldc.i4.0
+				IL_00dd: ldc.i4.1
+				IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+				IL_00e8: stloc.s 5
+				IL_00ea: ldloc.s 4
+				IL_00ec: ldstr "unlink"
+				IL_00f1: ldloc.3
+				IL_00f2: ldloc.s 5
+				IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00f9: pop
+				IL_00fa: ldnull
+				IL_00fb: ret
 			} // end of method ArrowFunction_L21C32::__js_call__
 
 		} // end of class ArrowFunction_L21C32
@@ -441,7 +390,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x268f
+					// Method begins at RVA 0x25db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -462,7 +411,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2686
+				// Method begins at RVA 0x25d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -491,7 +440,7 @@
 			)
 			// Method begins at RVA 0x22e0
 			// Header size: 12
-			// Code size: 220 (0xdc)
+			// Code size: 178 (0xb2)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/Scope,
@@ -532,60 +481,46 @@
 
 			IL_0049: ldarg.0
 			IL_004a: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-			IL_004f: stloc.3
-			IL_0050: ldstr "fs"
-			IL_0055: ldloc.3
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_005b: stloc.3
-			IL_005c: ldloc.3
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0062: stloc.3
-			IL_0063: ldarg.0
-			IL_0064: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-			IL_0069: stloc.s 4
-			IL_006b: ldstr "source"
-			IL_0070: ldloc.s 4
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0077: stloc.s 4
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0054: stloc.3
+			IL_0055: ldarg.0
+			IL_0056: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
+			IL_005b: stloc.s 4
+			IL_005d: ldarg.0
+			IL_005e: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+			IL_0063: stloc.s 5
+			IL_0065: ldnull
+			IL_0066: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32::__js_call__(object[], object, object)
+			IL_006c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0071: ldc.i4.2
+			IL_0072: newarr [System.Runtime]System.Object
+			IL_0077: dup
+			IL_0078: ldc.i4.0
 			IL_0079: ldarg.0
-			IL_007a: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-			IL_007f: stloc.s 5
-			IL_0081: ldstr "renamed"
-			IL_0086: ldloc.s 5
-			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_008d: stloc.s 5
-			IL_008f: ldnull
-			IL_0090: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32::__js_call__(object[], object, object)
-			IL_0096: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_009b: ldc.i4.2
-			IL_009c: newarr [System.Runtime]System.Object
-			IL_00a1: dup
-			IL_00a2: ldc.i4.0
-			IL_00a3: ldarg.0
-			IL_00a4: stelem.ref
-			IL_00a5: dup
-			IL_00a6: ldc.i4.1
-			IL_00a7: ldloc.0
-			IL_00a8: stelem.ref
-			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00b3: ldc.i4.1
-			IL_00b4: conv.r8
-			IL_00b5: ldstr ""
-			IL_00ba: ldc.i4.0
-			IL_00bb: ldc.i4.1
-			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_00c6: stloc.s 6
-			IL_00c8: ldloc.3
-			IL_00c9: ldstr "rename"
-			IL_00ce: ldloc.s 4
-			IL_00d0: ldloc.s 5
-			IL_00d2: ldloc.s 6
-			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_00d9: pop
-			IL_00da: ldnull
-			IL_00db: ret
+			IL_007a: stelem.ref
+			IL_007b: dup
+			IL_007c: ldc.i4.1
+			IL_007d: ldloc.0
+			IL_007e: stelem.ref
+			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0089: ldc.i4.1
+			IL_008a: conv.r8
+			IL_008b: ldstr ""
+			IL_0090: ldc.i4.0
+			IL_0091: ldc.i4.1
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_009c: stloc.s 6
+			IL_009e: ldloc.3
+			IL_009f: ldstr "rename"
+			IL_00a4: ldloc.s 4
+			IL_00a6: ldloc.s 5
+			IL_00a8: ldloc.s 6
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_00af: pop
+			IL_00b0: ldnull
+			IL_00b1: ret
 		} // end of method ArrowFunction_L15C36::__js_call__
 
 	} // end of class ArrowFunction_L15C36
@@ -608,7 +543,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x267d
+			// Method begins at RVA 0x25c9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -882,7 +817,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26bc
+		// Method begins at RVA 0x2608
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateReadStream_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateReadStream_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24fa
+				// Method begins at RVA 0x249a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,11 +54,10 @@
 			)
 			// Method begins at RVA 0x234c
 			// Header size: 12
-			// Code size: 77 (0x4d)
+			// Code size: 51 (0x33)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object
 			)
 
 			IL_0000: ldstr "console"
@@ -75,21 +74,11 @@
 			IL_0023: pop
 			IL_0024: ldarg.0
 			IL_0025: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FS_CreateReadStream_Basic/Scope::chunks
-			IL_002a: stloc.1
-			IL_002b: ldstr "chunks"
-			IL_0030: ldloc.1
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003d: stloc.0
-			IL_003e: ldloc.0
-			IL_003f: ldstr "push"
-			IL_0044: ldarg.2
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_004a: pop
-			IL_004b: ldnull
-			IL_004c: ret
+			IL_002a: ldarg.2
+			IL_002b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0030: pop
+			IL_0031: ldnull
+			IL_0032: ret
 		} // end of method ArrowFunction_L15C19::__js_call__
 
 	} // end of class ArrowFunction_L15C19
@@ -105,7 +94,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2503
+				// Method begins at RVA 0x24a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,13 +120,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x23a8
+			// Method begins at RVA 0x238c
 			// Header size: 12
-			// Code size: 156 (0x9c)
+			// Code size: 113 (0x71)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[1] string,
 				[2] object
 			)
 
@@ -149,54 +138,39 @@
 			IL_0011: stloc.0
 			IL_0012: ldarg.0
 			IL_0013: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FS_CreateReadStream_Basic/Scope::chunks
-			IL_0018: stloc.1
-			IL_0019: ldstr "chunks"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.2
-			IL_0025: ldloc.2
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: ldstr "join"
-			IL_0032: ldstr "|"
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.0
-			IL_003e: ldstr "log"
-			IL_0043: ldstr "Combined:"
-			IL_0048: ldloc.2
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004e: pop
-			IL_004f: ldarg.0
-			IL_0050: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-			IL_0055: stloc.2
-			IL_0056: ldstr "fs"
-			IL_005b: ldloc.2
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0061: stloc.2
-			IL_0062: ldloc.2
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0068: stloc.2
-			IL_0069: ldarg.0
-			IL_006a: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
-			IL_006f: stloc.0
-			IL_0070: ldstr "file"
-			IL_0075: ldloc.0
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_007b: stloc.0
-			IL_007c: ldloc.2
-			IL_007d: ldstr "rmSync"
-			IL_0082: ldloc.0
-			IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0088: dup
-			IL_0089: ldstr "force"
-			IL_008e: ldc.i4.1
-			IL_008f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0099: pop
-			IL_009a: ldnull
-			IL_009b: ret
+			IL_0018: ldc.i4.1
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: dup
+			IL_001f: ldc.i4.0
+			IL_0020: ldstr "|"
+			IL_0025: stelem.ref
+			IL_0026: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_002b: stloc.1
+			IL_002c: ldloc.0
+			IL_002d: ldstr "log"
+			IL_0032: ldstr "Combined:"
+			IL_0037: ldloc.1
+			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_003d: pop
+			IL_003e: ldarg.0
+			IL_003f: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0049: stloc.0
+			IL_004a: ldarg.0
+			IL_004b: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
+			IL_0050: stloc.2
+			IL_0051: ldloc.0
+			IL_0052: ldstr "rmSync"
+			IL_0057: ldloc.2
+			IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_005d: dup
+			IL_005e: ldstr "force"
+			IL_0063: ldc.i4.1
+			IL_0064: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_006e: pop
+			IL_006f: ldnull
+			IL_0070: ret
 		} // end of method ArrowFunction_L20C18::__js_call__
 
 	} // end of class ArrowFunction_L20C18
@@ -219,7 +193,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x250c
+				// Method begins at RVA 0x24ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -246,9 +220,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2450
+			// Method begins at RVA 0x240c
 			// Header size: 12
-			// Code size: 149 (0x95)
+			// Code size: 121 (0x79)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -287,33 +261,23 @@
 			IL_0043: pop
 			IL_0044: ldarg.0
 			IL_0045: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-			IL_004a: stloc.0
-			IL_004b: ldstr "fs"
-			IL_0050: ldloc.0
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0056: stloc.0
-			IL_0057: ldloc.0
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005d: stloc.0
-			IL_005e: ldarg.0
-			IL_005f: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
-			IL_0064: stloc.s 4
-			IL_0066: ldstr "file"
-			IL_006b: ldloc.s 4
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0072: stloc.s 4
-			IL_0074: ldloc.0
-			IL_0075: ldstr "rmSync"
-			IL_007a: ldloc.s 4
-			IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0081: dup
-			IL_0082: ldstr "force"
-			IL_0087: ldc.i4.1
-			IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0092: pop
-			IL_0093: ldnull
-			IL_0094: ret
+			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_004f: stloc.0
+			IL_0050: ldarg.0
+			IL_0051: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
+			IL_0056: stloc.s 4
+			IL_0058: ldloc.0
+			IL_0059: ldstr "rmSync"
+			IL_005e: ldloc.s 4
+			IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0065: dup
+			IL_0066: ldstr "force"
+			IL_006b: ldc.i4.1
+			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0076: pop
+			IL_0077: ldnull
+			IL_0078: ret
 		} // end of method ArrowFunction_L25C20::__js_call__
 
 	} // end of class ArrowFunction_L25C20
@@ -335,7 +299,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24f1
+			// Method begins at RVA 0x2491
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -641,7 +605,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2515
+		// Method begins at RVA 0x24b5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateReadStream_Missing_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateReadStream_Missing_Error.verified.txt
@@ -91,9 +91,9 @@
 			IL_0049: stloc.s 5
 
 			IL_004b: ldloc.2
-			IL_004c: ldstr "test"
+			IL_004c: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			IL_0051: ldloc.s 5
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0053: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 			IL_0058: stloc.2
 			IL_0059: ldloc.0
 			IL_005a: ldstr "log"

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24c2
+				// Method begins at RVA 0x2472
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 			)
 			// Method begins at RVA 0x2324
 			// Header size: 12
-			// Code size: 176 (0xb0)
+			// Code size: 124 (0x7c)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -62,62 +62,42 @@
 			IL_0011: stloc.0
 			IL_0012: ldarg.0
 			IL_0013: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-			IL_0018: stloc.1
-			IL_0019: ldstr "fs"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001d: stloc.1
+			IL_001e: ldarg.0
+			IL_001f: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+			IL_0024: stloc.2
 			IL_0025: ldloc.1
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002b: stloc.1
-			IL_002c: ldarg.0
-			IL_002d: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-			IL_0032: stloc.2
-			IL_0033: ldstr "file"
-			IL_0038: ldloc.2
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003e: stloc.2
-			IL_003f: ldloc.1
-			IL_0040: ldstr "readFileSync"
-			IL_0045: ldloc.2
-			IL_0046: ldstr "utf8"
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0050: stloc.2
-			IL_0051: ldloc.0
-			IL_0052: ldstr "log"
-			IL_0057: ldstr "FileText:"
+			IL_0026: ldstr "readFileSync"
+			IL_002b: ldloc.2
+			IL_002c: ldstr "utf8"
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0036: stloc.2
+			IL_0037: ldloc.0
+			IL_0038: ldstr "log"
+			IL_003d: ldstr "FileText:"
+			IL_0042: ldloc.2
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0048: pop
+			IL_0049: ldarg.0
+			IL_004a: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0054: stloc.2
+			IL_0055: ldarg.0
+			IL_0056: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+			IL_005b: stloc.0
 			IL_005c: ldloc.2
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0062: pop
-			IL_0063: ldarg.0
-			IL_0064: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-			IL_0069: stloc.2
-			IL_006a: ldstr "fs"
-			IL_006f: ldloc.2
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0075: stloc.2
-			IL_0076: ldloc.2
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007c: stloc.2
-			IL_007d: ldarg.0
-			IL_007e: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-			IL_0083: stloc.0
-			IL_0084: ldstr "file"
-			IL_0089: ldloc.0
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_008f: stloc.0
-			IL_0090: ldloc.2
-			IL_0091: ldstr "rmSync"
-			IL_0096: ldloc.0
-			IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_009c: dup
-			IL_009d: ldstr "force"
-			IL_00a2: ldc.i4.1
-			IL_00a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00ad: pop
-			IL_00ae: ldnull
-			IL_00af: ret
+			IL_005d: ldstr "rmSync"
+			IL_0062: ldloc.0
+			IL_0063: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0068: dup
+			IL_0069: ldstr "force"
+			IL_006e: ldc.i4.1
+			IL_006f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0079: pop
+			IL_007a: ldnull
+			IL_007b: ret
 		} // end of method ArrowFunction_L13C21::__js_call__
 
 	} // end of class ArrowFunction_L13C21
@@ -133,7 +113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24cb
+				// Method begins at RVA 0x247b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -156,7 +136,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23e0
+			// Method begins at RVA 0x23ac
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -201,7 +181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d4
+				// Method begins at RVA 0x2484
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -228,9 +208,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2418
+			// Method begins at RVA 0x23e4
 			// Header size: 12
-			// Code size: 149 (0x95)
+			// Code size: 121 (0x79)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -269,33 +249,23 @@
 			IL_0043: pop
 			IL_0044: ldarg.0
 			IL_0045: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-			IL_004a: stloc.0
-			IL_004b: ldstr "fs"
-			IL_0050: ldloc.0
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0056: stloc.0
-			IL_0057: ldloc.0
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005d: stloc.0
-			IL_005e: ldarg.0
-			IL_005f: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-			IL_0064: stloc.s 4
-			IL_0066: ldstr "file"
-			IL_006b: ldloc.s 4
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0072: stloc.s 4
-			IL_0074: ldloc.0
-			IL_0075: ldstr "rmSync"
-			IL_007a: ldloc.s 4
-			IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0081: dup
-			IL_0082: ldstr "force"
-			IL_0087: ldc.i4.1
-			IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0092: pop
-			IL_0093: ldnull
-			IL_0094: ret
+			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_004f: stloc.0
+			IL_0050: ldarg.0
+			IL_0051: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+			IL_0056: stloc.s 4
+			IL_0058: ldloc.0
+			IL_0059: ldstr "rmSync"
+			IL_005e: ldloc.s 4
+			IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0065: dup
+			IL_0066: ldstr "force"
+			IL_006b: ldc.i4.1
+			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0076: pop
+			IL_0077: ldnull
+			IL_0078: ret
 		} // end of method ArrowFunction_L22C20::__js_call__
 
 	} // end of class ArrowFunction_L22C20
@@ -315,7 +285,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24b9
+			// Method begins at RVA 0x2469
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -607,7 +577,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24dd
+		// Method begins at RVA 0x248d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Missing_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Missing_Error.verified.txt
@@ -91,9 +91,9 @@
 			IL_0049: stloc.s 5
 
 			IL_004b: ldloc.2
-			IL_004c: ldstr "test"
+			IL_004c: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			IL_0051: ldloc.s 5
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0053: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 			IL_0058: stloc.2
 			IL_0059: ldloc.0
 			IL_005a: ldstr "log"

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_Open_Callback_FileHandle.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_Open_Callback_FileHandle.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25f2
+					// Method begins at RVA 0x257a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,9 +46,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2414
+				// Method begins at RVA 0x23f8
 				// Header size: 12
-				// Code size: 47 (0x2f)
+				// Code size: 33 (0x21)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -59,20 +59,14 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope
 				IL_0008: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
-				IL_000d: stloc.0
-				IL_000e: ldstr "handle"
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
 				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldloc.0
-				IL_0022: ldstr "close"
-				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_002c: stloc.0
-				IL_002d: ldloc.0
-				IL_002e: ret
+				IL_0014: ldstr "close"
+				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_001e: stloc.0
+				IL_001f: ldloc.0
+				IL_0020: ret
 			} // end of method ArrowFunction_L20C40::__js_call__
 
 		} // end of class ArrowFunction_L20C40
@@ -88,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25fb
+					// Method begins at RVA 0x2583
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -112,9 +106,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2450
+				// Method begins at RVA 0x2428
 				// Header size: 12
-				// Code size: 204 (0xcc)
+				// Code size: 152 (0x98)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -133,71 +127,51 @@
 				IL_0014: ldelem.ref
 				IL_0015: castclass Modules.FS_Open_Callback_FileHandle/Scope
 				IL_001a: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-				IL_001f: stloc.1
-				IL_0020: ldstr "fs"
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002b: stloc.1
-				IL_002c: ldloc.1
-				IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0032: stloc.1
-				IL_0033: ldarg.0
-				IL_0034: ldc.i4.0
-				IL_0035: ldelem.ref
-				IL_0036: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_003b: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-				IL_0040: stloc.2
-				IL_0041: ldstr "file"
-				IL_0046: ldloc.2
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_004c: stloc.2
-				IL_004d: ldloc.1
-				IL_004e: ldstr "readFileSync"
-				IL_0053: ldloc.2
-				IL_0054: ldstr "utf8"
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_005e: stloc.2
-				IL_005f: ldloc.0
-				IL_0060: ldstr "log"
-				IL_0065: ldstr "FileText:"
-				IL_006a: ldloc.2
-				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0070: pop
-				IL_0071: ldarg.0
-				IL_0072: ldc.i4.0
-				IL_0073: ldelem.ref
-				IL_0074: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_0079: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-				IL_007e: stloc.2
-				IL_007f: ldstr "fs"
-				IL_0084: ldloc.2
-				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_008a: stloc.2
-				IL_008b: ldloc.2
-				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0091: stloc.2
-				IL_0092: ldarg.0
-				IL_0093: ldc.i4.0
-				IL_0094: ldelem.ref
-				IL_0095: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_009a: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-				IL_009f: stloc.0
-				IL_00a0: ldstr "file"
-				IL_00a5: ldloc.0
-				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00ab: stloc.0
-				IL_00ac: ldloc.2
-				IL_00ad: ldstr "rmSync"
-				IL_00b2: ldloc.0
-				IL_00b3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00b8: dup
-				IL_00b9: ldstr "force"
-				IL_00be: ldc.i4.1
-				IL_00bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00c9: pop
-				IL_00ca: ldnull
-				IL_00cb: ret
+				IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0024: stloc.1
+				IL_0025: ldarg.0
+				IL_0026: ldc.i4.0
+				IL_0027: ldelem.ref
+				IL_0028: castclass Modules.FS_Open_Callback_FileHandle/Scope
+				IL_002d: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+				IL_0032: stloc.2
+				IL_0033: ldloc.1
+				IL_0034: ldstr "readFileSync"
+				IL_0039: ldloc.2
+				IL_003a: ldstr "utf8"
+				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0044: stloc.2
+				IL_0045: ldloc.0
+				IL_0046: ldstr "log"
+				IL_004b: ldstr "FileText:"
+				IL_0050: ldloc.2
+				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0056: pop
+				IL_0057: ldarg.0
+				IL_0058: ldc.i4.0
+				IL_0059: ldelem.ref
+				IL_005a: castclass Modules.FS_Open_Callback_FileHandle/Scope
+				IL_005f: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
+				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0069: stloc.2
+				IL_006a: ldarg.0
+				IL_006b: ldc.i4.0
+				IL_006c: ldelem.ref
+				IL_006d: castclass Modules.FS_Open_Callback_FileHandle/Scope
+				IL_0072: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+				IL_0077: stloc.0
+				IL_0078: ldloc.2
+				IL_0079: ldstr "rmSync"
+				IL_007e: ldloc.0
+				IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0084: dup
+				IL_0085: ldstr "force"
+				IL_008a: ldc.i4.1
+				IL_008b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0095: pop
+				IL_0096: ldnull
+				IL_0097: ret
 			} // end of method ArrowFunction_L20C67::__js_call__
 
 		} // end of class ArrowFunction_L20C67
@@ -220,7 +194,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2604
+					// Method begins at RVA 0x258c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -245,9 +219,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2528
+				// Method begins at RVA 0x24cc
 				// Header size: 12
-				// Code size: 163 (0xa3)
+				// Code size: 135 (0x87)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -289,36 +263,26 @@
 				IL_0046: ldelem.ref
 				IL_0047: castclass Modules.FS_Open_Callback_FileHandle/Scope
 				IL_004c: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-				IL_0051: stloc.0
-				IL_0052: ldstr "fs"
-				IL_0057: ldloc.0
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005d: stloc.0
-				IL_005e: ldloc.0
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0064: stloc.0
-				IL_0065: ldarg.0
-				IL_0066: ldc.i4.0
-				IL_0067: ldelem.ref
-				IL_0068: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_006d: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-				IL_0072: stloc.s 4
-				IL_0074: ldstr "file"
-				IL_0079: ldloc.s 4
-				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0080: stloc.s 4
-				IL_0082: ldloc.0
-				IL_0083: ldstr "rmSync"
-				IL_0088: ldloc.s 4
-				IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_008f: dup
-				IL_0090: ldstr "force"
-				IL_0095: ldc.i4.1
-				IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00a0: pop
-				IL_00a1: ldnull
-				IL_00a2: ret
+				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0056: stloc.0
+				IL_0057: ldarg.0
+				IL_0058: ldc.i4.0
+				IL_0059: ldelem.ref
+				IL_005a: castclass Modules.FS_Open_Callback_FileHandle/Scope
+				IL_005f: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+				IL_0064: stloc.s 4
+				IL_0066: ldloc.0
+				IL_0067: ldstr "rmSync"
+				IL_006c: ldloc.s 4
+				IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0073: dup
+				IL_0074: ldstr "force"
+				IL_0079: ldc.i4.1
+				IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0084: pop
+				IL_0085: ldnull
+				IL_0086: ret
 			} // end of method ArrowFunction_L23C8::__js_call__
 
 		} // end of class ArrowFunction_L23C8
@@ -339,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25e9
+					// Method begins at RVA 0x2571
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -361,7 +325,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25e0
+				// Method begins at RVA 0x2568
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -391,7 +355,7 @@
 			)
 			// Method begins at RVA 0x2208
 			// Header size: 12
-			// Code size: 509 (0x1fd)
+			// Code size: 481 (0x1e1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope,
@@ -412,7 +376,7 @@
 			IL_000e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0013: stloc.2
 			IL_0014: ldloc.2
-			IL_0015: brfalse IL_009f
+			IL_0015: brfalse IL_0083
 
 			IL_001a: newobj instance void Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope/Block_L12C13::.ctor()
 			IL_001f: stloc.1
@@ -432,157 +396,147 @@
 			IL_004d: pop
 			IL_004e: ldarg.0
 			IL_004f: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-			IL_0054: stloc.3
-			IL_0055: ldstr "fs"
-			IL_005a: ldloc.3
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0060: stloc.3
-			IL_0061: ldloc.3
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0067: stloc.3
-			IL_0068: ldarg.0
-			IL_0069: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-			IL_006e: stloc.s 4
-			IL_0070: ldstr "file"
-			IL_0075: ldloc.s 4
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_007c: stloc.s 4
-			IL_007e: ldloc.3
-			IL_007f: ldstr "rmSync"
-			IL_0084: ldloc.s 4
-			IL_0086: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_008b: dup
-			IL_008c: ldstr "force"
-			IL_0091: ldc.i4.1
-			IL_0092: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_009c: pop
-			IL_009d: ldnull
-			IL_009e: ret
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0059: stloc.3
+			IL_005a: ldarg.0
+			IL_005b: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+			IL_0060: stloc.s 4
+			IL_0062: ldloc.3
+			IL_0063: ldstr "rmSync"
+			IL_0068: ldloc.s 4
+			IL_006a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006f: dup
+			IL_0070: ldstr "force"
+			IL_0075: ldc.i4.1
+			IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0080: pop
+			IL_0081: ldnull
+			IL_0082: ret
 
-			IL_009f: ldstr "console"
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00a9: stloc.s 4
-			IL_00ab: ldloc.s 4
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b2: stloc.s 4
-			IL_00b4: ldloc.0
-			IL_00b5: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
-			IL_00ba: ldstr "fd"
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c4: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_00c9: ldstr "number"
-			IL_00ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00d3: stloc.2
-			IL_00d4: ldloc.2
-			IL_00d5: box [System.Runtime]System.Boolean
-			IL_00da: stloc.s 5
-			IL_00dc: ldloc.s 4
-			IL_00de: ldstr "log"
-			IL_00e3: ldstr "FDIsNumber:"
-			IL_00e8: ldloc.s 5
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00ef: pop
-			IL_00f0: ldloc.0
-			IL_00f1: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fb: stloc.s 4
-			IL_00fd: ldloc.s 4
-			IL_00ff: ldstr "write"
-			IL_0104: ldstr "ok"
-			IL_0109: ldc.r8 0.0
-			IL_0112: box [System.Runtime]System.Double
-			IL_0117: ldstr "utf8"
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0121: stloc.s 4
-			IL_0123: ldloc.s 4
-			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_012a: stloc.s 4
-			IL_012c: ldnull
-			IL_012d: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C40::__js_call__(object[], object)
-			IL_0133: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0138: ldc.i4.2
-			IL_0139: newarr [System.Runtime]System.Object
-			IL_013e: dup
-			IL_013f: ldc.i4.0
-			IL_0140: ldarg.0
-			IL_0141: stelem.ref
-			IL_0142: dup
-			IL_0143: ldc.i4.1
-			IL_0144: ldloc.0
-			IL_0145: stelem.ref
-			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0150: ldc.i4.0
-			IL_0151: conv.r8
-			IL_0152: ldstr ""
-			IL_0157: ldc.i4.0
-			IL_0158: ldc.i4.1
-			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0163: stloc.3
-			IL_0164: ldloc.s 4
-			IL_0166: ldstr "then"
-			IL_016b: ldloc.3
-			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0171: stloc.3
-			IL_0172: ldloc.3
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0178: stloc.3
-			IL_0179: ldnull
-			IL_017a: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C67::__js_call__(object[], object)
-			IL_0180: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0185: ldc.i4.2
-			IL_0186: newarr [System.Runtime]System.Object
-			IL_018b: dup
-			IL_018c: ldc.i4.0
-			IL_018d: ldarg.0
-			IL_018e: stelem.ref
-			IL_018f: dup
-			IL_0190: ldc.i4.1
-			IL_0191: ldloc.0
-			IL_0192: stelem.ref
-			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_019d: ldc.i4.0
-			IL_019e: conv.r8
-			IL_019f: ldstr ""
-			IL_01a4: ldc.i4.0
-			IL_01a5: ldc.i4.1
-			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_01b0: stloc.s 4
-			IL_01b2: ldnull
-			IL_01b3: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L23C8::__js_call__(object[], object, object)
-			IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_01be: ldc.i4.2
-			IL_01bf: newarr [System.Runtime]System.Object
-			IL_01c4: dup
-			IL_01c5: ldc.i4.0
-			IL_01c6: ldarg.0
-			IL_01c7: stelem.ref
-			IL_01c8: dup
-			IL_01c9: ldc.i4.1
-			IL_01ca: ldloc.0
-			IL_01cb: stelem.ref
-			IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_01d6: ldc.i4.1
-			IL_01d7: conv.r8
-			IL_01d8: ldstr ""
-			IL_01dd: ldc.i4.0
-			IL_01de: ldc.i4.1
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_01e9: stloc.s 6
-			IL_01eb: ldloc.3
-			IL_01ec: ldstr "then"
-			IL_01f1: ldloc.s 4
-			IL_01f3: ldloc.s 6
-			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01fa: pop
-			IL_01fb: ldnull
-			IL_01fc: ret
+			IL_0083: ldstr "console"
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_008d: stloc.s 4
+			IL_008f: ldloc.s 4
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0096: stloc.s 4
+			IL_0098: ldloc.0
+			IL_0099: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
+			IL_009e: ldstr "fd"
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a8: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_00ad: ldstr "number"
+			IL_00b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00b7: stloc.2
+			IL_00b8: ldloc.2
+			IL_00b9: box [System.Runtime]System.Boolean
+			IL_00be: stloc.s 5
+			IL_00c0: ldloc.s 4
+			IL_00c2: ldstr "log"
+			IL_00c7: ldstr "FDIsNumber:"
+			IL_00cc: ldloc.s 5
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00d3: pop
+			IL_00d4: ldloc.0
+			IL_00d5: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
+			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00df: stloc.s 4
+			IL_00e1: ldloc.s 4
+			IL_00e3: ldstr "write"
+			IL_00e8: ldstr "ok"
+			IL_00ed: ldc.r8 0.0
+			IL_00f6: box [System.Runtime]System.Double
+			IL_00fb: ldstr "utf8"
+			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0105: stloc.s 4
+			IL_0107: ldloc.s 4
+			IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010e: stloc.s 4
+			IL_0110: ldnull
+			IL_0111: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C40::__js_call__(object[], object)
+			IL_0117: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_011c: ldc.i4.2
+			IL_011d: newarr [System.Runtime]System.Object
+			IL_0122: dup
+			IL_0123: ldc.i4.0
+			IL_0124: ldarg.0
+			IL_0125: stelem.ref
+			IL_0126: dup
+			IL_0127: ldc.i4.1
+			IL_0128: ldloc.0
+			IL_0129: stelem.ref
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0134: ldc.i4.0
+			IL_0135: conv.r8
+			IL_0136: ldstr ""
+			IL_013b: ldc.i4.0
+			IL_013c: ldc.i4.1
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0147: stloc.3
+			IL_0148: ldloc.s 4
+			IL_014a: ldstr "then"
+			IL_014f: ldloc.3
+			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0155: stloc.3
+			IL_0156: ldloc.3
+			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015c: stloc.3
+			IL_015d: ldnull
+			IL_015e: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C67::__js_call__(object[], object)
+			IL_0164: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0169: ldc.i4.2
+			IL_016a: newarr [System.Runtime]System.Object
+			IL_016f: dup
+			IL_0170: ldc.i4.0
+			IL_0171: ldarg.0
+			IL_0172: stelem.ref
+			IL_0173: dup
+			IL_0174: ldc.i4.1
+			IL_0175: ldloc.0
+			IL_0176: stelem.ref
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0181: ldc.i4.0
+			IL_0182: conv.r8
+			IL_0183: ldstr ""
+			IL_0188: ldc.i4.0
+			IL_0189: ldc.i4.1
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0194: stloc.s 4
+			IL_0196: ldnull
+			IL_0197: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L23C8::__js_call__(object[], object, object)
+			IL_019d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_01a2: ldc.i4.2
+			IL_01a3: newarr [System.Runtime]System.Object
+			IL_01a8: dup
+			IL_01a9: ldc.i4.0
+			IL_01aa: ldarg.0
+			IL_01ab: stelem.ref
+			IL_01ac: dup
+			IL_01ad: ldc.i4.1
+			IL_01ae: ldloc.0
+			IL_01af: stelem.ref
+			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_01ba: ldc.i4.1
+			IL_01bb: conv.r8
+			IL_01bc: ldstr ""
+			IL_01c1: ldc.i4.0
+			IL_01c2: ldc.i4.1
+			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_01cd: stloc.s 6
+			IL_01cf: ldloc.3
+			IL_01d0: ldstr "then"
+			IL_01d5: ldloc.s 4
+			IL_01d7: ldloc.s 6
+			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01de: pop
+			IL_01df: ldnull
+			IL_01e0: ret
 		} // end of method ArrowFunction_L11C21::__js_call__
 
 	} // end of class ArrowFunction_L11C21
@@ -602,7 +556,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25d7
+			// Method begins at RVA 0x255f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -800,7 +754,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x260d
+		// Method begins at RVA 0x2595
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Agent_KeepAlive_Reuses_Connection.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Agent_KeepAlive_Reuses_Connection.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28ee
+				// Method begins at RVA 0x27f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,58 +48,45 @@
 			)
 			// Method begins at RVA 0x21c4
 			// Header size: 12
-			// Code size: 124 (0x7c)
+			// Code size: 96 (0x60)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] object
+				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::responses
-			IL_0006: stloc.0
-			IL_0007: ldstr "responses"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.r8 1
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0006: ldc.r8 1
+			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0014: stloc.0
+			IL_0015: ldarg.0
+			IL_0016: ldloc.0
+			IL_0017: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::responses
+			IL_001c: ldarg.3
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0022: stloc.1
-			IL_0023: ldarg.0
-			IL_0024: ldloc.1
-			IL_0025: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::responses
-			IL_002a: ldarg.3
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0030: stloc.0
-			IL_0031: ldloc.0
-			IL_0032: ldstr "setHeader"
-			IL_0037: ldstr "Content-Type"
-			IL_003c: ldstr "text/plain"
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0046: pop
-			IL_0047: ldarg.3
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004d: stloc.0
-			IL_004e: ldarg.0
-			IL_004f: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::responses
-			IL_0054: stloc.2
-			IL_0055: ldstr "responses"
-			IL_005a: ldloc.2
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0060: stloc.2
-			IL_0061: ldstr "resp"
-			IL_0066: ldloc.2
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006c: stloc.1
-			IL_006d: ldloc.0
-			IL_006e: ldstr "end"
-			IL_0073: ldloc.1
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0079: pop
-			IL_007a: ldnull
-			IL_007b: ret
+			IL_0023: ldloc.1
+			IL_0024: ldstr "setHeader"
+			IL_0029: ldstr "Content-Type"
+			IL_002e: ldstr "text/plain"
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0038: pop
+			IL_0039: ldarg.3
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003f: stloc.1
+			IL_0040: ldstr "resp"
+			IL_0045: ldarg.0
+			IL_0046: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::responses
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0050: stloc.0
+			IL_0051: ldloc.1
+			IL_0052: ldstr "end"
+			IL_0057: ldloc.0
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_005d: pop
+			IL_005e: ldnull
+			IL_005f: ret
 		} // end of method FunctionExpression_server::__js_call__
 
 	} // end of class FunctionExpression_server
@@ -115,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28f7
+				// Method begins at RVA 0x27fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -141,31 +128,24 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x224c
+			// Method begins at RVA 0x2230
 			// Header size: 12
-			// Code size: 44 (0x2c)
+			// Code size: 30 (0x1e)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::connections
-			IL_0006: stloc.0
-			IL_0007: ldstr "connections"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.r8 1
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0022: stloc.1
-			IL_0023: ldarg.0
-			IL_0024: ldloc.1
-			IL_0025: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::connections
-			IL_002a: ldnull
-			IL_002b: ret
+			IL_0006: ldc.r8 1
+			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0014: stloc.0
+			IL_0015: ldarg.0
+			IL_0016: ldloc.0
+			IL_0017: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::connections
+			IL_001c: ldnull
+			IL_001d: ret
 		} // end of method FunctionExpression_L15C24::__js_call__
 
 	} // end of class FunctionExpression_L15C24
@@ -189,7 +169,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2912
+						// Method begins at RVA 0x2816
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -214,13 +194,12 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2494
+					// Method begins at RVA 0x243c
 					// Header size: 12
-					// Code size: 50 (0x32)
+					// Code size: 36 (0x24)
 					.maxstack 8
 					.locals init (
-						[0] object,
-						[1] object
+						[0] object
 					)
 
 					IL_0000: ldarg.0
@@ -228,23 +207,17 @@
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
 					IL_0008: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope::body
-					IL_000d: stloc.0
-					IL_000e: ldstr "body"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldloc.0
-					IL_001b: ldarg.2
-					IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0021: stloc.1
-					IL_0022: ldarg.0
-					IL_0023: ldc.i4.2
-					IL_0024: ldelem.ref
-					IL_0025: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
-					IL_002a: ldloc.1
-					IL_002b: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope::body
-					IL_0030: ldnull
-					IL_0031: ret
+					IL_000d: ldarg.2
+					IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0013: stloc.0
+					IL_0014: ldarg.0
+					IL_0015: ldc.i4.2
+					IL_0016: ldelem.ref
+					IL_0017: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
+					IL_001c: ldloc.0
+					IL_001d: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope::body
+					IL_0022: ldnull
+					IL_0023: ret
 				} // end of method FunctionExpression_L34C21::__js_call__
 
 			} // end of class FunctionExpression_L34C21
@@ -268,7 +241,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x292d
+								// Method begins at RVA 0x2831
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -293,13 +266,12 @@
 							.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 								01 00 02 00 00 00 00 00
 							)
-							// Method begins at RVA 0x2760
+							// Method begins at RVA 0x26ac
 							// Header size: 12
-							// Code size: 50 (0x32)
+							// Code size: 36 (0x24)
 							.maxstack 8
 							.locals init (
-								[0] object,
-								[1] object
+								[0] object
 							)
 
 							IL_0000: ldarg.0
@@ -307,23 +279,17 @@
 							IL_0002: ldelem.ref
 							IL_0003: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
 							IL_0008: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope::nextBody
-							IL_000d: stloc.0
-							IL_000e: ldstr "nextBody"
-							IL_0013: ldloc.0
-							IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-							IL_0019: stloc.0
-							IL_001a: ldloc.0
-							IL_001b: ldarg.2
-							IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-							IL_0021: stloc.1
-							IL_0022: ldarg.0
-							IL_0023: ldc.i4.4
-							IL_0024: ldelem.ref
-							IL_0025: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
-							IL_002a: ldloc.1
-							IL_002b: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope::nextBody
-							IL_0030: ldnull
-							IL_0031: ret
+							IL_000d: ldarg.2
+							IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+							IL_0013: stloc.0
+							IL_0014: ldarg.0
+							IL_0015: ldc.i4.4
+							IL_0016: ldelem.ref
+							IL_0017: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
+							IL_001c: ldloc.0
+							IL_001d: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope::nextBody
+							IL_0022: ldnull
+							IL_0023: ret
 						} // end of method FunctionExpression_L53C31::__js_call__
 
 					} // end of class FunctionExpression_L53C31
@@ -343,7 +309,7 @@
 								.method public hidebysig specialname rtspecialname 
 									instance void .ctor () cil managed 
 								{
-									// Method begins at RVA 0x293f
+									// Method begins at RVA 0x2843
 									// Header size: 1
 									// Code size: 8 (0x8)
 									.maxstack 8
@@ -366,7 +332,7 @@
 								.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 									01 00 00 00 00 00 00 00
 								)
-								// Method begins at RVA 0x28b4
+								// Method begins at RVA 0x27b8
 								// Header size: 12
 								// Code size: 37 (0x25)
 								.maxstack 8
@@ -398,7 +364,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x2936
+								// Method begins at RVA 0x283a
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -422,9 +388,9 @@
 							.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 								01 00 02 00 00 00 00 00
 							)
-							// Method begins at RVA 0x27a0
+							// Method begins at RVA 0x26dc
 							// Header size: 12
-							// Code size: 264 (0x108)
+							// Code size: 208 (0xd0)
 							.maxstack 8
 							.locals init (
 								[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/Scope,
@@ -441,97 +407,73 @@
 							IL_0011: ldloc.1
 							IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 							IL_0017: stloc.1
-							IL_0018: ldarg.0
-							IL_0019: ldc.i4.4
-							IL_001a: ldelem.ref
-							IL_001b: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
-							IL_0020: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope::nextBody
-							IL_0025: stloc.2
-							IL_0026: ldstr "nextBody"
-							IL_002b: ldloc.2
-							IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-							IL_0031: stloc.2
-							IL_0032: ldstr "body2:"
-							IL_0037: ldloc.2
-							IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-							IL_003d: stloc.3
-							IL_003e: ldloc.1
-							IL_003f: ldstr "log"
-							IL_0044: ldloc.3
-							IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-							IL_004a: pop
-							IL_004b: ldstr "console"
-							IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-							IL_0055: stloc.1
-							IL_0056: ldloc.1
-							IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-							IL_005c: stloc.1
-							IL_005d: ldarg.0
-							IL_005e: ldc.i4.0
-							IL_005f: ldelem.ref
-							IL_0060: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-							IL_0065: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::connections
-							IL_006a: stloc.2
-							IL_006b: ldstr "connections"
-							IL_0070: ldloc.2
-							IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-							IL_0076: stloc.2
-							IL_0077: ldstr "connections:"
-							IL_007c: ldloc.2
-							IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-							IL_0082: stloc.3
-							IL_0083: ldloc.1
-							IL_0084: ldstr "log"
-							IL_0089: ldloc.3
-							IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-							IL_008f: pop
-							IL_0090: ldarg.0
-							IL_0091: ldc.i4.0
-							IL_0092: ldelem.ref
-							IL_0093: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-							IL_0098: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
-							IL_009d: stloc.1
-							IL_009e: ldstr "agent"
-							IL_00a3: ldloc.1
-							IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-							IL_00a9: stloc.1
-							IL_00aa: ldloc.1
-							IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-							IL_00b0: stloc.1
-							IL_00b1: ldloc.1
-							IL_00b2: ldstr "destroy"
-							IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-							IL_00bc: pop
-							IL_00bd: ldarg.0
-							IL_00be: ldc.i4.0
-							IL_00bf: ldelem.ref
-							IL_00c0: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-							IL_00c5: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
-							IL_00ca: stloc.1
-							IL_00cb: ldstr "server"
-							IL_00d0: ldloc.1
-							IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-							IL_00d6: stloc.1
-							IL_00d7: ldloc.1
-							IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-							IL_00dd: stloc.1
-							IL_00de: ldnull
-							IL_00df: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27::__js_call__(object)
-							IL_00e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-							IL_00ea: ldc.i4.0
-							IL_00eb: conv.r8
-							IL_00ec: ldstr ""
-							IL_00f1: ldc.i4.0
-							IL_00f2: ldc.i4.1
-							IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-							IL_00f8: stloc.2
-							IL_00f9: ldloc.1
-							IL_00fa: ldstr "close"
-							IL_00ff: ldloc.2
-							IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-							IL_0105: pop
-							IL_0106: ldnull
-							IL_0107: ret
+							IL_0018: ldstr "body2:"
+							IL_001d: ldarg.0
+							IL_001e: ldc.i4.4
+							IL_001f: ldelem.ref
+							IL_0020: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
+							IL_0025: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope::nextBody
+							IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+							IL_002f: stloc.2
+							IL_0030: ldloc.1
+							IL_0031: ldstr "log"
+							IL_0036: ldloc.2
+							IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+							IL_003c: pop
+							IL_003d: ldstr "console"
+							IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+							IL_0047: stloc.1
+							IL_0048: ldloc.1
+							IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+							IL_004e: stloc.1
+							IL_004f: ldstr "connections:"
+							IL_0054: ldarg.0
+							IL_0055: ldc.i4.0
+							IL_0056: ldelem.ref
+							IL_0057: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+							IL_005c: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::connections
+							IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+							IL_0066: stloc.2
+							IL_0067: ldloc.1
+							IL_0068: ldstr "log"
+							IL_006d: ldloc.2
+							IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+							IL_0073: pop
+							IL_0074: ldarg.0
+							IL_0075: ldc.i4.0
+							IL_0076: ldelem.ref
+							IL_0077: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+							IL_007c: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
+							IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+							IL_0086: stloc.1
+							IL_0087: ldloc.1
+							IL_0088: ldstr "destroy"
+							IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+							IL_0092: pop
+							IL_0093: ldarg.0
+							IL_0094: ldc.i4.0
+							IL_0095: ldelem.ref
+							IL_0096: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+							IL_009b: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
+							IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+							IL_00a5: stloc.1
+							IL_00a6: ldnull
+							IL_00a7: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27::__js_call__(object)
+							IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+							IL_00b2: ldc.i4.0
+							IL_00b3: conv.r8
+							IL_00b4: ldstr ""
+							IL_00b9: ldc.i4.0
+							IL_00ba: ldc.i4.1
+							IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+							IL_00c0: stloc.3
+							IL_00c1: ldloc.1
+							IL_00c2: ldstr "close"
+							IL_00c7: ldloc.3
+							IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+							IL_00cd: pop
+							IL_00ce: ldnull
+							IL_00cf: ret
 						} // end of method FunctionExpression_L57C30::__js_call__
 
 					} // end of class FunctionExpression_L57C30
@@ -550,7 +492,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2924
+							// Method begins at RVA 0x2828
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -575,7 +517,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x2640
+						// Method begins at RVA 0x258c
 						// Header size: 12
 						// Code size: 276 (0x114)
 						.maxstack 8
@@ -727,7 +669,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x291b
+						// Method begins at RVA 0x281f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -751,9 +693,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x24d4
+					// Method begins at RVA 0x246c
 					// Header size: 12
-					// Code size: 352 (0x160)
+					// Code size: 274 (0x112)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/Scope,
@@ -761,8 +703,7 @@
 						[2] object,
 						[3] object,
 						[4] object,
-						[5] object,
-						[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+						[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 					)
 
 					IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/Scope::.ctor()
@@ -773,135 +714,105 @@
 					IL_0011: ldloc.1
 					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0017: stloc.1
-					IL_0018: ldarg.0
-					IL_0019: ldc.i4.2
-					IL_001a: ldelem.ref
-					IL_001b: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
-					IL_0020: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope::body
-					IL_0025: stloc.2
-					IL_0026: ldstr "body"
-					IL_002b: ldloc.2
-					IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0031: stloc.2
-					IL_0032: ldstr "body1:"
-					IL_0037: ldloc.2
-					IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_003d: stloc.3
-					IL_003e: ldloc.1
-					IL_003f: ldstr "log"
-					IL_0044: ldloc.3
-					IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_004a: pop
-					IL_004b: ldarg.0
-					IL_004c: ldc.i4.0
-					IL_004d: ldelem.ref
-					IL_004e: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-					IL_0053: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
-					IL_0058: stloc.1
-					IL_0059: ldstr "http"
-					IL_005e: ldloc.1
-					IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0064: stloc.1
-					IL_0065: ldloc.1
-					IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_006b: stloc.1
-					IL_006c: ldarg.0
-					IL_006d: ldc.i4.1
-					IL_006e: ldelem.ref
-					IL_006f: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
-					IL_0074: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-					IL_0079: stloc.2
-					IL_007a: ldstr "info"
-					IL_007f: ldloc.2
-					IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0085: stloc.2
-					IL_0086: ldloc.2
-					IL_0087: ldstr "address"
-					IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0091: stloc.2
-					IL_0092: ldarg.0
-					IL_0093: ldc.i4.1
-					IL_0094: ldelem.ref
-					IL_0095: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
-					IL_009a: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-					IL_009f: stloc.s 4
-					IL_00a1: ldstr "info"
-					IL_00a6: ldloc.s 4
-					IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_00ad: stloc.s 4
-					IL_00af: ldloc.s 4
-					IL_00b1: ldstr "port"
-					IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_00bb: stloc.s 4
-					IL_00bd: ldarg.0
-					IL_00be: ldc.i4.0
-					IL_00bf: ldelem.ref
-					IL_00c0: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-					IL_00c5: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
-					IL_00ca: stloc.s 5
-					IL_00cc: ldstr "agent"
-					IL_00d1: ldloc.s 5
-					IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_00d8: stloc.s 5
-					IL_00da: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-					IL_00df: dup
-					IL_00e0: ldstr "host"
-					IL_00e5: ldloc.2
-					IL_00e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_00eb: dup
-					IL_00ec: ldstr "port"
-					IL_00f1: ldloc.s 4
-					IL_00f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_00f8: dup
-					IL_00f9: ldstr "path"
-					IL_00fe: ldstr "/two"
-					IL_0103: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_0108: dup
-					IL_0109: ldstr "agent"
-					IL_010e: ldloc.s 5
-					IL_0110: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_0115: stloc.s 6
-					IL_0117: ldc.i4.4
-					IL_0118: newarr [System.Runtime]System.Object
-					IL_011d: dup
-					IL_011e: ldc.i4.0
-					IL_011f: ldarg.0
-					IL_0120: ldc.i4.0
-					IL_0121: ldelem.ref
-					IL_0122: stelem.ref
-					IL_0123: dup
-					IL_0124: ldc.i4.1
-					IL_0125: ldarg.0
-					IL_0126: ldc.i4.1
-					IL_0127: ldelem.ref
-					IL_0128: stelem.ref
-					IL_0129: dup
-					IL_012a: ldc.i4.2
-					IL_012b: ldarg.0
-					IL_012c: ldc.i4.2
-					IL_012d: ldelem.ref
-					IL_012e: stelem.ref
-					IL_012f: dup
-					IL_0130: ldc.i4.3
-					IL_0131: ldloc.0
-					IL_0132: stelem.ref
-					IL_0133: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10::__js_call__(object[], object, object)
-					IL_0139: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_013e: ldc.i4.1
-					IL_013f: conv.r8
-					IL_0140: ldstr ""
-					IL_0145: ldc.i4.0
-					IL_0146: ldc.i4.1
-					IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_014c: stloc.s 5
-					IL_014e: ldloc.1
-					IL_014f: ldstr "get"
-					IL_0154: ldloc.s 6
-					IL_0156: ldloc.s 5
-					IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_015d: pop
-					IL_015e: ldnull
-					IL_015f: ret
+					IL_0018: ldstr "body1:"
+					IL_001d: ldarg.0
+					IL_001e: ldc.i4.2
+					IL_001f: ldelem.ref
+					IL_0020: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
+					IL_0025: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope::body
+					IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_002f: stloc.2
+					IL_0030: ldloc.1
+					IL_0031: ldstr "log"
+					IL_0036: ldloc.2
+					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_003c: pop
+					IL_003d: ldarg.0
+					IL_003e: ldc.i4.0
+					IL_003f: ldelem.ref
+					IL_0040: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+					IL_0045: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
+					IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_004f: stloc.1
+					IL_0050: ldarg.0
+					IL_0051: ldc.i4.1
+					IL_0052: ldelem.ref
+					IL_0053: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
+					IL_0058: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+					IL_005d: ldstr "address"
+					IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0067: stloc.3
+					IL_0068: ldarg.0
+					IL_0069: ldc.i4.1
+					IL_006a: ldelem.ref
+					IL_006b: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
+					IL_0070: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+					IL_0075: ldstr "port"
+					IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_007f: stloc.s 4
+					IL_0081: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+					IL_0086: dup
+					IL_0087: ldstr "host"
+					IL_008c: ldloc.3
+					IL_008d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_0092: dup
+					IL_0093: ldstr "port"
+					IL_0098: ldloc.s 4
+					IL_009a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_009f: dup
+					IL_00a0: ldstr "path"
+					IL_00a5: ldstr "/two"
+					IL_00aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_00af: dup
+					IL_00b0: ldstr "agent"
+					IL_00b5: ldarg.0
+					IL_00b6: ldc.i4.0
+					IL_00b7: ldelem.ref
+					IL_00b8: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+					IL_00bd: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
+					IL_00c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_00c7: stloc.s 5
+					IL_00c9: ldc.i4.4
+					IL_00ca: newarr [System.Runtime]System.Object
+					IL_00cf: dup
+					IL_00d0: ldc.i4.0
+					IL_00d1: ldarg.0
+					IL_00d2: ldc.i4.0
+					IL_00d3: ldelem.ref
+					IL_00d4: stelem.ref
+					IL_00d5: dup
+					IL_00d6: ldc.i4.1
+					IL_00d7: ldarg.0
+					IL_00d8: ldc.i4.1
+					IL_00d9: ldelem.ref
+					IL_00da: stelem.ref
+					IL_00db: dup
+					IL_00dc: ldc.i4.2
+					IL_00dd: ldarg.0
+					IL_00de: ldc.i4.2
+					IL_00df: ldelem.ref
+					IL_00e0: stelem.ref
+					IL_00e1: dup
+					IL_00e2: ldc.i4.3
+					IL_00e3: ldloc.0
+					IL_00e4: stelem.ref
+					IL_00e5: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10::__js_call__(object[], object, object)
+					IL_00eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+					IL_00f0: ldc.i4.1
+					IL_00f1: conv.r8
+					IL_00f2: ldstr ""
+					IL_00f7: ldc.i4.0
+					IL_00f8: ldc.i4.1
+					IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_00fe: stloc.s 4
+					IL_0100: ldloc.1
+					IL_0101: ldstr "get"
+					IL_0106: ldloc.s 5
+					IL_0108: ldloc.s 4
+					IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_010f: pop
+					IL_0110: ldnull
+					IL_0111: ret
 				} // end of method FunctionExpression_L38C20::__js_call__
 
 			} // end of class FunctionExpression_L38C20
@@ -920,7 +831,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2909
+					// Method begins at RVA 0x280d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -945,7 +856,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x238c
+				// Method begins at RVA 0x2334
 				// Header size: 12
 				// Code size: 252 (0xfc)
 				.maxstack 8
@@ -1080,7 +991,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2900
+				// Method begins at RVA 0x2804
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1106,110 +1017,91 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2284
+			// Method begins at RVA 0x225c
 			// Header size: 12
-			// Code size: 252 (0xfc)
+			// Code size: 204 (0xcc)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope,
 				[1] object,
 				[2] object,
 				[3] object,
-				[4] object,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
-			IL_000c: stloc.1
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.1
 			IL_0012: ldloc.1
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.1
-			IL_0019: ldloc.1
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.1
-			IL_0020: ldloc.1
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_002b: stloc.1
-			IL_002c: ldloc.0
-			IL_002d: ldloc.1
-			IL_002e: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-			IL_0033: ldarg.0
-			IL_0034: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
-			IL_0039: stloc.1
-			IL_003a: ldstr "http"
-			IL_003f: ldloc.1
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0045: stloc.1
-			IL_0046: ldloc.1
-			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004c: stloc.1
-			IL_004d: ldloc.0
-			IL_004e: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-			IL_0053: ldstr "address"
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005d: stloc.2
-			IL_005e: ldloc.0
-			IL_005f: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-			IL_0064: ldstr "port"
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006e: stloc.3
-			IL_006f: ldarg.0
-			IL_0070: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
-			IL_0075: stloc.s 4
-			IL_0077: ldstr "agent"
-			IL_007c: ldloc.s 4
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0083: stloc.s 4
-			IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_008a: dup
-			IL_008b: ldstr "host"
-			IL_0090: ldloc.2
-			IL_0091: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0096: dup
-			IL_0097: ldstr "port"
-			IL_009c: ldloc.3
-			IL_009d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00a2: dup
-			IL_00a3: ldstr "path"
-			IL_00a8: ldstr "/one"
-			IL_00ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00b2: dup
-			IL_00b3: ldstr "agent"
-			IL_00b8: ldloc.s 4
-			IL_00ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00bf: stloc.s 5
-			IL_00c1: ldc.i4.2
-			IL_00c2: newarr [System.Runtime]System.Object
-			IL_00c7: dup
-			IL_00c8: ldc.i4.0
-			IL_00c9: ldarg.0
-			IL_00ca: stelem.ref
-			IL_00cb: dup
-			IL_00cc: ldc.i4.1
-			IL_00cd: ldloc.0
-			IL_00ce: stelem.ref
-			IL_00cf: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4::__js_call__(object[], object, object)
-			IL_00d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00da: ldc.i4.1
-			IL_00db: conv.r8
-			IL_00dc: ldstr ""
-			IL_00e1: ldc.i4.0
-			IL_00e2: ldc.i4.1
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00e8: stloc.s 4
-			IL_00ea: ldloc.1
-			IL_00eb: ldstr "get"
-			IL_00f0: ldloc.s 5
-			IL_00f2: ldloc.s 4
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f9: pop
-			IL_00fa: ldnull
-			IL_00fb: ret
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.1
+			IL_001e: ldloc.0
+			IL_001f: ldloc.1
+			IL_0020: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+			IL_0025: ldarg.0
+			IL_0026: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0030: stloc.1
+			IL_0031: ldloc.0
+			IL_0032: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+			IL_0037: ldstr "address"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0041: stloc.2
+			IL_0042: ldloc.0
+			IL_0043: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+			IL_0048: ldstr "port"
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0052: stloc.3
+			IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0058: dup
+			IL_0059: ldstr "host"
+			IL_005e: ldloc.2
+			IL_005f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0064: dup
+			IL_0065: ldstr "port"
+			IL_006a: ldloc.3
+			IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0070: dup
+			IL_0071: ldstr "path"
+			IL_0076: ldstr "/one"
+			IL_007b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0080: dup
+			IL_0081: ldstr "agent"
+			IL_0086: ldarg.0
+			IL_0087: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
+			IL_008c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0091: stloc.s 4
+			IL_0093: ldc.i4.2
+			IL_0094: newarr [System.Runtime]System.Object
+			IL_0099: dup
+			IL_009a: ldc.i4.0
+			IL_009b: ldarg.0
+			IL_009c: stelem.ref
+			IL_009d: dup
+			IL_009e: ldc.i4.1
+			IL_009f: ldloc.0
+			IL_00a0: stelem.ref
+			IL_00a1: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4::__js_call__(object[], object, object)
+			IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00ac: ldc.i4.1
+			IL_00ad: conv.r8
+			IL_00ae: ldstr ""
+			IL_00b3: ldc.i4.0
+			IL_00b4: ldc.i4.1
+			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00ba: stloc.3
+			IL_00bb: ldloc.1
+			IL_00bc: ldstr "get"
+			IL_00c1: ldloc.s 4
+			IL_00c3: ldloc.3
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00c9: pop
+			IL_00ca: ldnull
+			IL_00cb: ret
 		} // end of method FunctionExpression_L19C30::__js_call__
 
 	} // end of class FunctionExpression_L19C30
@@ -1237,7 +1129,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x28e5
+			// Method begins at RVA 0x27e9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1409,7 +1301,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2948
+		// Method begins at RVA 0x284c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25ea
+				// Method begins at RVA 0x25a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -178,7 +178,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2605
+						// Method begins at RVA 0x25bd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -203,13 +203,12 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x24cc
+					// Method begins at RVA 0x24b0
 					// Header size: 12
-					// Code size: 50 (0x32)
+					// Code size: 36 (0x24)
 					.maxstack 8
 					.locals init (
-						[0] object,
-						[1] object
+						[0] object
 					)
 
 					IL_0000: ldarg.0
@@ -217,23 +216,17 @@
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
 					IL_0008: ldfld object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope::body
-					IL_000d: stloc.0
-					IL_000e: ldstr "body"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldloc.0
-					IL_001b: ldarg.2
-					IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0021: stloc.1
-					IL_0022: ldarg.0
-					IL_0023: ldc.i4.2
-					IL_0024: ldelem.ref
-					IL_0025: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
-					IL_002a: ldloc.1
-					IL_002b: stfld object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope::body
-					IL_0030: ldnull
-					IL_0031: ret
+					IL_000d: ldarg.2
+					IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0013: stloc.0
+					IL_0014: ldarg.0
+					IL_0015: ldc.i4.2
+					IL_0016: ldelem.ref
+					IL_0017: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
+					IL_001c: ldloc.0
+					IL_001d: stfld object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope::body
+					IL_0022: ldnull
+					IL_0023: ret
 				} // end of method FunctionExpression_L25C19::__js_call__
 
 			} // end of class FunctionExpression_L25C19
@@ -253,7 +246,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2617
+							// Method begins at RVA 0x25cf
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -276,7 +269,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x25b0
+						// Method begins at RVA 0x2568
 						// Header size: 12
 						// Code size: 37 (0x25)
 						.maxstack 8
@@ -308,7 +301,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x260e
+						// Method begins at RVA 0x25c6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -332,9 +325,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x250c
+					// Method begins at RVA 0x24e0
 					// Header size: 12
-					// Code size: 150 (0x96)
+					// Code size: 122 (0x7a)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/Scope,
@@ -351,55 +344,43 @@
 					IL_0011: ldloc.1
 					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0017: stloc.1
-					IL_0018: ldarg.0
-					IL_0019: ldc.i4.2
-					IL_001a: ldelem.ref
-					IL_001b: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
-					IL_0020: ldfld object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope::body
-					IL_0025: stloc.2
-					IL_0026: ldstr "body"
-					IL_002b: ldloc.2
-					IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0031: stloc.2
-					IL_0032: ldstr "body:"
-					IL_0037: ldloc.2
-					IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_003d: stloc.3
-					IL_003e: ldloc.1
-					IL_003f: ldstr "log"
-					IL_0044: ldloc.3
-					IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_004a: pop
-					IL_004b: ldarg.0
-					IL_004c: ldc.i4.0
-					IL_004d: ldelem.ref
-					IL_004e: castclass Modules.Http_CreateServer_Get_Loopback/Scope
-					IL_0053: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
-					IL_0058: stloc.1
-					IL_0059: ldstr "server"
-					IL_005e: ldloc.1
-					IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0064: stloc.1
-					IL_0065: ldloc.1
-					IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_006b: stloc.1
-					IL_006c: ldnull
-					IL_006d: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19::__js_call__(object)
-					IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_0078: ldc.i4.0
-					IL_0079: conv.r8
-					IL_007a: ldstr ""
-					IL_007f: ldc.i4.0
-					IL_0080: ldc.i4.1
-					IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0086: stloc.2
-					IL_0087: ldloc.1
-					IL_0088: ldstr "close"
-					IL_008d: ldloc.2
-					IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0093: pop
-					IL_0094: ldnull
-					IL_0095: ret
+					IL_0018: ldstr "body:"
+					IL_001d: ldarg.0
+					IL_001e: ldc.i4.2
+					IL_001f: ldelem.ref
+					IL_0020: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
+					IL_0025: ldfld object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope::body
+					IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_002f: stloc.2
+					IL_0030: ldloc.1
+					IL_0031: ldstr "log"
+					IL_0036: ldloc.2
+					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_003c: pop
+					IL_003d: ldarg.0
+					IL_003e: ldc.i4.0
+					IL_003f: ldelem.ref
+					IL_0040: castclass Modules.Http_CreateServer_Get_Loopback/Scope
+					IL_0045: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
+					IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_004f: stloc.1
+					IL_0050: ldnull
+					IL_0051: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19::__js_call__(object)
+					IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_005c: ldc.i4.0
+					IL_005d: conv.r8
+					IL_005e: ldstr ""
+					IL_0063: ldc.i4.0
+					IL_0064: ldc.i4.1
+					IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_006a: stloc.3
+					IL_006b: ldloc.1
+					IL_006c: ldstr "close"
+					IL_0071: ldloc.3
+					IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0077: pop
+					IL_0078: ldnull
+					IL_0079: ret
 				} // end of method FunctionExpression_L29C18::__js_call__
 
 			} // end of class FunctionExpression_L29C18
@@ -418,7 +399,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25fc
+					// Method begins at RVA 0x25b4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -443,7 +424,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x238c
+				// Method begins at RVA 0x2370
 				// Header size: 12
 				// Code size: 305 (0x131)
 				.maxstack 8
@@ -588,7 +569,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25f3
+				// Method begins at RVA 0x25ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -616,7 +597,7 @@
 			)
 			// Method begins at RVA 0x2254
 			// Header size: 12
-			// Code size: 298 (0x12a)
+			// Code size: 270 (0x10e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/Scope,
@@ -630,108 +611,96 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
-			IL_000c: stloc.2
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.2
 			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: stloc.1
-			IL_002e: ldstr "console"
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0038: stloc.2
-			IL_0039: ldloc.2
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003f: stloc.2
-			IL_0040: ldstr "server ready:"
-			IL_0045: ldloc.1
-			IL_0046: ldstr "address"
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0055: stloc.3
-			IL_0056: ldloc.3
-			IL_0057: ldstr ":"
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0061: stloc.3
-			IL_0062: ldloc.3
-			IL_0063: ldloc.1
-			IL_0064: ldstr "port"
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0073: ldc.r8 0.0
-			IL_007c: cgt
-			IL_007e: box [System.Runtime]System.Boolean
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0088: stloc.3
-			IL_0089: ldloc.2
-			IL_008a: ldstr "log"
-			IL_008f: ldloc.3
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0095: pop
-			IL_0096: ldarg.0
-			IL_0097: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::http
-			IL_009c: stloc.2
-			IL_009d: ldstr "http"
-			IL_00a2: ldloc.2
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a8: stloc.2
-			IL_00a9: ldloc.2
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00af: stloc.2
-			IL_00b0: ldstr "http://"
-			IL_00b5: ldloc.1
-			IL_00b6: ldstr "address"
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00c5: stloc.3
-			IL_00c6: ldloc.3
-			IL_00c7: ldstr ":"
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00d1: stloc.3
-			IL_00d2: ldloc.3
-			IL_00d3: ldloc.1
-			IL_00d4: ldstr "port"
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00e3: stloc.3
-			IL_00e4: ldloc.3
-			IL_00e5: ldstr "/hello?name=jroc"
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00ef: stloc.3
-			IL_00f0: ldc.i4.2
-			IL_00f1: newarr [System.Runtime]System.Object
-			IL_00f6: dup
-			IL_00f7: ldc.i4.0
-			IL_00f8: ldarg.0
-			IL_00f9: stelem.ref
-			IL_00fa: dup
-			IL_00fb: ldc.i4.1
-			IL_00fc: ldloc.0
-			IL_00fd: stelem.ref
-			IL_00fe: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76::__js_call__(object[], object, object)
-			IL_0104: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0109: ldc.i4.1
-			IL_010a: conv.r8
-			IL_010b: ldstr ""
-			IL_0110: ldc.i4.0
-			IL_0111: ldc.i4.1
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0117: stloc.s 4
-			IL_0119: ldloc.2
-			IL_011a: ldstr "get"
-			IL_011f: ldloc.3
-			IL_0120: ldloc.s 4
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0127: pop
-			IL_0128: ldnull
-			IL_0129: ret
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.2
+			IL_001e: ldloc.2
+			IL_001f: stloc.1
+			IL_0020: ldstr "console"
+			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_002a: stloc.2
+			IL_002b: ldloc.2
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0031: stloc.2
+			IL_0032: ldstr "server ready:"
+			IL_0037: ldloc.1
+			IL_0038: ldstr "address"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0047: stloc.3
+			IL_0048: ldloc.3
+			IL_0049: ldstr ":"
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0053: stloc.3
+			IL_0054: ldloc.3
+			IL_0055: ldloc.1
+			IL_0056: ldstr "port"
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0065: ldc.r8 0.0
+			IL_006e: cgt
+			IL_0070: box [System.Runtime]System.Boolean
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_007a: stloc.3
+			IL_007b: ldloc.2
+			IL_007c: ldstr "log"
+			IL_0081: ldloc.3
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0087: pop
+			IL_0088: ldarg.0
+			IL_0089: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::http
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0093: stloc.2
+			IL_0094: ldstr "http://"
+			IL_0099: ldloc.1
+			IL_009a: ldstr "address"
+			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00a9: stloc.3
+			IL_00aa: ldloc.3
+			IL_00ab: ldstr ":"
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00b5: stloc.3
+			IL_00b6: ldloc.3
+			IL_00b7: ldloc.1
+			IL_00b8: ldstr "port"
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00c7: stloc.3
+			IL_00c8: ldloc.3
+			IL_00c9: ldstr "/hello?name=jroc"
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00d3: stloc.3
+			IL_00d4: ldc.i4.2
+			IL_00d5: newarr [System.Runtime]System.Object
+			IL_00da: dup
+			IL_00db: ldc.i4.0
+			IL_00dc: ldarg.0
+			IL_00dd: stelem.ref
+			IL_00de: dup
+			IL_00df: ldc.i4.1
+			IL_00e0: ldloc.0
+			IL_00e1: stelem.ref
+			IL_00e2: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76::__js_call__(object[], object, object)
+			IL_00e8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00ed: ldc.i4.1
+			IL_00ee: conv.r8
+			IL_00ef: ldstr ""
+			IL_00f4: ldc.i4.0
+			IL_00f5: ldc.i4.1
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00fb: stloc.s 4
+			IL_00fd: ldloc.2
+			IL_00fe: ldstr "get"
+			IL_0103: ldloc.3
+			IL_0104: ldloc.s 4
+			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_010b: pop
+			IL_010c: ldnull
+			IL_010d: ret
 		} // end of method FunctionExpression_L15C30::__js_call__
 
 	} // end of class FunctionExpression_L15C30
@@ -752,7 +721,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25e1
+			// Method begins at RVA 0x2599
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -859,7 +828,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2620
+		// Method begins at RVA 0x25d8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2883
+					// Method begins at RVA 0x27a7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,13 +47,12 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2334
+				// Method begins at RVA 0x2318
 				// Header size: 12
-				// Code size: 50 (0x32)
+				// Code size: 36 (0x24)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldarg.0
@@ -61,23 +60,17 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
 				IL_0008: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
-				IL_000d: stloc.0
-				IL_000e: ldstr "body"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ldarg.2
-				IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0021: stloc.1
-				IL_0022: ldarg.0
-				IL_0023: ldc.i4.1
-				IL_0024: ldelem.ref
-				IL_0025: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-				IL_002a: ldloc.1
-				IL_002b: stfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
-				IL_0030: ldnull
-				IL_0031: ret
+				IL_000d: ldarg.2
+				IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0013: stloc.0
+				IL_0014: ldarg.0
+				IL_0015: ldc.i4.1
+				IL_0016: ldelem.ref
+				IL_0017: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+				IL_001c: ldloc.0
+				IL_001d: stfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
+				IL_0022: ldnull
+				IL_0023: ret
 			} // end of method FunctionExpression_server::__js_call__
 
 		} // end of class FunctionExpression_server
@@ -93,7 +86,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x288c
+					// Method begins at RVA 0x27b0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -117,16 +110,16 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2374
+				// Method begins at RVA 0x2348
 				// Header size: 12
-				// Code size: 608 (0x260)
+				// Code size: 474 (0x1da)
 				.maxstack 8
 				.locals init (
 					[0] object,
 					[1] object,
-					[2] object,
-					[3] string,
-					[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+					[2] string,
+					[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+					[4] object
 				)
 
 				IL_0000: ldstr "console"
@@ -135,218 +128,154 @@
 				IL_000b: ldloc.0
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0011: stloc.0
-				IL_0012: ldarg.0
-				IL_0013: ldc.i4.1
-				IL_0014: ldelem.ref
-				IL_0015: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-				IL_001a: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
-				IL_001f: stloc.1
-				IL_0020: ldstr "req"
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002b: stloc.1
-				IL_002c: ldloc.1
-				IL_002d: ldstr "method"
-				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0037: stloc.1
-				IL_0038: ldstr "server method:"
-				IL_003d: ldloc.1
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0043: stloc.2
-				IL_0044: ldloc.0
-				IL_0045: ldstr "log"
-				IL_004a: ldloc.2
-				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0050: pop
-				IL_0051: ldstr "console"
-				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_005b: stloc.0
-				IL_005c: ldloc.0
-				IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0062: stloc.0
-				IL_0063: ldarg.0
-				IL_0064: ldc.i4.1
-				IL_0065: ldelem.ref
-				IL_0066: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-				IL_006b: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
-				IL_0070: stloc.1
-				IL_0071: ldstr "req"
-				IL_0076: ldloc.1
-				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_007c: stloc.1
-				IL_007d: ldloc.1
-				IL_007e: ldstr "url"
-				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0088: stloc.1
-				IL_0089: ldstr "server url:"
-				IL_008e: ldloc.1
-				IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0094: stloc.2
-				IL_0095: ldloc.0
-				IL_0096: ldstr "log"
-				IL_009b: ldloc.2
-				IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00a1: pop
-				IL_00a2: ldstr "console"
-				IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00ac: stloc.0
-				IL_00ad: ldloc.0
-				IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00b3: stloc.0
-				IL_00b4: ldarg.0
-				IL_00b5: ldc.i4.1
-				IL_00b6: ldelem.ref
-				IL_00b7: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-				IL_00bc: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
-				IL_00c1: stloc.1
-				IL_00c2: ldstr "req"
-				IL_00c7: ldloc.1
-				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00cd: stloc.1
-				IL_00ce: ldloc.1
-				IL_00cf: ldstr "headers"
-				IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00d9: stloc.1
-				IL_00da: ldloc.1
-				IL_00db: ldstr "content-type"
-				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00e5: stloc.1
-				IL_00e6: ldstr "server type:"
-				IL_00eb: ldloc.1
-				IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00f1: stloc.2
-				IL_00f2: ldloc.0
-				IL_00f3: ldstr "log"
-				IL_00f8: ldloc.2
-				IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00fe: pop
-				IL_00ff: ldstr "console"
-				IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0109: stloc.0
-				IL_010a: ldloc.0
-				IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0110: stloc.0
-				IL_0111: ldarg.0
-				IL_0112: ldc.i4.1
-				IL_0113: ldelem.ref
-				IL_0114: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-				IL_0119: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
-				IL_011e: stloc.1
-				IL_011f: ldstr "body"
-				IL_0124: ldloc.1
-				IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_012a: stloc.1
-				IL_012b: ldstr "server body:"
-				IL_0130: ldloc.1
-				IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0136: stloc.2
-				IL_0137: ldloc.0
-				IL_0138: ldstr "log"
-				IL_013d: ldloc.2
-				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0143: pop
-				IL_0144: ldarg.0
-				IL_0145: ldc.i4.1
-				IL_0146: ldelem.ref
-				IL_0147: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-				IL_014c: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::res
-				IL_0151: stloc.0
-				IL_0152: ldstr "res"
-				IL_0157: ldloc.0
-				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_015d: stloc.0
-				IL_015e: ldloc.0
-				IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0164: stloc.0
-				IL_0165: ldarg.0
-				IL_0166: ldc.i4.1
-				IL_0167: ldelem.ref
-				IL_0168: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-				IL_016d: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
-				IL_0172: stloc.1
-				IL_0173: ldstr "body"
-				IL_0178: ldloc.1
-				IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_017e: stloc.1
-				IL_017f: ldloc.1
-				IL_0180: ldstr "length"
-				IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_018a: stloc.1
-				IL_018b: ldloc.1
-				IL_018c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0191: stloc.3
-				IL_0192: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0197: dup
-				IL_0198: ldstr "Content-Type"
-				IL_019d: ldstr "text/plain"
-				IL_01a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_01a7: dup
-				IL_01a8: ldstr "X-Body-Length"
-				IL_01ad: ldloc.3
-				IL_01ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_01b3: stloc.s 4
-				IL_01b5: ldloc.0
-				IL_01b6: ldstr "writeHead"
-				IL_01bb: ldc.r8 202
-				IL_01c4: box [System.Runtime]System.Double
-				IL_01c9: ldloc.s 4
-				IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_01d0: pop
-				IL_01d1: ldarg.0
-				IL_01d2: ldc.i4.1
-				IL_01d3: ldelem.ref
-				IL_01d4: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-				IL_01d9: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::res
-				IL_01de: stloc.0
-				IL_01df: ldstr "res"
-				IL_01e4: ldloc.0
-				IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_01ea: stloc.0
-				IL_01eb: ldloc.0
-				IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01f1: stloc.0
-				IL_01f2: ldloc.0
-				IL_01f3: ldstr "write"
-				IL_01f8: ldstr "accepted:"
-				IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0202: pop
-				IL_0203: ldarg.0
-				IL_0204: ldc.i4.1
-				IL_0205: ldelem.ref
-				IL_0206: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-				IL_020b: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::res
-				IL_0210: stloc.0
-				IL_0211: ldstr "res"
-				IL_0216: ldloc.0
-				IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_021c: stloc.0
-				IL_021d: ldloc.0
-				IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0223: stloc.0
-				IL_0224: ldarg.0
-				IL_0225: ldc.i4.1
-				IL_0226: ldelem.ref
-				IL_0227: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-				IL_022c: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
-				IL_0231: stloc.1
-				IL_0232: ldstr "body"
-				IL_0237: ldloc.1
-				IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_023d: stloc.1
-				IL_023e: ldloc.1
-				IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0244: stloc.1
-				IL_0245: ldloc.1
-				IL_0246: ldstr "toUpperCase"
-				IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0250: stloc.1
-				IL_0251: ldloc.0
-				IL_0252: ldstr "end"
-				IL_0257: ldloc.1
-				IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_025d: pop
-				IL_025e: ldnull
-				IL_025f: ret
+				IL_0012: ldstr "server method:"
+				IL_0017: ldarg.0
+				IL_0018: ldc.i4.1
+				IL_0019: ldelem.ref
+				IL_001a: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+				IL_001f: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
+				IL_0024: ldstr "method"
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0033: stloc.1
+				IL_0034: ldloc.0
+				IL_0035: ldstr "log"
+				IL_003a: ldloc.1
+				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0040: pop
+				IL_0041: ldstr "console"
+				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_004b: stloc.0
+				IL_004c: ldloc.0
+				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0052: stloc.0
+				IL_0053: ldstr "server url:"
+				IL_0058: ldarg.0
+				IL_0059: ldc.i4.1
+				IL_005a: ldelem.ref
+				IL_005b: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+				IL_0060: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
+				IL_0065: ldstr "url"
+				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0074: stloc.1
+				IL_0075: ldloc.0
+				IL_0076: ldstr "log"
+				IL_007b: ldloc.1
+				IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0081: pop
+				IL_0082: ldstr "console"
+				IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_008c: stloc.0
+				IL_008d: ldloc.0
+				IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0093: stloc.0
+				IL_0094: ldstr "server type:"
+				IL_0099: ldarg.0
+				IL_009a: ldc.i4.1
+				IL_009b: ldelem.ref
+				IL_009c: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+				IL_00a1: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
+				IL_00a6: ldstr "headers"
+				IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00b0: ldstr "content-type"
+				IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00bf: stloc.1
+				IL_00c0: ldloc.0
+				IL_00c1: ldstr "log"
+				IL_00c6: ldloc.1
+				IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00cc: pop
+				IL_00cd: ldstr "console"
+				IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00d7: stloc.0
+				IL_00d8: ldloc.0
+				IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00de: stloc.0
+				IL_00df: ldstr "server body:"
+				IL_00e4: ldarg.0
+				IL_00e5: ldc.i4.1
+				IL_00e6: ldelem.ref
+				IL_00e7: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+				IL_00ec: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
+				IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00f6: stloc.1
+				IL_00f7: ldloc.0
+				IL_00f8: ldstr "log"
+				IL_00fd: ldloc.1
+				IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0103: pop
+				IL_0104: ldarg.0
+				IL_0105: ldc.i4.1
+				IL_0106: ldelem.ref
+				IL_0107: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+				IL_010c: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::res
+				IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0116: stloc.0
+				IL_0117: ldarg.0
+				IL_0118: ldc.i4.1
+				IL_0119: ldelem.ref
+				IL_011a: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+				IL_011f: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
+				IL_0124: ldstr "length"
+				IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_012e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0133: stloc.2
+				IL_0134: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0139: dup
+				IL_013a: ldstr "Content-Type"
+				IL_013f: ldstr "text/plain"
+				IL_0144: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0149: dup
+				IL_014a: ldstr "X-Body-Length"
+				IL_014f: ldloc.2
+				IL_0150: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0155: stloc.3
+				IL_0156: ldloc.0
+				IL_0157: ldstr "writeHead"
+				IL_015c: ldc.r8 202
+				IL_0165: box [System.Runtime]System.Double
+				IL_016a: ldloc.3
+				IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0170: pop
+				IL_0171: ldarg.0
+				IL_0172: ldc.i4.1
+				IL_0173: ldelem.ref
+				IL_0174: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+				IL_0179: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::res
+				IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0183: stloc.0
+				IL_0184: ldloc.0
+				IL_0185: ldstr "write"
+				IL_018a: ldstr "accepted:"
+				IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0194: pop
+				IL_0195: ldarg.0
+				IL_0196: ldc.i4.1
+				IL_0197: ldelem.ref
+				IL_0198: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+				IL_019d: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::res
+				IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01a7: stloc.0
+				IL_01a8: ldarg.0
+				IL_01a9: ldc.i4.1
+				IL_01aa: ldelem.ref
+				IL_01ab: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+				IL_01b0: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
+				IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01ba: stloc.s 4
+				IL_01bc: ldloc.s 4
+				IL_01be: ldstr "toUpperCase"
+				IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_01c8: stloc.s 4
+				IL_01ca: ldloc.0
+				IL_01cb: ldstr "end"
+				IL_01d0: ldloc.s 4
+				IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_01d7: pop
+				IL_01d8: ldnull
+				IL_01d9: ret
 			} // end of method FunctionExpression_server_L13C16::__js_call__
 
 		} // end of class FunctionExpression_server_L13C16
@@ -368,7 +297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x287a
+				// Method begins at RVA 0x279e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -509,7 +438,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x28a7
+						// Method begins at RVA 0x27cb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -534,13 +463,12 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x275c
+					// Method begins at RVA 0x26ac
 					// Header size: 12
-					// Code size: 50 (0x32)
+					// Code size: 36 (0x24)
 					.maxstack 8
 					.locals init (
-						[0] object,
-						[1] object
+						[0] object
 					)
 
 					IL_0000: ldarg.0
@@ -548,23 +476,17 @@
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
 					IL_0008: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope::responseBody
-					IL_000d: stloc.0
-					IL_000e: ldstr "responseBody"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldloc.0
-					IL_001b: ldarg.2
-					IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0021: stloc.1
-					IL_0022: ldarg.0
-					IL_0023: ldc.i4.2
-					IL_0024: ldelem.ref
-					IL_0025: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
-					IL_002a: ldloc.1
-					IL_002b: stfld object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope::responseBody
-					IL_0030: ldnull
-					IL_0031: ret
+					IL_000d: ldarg.2
+					IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0013: stloc.0
+					IL_0014: ldarg.0
+					IL_0015: ldc.i4.2
+					IL_0016: ldelem.ref
+					IL_0017: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
+					IL_001c: ldloc.0
+					IL_001d: stfld object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope::responseBody
+					IL_0022: ldnull
+					IL_0023: ret
 				} // end of method FunctionExpression_req::__js_call__
 
 			} // end of class FunctionExpression_req
@@ -584,7 +506,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x28b9
+							// Method begins at RVA 0x27dd
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -607,7 +529,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x2840
+						// Method begins at RVA 0x2764
 						// Header size: 12
 						// Code size: 37 (0x25)
 						.maxstack 8
@@ -639,7 +561,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x28b0
+						// Method begins at RVA 0x27d4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -663,9 +585,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x279c
+					// Method begins at RVA 0x26dc
 					// Header size: 12
-					// Code size: 150 (0x96)
+					// Code size: 122 (0x7a)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/Scope,
@@ -682,55 +604,43 @@
 					IL_0011: ldloc.1
 					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0017: stloc.1
-					IL_0018: ldarg.0
-					IL_0019: ldc.i4.2
-					IL_001a: ldelem.ref
-					IL_001b: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
-					IL_0020: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope::responseBody
-					IL_0025: stloc.2
-					IL_0026: ldstr "responseBody"
-					IL_002b: ldloc.2
-					IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0031: stloc.2
-					IL_0032: ldstr "client body:"
-					IL_0037: ldloc.2
-					IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_003d: stloc.3
-					IL_003e: ldloc.1
-					IL_003f: ldstr "log"
-					IL_0044: ldloc.3
-					IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_004a: pop
-					IL_004b: ldarg.0
-					IL_004c: ldc.i4.0
-					IL_004d: ldelem.ref
-					IL_004e: castclass Modules.Http_Request_Post_Basic/Scope
-					IL_0053: ldfld object Modules.Http_Request_Post_Basic/Scope::server
-					IL_0058: stloc.1
-					IL_0059: ldstr "server"
-					IL_005e: ldloc.1
-					IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0064: stloc.1
-					IL_0065: ldloc.1
-					IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_006b: stloc.1
-					IL_006c: ldnull
-					IL_006d: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req::__js_call__(object)
-					IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_0078: ldc.i4.0
-					IL_0079: conv.r8
-					IL_007a: ldstr ""
-					IL_007f: ldc.i4.0
-					IL_0080: ldc.i4.1
-					IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0086: stloc.2
-					IL_0087: ldloc.1
-					IL_0088: ldstr "close"
-					IL_008d: ldloc.2
-					IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0093: pop
-					IL_0094: ldnull
-					IL_0095: ret
+					IL_0018: ldstr "client body:"
+					IL_001d: ldarg.0
+					IL_001e: ldc.i4.2
+					IL_001f: ldelem.ref
+					IL_0020: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
+					IL_0025: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope::responseBody
+					IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_002f: stloc.2
+					IL_0030: ldloc.1
+					IL_0031: ldstr "log"
+					IL_0036: ldloc.2
+					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_003c: pop
+					IL_003d: ldarg.0
+					IL_003e: ldc.i4.0
+					IL_003f: ldelem.ref
+					IL_0040: castclass Modules.Http_Request_Post_Basic/Scope
+					IL_0045: ldfld object Modules.Http_Request_Post_Basic/Scope::server
+					IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_004f: stloc.1
+					IL_0050: ldnull
+					IL_0051: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req::__js_call__(object)
+					IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_005c: ldc.i4.0
+					IL_005d: conv.r8
+					IL_005e: ldstr ""
+					IL_0063: ldc.i4.0
+					IL_0064: ldc.i4.1
+					IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_006a: stloc.3
+					IL_006b: ldloc.1
+					IL_006c: ldstr "close"
+					IL_0071: ldloc.3
+					IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0077: pop
+					IL_0078: ldnull
+					IL_0079: ret
 				} // end of method FunctionExpression_req_L51C20::__js_call__
 
 			} // end of class FunctionExpression_req_L51C20
@@ -750,7 +660,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x289e
+					// Method begins at RVA 0x27c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -775,7 +685,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25e0
+				// Method begins at RVA 0x2530
 				// Header size: 12
 				// Code size: 368 (0x170)
 				.maxstack 8
@@ -939,7 +849,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2895
+				// Method begins at RVA 0x27b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -967,7 +877,7 @@
 			)
 			// Method begins at RVA 0x21f0
 			// Header size: 12
-			// Code size: 310 (0x136)
+			// Code size: 282 (0x11a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/Scope,
@@ -983,109 +893,97 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Http_Request_Post_Basic/Scope::server
-			IL_000c: stloc.3
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.3
 			IL_0012: ldloc.3
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.3
-			IL_0019: ldloc.3
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.3
-			IL_0020: ldloc.3
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.3
+			IL_001e: ldloc.3
+			IL_001f: stloc.1
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Http_Request_Post_Basic/Scope::http
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002b: stloc.3
-			IL_002c: ldloc.3
-			IL_002d: stloc.1
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Http_Request_Post_Basic/Scope::http
-			IL_0034: stloc.3
-			IL_0035: ldstr "http"
-			IL_003a: ldloc.3
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0040: stloc.3
-			IL_0041: ldloc.3
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0047: stloc.3
-			IL_0048: ldloc.1
-			IL_0049: ldstr "address"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0053: stloc.s 4
-			IL_0055: ldloc.1
-			IL_0056: ldstr "port"
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0060: stloc.s 5
-			IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0067: dup
-			IL_0068: ldstr "host"
-			IL_006d: ldloc.s 4
-			IL_006f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0074: dup
-			IL_0075: ldstr "port"
-			IL_007a: ldloc.s 5
-			IL_007c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0081: dup
-			IL_0082: ldstr "path"
-			IL_0087: ldstr "/submit"
-			IL_008c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0091: dup
-			IL_0092: ldstr "method"
-			IL_0097: ldstr "POST"
-			IL_009c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00a1: dup
-			IL_00a2: ldstr "headers"
-			IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00ac: dup
-			IL_00ad: ldstr "Content-Type"
-			IL_00b2: ldstr "text/plain"
-			IL_00b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00c1: stloc.s 6
-			IL_00c3: ldc.i4.2
-			IL_00c4: newarr [System.Runtime]System.Object
-			IL_00c9: dup
-			IL_00ca: ldc.i4.0
-			IL_00cb: ldarg.0
-			IL_00cc: stelem.ref
-			IL_00cd: dup
-			IL_00ce: ldc.i4.1
-			IL_00cf: ldloc.0
-			IL_00d0: stelem.ref
-			IL_00d1: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req::__js_call__(object[], object, object)
-			IL_00d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00dc: ldc.i4.1
-			IL_00dd: conv.r8
-			IL_00de: ldstr ""
-			IL_00e3: ldc.i4.0
-			IL_00e4: ldc.i4.1
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_002c: ldloc.1
+			IL_002d: ldstr "address"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.s 4
+			IL_0039: ldloc.1
+			IL_003a: ldstr "port"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0044: stloc.s 5
+			IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_004b: dup
+			IL_004c: ldstr "host"
+			IL_0051: ldloc.s 4
+			IL_0053: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0058: dup
+			IL_0059: ldstr "port"
+			IL_005e: ldloc.s 5
+			IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0065: dup
+			IL_0066: ldstr "path"
+			IL_006b: ldstr "/submit"
+			IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0075: dup
+			IL_0076: ldstr "method"
+			IL_007b: ldstr "POST"
+			IL_0080: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0085: dup
+			IL_0086: ldstr "headers"
+			IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0090: dup
+			IL_0091: ldstr "Content-Type"
+			IL_0096: ldstr "text/plain"
+			IL_009b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00a5: stloc.s 6
+			IL_00a7: ldc.i4.2
+			IL_00a8: newarr [System.Runtime]System.Object
+			IL_00ad: dup
+			IL_00ae: ldc.i4.0
+			IL_00af: ldarg.0
+			IL_00b0: stelem.ref
+			IL_00b1: dup
+			IL_00b2: ldc.i4.1
+			IL_00b3: ldloc.0
+			IL_00b4: stelem.ref
+			IL_00b5: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req::__js_call__(object[], object, object)
+			IL_00bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00c0: ldc.i4.1
+			IL_00c1: conv.r8
+			IL_00c2: ldstr ""
+			IL_00c7: ldc.i4.0
+			IL_00c8: ldc.i4.1
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00ce: stloc.s 5
+			IL_00d0: ldloc.3
+			IL_00d1: ldstr "request"
+			IL_00d6: ldloc.s 6
+			IL_00d8: ldloc.s 5
+			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00df: stloc.s 5
+			IL_00e1: ldloc.s 5
+			IL_00e3: stloc.2
+			IL_00e4: ldloc.2
+			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00ea: stloc.s 5
-			IL_00ec: ldloc.3
-			IL_00ed: ldstr "request"
-			IL_00f2: ldloc.s 6
-			IL_00f4: ldloc.s 5
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00fb: stloc.s 5
-			IL_00fd: ldloc.s 5
-			IL_00ff: stloc.2
-			IL_0100: ldloc.2
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0106: stloc.s 5
-			IL_0108: ldloc.s 5
-			IL_010a: ldstr "write"
-			IL_010f: ldstr "node "
-			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0119: pop
-			IL_011a: ldloc.2
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0120: stloc.s 5
-			IL_0122: ldloc.s 5
-			IL_0124: ldstr "end"
-			IL_0129: ldstr "baseline"
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0133: pop
-			IL_0134: ldnull
-			IL_0135: ret
+			IL_00ec: ldloc.s 5
+			IL_00ee: ldstr "write"
+			IL_00f3: ldstr "node "
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00fd: pop
+			IL_00fe: ldloc.2
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0104: stloc.s 5
+			IL_0106: ldloc.s 5
+			IL_0108: ldstr "end"
+			IL_010d: ldstr "baseline"
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0117: pop
+			IL_0118: ldnull
+			IL_0119: ret
 		} // end of method FunctionExpression_L28C30::__js_call__
 
 	} // end of class FunctionExpression_L28C30
@@ -1106,7 +1004,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2871
+			// Method begins at RVA 0x2795
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1221,7 +1119,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x28c2
+		// Method begins at RVA 0x27e6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Streaming_Chunked_RequestBody.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Streaming_Chunked_RequestBody.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26ff
+					// Method begins at RVA 0x2663
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,14 +47,13 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2370
+				// Method begins at RVA 0x2354
 				// Header size: 12
-				// Code size: 195 (0xc3)
+				// Code size: 153 (0x99)
 				.maxstack 8
 				.locals init (
 					[0] object,
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: ldarg.0
@@ -62,76 +61,58 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
 				IL_0008: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::chunkCount
-				IL_000d: stloc.0
-				IL_000e: ldstr "chunkCount"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ldc.r8 1
-				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0029: stloc.1
-				IL_002a: ldarg.0
-				IL_002b: ldc.i4.1
-				IL_002c: ldelem.ref
-				IL_002d: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
-				IL_0032: ldloc.1
-				IL_0033: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::chunkCount
-				IL_0038: ldstr "console"
-				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0042: stloc.0
-				IL_0043: ldloc.0
-				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0049: stloc.0
-				IL_004a: ldarg.0
-				IL_004b: ldc.i4.1
-				IL_004c: ldelem.ref
-				IL_004d: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
-				IL_0052: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::chunkCount
-				IL_0057: stloc.2
-				IL_0058: ldstr "chunkCount"
-				IL_005d: ldloc.2
-				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0063: stloc.2
-				IL_0064: ldstr "chunk"
-				IL_0069: ldloc.2
-				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_006f: stloc.1
-				IL_0070: ldloc.1
-				IL_0071: ldstr ":"
-				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_007b: stloc.1
-				IL_007c: ldloc.1
-				IL_007d: ldarg.2
-				IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0083: stloc.1
-				IL_0084: ldloc.0
-				IL_0085: ldstr "log"
-				IL_008a: ldloc.1
-				IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0090: pop
-				IL_0091: ldarg.0
-				IL_0092: ldc.i4.1
-				IL_0093: ldelem.ref
-				IL_0094: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
-				IL_0099: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::body
-				IL_009e: stloc.0
-				IL_009f: ldstr "body"
-				IL_00a4: ldloc.0
-				IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00aa: stloc.0
-				IL_00ab: ldloc.0
-				IL_00ac: ldarg.2
-				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00b2: stloc.1
-				IL_00b3: ldarg.0
-				IL_00b4: ldc.i4.1
-				IL_00b5: ldelem.ref
-				IL_00b6: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
-				IL_00bb: ldloc.1
-				IL_00bc: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::body
-				IL_00c1: ldnull
-				IL_00c2: ret
+				IL_000d: ldc.r8 1
+				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_001b: stloc.0
+				IL_001c: ldarg.0
+				IL_001d: ldc.i4.1
+				IL_001e: ldelem.ref
+				IL_001f: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
+				IL_0024: ldloc.0
+				IL_0025: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::chunkCount
+				IL_002a: ldstr "console"
+				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0034: stloc.1
+				IL_0035: ldloc.1
+				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003b: stloc.1
+				IL_003c: ldstr "chunk"
+				IL_0041: ldarg.0
+				IL_0042: ldc.i4.1
+				IL_0043: ldelem.ref
+				IL_0044: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
+				IL_0049: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::chunkCount
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0053: stloc.0
+				IL_0054: ldloc.0
+				IL_0055: ldstr ":"
+				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_005f: stloc.0
+				IL_0060: ldloc.0
+				IL_0061: ldarg.2
+				IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0067: stloc.0
+				IL_0068: ldloc.1
+				IL_0069: ldstr "log"
+				IL_006e: ldloc.0
+				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0074: pop
+				IL_0075: ldarg.0
+				IL_0076: ldc.i4.1
+				IL_0077: ldelem.ref
+				IL_0078: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
+				IL_007d: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::body
+				IL_0082: ldarg.2
+				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0088: stloc.0
+				IL_0089: ldarg.0
+				IL_008a: ldc.i4.1
+				IL_008b: ldelem.ref
+				IL_008c: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
+				IL_0091: ldloc.0
+				IL_0092: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::body
+				IL_0097: ldnull
+				IL_0098: ret
 			} // end of method FunctionExpression_server::__js_call__
 
 		} // end of class FunctionExpression_server
@@ -147,7 +128,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2708
+					// Method begins at RVA 0x266c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -171,14 +152,13 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2440
+				// Method begins at RVA 0x23fc
 				// Header size: 12
-				// Code size: 190 (0xbe)
+				// Code size: 148 (0x94)
 				.maxstack 8
 				.locals init (
 					[0] object,
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: ldstr "console"
@@ -187,70 +167,52 @@
 				IL_000b: ldloc.0
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0011: stloc.0
-				IL_0012: ldarg.0
-				IL_0013: ldc.i4.1
-				IL_0014: ldelem.ref
-				IL_0015: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
-				IL_001a: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::chunkCount
-				IL_001f: stloc.1
-				IL_0020: ldstr "chunkCount"
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002b: stloc.1
-				IL_002c: ldstr "chunkCount:"
-				IL_0031: ldloc.1
-				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0037: stloc.2
-				IL_0038: ldloc.0
-				IL_0039: ldstr "log"
-				IL_003e: ldloc.2
-				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0044: pop
-				IL_0045: ldstr "console"
-				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_004f: stloc.0
-				IL_0050: ldloc.0
-				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0056: stloc.0
-				IL_0057: ldarg.0
-				IL_0058: ldc.i4.1
-				IL_0059: ldelem.ref
-				IL_005a: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
-				IL_005f: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::body
-				IL_0064: stloc.1
-				IL_0065: ldstr "body"
-				IL_006a: ldloc.1
-				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0070: stloc.1
-				IL_0071: ldstr "body:"
-				IL_0076: ldloc.1
-				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_007c: stloc.2
-				IL_007d: ldloc.0
-				IL_007e: ldstr "log"
-				IL_0083: ldloc.2
-				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0089: pop
-				IL_008a: ldarg.0
-				IL_008b: ldc.i4.1
-				IL_008c: ldelem.ref
-				IL_008d: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
-				IL_0092: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::res
-				IL_0097: stloc.0
-				IL_0098: ldstr "res"
-				IL_009d: ldloc.0
-				IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00a3: stloc.0
-				IL_00a4: ldloc.0
-				IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00aa: stloc.0
-				IL_00ab: ldloc.0
-				IL_00ac: ldstr "end"
-				IL_00b1: ldstr "ok"
-				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00bb: pop
-				IL_00bc: ldnull
-				IL_00bd: ret
+				IL_0012: ldstr "chunkCount:"
+				IL_0017: ldarg.0
+				IL_0018: ldc.i4.1
+				IL_0019: ldelem.ref
+				IL_001a: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
+				IL_001f: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::chunkCount
+				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0029: stloc.1
+				IL_002a: ldloc.0
+				IL_002b: ldstr "log"
+				IL_0030: ldloc.1
+				IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0036: pop
+				IL_0037: ldstr "console"
+				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0041: stloc.0
+				IL_0042: ldloc.0
+				IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0048: stloc.0
+				IL_0049: ldstr "body:"
+				IL_004e: ldarg.0
+				IL_004f: ldc.i4.1
+				IL_0050: ldelem.ref
+				IL_0051: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
+				IL_0056: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::body
+				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0060: stloc.1
+				IL_0061: ldloc.0
+				IL_0062: ldstr "log"
+				IL_0067: ldloc.1
+				IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_006d: pop
+				IL_006e: ldarg.0
+				IL_006f: ldc.i4.1
+				IL_0070: ldelem.ref
+				IL_0071: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
+				IL_0076: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::res
+				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0080: stloc.0
+				IL_0081: ldloc.0
+				IL_0082: ldstr "end"
+				IL_0087: ldstr "ok"
+				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0091: pop
+				IL_0092: ldnull
+				IL_0093: ret
 			} // end of method FunctionExpression_server_L19C16::__js_call__
 
 		} // end of class FunctionExpression_server_L19C16
@@ -273,7 +235,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26f6
+				// Method begins at RVA 0x265a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -432,7 +394,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2723
+						// Method begins at RVA 0x2687
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -457,13 +419,12 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x25d8
+					// Method begins at RVA 0x2568
 					// Header size: 12
-					// Code size: 50 (0x32)
+					// Code size: 36 (0x24)
 					.maxstack 8
 					.locals init (
-						[0] object,
-						[1] object
+						[0] object
 					)
 
 					IL_0000: ldarg.0
@@ -471,23 +432,17 @@
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
 					IL_0008: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope::responseBody
-					IL_000d: stloc.0
-					IL_000e: ldstr "responseBody"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldloc.0
-					IL_001b: ldarg.2
-					IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0021: stloc.1
-					IL_0022: ldarg.0
-					IL_0023: ldc.i4.2
-					IL_0024: ldelem.ref
-					IL_0025: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
-					IL_002a: ldloc.1
-					IL_002b: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope::responseBody
-					IL_0030: ldnull
-					IL_0031: ret
+					IL_000d: ldarg.2
+					IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0013: stloc.0
+					IL_0014: ldarg.0
+					IL_0015: ldc.i4.2
+					IL_0016: ldelem.ref
+					IL_0017: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
+					IL_001c: ldloc.0
+					IL_001d: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope::responseBody
+					IL_0022: ldnull
+					IL_0023: ret
 				} // end of method FunctionExpression_req::__js_call__
 
 			} // end of class FunctionExpression_req
@@ -507,7 +462,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2735
+							// Method begins at RVA 0x2699
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -530,7 +485,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x26bc
+						// Method begins at RVA 0x2620
 						// Header size: 12
 						// Code size: 37 (0x25)
 						.maxstack 8
@@ -562,7 +517,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x272c
+						// Method begins at RVA 0x2690
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -586,9 +541,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2618
+					// Method begins at RVA 0x2598
 					// Header size: 12
-					// Code size: 150 (0x96)
+					// Code size: 122 (0x7a)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/Scope,
@@ -605,55 +560,43 @@
 					IL_0011: ldloc.1
 					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0017: stloc.1
-					IL_0018: ldarg.0
-					IL_0019: ldc.i4.2
-					IL_001a: ldelem.ref
-					IL_001b: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
-					IL_0020: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope::responseBody
-					IL_0025: stloc.2
-					IL_0026: ldstr "responseBody"
-					IL_002b: ldloc.2
-					IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0031: stloc.2
-					IL_0032: ldstr "response:"
-					IL_0037: ldloc.2
-					IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_003d: stloc.3
-					IL_003e: ldloc.1
-					IL_003f: ldstr "log"
-					IL_0044: ldloc.3
-					IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_004a: pop
-					IL_004b: ldarg.0
-					IL_004c: ldc.i4.0
-					IL_004d: ldelem.ref
-					IL_004e: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-					IL_0053: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
-					IL_0058: stloc.1
-					IL_0059: ldstr "server"
-					IL_005e: ldloc.1
-					IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0064: stloc.1
-					IL_0065: ldloc.1
-					IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_006b: stloc.1
-					IL_006c: ldnull
-					IL_006d: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req::__js_call__(object)
-					IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_0078: ldc.i4.0
-					IL_0079: conv.r8
-					IL_007a: ldstr ""
-					IL_007f: ldc.i4.0
-					IL_0080: ldc.i4.1
-					IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0086: stloc.2
-					IL_0087: ldloc.1
-					IL_0088: ldstr "close"
-					IL_008d: ldloc.2
-					IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0093: pop
-					IL_0094: ldnull
-					IL_0095: ret
+					IL_0018: ldstr "response:"
+					IL_001d: ldarg.0
+					IL_001e: ldc.i4.2
+					IL_001f: ldelem.ref
+					IL_0020: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
+					IL_0025: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope::responseBody
+					IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_002f: stloc.2
+					IL_0030: ldloc.1
+					IL_0031: ldstr "log"
+					IL_0036: ldloc.2
+					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_003c: pop
+					IL_003d: ldarg.0
+					IL_003e: ldc.i4.0
+					IL_003f: ldelem.ref
+					IL_0040: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
+					IL_0045: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
+					IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_004f: stloc.1
+					IL_0050: ldnull
+					IL_0051: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req::__js_call__(object)
+					IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_005c: ldc.i4.0
+					IL_005d: conv.r8
+					IL_005e: ldstr ""
+					IL_0063: ldc.i4.0
+					IL_0064: ldc.i4.1
+					IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_006a: stloc.3
+					IL_006b: ldloc.1
+					IL_006c: ldstr "close"
+					IL_0071: ldloc.3
+					IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0077: pop
+					IL_0078: ldnull
+					IL_0079: ret
 				} // end of method FunctionExpression_req_L46C20::__js_call__
 
 			} // end of class FunctionExpression_req_L46C20
@@ -673,7 +616,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x271a
+					// Method begins at RVA 0x267e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -698,7 +641,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x250c
+				// Method begins at RVA 0x249c
 				// Header size: 12
 				// Code size: 189 (0xbd)
 				.maxstack 8
@@ -806,7 +749,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2711
+				// Method begins at RVA 0x2675
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -834,7 +777,7 @@
 			)
 			// Method begins at RVA 0x222c
 			// Header size: 12
-			// Code size: 310 (0x136)
+			// Code size: 282 (0x11a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/Scope,
@@ -850,109 +793,97 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
-			IL_000c: stloc.3
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.3
 			IL_0012: ldloc.3
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.3
-			IL_0019: ldloc.3
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.3
-			IL_0020: ldloc.3
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.3
+			IL_001e: ldloc.3
+			IL_001f: stloc.1
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002b: stloc.3
-			IL_002c: ldloc.3
-			IL_002d: stloc.1
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
-			IL_0034: stloc.3
-			IL_0035: ldstr "http"
-			IL_003a: ldloc.3
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0040: stloc.3
-			IL_0041: ldloc.3
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0047: stloc.3
-			IL_0048: ldloc.1
-			IL_0049: ldstr "address"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0053: stloc.s 4
-			IL_0055: ldloc.1
-			IL_0056: ldstr "port"
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0060: stloc.s 5
-			IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0067: dup
-			IL_0068: ldstr "host"
-			IL_006d: ldloc.s 4
-			IL_006f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0074: dup
-			IL_0075: ldstr "port"
-			IL_007a: ldloc.s 5
-			IL_007c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0081: dup
-			IL_0082: ldstr "path"
-			IL_0087: ldstr "/stream"
-			IL_008c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0091: dup
-			IL_0092: ldstr "method"
-			IL_0097: ldstr "POST"
-			IL_009c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00a1: dup
-			IL_00a2: ldstr "headers"
-			IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00ac: dup
-			IL_00ad: ldstr "Content-Type"
-			IL_00b2: ldstr "text/plain"
-			IL_00b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00c1: stloc.s 6
-			IL_00c3: ldc.i4.2
-			IL_00c4: newarr [System.Runtime]System.Object
-			IL_00c9: dup
-			IL_00ca: ldc.i4.0
-			IL_00cb: ldarg.0
-			IL_00cc: stelem.ref
-			IL_00cd: dup
-			IL_00ce: ldc.i4.1
-			IL_00cf: ldloc.0
-			IL_00d0: stelem.ref
-			IL_00d1: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req::__js_call__(object[], object, object)
-			IL_00d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00dc: ldc.i4.1
-			IL_00dd: conv.r8
-			IL_00de: ldstr ""
-			IL_00e3: ldc.i4.0
-			IL_00e4: ldc.i4.1
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_002c: ldloc.1
+			IL_002d: ldstr "address"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.s 4
+			IL_0039: ldloc.1
+			IL_003a: ldstr "port"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0044: stloc.s 5
+			IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_004b: dup
+			IL_004c: ldstr "host"
+			IL_0051: ldloc.s 4
+			IL_0053: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0058: dup
+			IL_0059: ldstr "port"
+			IL_005e: ldloc.s 5
+			IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0065: dup
+			IL_0066: ldstr "path"
+			IL_006b: ldstr "/stream"
+			IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0075: dup
+			IL_0076: ldstr "method"
+			IL_007b: ldstr "POST"
+			IL_0080: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0085: dup
+			IL_0086: ldstr "headers"
+			IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0090: dup
+			IL_0091: ldstr "Content-Type"
+			IL_0096: ldstr "text/plain"
+			IL_009b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00a5: stloc.s 6
+			IL_00a7: ldc.i4.2
+			IL_00a8: newarr [System.Runtime]System.Object
+			IL_00ad: dup
+			IL_00ae: ldc.i4.0
+			IL_00af: ldarg.0
+			IL_00b0: stelem.ref
+			IL_00b1: dup
+			IL_00b2: ldc.i4.1
+			IL_00b3: ldloc.0
+			IL_00b4: stelem.ref
+			IL_00b5: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req::__js_call__(object[], object, object)
+			IL_00bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00c0: ldc.i4.1
+			IL_00c1: conv.r8
+			IL_00c2: ldstr ""
+			IL_00c7: ldc.i4.0
+			IL_00c8: ldc.i4.1
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00ce: stloc.s 5
+			IL_00d0: ldloc.3
+			IL_00d1: ldstr "request"
+			IL_00d6: ldloc.s 6
+			IL_00d8: ldloc.s 5
+			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00df: stloc.s 5
+			IL_00e1: ldloc.s 5
+			IL_00e3: stloc.2
+			IL_00e4: ldloc.2
+			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00ea: stloc.s 5
-			IL_00ec: ldloc.3
-			IL_00ed: ldstr "request"
-			IL_00f2: ldloc.s 6
-			IL_00f4: ldloc.s 5
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00fb: stloc.s 5
-			IL_00fd: ldloc.s 5
-			IL_00ff: stloc.2
-			IL_0100: ldloc.2
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0106: stloc.s 5
-			IL_0108: ldloc.s 5
-			IL_010a: ldstr "write"
-			IL_010f: ldstr "alpha"
-			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0119: pop
-			IL_011a: ldloc.2
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0120: stloc.s 5
-			IL_0122: ldloc.s 5
-			IL_0124: ldstr "end"
-			IL_0129: ldstr "beta"
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0133: pop
-			IL_0134: ldnull
-			IL_0135: ret
+			IL_00ec: ldloc.s 5
+			IL_00ee: ldstr "write"
+			IL_00f3: ldstr "alpha"
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00fd: pop
+			IL_00fe: ldloc.2
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0104: stloc.s 5
+			IL_0106: ldloc.s 5
+			IL_0108: ldstr "end"
+			IL_010d: ldstr "beta"
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0117: pop
+			IL_0118: ldnull
+			IL_0119: ret
 		} // end of method FunctionExpression_L26C30::__js_call__
 
 	} // end of class FunctionExpression_L26C30
@@ -973,7 +904,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26ed
+			// Method begins at RVA 0x2651
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1088,7 +1019,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x273e
+		// Method begins at RVA 0x26a2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Unsupported_Connect_Fails_Clearly.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Unsupported_Connect_Fails_Clearly.verified.txt
@@ -201,11 +201,11 @@
 			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0129: stloc.s 11
 			IL_012b: ldloc.s 11
-			IL_012d: ldstr "test"
+			IL_012d: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			IL_0132: ldloc.s 6
 			IL_0134: ldstr "message"
 			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_013e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 			IL_0143: stloc.s 11
 			IL_0145: ldstr "connect unsupported:"
 			IL_014a: ldloc.s 11

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Response_Streaming_Chunked_ResponseBody.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Response_Streaming_Chunked_ResponseBody.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x254a
+				// Method begins at RVA 0x24de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,7 +101,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2565
+						// Method begins at RVA 0x24f9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,14 +126,13 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2358
+					// Method begins at RVA 0x233c
 					// Header size: 12
-					// Code size: 195 (0xc3)
+					// Code size: 153 (0x99)
 					.maxstack 8
 					.locals init (
 						[0] object,
-						[1] object,
-						[2] object
+						[1] object
 					)
 
 					IL_0000: ldarg.0
@@ -141,76 +140,58 @@
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
 					IL_0008: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::chunkCount
-					IL_000d: stloc.0
-					IL_000e: ldstr "chunkCount"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldloc.0
-					IL_001b: ldc.r8 1
-					IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-					IL_0029: stloc.1
-					IL_002a: ldarg.0
-					IL_002b: ldc.i4.2
-					IL_002c: ldelem.ref
-					IL_002d: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
-					IL_0032: ldloc.1
-					IL_0033: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::chunkCount
-					IL_0038: ldstr "console"
-					IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_0042: stloc.0
-					IL_0043: ldloc.0
-					IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0049: stloc.0
-					IL_004a: ldarg.0
-					IL_004b: ldc.i4.2
-					IL_004c: ldelem.ref
-					IL_004d: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
-					IL_0052: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::chunkCount
-					IL_0057: stloc.2
-					IL_0058: ldstr "chunkCount"
-					IL_005d: ldloc.2
-					IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0063: stloc.2
-					IL_0064: ldstr "chunk"
-					IL_0069: ldloc.2
-					IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_006f: stloc.1
-					IL_0070: ldloc.1
-					IL_0071: ldstr ":"
-					IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_007b: stloc.1
-					IL_007c: ldloc.1
-					IL_007d: ldarg.2
-					IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0083: stloc.1
-					IL_0084: ldloc.0
-					IL_0085: ldstr "log"
-					IL_008a: ldloc.1
-					IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0090: pop
-					IL_0091: ldarg.0
-					IL_0092: ldc.i4.2
-					IL_0093: ldelem.ref
-					IL_0094: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
-					IL_0099: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::body
-					IL_009e: stloc.0
-					IL_009f: ldstr "body"
-					IL_00a4: ldloc.0
-					IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_00aa: stloc.0
-					IL_00ab: ldloc.0
-					IL_00ac: ldarg.2
-					IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_00b2: stloc.1
-					IL_00b3: ldarg.0
-					IL_00b4: ldc.i4.2
-					IL_00b5: ldelem.ref
-					IL_00b6: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
-					IL_00bb: ldloc.1
-					IL_00bc: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::body
-					IL_00c1: ldnull
-					IL_00c2: ret
+					IL_000d: ldc.r8 1
+					IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+					IL_001b: stloc.0
+					IL_001c: ldarg.0
+					IL_001d: ldc.i4.2
+					IL_001e: ldelem.ref
+					IL_001f: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
+					IL_0024: ldloc.0
+					IL_0025: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::chunkCount
+					IL_002a: ldstr "console"
+					IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+					IL_0034: stloc.1
+					IL_0035: ldloc.1
+					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_003b: stloc.1
+					IL_003c: ldstr "chunk"
+					IL_0041: ldarg.0
+					IL_0042: ldc.i4.2
+					IL_0043: ldelem.ref
+					IL_0044: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
+					IL_0049: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::chunkCount
+					IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0053: stloc.0
+					IL_0054: ldloc.0
+					IL_0055: ldstr ":"
+					IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_005f: stloc.0
+					IL_0060: ldloc.0
+					IL_0061: ldarg.2
+					IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0067: stloc.0
+					IL_0068: ldloc.1
+					IL_0069: ldstr "log"
+					IL_006e: ldloc.0
+					IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0074: pop
+					IL_0075: ldarg.0
+					IL_0076: ldc.i4.2
+					IL_0077: ldelem.ref
+					IL_0078: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
+					IL_007d: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::body
+					IL_0082: ldarg.2
+					IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0088: stloc.0
+					IL_0089: ldarg.0
+					IL_008a: ldc.i4.2
+					IL_008b: ldelem.ref
+					IL_008c: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
+					IL_0091: ldloc.0
+					IL_0092: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::body
+					IL_0097: ldnull
+					IL_0098: ret
 				} // end of method FunctionExpression_L26C21::__js_call__
 
 			} // end of class FunctionExpression_L26C21
@@ -230,7 +211,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2577
+							// Method begins at RVA 0x250b
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -253,7 +234,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x2510
+						// Method begins at RVA 0x24a4
 						// Header size: 12
 						// Code size: 37 (0x25)
 						.maxstack 8
@@ -285,7 +266,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x256e
+						// Method begins at RVA 0x2502
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -309,9 +290,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2428
+					// Method begins at RVA 0x23e4
 					// Header size: 12
-					// Code size: 219 (0xdb)
+					// Code size: 177 (0xb1)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/Scope,
@@ -328,80 +309,62 @@
 					IL_0011: ldloc.1
 					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0017: stloc.1
-					IL_0018: ldarg.0
-					IL_0019: ldc.i4.2
-					IL_001a: ldelem.ref
-					IL_001b: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
-					IL_0020: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::chunkCount
-					IL_0025: stloc.2
-					IL_0026: ldstr "chunkCount"
-					IL_002b: ldloc.2
-					IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0031: stloc.2
-					IL_0032: ldstr "chunkCount:"
-					IL_0037: ldloc.2
-					IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_003d: stloc.3
-					IL_003e: ldloc.1
-					IL_003f: ldstr "log"
-					IL_0044: ldloc.3
-					IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_004a: pop
-					IL_004b: ldstr "console"
-					IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_0055: stloc.1
-					IL_0056: ldloc.1
-					IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_005c: stloc.1
-					IL_005d: ldarg.0
-					IL_005e: ldc.i4.2
-					IL_005f: ldelem.ref
-					IL_0060: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
-					IL_0065: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::body
-					IL_006a: stloc.2
-					IL_006b: ldstr "body"
-					IL_0070: ldloc.2
-					IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0076: stloc.2
-					IL_0077: ldstr "body:"
-					IL_007c: ldloc.2
-					IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0082: stloc.3
-					IL_0083: ldloc.1
-					IL_0084: ldstr "log"
-					IL_0089: ldloc.3
-					IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_008f: pop
-					IL_0090: ldarg.0
-					IL_0091: ldc.i4.0
-					IL_0092: ldelem.ref
-					IL_0093: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
-					IL_0098: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
-					IL_009d: stloc.1
-					IL_009e: ldstr "server"
-					IL_00a3: ldloc.1
-					IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_00a9: stloc.1
-					IL_00aa: ldloc.1
-					IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_00b0: stloc.1
-					IL_00b1: ldnull
-					IL_00b2: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21::__js_call__(object)
-					IL_00b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_00bd: ldc.i4.0
-					IL_00be: conv.r8
-					IL_00bf: ldstr ""
-					IL_00c4: ldc.i4.0
-					IL_00c5: ldc.i4.1
-					IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_00cb: stloc.2
-					IL_00cc: ldloc.1
-					IL_00cd: ldstr "close"
-					IL_00d2: ldloc.2
-					IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00d8: pop
-					IL_00d9: ldnull
-					IL_00da: ret
+					IL_0018: ldstr "chunkCount:"
+					IL_001d: ldarg.0
+					IL_001e: ldc.i4.2
+					IL_001f: ldelem.ref
+					IL_0020: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
+					IL_0025: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::chunkCount
+					IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_002f: stloc.2
+					IL_0030: ldloc.1
+					IL_0031: ldstr "log"
+					IL_0036: ldloc.2
+					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_003c: pop
+					IL_003d: ldstr "console"
+					IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+					IL_0047: stloc.1
+					IL_0048: ldloc.1
+					IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_004e: stloc.1
+					IL_004f: ldstr "body:"
+					IL_0054: ldarg.0
+					IL_0055: ldc.i4.2
+					IL_0056: ldelem.ref
+					IL_0057: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
+					IL_005c: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::body
+					IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0066: stloc.2
+					IL_0067: ldloc.1
+					IL_0068: ldstr "log"
+					IL_006d: ldloc.2
+					IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0073: pop
+					IL_0074: ldarg.0
+					IL_0075: ldc.i4.0
+					IL_0076: ldelem.ref
+					IL_0077: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
+					IL_007c: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
+					IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0086: stloc.1
+					IL_0087: ldnull
+					IL_0088: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21::__js_call__(object)
+					IL_008e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_0093: ldc.i4.0
+					IL_0094: conv.r8
+					IL_0095: ldstr ""
+					IL_009a: ldc.i4.0
+					IL_009b: ldc.i4.1
+					IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_00a1: stloc.3
+					IL_00a2: ldloc.1
+					IL_00a3: ldstr "close"
+					IL_00a8: ldloc.3
+					IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_00ae: pop
+					IL_00af: ldnull
+					IL_00b0: ret
 				} // end of method FunctionExpression_L32C20::__js_call__
 
 			} // end of class FunctionExpression_L32C20
@@ -422,7 +385,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x255c
+					// Method begins at RVA 0x24f0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -447,7 +410,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x223c
+				// Method begins at RVA 0x2220
 				// Header size: 12
 				// Code size: 272 (0x110)
 				.maxstack 8
@@ -579,7 +542,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2553
+				// Method begins at RVA 0x24e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -607,7 +570,7 @@
 			)
 			// Method begins at RVA 0x2164
 			// Header size: 12
-			// Code size: 204 (0xcc)
+			// Code size: 176 (0xb0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/Scope,
@@ -622,79 +585,67 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
-			IL_000c: stloc.2
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.2
 			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.2
+			IL_001e: ldloc.2
+			IL_001f: stloc.1
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: stloc.1
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
-			IL_0034: stloc.2
-			IL_0035: ldstr "http"
-			IL_003a: ldloc.2
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0040: stloc.2
-			IL_0041: ldloc.2
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0047: stloc.2
-			IL_0048: ldloc.1
-			IL_0049: ldstr "address"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0053: stloc.3
-			IL_0054: ldloc.1
-			IL_0055: ldstr "port"
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005f: stloc.s 4
-			IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0066: dup
-			IL_0067: ldstr "host"
-			IL_006c: ldloc.3
-			IL_006d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0072: dup
-			IL_0073: ldstr "port"
-			IL_0078: ldloc.s 4
-			IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_002c: ldloc.1
+			IL_002d: ldstr "address"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.3
+			IL_0038: ldloc.1
+			IL_0039: ldstr "port"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0043: stloc.s 4
+			IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_004a: dup
+			IL_004b: ldstr "host"
+			IL_0050: ldloc.3
+			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0056: dup
+			IL_0057: ldstr "port"
+			IL_005c: ldloc.s 4
+			IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0063: dup
+			IL_0064: ldstr "path"
+			IL_0069: ldstr "/stream"
+			IL_006e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0073: stloc.s 5
+			IL_0075: ldc.i4.2
+			IL_0076: newarr [System.Runtime]System.Object
+			IL_007b: dup
+			IL_007c: ldc.i4.0
+			IL_007d: ldarg.0
+			IL_007e: stelem.ref
 			IL_007f: dup
-			IL_0080: ldstr "path"
-			IL_0085: ldstr "/stream"
-			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_008f: stloc.s 5
-			IL_0091: ldc.i4.2
-			IL_0092: newarr [System.Runtime]System.Object
-			IL_0097: dup
-			IL_0098: ldc.i4.0
-			IL_0099: ldarg.0
-			IL_009a: stelem.ref
-			IL_009b: dup
-			IL_009c: ldc.i4.1
-			IL_009d: ldloc.0
-			IL_009e: stelem.ref
-			IL_009f: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4::__js_call__(object[], object, object)
-			IL_00a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00aa: ldc.i4.1
-			IL_00ab: conv.r8
-			IL_00ac: ldstr ""
-			IL_00b1: ldc.i4.0
-			IL_00b2: ldc.i4.1
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00b8: stloc.s 4
-			IL_00ba: ldloc.2
-			IL_00bb: ldstr "get"
-			IL_00c0: ldloc.s 5
-			IL_00c2: ldloc.s 4
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00c9: pop
-			IL_00ca: ldnull
-			IL_00cb: ret
+			IL_0080: ldc.i4.1
+			IL_0081: ldloc.0
+			IL_0082: stelem.ref
+			IL_0083: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4::__js_call__(object[], object, object)
+			IL_0089: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_008e: ldc.i4.1
+			IL_008f: conv.r8
+			IL_0090: ldstr ""
+			IL_0095: ldc.i4.0
+			IL_0096: ldc.i4.1
+			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_009c: stloc.s 4
+			IL_009e: ldloc.2
+			IL_009f: ldstr "get"
+			IL_00a4: ldloc.s 5
+			IL_00a6: ldloc.s 4
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00ad: pop
+			IL_00ae: ldnull
+			IL_00af: ret
 		} // end of method FunctionExpression_L11C30::__js_call__
 
 	} // end of class FunctionExpression_L11C30
@@ -715,7 +666,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2541
+			// Method begins at RVA 0x24d5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -822,7 +773,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2580
+		// Method begins at RVA 0x2514
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Get_Loopback_SelfSigned.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Get_Loopback_SelfSigned.verified.txt
@@ -26,7 +26,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x260e
+				// Method begins at RVA 0x25c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -142,7 +142,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2629
+						// Method begins at RVA 0x25e1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -167,13 +167,12 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x24d4
+					// Method begins at RVA 0x24b8
 					// Header size: 12
-					// Code size: 50 (0x32)
+					// Code size: 36 (0x24)
 					.maxstack 8
 					.locals init (
-						[0] object,
-						[1] object
+						[0] object
 					)
 
 					IL_0000: ldarg.0
@@ -181,23 +180,17 @@
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope
 					IL_0008: ldfld object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope::body
-					IL_000d: stloc.0
-					IL_000e: ldstr "body"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldloc.0
-					IL_001b: ldarg.2
-					IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0021: stloc.1
-					IL_0022: ldarg.0
-					IL_0023: ldc.i4.2
-					IL_0024: ldelem.ref
-					IL_0025: castclass Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope
-					IL_002a: ldloc.1
-					IL_002b: stfld object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope::body
-					IL_0030: ldnull
-					IL_0031: ret
+					IL_000d: ldarg.2
+					IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0013: stloc.0
+					IL_0014: ldarg.0
+					IL_0015: ldc.i4.2
+					IL_0016: ldelem.ref
+					IL_0017: castclass Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope
+					IL_001c: ldloc.0
+					IL_001d: stfld object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope::body
+					IL_0022: ldnull
+					IL_0023: ret
 				} // end of method ArrowFunction_L25C22::__js_call__
 
 			} // end of class ArrowFunction_L25C22
@@ -217,7 +210,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x263b
+							// Method begins at RVA 0x25f3
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -240,7 +233,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x25d4
+						// Method begins at RVA 0x258c
 						// Header size: 12
 						// Code size: 37 (0x25)
 						.maxstack 8
@@ -272,7 +265,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2632
+						// Method begins at RVA 0x25ea
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -296,9 +289,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2514
+					// Method begins at RVA 0x24e8
 					// Header size: 12
-					// Code size: 177 (0xb1)
+					// Code size: 149 (0x95)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/Scope,
@@ -315,66 +308,54 @@
 					IL_0011: ldloc.1
 					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0017: stloc.1
-					IL_0018: ldarg.0
-					IL_0019: ldc.i4.2
-					IL_001a: ldelem.ref
-					IL_001b: castclass Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope
-					IL_0020: ldfld object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope::body
-					IL_0025: stloc.2
-					IL_0026: ldstr "body"
-					IL_002b: ldloc.2
-					IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0031: stloc.2
-					IL_0032: ldstr "body:"
-					IL_0037: ldloc.2
-					IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_003d: stloc.3
-					IL_003e: ldloc.1
-					IL_003f: ldstr "log"
-					IL_0044: ldloc.3
-					IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_004a: pop
-					IL_004b: ldarg.0
-					IL_004c: ldc.i4.0
-					IL_004d: ldelem.ref
-					IL_004e: castclass Modules.Https_Get_Loopback_SelfSigned/Scope
-					IL_0053: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
-					IL_0058: stloc.1
-					IL_0059: ldstr "server"
-					IL_005e: ldloc.1
-					IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0064: stloc.1
-					IL_0065: ldloc.1
-					IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_006b: stloc.1
-					IL_006c: ldnull
-					IL_006d: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/ArrowFunction_L30C22::__js_call__(object)
-					IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_0078: ldc.i4.1
-					IL_0079: newarr [System.Runtime]System.Object
-					IL_007e: dup
-					IL_007f: ldc.i4.0
-					IL_0080: ldarg.0
-					IL_0081: ldc.i4.0
-					IL_0082: ldelem.ref
-					IL_0083: stelem.ref
-					IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_008e: ldc.i4.0
-					IL_008f: conv.r8
-					IL_0090: ldstr ""
-					IL_0095: ldc.i4.0
-					IL_0096: ldc.i4.1
-					IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_00a1: stloc.2
-					IL_00a2: ldloc.1
-					IL_00a3: ldstr "close"
-					IL_00a8: ldloc.2
-					IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00ae: pop
-					IL_00af: ldnull
-					IL_00b0: ret
+					IL_0018: ldstr "body:"
+					IL_001d: ldarg.0
+					IL_001e: ldc.i4.2
+					IL_001f: ldelem.ref
+					IL_0020: castclass Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope
+					IL_0025: ldfld object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope::body
+					IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_002f: stloc.2
+					IL_0030: ldloc.1
+					IL_0031: ldstr "log"
+					IL_0036: ldloc.2
+					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_003c: pop
+					IL_003d: ldarg.0
+					IL_003e: ldc.i4.0
+					IL_003f: ldelem.ref
+					IL_0040: castclass Modules.Https_Get_Loopback_SelfSigned/Scope
+					IL_0045: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
+					IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_004f: stloc.1
+					IL_0050: ldnull
+					IL_0051: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/ArrowFunction_L30C22::__js_call__(object)
+					IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_005c: ldc.i4.1
+					IL_005d: newarr [System.Runtime]System.Object
+					IL_0062: dup
+					IL_0063: ldc.i4.0
+					IL_0064: ldarg.0
+					IL_0065: ldc.i4.0
+					IL_0066: ldelem.ref
+					IL_0067: stelem.ref
+					IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0072: ldc.i4.0
+					IL_0073: conv.r8
+					IL_0074: ldstr ""
+					IL_0079: ldc.i4.0
+					IL_007a: ldc.i4.1
+					IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0085: stloc.3
+					IL_0086: ldloc.1
+					IL_0087: ldstr "close"
+					IL_008c: ldloc.3
+					IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0092: pop
+					IL_0093: ldnull
+					IL_0094: ret
 				} // end of method ArrowFunction_L28C21::__js_call__
 
 			} // end of class ArrowFunction_L28C21
@@ -394,7 +375,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2620
+					// Method begins at RVA 0x25d8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -419,7 +400,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23b4
+				// Method begins at RVA 0x2398
 				// Header size: 12
 				// Code size: 274 (0x112)
 				.maxstack 8
@@ -553,7 +534,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2617
+				// Method begins at RVA 0x25cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -581,7 +562,7 @@
 			)
 			// Method begins at RVA 0x229c
 			// Header size: 12
-			// Code size: 266 (0x10a)
+			// Code size: 238 (0xee)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/Scope,
@@ -596,99 +577,87 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
-			IL_000c: stloc.2
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.2
 			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: stloc.1
-			IL_002e: ldstr "console"
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0038: stloc.2
-			IL_0039: ldloc.2
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003f: stloc.2
-			IL_0040: ldstr "listening:"
-			IL_0045: ldloc.1
-			IL_0046: ldstr "address"
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0055: stloc.3
-			IL_0056: ldloc.3
-			IL_0057: ldstr ":ready"
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0061: stloc.3
-			IL_0062: ldloc.2
-			IL_0063: ldstr "log"
-			IL_0068: ldloc.3
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_006e: pop
-			IL_006f: ldarg.0
-			IL_0070: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::https
-			IL_0075: stloc.2
-			IL_0076: ldstr "https"
-			IL_007b: ldloc.2
-			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0081: stloc.2
-			IL_0082: ldloc.2
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0088: stloc.2
-			IL_0089: ldstr "https://127.0.0.1:"
-			IL_008e: ldloc.1
-			IL_008f: ldstr "port"
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_009e: stloc.3
-			IL_009f: ldloc.3
-			IL_00a0: ldstr "/hello?x=1"
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00aa: stloc.3
-			IL_00ab: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00b0: dup
-			IL_00b1: ldstr "rejectUnauthorized"
-			IL_00b6: ldc.i4.0
-			IL_00b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00bc: stloc.s 4
-			IL_00be: ldnull
-			IL_00bf: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5::__js_call__(object[], object, object)
-			IL_00c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_00ca: ldc.i4.2
-			IL_00cb: newarr [System.Runtime]System.Object
-			IL_00d0: dup
-			IL_00d1: ldc.i4.0
-			IL_00d2: ldarg.0
-			IL_00d3: stelem.ref
-			IL_00d4: dup
-			IL_00d5: ldc.i4.1
-			IL_00d6: ldloc.0
-			IL_00d7: stelem.ref
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00e2: ldc.i4.1
-			IL_00e3: conv.r8
-			IL_00e4: ldstr ""
-			IL_00e9: ldc.i4.0
-			IL_00ea: ldc.i4.1
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_00f5: stloc.s 5
-			IL_00f7: ldloc.2
-			IL_00f8: ldstr "get"
-			IL_00fd: ldloc.3
-			IL_00fe: ldloc.s 4
-			IL_0100: ldloc.s 5
-			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0107: pop
-			IL_0108: ldnull
-			IL_0109: ret
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.2
+			IL_001e: ldloc.2
+			IL_001f: stloc.1
+			IL_0020: ldstr "console"
+			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_002a: stloc.2
+			IL_002b: ldloc.2
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0031: stloc.2
+			IL_0032: ldstr "listening:"
+			IL_0037: ldloc.1
+			IL_0038: ldstr "address"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0047: stloc.3
+			IL_0048: ldloc.3
+			IL_0049: ldstr ":ready"
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0053: stloc.3
+			IL_0054: ldloc.2
+			IL_0055: ldstr "log"
+			IL_005a: ldloc.3
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0060: pop
+			IL_0061: ldarg.0
+			IL_0062: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::https
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006c: stloc.2
+			IL_006d: ldstr "https://127.0.0.1:"
+			IL_0072: ldloc.1
+			IL_0073: ldstr "port"
+			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0082: stloc.3
+			IL_0083: ldloc.3
+			IL_0084: ldstr "/hello?x=1"
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_008e: stloc.3
+			IL_008f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0094: dup
+			IL_0095: ldstr "rejectUnauthorized"
+			IL_009a: ldc.i4.0
+			IL_009b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00a0: stloc.s 4
+			IL_00a2: ldnull
+			IL_00a3: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5::__js_call__(object[], object, object)
+			IL_00a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_00ae: ldc.i4.2
+			IL_00af: newarr [System.Runtime]System.Object
+			IL_00b4: dup
+			IL_00b5: ldc.i4.0
+			IL_00b6: ldarg.0
+			IL_00b7: stelem.ref
+			IL_00b8: dup
+			IL_00b9: ldc.i4.1
+			IL_00ba: ldloc.0
+			IL_00bb: stelem.ref
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00c6: ldc.i4.1
+			IL_00c7: conv.r8
+			IL_00c8: ldstr ""
+			IL_00cd: ldc.i4.0
+			IL_00ce: ldc.i4.1
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_00d9: stloc.s 5
+			IL_00db: ldloc.2
+			IL_00dc: ldstr "get"
+			IL_00e1: ldloc.3
+			IL_00e2: ldloc.s 4
+			IL_00e4: ldloc.s 5
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_00eb: pop
+			IL_00ec: ldnull
+			IL_00ed: ret
 		} // end of method ArrowFunction_L13C31::__js_call__
 
 	} // end of class ArrowFunction_L13C31
@@ -709,7 +678,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2605
+			// Method begins at RVA 0x25bd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -876,7 +845,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2644
+			// Method begins at RVA 0x25fc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -939,7 +908,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x264d
+		// Method begins at RVA 0x2605
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_Post_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_Post_Basic.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2803
+					// Method begins at RVA 0x2753
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -54,13 +54,12 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2414
+				// Method begins at RVA 0x23f8
 				// Header size: 12
-				// Code size: 50 (0x32)
+				// Code size: 36 (0x24)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldarg.0
@@ -68,23 +67,17 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
 				IL_0008: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::requestBody
-				IL_000d: stloc.0
-				IL_000e: ldstr "requestBody"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ldarg.2
-				IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0021: stloc.1
-				IL_0022: ldarg.0
-				IL_0023: ldc.i4.1
-				IL_0024: ldelem.ref
-				IL_0025: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
-				IL_002a: ldloc.1
-				IL_002b: stfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::requestBody
-				IL_0030: ldnull
-				IL_0031: ret
+				IL_000d: ldarg.2
+				IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0013: stloc.0
+				IL_0014: ldarg.0
+				IL_0015: ldc.i4.1
+				IL_0016: ldelem.ref
+				IL_0017: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
+				IL_001c: ldloc.0
+				IL_001d: stfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::requestBody
+				IL_0022: ldnull
+				IL_0023: ret
 			} // end of method ArrowFunction_L10C18::__js_call__
 
 		} // end of class ArrowFunction_L10C18
@@ -100,7 +93,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x280c
+					// Method begins at RVA 0x275c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -124,14 +117,13 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2454
+				// Method begins at RVA 0x2428
 				// Header size: 12
-				// Code size: 319 (0x13f)
+				// Code size: 231 (0xe7)
 				.maxstack 8
 				.locals init (
 					[0] object,
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: ldstr "console"
@@ -140,119 +132,79 @@
 				IL_000b: ldloc.0
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0011: stloc.0
-				IL_0012: ldarg.0
-				IL_0013: ldc.i4.1
-				IL_0014: ldelem.ref
-				IL_0015: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
-				IL_001a: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::req
-				IL_001f: stloc.1
-				IL_0020: ldstr "req"
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002b: stloc.1
-				IL_002c: ldloc.1
-				IL_002d: ldstr "method"
-				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0037: stloc.1
-				IL_0038: ldstr "req:"
-				IL_003d: ldloc.1
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0043: stloc.2
-				IL_0044: ldloc.2
-				IL_0045: ldstr ":"
-				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_004f: stloc.2
-				IL_0050: ldarg.0
-				IL_0051: ldc.i4.1
-				IL_0052: ldelem.ref
-				IL_0053: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
-				IL_0058: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::req
+				IL_0012: ldstr "req:"
+				IL_0017: ldarg.0
+				IL_0018: ldc.i4.1
+				IL_0019: ldelem.ref
+				IL_001a: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
+				IL_001f: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::req
+				IL_0024: ldstr "method"
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0033: stloc.1
+				IL_0034: ldloc.1
+				IL_0035: ldstr ":"
+				IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_003f: stloc.1
+				IL_0040: ldloc.1
+				IL_0041: ldarg.0
+				IL_0042: ldc.i4.1
+				IL_0043: ldelem.ref
+				IL_0044: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
+				IL_0049: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::req
+				IL_004e: ldstr "url"
+				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 				IL_005d: stloc.1
-				IL_005e: ldstr "req"
-				IL_0063: ldloc.1
-				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
+				IL_005e: ldloc.1
+				IL_005f: ldstr ":"
+				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 				IL_0069: stloc.1
 				IL_006a: ldloc.1
-				IL_006b: ldstr "url"
-				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0075: stloc.1
-				IL_0076: ldloc.2
-				IL_0077: ldloc.1
+				IL_006b: ldarg.0
+				IL_006c: ldc.i4.1
+				IL_006d: ldelem.ref
+				IL_006e: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
+				IL_0073: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::requestBody
 				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_007d: stloc.2
-				IL_007e: ldloc.2
-				IL_007f: ldstr ":"
-				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0089: stloc.2
-				IL_008a: ldarg.0
-				IL_008b: ldc.i4.1
-				IL_008c: ldelem.ref
-				IL_008d: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
-				IL_0092: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::requestBody
-				IL_0097: stloc.1
-				IL_0098: ldstr "requestBody"
-				IL_009d: ldloc.1
-				IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00a3: stloc.1
-				IL_00a4: ldloc.2
-				IL_00a5: ldloc.1
-				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00ab: stloc.2
-				IL_00ac: ldloc.0
-				IL_00ad: ldstr "log"
-				IL_00b2: ldloc.2
-				IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00b8: pop
-				IL_00b9: ldarg.0
-				IL_00ba: ldc.i4.1
-				IL_00bb: ldelem.ref
-				IL_00bc: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
-				IL_00c1: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::res
-				IL_00c6: stloc.0
-				IL_00c7: ldstr "res"
-				IL_00cc: ldloc.0
-				IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00d2: stloc.0
-				IL_00d3: ldloc.0
-				IL_00d4: ldstr "statusCode"
-				IL_00d9: ldc.r8 200
-				IL_00e2: ldc.i4.1
-				IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_00e8: pop
-				IL_00e9: ldarg.0
-				IL_00ea: ldc.i4.1
-				IL_00eb: ldelem.ref
-				IL_00ec: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
-				IL_00f1: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::res
-				IL_00f6: stloc.0
-				IL_00f7: ldstr "res"
-				IL_00fc: ldloc.0
-				IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0102: stloc.0
-				IL_0103: ldloc.0
-				IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0109: stloc.0
-				IL_010a: ldarg.0
-				IL_010b: ldc.i4.1
-				IL_010c: ldelem.ref
-				IL_010d: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
-				IL_0112: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::requestBody
-				IL_0117: stloc.1
-				IL_0118: ldstr "requestBody"
-				IL_011d: ldloc.1
-				IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0123: stloc.1
-				IL_0124: ldstr "echo:"
-				IL_0129: ldloc.1
-				IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_012f: stloc.2
-				IL_0130: ldloc.0
-				IL_0131: ldstr "end"
-				IL_0136: ldloc.2
-				IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_013c: pop
-				IL_013d: ldnull
-				IL_013e: ret
+				IL_007d: stloc.1
+				IL_007e: ldloc.0
+				IL_007f: ldstr "log"
+				IL_0084: ldloc.1
+				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_008a: pop
+				IL_008b: ldarg.0
+				IL_008c: ldc.i4.1
+				IL_008d: ldelem.ref
+				IL_008e: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
+				IL_0093: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::res
+				IL_0098: ldstr "statusCode"
+				IL_009d: ldc.r8 200
+				IL_00a6: ldc.i4.1
+				IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_00ac: pop
+				IL_00ad: ldarg.0
+				IL_00ae: ldc.i4.1
+				IL_00af: ldelem.ref
+				IL_00b0: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
+				IL_00b5: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::res
+				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00bf: stloc.0
+				IL_00c0: ldstr "echo:"
+				IL_00c5: ldarg.0
+				IL_00c6: ldc.i4.1
+				IL_00c7: ldelem.ref
+				IL_00c8: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
+				IL_00cd: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::requestBody
+				IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00d7: stloc.1
+				IL_00d8: ldloc.0
+				IL_00d9: ldstr "end"
+				IL_00de: ldloc.1
+				IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00e4: pop
+				IL_00e5: ldnull
+				IL_00e6: ret
 			} // end of method ArrowFunction_L14C17::__js_call__
 
 		} // end of class ArrowFunction_L14C17
@@ -275,7 +227,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27fa
+				// Method begins at RVA 0x274a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -431,7 +383,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2827
+						// Method begins at RVA 0x2777
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -456,13 +408,12 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x26c0
+					// Method begins at RVA 0x263c
 					// Header size: 12
-					// Code size: 50 (0x32)
+					// Code size: 36 (0x24)
 					.maxstack 8
 					.locals init (
-						[0] object,
-						[1] object
+						[0] object
 					)
 
 					IL_0000: ldarg.0
@@ -470,23 +421,17 @@
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope
 					IL_0008: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope::body
-					IL_000d: stloc.0
-					IL_000e: ldstr "body"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldloc.0
-					IL_001b: ldarg.2
-					IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0021: stloc.1
-					IL_0022: ldarg.0
-					IL_0023: ldc.i4.2
-					IL_0024: ldelem.ref
-					IL_0025: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope
-					IL_002a: ldloc.1
-					IL_002b: stfld object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope::body
-					IL_0030: ldnull
-					IL_0031: ret
+					IL_000d: ldarg.2
+					IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0013: stloc.0
+					IL_0014: ldarg.0
+					IL_0015: ldc.i4.2
+					IL_0016: ldelem.ref
+					IL_0017: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope
+					IL_001c: ldloc.0
+					IL_001d: stfld object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope::body
+					IL_0022: ldnull
+					IL_0023: ret
 				} // end of method ArrowFunction_L36C22::__js_call__
 
 			} // end of class ArrowFunction_L36C22
@@ -506,7 +451,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2839
+							// Method begins at RVA 0x2789
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -529,7 +474,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x27c0
+						// Method begins at RVA 0x2710
 						// Header size: 12
 						// Code size: 37 (0x25)
 						.maxstack 8
@@ -561,7 +506,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2830
+						// Method begins at RVA 0x2780
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -585,9 +530,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2700
+					// Method begins at RVA 0x266c
 					// Header size: 12
-					// Code size: 177 (0xb1)
+					// Code size: 149 (0x95)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/Scope,
@@ -604,66 +549,54 @@
 					IL_0011: ldloc.1
 					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0017: stloc.1
-					IL_0018: ldarg.0
-					IL_0019: ldc.i4.2
-					IL_001a: ldelem.ref
-					IL_001b: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope
-					IL_0020: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope::body
-					IL_0025: stloc.2
-					IL_0026: ldstr "body"
-					IL_002b: ldloc.2
-					IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0031: stloc.2
-					IL_0032: ldstr "body:"
-					IL_0037: ldloc.2
-					IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_003d: stloc.3
-					IL_003e: ldloc.1
-					IL_003f: ldstr "log"
-					IL_0044: ldloc.3
-					IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_004a: pop
-					IL_004b: ldarg.0
-					IL_004c: ldc.i4.0
-					IL_004d: ldelem.ref
-					IL_004e: castclass Modules.Https_Request_Post_Basic/Scope
-					IL_0053: ldfld object Modules.Https_Request_Post_Basic/Scope::server
-					IL_0058: stloc.1
-					IL_0059: ldstr "server"
-					IL_005e: ldloc.1
-					IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0064: stloc.1
-					IL_0065: ldloc.1
-					IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_006b: stloc.1
-					IL_006c: ldnull
-					IL_006d: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/ArrowFunction_L41C22::__js_call__(object)
-					IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_0078: ldc.i4.1
-					IL_0079: newarr [System.Runtime]System.Object
-					IL_007e: dup
-					IL_007f: ldc.i4.0
-					IL_0080: ldarg.0
-					IL_0081: ldc.i4.0
-					IL_0082: ldelem.ref
-					IL_0083: stelem.ref
-					IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_008e: ldc.i4.0
-					IL_008f: conv.r8
-					IL_0090: ldstr ""
-					IL_0095: ldc.i4.0
-					IL_0096: ldc.i4.1
-					IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_00a1: stloc.2
-					IL_00a2: ldloc.1
-					IL_00a3: ldstr "close"
-					IL_00a8: ldloc.2
-					IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00ae: pop
-					IL_00af: ldnull
-					IL_00b0: ret
+					IL_0018: ldstr "body:"
+					IL_001d: ldarg.0
+					IL_001e: ldc.i4.2
+					IL_001f: ldelem.ref
+					IL_0020: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope
+					IL_0025: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope::body
+					IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_002f: stloc.2
+					IL_0030: ldloc.1
+					IL_0031: ldstr "log"
+					IL_0036: ldloc.2
+					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_003c: pop
+					IL_003d: ldarg.0
+					IL_003e: ldc.i4.0
+					IL_003f: ldelem.ref
+					IL_0040: castclass Modules.Https_Request_Post_Basic/Scope
+					IL_0045: ldfld object Modules.Https_Request_Post_Basic/Scope::server
+					IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_004f: stloc.1
+					IL_0050: ldnull
+					IL_0051: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/ArrowFunction_L41C22::__js_call__(object)
+					IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_005c: ldc.i4.1
+					IL_005d: newarr [System.Runtime]System.Object
+					IL_0062: dup
+					IL_0063: ldc.i4.0
+					IL_0064: ldarg.0
+					IL_0065: ldc.i4.0
+					IL_0066: ldelem.ref
+					IL_0067: stelem.ref
+					IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0072: ldc.i4.0
+					IL_0073: conv.r8
+					IL_0074: ldstr ""
+					IL_0079: ldc.i4.0
+					IL_007a: ldc.i4.1
+					IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0085: stloc.3
+					IL_0086: ldloc.1
+					IL_0087: ldstr "close"
+					IL_008c: ldloc.3
+					IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0092: pop
+					IL_0093: ldnull
+					IL_0094: ret
 				} // end of method ArrowFunction_L39C21::__js_call__
 
 			} // end of class ArrowFunction_L39C21
@@ -683,7 +616,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x281e
+					// Method begins at RVA 0x276e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -708,7 +641,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25a0
+				// Method begins at RVA 0x251c
 				// Header size: 12
 				// Code size: 274 (0x112)
 				.maxstack 8
@@ -842,7 +775,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2815
+				// Method begins at RVA 0x2765
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -870,7 +803,7 @@
 			)
 			// Method begins at RVA 0x22f8
 			// Header size: 12
-			// Code size: 270 (0x10e)
+			// Code size: 242 (0xf2)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/Scope,
@@ -885,97 +818,85 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Https_Request_Post_Basic/Scope::server
-			IL_000c: stloc.3
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.3
 			IL_0012: ldloc.3
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.3
-			IL_0019: ldloc.3
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.3
-			IL_0020: ldloc.3
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.3
+			IL_001e: ldloc.3
+			IL_001f: stloc.1
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Https_Request_Post_Basic/Scope::https
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002b: stloc.3
-			IL_002c: ldloc.3
-			IL_002d: stloc.1
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Https_Request_Post_Basic/Scope::https
-			IL_0034: stloc.3
-			IL_0035: ldstr "https"
-			IL_003a: ldloc.3
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0040: stloc.3
-			IL_0041: ldloc.3
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0047: stloc.3
-			IL_0048: ldloc.1
-			IL_0049: ldstr "port"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0053: stloc.s 4
-			IL_0055: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_005a: dup
-			IL_005b: ldstr "host"
-			IL_0060: ldstr "127.0.0.1"
-			IL_0065: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_006a: dup
-			IL_006b: ldstr "port"
-			IL_0070: ldloc.s 4
-			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0077: dup
-			IL_0078: ldstr "method"
-			IL_007d: ldstr "POST"
-			IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0087: dup
-			IL_0088: ldstr "path"
-			IL_008d: ldstr "/submit"
-			IL_0092: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0097: dup
-			IL_0098: ldstr "rejectUnauthorized"
-			IL_009d: ldc.i4.0
-			IL_009e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a3: stloc.s 5
-			IL_00a5: ldnull
-			IL_00a6: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5::__js_call__(object[], object, object)
-			IL_00ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_00b1: ldc.i4.2
-			IL_00b2: newarr [System.Runtime]System.Object
-			IL_00b7: dup
-			IL_00b8: ldc.i4.0
-			IL_00b9: ldarg.0
-			IL_00ba: stelem.ref
-			IL_00bb: dup
-			IL_00bc: ldc.i4.1
-			IL_00bd: ldloc.0
-			IL_00be: stelem.ref
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00c9: ldc.i4.1
-			IL_00ca: conv.r8
-			IL_00cb: ldstr ""
-			IL_00d0: ldc.i4.0
-			IL_00d1: ldc.i4.1
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_002c: ldloc.1
+			IL_002d: ldstr "port"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.s 4
+			IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_003e: dup
+			IL_003f: ldstr "host"
+			IL_0044: ldstr "127.0.0.1"
+			IL_0049: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_004e: dup
+			IL_004f: ldstr "port"
+			IL_0054: ldloc.s 4
+			IL_0056: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_005b: dup
+			IL_005c: ldstr "method"
+			IL_0061: ldstr "POST"
+			IL_0066: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_006b: dup
+			IL_006c: ldstr "path"
+			IL_0071: ldstr "/submit"
+			IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_007b: dup
+			IL_007c: ldstr "rejectUnauthorized"
+			IL_0081: ldc.i4.0
+			IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0087: stloc.s 5
+			IL_0089: ldnull
+			IL_008a: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5::__js_call__(object[], object, object)
+			IL_0090: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0095: ldc.i4.2
+			IL_0096: newarr [System.Runtime]System.Object
+			IL_009b: dup
+			IL_009c: ldc.i4.0
+			IL_009d: ldarg.0
+			IL_009e: stelem.ref
+			IL_009f: dup
+			IL_00a0: ldc.i4.1
+			IL_00a1: ldloc.0
+			IL_00a2: stelem.ref
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00ad: ldc.i4.1
+			IL_00ae: conv.r8
+			IL_00af: ldstr ""
+			IL_00b4: ldc.i4.0
+			IL_00b5: ldc.i4.1
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_00c0: stloc.s 4
+			IL_00c2: ldloc.3
+			IL_00c3: ldstr "request"
+			IL_00c8: ldloc.s 5
+			IL_00ca: ldloc.s 4
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00d1: stloc.s 4
+			IL_00d3: ldloc.s 4
+			IL_00d5: stloc.2
+			IL_00d6: ldloc.2
+			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00dc: stloc.s 4
-			IL_00de: ldloc.3
-			IL_00df: ldstr "request"
-			IL_00e4: ldloc.s 5
-			IL_00e6: ldloc.s 4
-			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00ed: stloc.s 4
-			IL_00ef: ldloc.s 4
-			IL_00f1: stloc.2
-			IL_00f2: ldloc.2
-			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f8: stloc.s 4
-			IL_00fa: ldloc.s 4
-			IL_00fc: ldstr "end"
-			IL_0101: ldstr "hello tls"
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_010b: pop
-			IL_010c: ldnull
-			IL_010d: ret
+			IL_00de: ldloc.s 4
+			IL_00e0: ldstr "end"
+			IL_00e5: ldstr "hello tls"
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00ef: pop
+			IL_00f0: ldnull
+			IL_00f1: ret
 		} // end of method ArrowFunction_L21C31::__js_call__
 
 	} // end of class ArrowFunction_L21C31
@@ -996,7 +917,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27f1
+			// Method begins at RVA 0x2741
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1171,7 +1092,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2842
+			// Method begins at RVA 0x2792
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1234,7 +1155,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x284b
+		// Method begins at RVA 0x279b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_UrlObject_WithOptions.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_UrlObject_WithOptions.verified.txt
@@ -26,7 +26,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26a6
+				// Method begins at RVA 0x264a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26c1
+						// Method begins at RVA 0x2665
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -170,13 +170,12 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x256c
+					// Method begins at RVA 0x253c
 					// Header size: 12
-					// Code size: 50 (0x32)
+					// Code size: 36 (0x24)
 					.maxstack 8
 					.locals init (
-						[0] object,
-						[1] object
+						[0] object
 					)
 
 					IL_0000: ldarg.0
@@ -184,23 +183,17 @@
 					IL_0002: ldelem.ref
 					IL_0003: castclass Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope
 					IL_0008: ldfld object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope::body
-					IL_000d: stloc.0
-					IL_000e: ldstr "body"
-					IL_0013: ldloc.0
-					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0019: stloc.0
-					IL_001a: ldloc.0
-					IL_001b: ldarg.2
-					IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0021: stloc.1
-					IL_0022: ldarg.0
-					IL_0023: ldc.i4.2
-					IL_0024: ldelem.ref
-					IL_0025: castclass Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope
-					IL_002a: ldloc.1
-					IL_002b: stfld object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope::body
-					IL_0030: ldnull
-					IL_0031: ret
+					IL_000d: ldarg.2
+					IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0013: stloc.0
+					IL_0014: ldarg.0
+					IL_0015: ldc.i4.2
+					IL_0016: ldelem.ref
+					IL_0017: castclass Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope
+					IL_001c: ldloc.0
+					IL_001d: stfld object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope::body
+					IL_0022: ldnull
+					IL_0023: ret
 				} // end of method ArrowFunction_L30C22::__js_call__
 
 			} // end of class ArrowFunction_L30C22
@@ -220,7 +213,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x26d3
+							// Method begins at RVA 0x2677
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -243,7 +236,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x266c
+						// Method begins at RVA 0x2610
 						// Header size: 12
 						// Code size: 37 (0x25)
 						.maxstack 8
@@ -275,7 +268,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26ca
+						// Method begins at RVA 0x266e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -299,9 +292,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x25ac
+					// Method begins at RVA 0x256c
 					// Header size: 12
-					// Code size: 177 (0xb1)
+					// Code size: 149 (0x95)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/Scope,
@@ -318,66 +311,54 @@
 					IL_0011: ldloc.1
 					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0017: stloc.1
-					IL_0018: ldarg.0
-					IL_0019: ldc.i4.2
-					IL_001a: ldelem.ref
-					IL_001b: castclass Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope
-					IL_0020: ldfld object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope::body
-					IL_0025: stloc.2
-					IL_0026: ldstr "body"
-					IL_002b: ldloc.2
-					IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0031: stloc.2
-					IL_0032: ldstr "body:"
-					IL_0037: ldloc.2
-					IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_003d: stloc.3
-					IL_003e: ldloc.1
-					IL_003f: ldstr "log"
-					IL_0044: ldloc.3
-					IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_004a: pop
-					IL_004b: ldarg.0
-					IL_004c: ldc.i4.0
-					IL_004d: ldelem.ref
-					IL_004e: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
-					IL_0053: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
-					IL_0058: stloc.1
-					IL_0059: ldstr "server"
-					IL_005e: ldloc.1
-					IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0064: stloc.1
-					IL_0065: ldloc.1
-					IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_006b: stloc.1
-					IL_006c: ldnull
-					IL_006d: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/ArrowFunction_L35C22::__js_call__(object)
-					IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-					IL_0078: ldc.i4.1
-					IL_0079: newarr [System.Runtime]System.Object
-					IL_007e: dup
-					IL_007f: ldc.i4.0
-					IL_0080: ldarg.0
-					IL_0081: ldc.i4.0
-					IL_0082: ldelem.ref
-					IL_0083: stelem.ref
-					IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_008e: ldc.i4.0
-					IL_008f: conv.r8
-					IL_0090: ldstr ""
-					IL_0095: ldc.i4.0
-					IL_0096: ldc.i4.1
-					IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_00a1: stloc.2
-					IL_00a2: ldloc.1
-					IL_00a3: ldstr "close"
-					IL_00a8: ldloc.2
-					IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00ae: pop
-					IL_00af: ldnull
-					IL_00b0: ret
+					IL_0018: ldstr "body:"
+					IL_001d: ldarg.0
+					IL_001e: ldc.i4.2
+					IL_001f: ldelem.ref
+					IL_0020: castclass Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope
+					IL_0025: ldfld object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope::body
+					IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_002f: stloc.2
+					IL_0030: ldloc.1
+					IL_0031: ldstr "log"
+					IL_0036: ldloc.2
+					IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_003c: pop
+					IL_003d: ldarg.0
+					IL_003e: ldc.i4.0
+					IL_003f: ldelem.ref
+					IL_0040: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
+					IL_0045: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
+					IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_004f: stloc.1
+					IL_0050: ldnull
+					IL_0051: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/ArrowFunction_L35C22::__js_call__(object)
+					IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+					IL_005c: ldc.i4.1
+					IL_005d: newarr [System.Runtime]System.Object
+					IL_0062: dup
+					IL_0063: ldc.i4.0
+					IL_0064: ldarg.0
+					IL_0065: ldc.i4.0
+					IL_0066: ldelem.ref
+					IL_0067: stelem.ref
+					IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0072: ldc.i4.0
+					IL_0073: conv.r8
+					IL_0074: ldstr ""
+					IL_0079: ldc.i4.0
+					IL_007a: ldc.i4.1
+					IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0085: stloc.3
+					IL_0086: ldloc.1
+					IL_0087: ldstr "close"
+					IL_008c: ldloc.3
+					IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0092: pop
+					IL_0093: ldnull
+					IL_0094: ret
 				} // end of method ArrowFunction_L33C21::__js_call__
 
 			} // end of class ArrowFunction_L33C21
@@ -397,7 +378,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26b8
+					// Method begins at RVA 0x265c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -422,7 +403,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x244c
+				// Method begins at RVA 0x241c
 				// Header size: 12
 				// Code size: 274 (0x112)
 				.maxstack 8
@@ -556,7 +537,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26af
+				// Method begins at RVA 0x2653
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -584,7 +565,7 @@
 			)
 			// Method begins at RVA 0x22e8
 			// Header size: 12
-			// Code size: 344 (0x158)
+			// Code size: 294 (0x126)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/Scope,
@@ -602,121 +583,105 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
-			IL_000c: stloc.s 4
-			IL_000e: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.s 4
 			IL_0013: ldloc.s 4
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001a: stloc.s 4
-			IL_001c: ldloc.s 4
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0023: stloc.s 4
-			IL_0025: ldloc.s 4
-			IL_0027: ldstr "address"
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0031: stloc.s 4
-			IL_0033: ldloc.s 4
-			IL_0035: stloc.1
-			IL_0036: ldarg.0
-			IL_0037: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::NodeUrl
-			IL_003c: stloc.s 4
-			IL_003e: ldstr "NodeUrl"
-			IL_0043: ldloc.s 4
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_004a: stloc.s 4
-			IL_004c: ldstr "https://127.0.0.1:"
-			IL_0051: ldloc.1
-			IL_0052: ldstr "port"
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0061: stloc.s 5
-			IL_0063: ldloc.s 5
-			IL_0065: ldstr "/spec?section=27.3"
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006f: stloc.s 5
-			IL_0071: ldc.i4.1
-			IL_0072: newarr [System.Runtime]System.Object
-			IL_0077: dup
-			IL_0078: ldc.i4.0
-			IL_0079: ldloc.s 5
-			IL_007b: stelem.ref
-			IL_007c: stloc.s 6
-			IL_007e: ldloc.s 4
-			IL_0080: ldloc.s 6
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0087: stloc.s 4
-			IL_0089: ldloc.s 4
-			IL_008b: stloc.2
-			IL_008c: ldarg.0
-			IL_008d: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::https
-			IL_0092: stloc.s 4
-			IL_0094: ldstr "https"
-			IL_0099: ldloc.s 4
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a0: stloc.s 4
-			IL_00a2: ldloc.s 4
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a9: stloc.s 4
-			IL_00ab: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00b0: dup
-			IL_00b1: ldstr "Accept-Encoding"
-			IL_00b6: ldstr "identity"
-			IL_00bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00c0: stloc.s 7
-			IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00c7: dup
-			IL_00c8: ldstr "method"
-			IL_00cd: ldstr "GET"
-			IL_00d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00d7: dup
-			IL_00d8: ldstr "headers"
-			IL_00dd: ldloc.s 7
-			IL_00df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00e4: dup
-			IL_00e5: ldstr "rejectUnauthorized"
-			IL_00ea: ldc.i4.0
-			IL_00eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00f0: stloc.s 7
-			IL_00f2: ldnull
-			IL_00f3: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5::__js_call__(object[], object, object)
-			IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_00fe: ldc.i4.2
-			IL_00ff: newarr [System.Runtime]System.Object
-			IL_0104: dup
-			IL_0105: ldc.i4.0
-			IL_0106: ldarg.0
-			IL_0107: stelem.ref
-			IL_0108: dup
-			IL_0109: ldc.i4.1
-			IL_010a: ldloc.0
-			IL_010b: stelem.ref
-			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0116: ldc.i4.1
-			IL_0117: conv.r8
-			IL_0118: ldstr ""
-			IL_011d: ldc.i4.0
-			IL_011e: ldc.i4.1
-			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0129: stloc.s 8
-			IL_012b: ldloc.s 4
-			IL_012d: ldstr "request"
-			IL_0132: ldloc.2
-			IL_0133: ldloc.s 7
-			IL_0135: ldloc.s 8
-			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_013c: stloc.s 8
-			IL_013e: ldloc.s 8
-			IL_0140: stloc.3
-			IL_0141: ldloc.3
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0147: stloc.s 8
-			IL_0149: ldloc.s 8
-			IL_014b: ldstr "end"
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0155: pop
-			IL_0156: ldnull
-			IL_0157: ret
+			IL_0015: ldstr "address"
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001f: stloc.s 4
+			IL_0021: ldloc.s 4
+			IL_0023: stloc.1
+			IL_0024: ldarg.0
+			IL_0025: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::NodeUrl
+			IL_002a: stloc.s 4
+			IL_002c: ldstr "https://127.0.0.1:"
+			IL_0031: ldloc.1
+			IL_0032: ldstr "port"
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0041: stloc.s 5
+			IL_0043: ldloc.s 5
+			IL_0045: ldstr "/spec?section=27.3"
+			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004f: stloc.s 5
+			IL_0051: ldc.i4.1
+			IL_0052: newarr [System.Runtime]System.Object
+			IL_0057: dup
+			IL_0058: ldc.i4.0
+			IL_0059: ldloc.s 5
+			IL_005b: stelem.ref
+			IL_005c: stloc.s 6
+			IL_005e: ldloc.s 4
+			IL_0060: ldloc.s 6
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0067: stloc.s 4
+			IL_0069: ldloc.s 4
+			IL_006b: stloc.2
+			IL_006c: ldarg.0
+			IL_006d: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::https
+			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0077: stloc.s 4
+			IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_007e: dup
+			IL_007f: ldstr "Accept-Encoding"
+			IL_0084: ldstr "identity"
+			IL_0089: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_008e: stloc.s 7
+			IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0095: dup
+			IL_0096: ldstr "method"
+			IL_009b: ldstr "GET"
+			IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00a5: dup
+			IL_00a6: ldstr "headers"
+			IL_00ab: ldloc.s 7
+			IL_00ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00b2: dup
+			IL_00b3: ldstr "rejectUnauthorized"
+			IL_00b8: ldc.i4.0
+			IL_00b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00be: stloc.s 7
+			IL_00c0: ldnull
+			IL_00c1: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5::__js_call__(object[], object, object)
+			IL_00c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_00cc: ldc.i4.2
+			IL_00cd: newarr [System.Runtime]System.Object
+			IL_00d2: dup
+			IL_00d3: ldc.i4.0
+			IL_00d4: ldarg.0
+			IL_00d5: stelem.ref
+			IL_00d6: dup
+			IL_00d7: ldc.i4.1
+			IL_00d8: ldloc.0
+			IL_00d9: stelem.ref
+			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00e4: ldc.i4.1
+			IL_00e5: conv.r8
+			IL_00e6: ldstr ""
+			IL_00eb: ldc.i4.0
+			IL_00ec: ldc.i4.1
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_00f7: stloc.s 8
+			IL_00f9: ldloc.s 4
+			IL_00fb: ldstr "request"
+			IL_0100: ldloc.2
+			IL_0101: ldloc.s 7
+			IL_0103: ldloc.s 8
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_010a: stloc.s 8
+			IL_010c: ldloc.s 8
+			IL_010e: stloc.3
+			IL_010f: ldloc.3
+			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0115: stloc.s 8
+			IL_0117: ldloc.s 8
+			IL_0119: ldstr "end"
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0123: pop
+			IL_0124: ldnull
+			IL_0125: ret
 		} // end of method ArrowFunction_L13C31::__js_call__
 
 	} // end of class ArrowFunction_L13C31
@@ -739,7 +704,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x269d
+			// Method begins at RVA 0x2641
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -929,7 +894,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26dc
+			// Method begins at RVA 0x2680
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -992,7 +957,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26e5
+		// Method begins at RVA 0x2689
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateSecureContext_Server_Handshake.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateSecureContext_Server_Handshake.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2586
+				// Method begins at RVA 0x2552
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -86,7 +86,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25a3
+					// Method begins at RVA 0x256f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -110,9 +110,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x244c
+				// Method begins at RVA 0x2430
 				// Header size: 12
-				// Code size: 62 (0x3e)
+				// Code size: 50 (0x32)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -126,20 +126,16 @@
 				IL_000d: ldstr "Cannot access 'client' before initialization"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_0017: stloc.0
-				IL_0018: ldstr "client"
-				IL_001d: ldloc.0
-				IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0023: stloc.0
-				IL_0024: ldloc.0
-				IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_002a: stloc.0
-				IL_002b: ldloc.0
-				IL_002c: ldstr "setEncoding"
-				IL_0031: ldstr "utf8"
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_003b: pop
-				IL_003c: ldnull
-				IL_003d: ret
+				IL_0018: ldloc.0
+				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_001e: stloc.0
+				IL_001f: ldloc.0
+				IL_0020: ldstr "setEncoding"
+				IL_0025: ldstr "utf8"
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_002f: pop
+				IL_0030: ldnull
+				IL_0031: ret
 			} // end of method ArrowFunction_L17C5::__js_call__
 
 		} // end of class ArrowFunction_L17C5
@@ -162,7 +158,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25ac
+					// Method begins at RVA 0x2578
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -186,7 +182,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2498
+				// Method begins at RVA 0x2470
 				// Header size: 12
 				// Code size: 45 (0x2d)
 				.maxstack 8
@@ -231,7 +227,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25be
+						// Method begins at RVA 0x258a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -254,7 +250,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x254c
+					// Method begins at RVA 0x2518
 					// Header size: 12
 					// Code size: 37 (0x25)
 					.maxstack 8
@@ -286,7 +282,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25b5
+					// Method begins at RVA 0x2581
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -310,9 +306,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24d4
+				// Method begins at RVA 0x24ac
 				// Header size: 12
-				// Code size: 108 (0x6c)
+				// Code size: 94 (0x5e)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22/Scope,
@@ -327,42 +323,36 @@
 				IL_0008: ldelem.ref
 				IL_0009: castclass Modules.Tls_CreateSecureContext_Server_Handshake/Scope
 				IL_000e: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
-				IL_0013: stloc.1
-				IL_0014: ldstr "server"
-				IL_0019: ldloc.1
-				IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_001f: stloc.1
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0026: stloc.1
-				IL_0027: ldnull
-				IL_0028: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22/ArrowFunction_L27C18::__js_call__(object)
-				IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0033: ldc.i4.1
-				IL_0034: newarr [System.Runtime]System.Object
-				IL_0039: dup
-				IL_003a: ldc.i4.0
-				IL_003b: ldarg.0
-				IL_003c: ldc.i4.0
-				IL_003d: ldelem.ref
-				IL_003e: stelem.ref
-				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_0049: ldc.i4.0
-				IL_004a: conv.r8
-				IL_004b: ldstr ""
-				IL_0050: ldc.i4.0
-				IL_0051: ldc.i4.1
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-				IL_005c: stloc.2
-				IL_005d: ldloc.1
-				IL_005e: ldstr "close"
-				IL_0063: ldloc.2
-				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0069: pop
-				IL_006a: ldnull
-				IL_006b: ret
+				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0018: stloc.1
+				IL_0019: ldnull
+				IL_001a: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22/ArrowFunction_L27C18::__js_call__(object)
+				IL_0020: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0025: ldc.i4.1
+				IL_0026: newarr [System.Runtime]System.Object
+				IL_002b: dup
+				IL_002c: ldc.i4.0
+				IL_002d: ldarg.0
+				IL_002e: ldc.i4.0
+				IL_002f: ldelem.ref
+				IL_0030: stelem.ref
+				IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_003b: ldc.i4.0
+				IL_003c: conv.r8
+				IL_003d: ldstr ""
+				IL_0042: ldc.i4.0
+				IL_0043: ldc.i4.1
+				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+				IL_004e: stloc.2
+				IL_004f: ldloc.1
+				IL_0050: ldstr "close"
+				IL_0055: ldloc.2
+				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_005b: pop
+				IL_005c: ldnull
+				IL_005d: ret
 			} // end of method ArrowFunction_L26C22::__js_call__
 
 		} // end of class ArrowFunction_L26C22
@@ -381,7 +371,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x258f
+				// Method begins at RVA 0x255b
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -412,7 +402,7 @@
 			)
 			// Method begins at RVA 0x22a4
 			// Header size: 12
-			// Code size: 409 (0x199)
+			// Code size: 381 (0x17d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope,
@@ -426,150 +416,138 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
-			IL_000c: stloc.2
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.2
 			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.2
+			IL_001e: ldloc.2
+			IL_001f: stloc.1
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: stloc.1
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
-			IL_0034: stloc.2
-			IL_0035: ldstr "tls"
-			IL_003a: ldloc.2
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0040: stloc.2
-			IL_0041: ldloc.2
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0047: stloc.2
-			IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_004d: dup
-			IL_004e: ldstr "port"
-			IL_0053: ldloc.1
-			IL_0054: ldstr "port"
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0063: dup
-			IL_0064: ldstr "host"
-			IL_0069: ldstr "127.0.0.1"
-			IL_006e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0073: dup
-			IL_0074: ldstr "rejectUnauthorized"
-			IL_0079: ldc.i4.0
-			IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_007f: stloc.3
-			IL_0080: ldnull
-			IL_0081: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L17C5::__js_call__(object[], object)
-			IL_0087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_008c: ldc.i4.2
-			IL_008d: newarr [System.Runtime]System.Object
-			IL_0092: dup
-			IL_0093: ldc.i4.0
-			IL_0094: ldarg.0
-			IL_0095: stelem.ref
-			IL_0096: dup
-			IL_0097: ldc.i4.1
-			IL_0098: ldloc.0
-			IL_0099: stelem.ref
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00a4: ldc.i4.0
-			IL_00a5: conv.r8
-			IL_00a6: ldstr ""
-			IL_00ab: ldc.i4.0
-			IL_00ac: ldc.i4.1
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_00b7: stloc.s 4
-			IL_00b9: ldloc.2
-			IL_00ba: ldstr "connect"
-			IL_00bf: ldloc.3
-			IL_00c0: ldloc.s 4
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00c7: stloc.s 4
-			IL_00c9: ldloc.0
-			IL_00ca: ldloc.s 4
-			IL_00cc: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
-			IL_00d1: ldloc.0
-			IL_00d2: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
-			IL_00d7: ldstr "Cannot access 'client' before initialization"
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00e1: stloc.s 4
-			IL_00e3: ldloc.s 4
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ea: stloc.s 4
-			IL_00ec: ldnull
-			IL_00ed: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L22C21::__js_call__(object, object)
-			IL_00f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0031: dup
+			IL_0032: ldstr "port"
+			IL_0037: ldloc.1
+			IL_0038: ldstr "port"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0042: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0047: dup
+			IL_0048: ldstr "host"
+			IL_004d: ldstr "127.0.0.1"
+			IL_0052: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0057: dup
+			IL_0058: ldstr "rejectUnauthorized"
+			IL_005d: ldc.i4.0
+			IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0063: stloc.3
+			IL_0064: ldnull
+			IL_0065: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L17C5::__js_call__(object[], object)
+			IL_006b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0070: ldc.i4.2
+			IL_0071: newarr [System.Runtime]System.Object
+			IL_0076: dup
+			IL_0077: ldc.i4.0
+			IL_0078: ldarg.0
+			IL_0079: stelem.ref
+			IL_007a: dup
+			IL_007b: ldc.i4.1
+			IL_007c: ldloc.0
+			IL_007d: stelem.ref
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0088: ldc.i4.0
+			IL_0089: conv.r8
+			IL_008a: ldstr ""
+			IL_008f: ldc.i4.0
+			IL_0090: ldc.i4.1
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_009b: stloc.s 4
+			IL_009d: ldloc.2
+			IL_009e: ldstr "connect"
+			IL_00a3: ldloc.3
+			IL_00a4: ldloc.s 4
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00ab: stloc.s 4
+			IL_00ad: ldloc.0
+			IL_00ae: ldloc.s 4
+			IL_00b0: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
+			IL_00b5: ldloc.0
+			IL_00b6: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
+			IL_00bb: ldstr "Cannot access 'client' before initialization"
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00c5: stloc.s 4
+			IL_00c7: ldloc.s 4
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ce: stloc.s 4
+			IL_00d0: ldnull
+			IL_00d1: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L22C21::__js_call__(object, object)
+			IL_00d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00dc: ldc.i4.1
+			IL_00dd: newarr [System.Runtime]System.Object
+			IL_00e2: dup
+			IL_00e3: ldc.i4.0
+			IL_00e4: ldarg.0
+			IL_00e5: stelem.ref
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00f0: ldc.i4.1
+			IL_00f1: conv.r8
+			IL_00f2: ldstr ""
+			IL_00f7: ldc.i4.0
 			IL_00f8: ldc.i4.1
-			IL_00f9: newarr [System.Runtime]System.Object
-			IL_00fe: dup
-			IL_00ff: ldc.i4.0
-			IL_0100: ldarg.0
-			IL_0101: stelem.ref
-			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_010c: ldc.i4.1
-			IL_010d: conv.r8
-			IL_010e: ldstr ""
-			IL_0113: ldc.i4.0
-			IL_0114: ldc.i4.1
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_011f: stloc.2
-			IL_0120: ldloc.s 4
-			IL_0122: ldstr "on"
-			IL_0127: ldstr "data"
-			IL_012c: ldloc.2
-			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0132: pop
-			IL_0133: ldloc.0
-			IL_0134: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
-			IL_0139: ldstr "Cannot access 'client' before initialization"
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0143: stloc.2
-			IL_0144: ldloc.2
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014a: stloc.2
-			IL_014b: ldnull
-			IL_014c: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22::__js_call__(object[], object)
-			IL_0152: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0157: ldc.i4.2
-			IL_0158: newarr [System.Runtime]System.Object
-			IL_015d: dup
-			IL_015e: ldc.i4.0
-			IL_015f: ldarg.0
-			IL_0160: stelem.ref
-			IL_0161: dup
-			IL_0162: ldc.i4.1
-			IL_0163: ldloc.0
-			IL_0164: stelem.ref
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_016f: ldc.i4.0
-			IL_0170: conv.r8
-			IL_0171: ldstr ""
-			IL_0176: ldc.i4.0
-			IL_0177: ldc.i4.1
-			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0182: stloc.s 4
-			IL_0184: ldloc.2
-			IL_0185: ldstr "on"
-			IL_018a: ldstr "close"
-			IL_018f: ldloc.s 4
-			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0196: pop
-			IL_0197: ldnull
-			IL_0198: ret
+			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0103: stloc.2
+			IL_0104: ldloc.s 4
+			IL_0106: ldstr "on"
+			IL_010b: ldstr "data"
+			IL_0110: ldloc.2
+			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0116: pop
+			IL_0117: ldloc.0
+			IL_0118: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
+			IL_011d: ldstr "Cannot access 'client' before initialization"
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0127: stloc.2
+			IL_0128: ldloc.2
+			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_012e: stloc.2
+			IL_012f: ldnull
+			IL_0130: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22::__js_call__(object[], object)
+			IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_013b: ldc.i4.2
+			IL_013c: newarr [System.Runtime]System.Object
+			IL_0141: dup
+			IL_0142: ldc.i4.0
+			IL_0143: ldarg.0
+			IL_0144: stelem.ref
+			IL_0145: dup
+			IL_0146: ldc.i4.1
+			IL_0147: ldloc.0
+			IL_0148: stelem.ref
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0153: ldc.i4.0
+			IL_0154: conv.r8
+			IL_0155: ldstr ""
+			IL_015a: ldc.i4.0
+			IL_015b: ldc.i4.1
+			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0166: stloc.s 4
+			IL_0168: ldloc.2
+			IL_0169: ldstr "on"
+			IL_016e: ldstr "close"
+			IL_0173: ldloc.s 4
+			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_017a: pop
+			IL_017b: ldnull
+			IL_017c: ret
 		} // end of method ArrowFunction_L13C31::__js_call__
 
 	} // end of class ArrowFunction_L13C31
@@ -590,7 +568,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x257d
+			// Method begins at RVA 0x2549
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -805,7 +783,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25c7
+			// Method begins at RVA 0x2593
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -868,7 +846,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25d0
+		// Method begins at RVA 0x259c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Connect_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x268a
+				// Method begins at RVA 0x2626
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -94,7 +94,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26a7
+					// Method begins at RVA 0x2643
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -118,9 +118,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2418
+				// Method begins at RVA 0x23fc
 				// Header size: 12
-				// Code size: 373 (0x175)
+				// Code size: 313 (0x139)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -138,131 +138,111 @@
 				IL_000d: ldstr "Cannot access 'client' before initialization"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_0017: stloc.0
-				IL_0018: ldstr "client"
-				IL_001d: ldloc.0
-				IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0023: stloc.0
-				IL_0024: ldloc.0
-				IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_002a: stloc.0
-				IL_002b: ldloc.0
-				IL_002c: ldstr "setEncoding"
-				IL_0031: ldstr "utf8"
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_003b: pop
-				IL_003c: ldstr "console"
-				IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0046: stloc.0
-				IL_0047: ldloc.0
-				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004d: stloc.0
-				IL_004e: ldarg.0
-				IL_004f: ldc.i4.1
-				IL_0050: ldelem.ref
-				IL_0051: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
-				IL_0056: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-				IL_005b: ldstr "Cannot access 'client' before initialization"
-				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_0018: ldloc.0
+				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_001e: stloc.0
+				IL_001f: ldloc.0
+				IL_0020: ldstr "setEncoding"
+				IL_0025: ldstr "utf8"
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_002f: pop
+				IL_0030: ldstr "console"
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_003a: stloc.0
+				IL_003b: ldloc.0
+				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0041: stloc.0
+				IL_0042: ldarg.0
+				IL_0043: ldc.i4.1
+				IL_0044: ldelem.ref
+				IL_0045: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
+				IL_004a: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+				IL_004f: ldstr "Cannot access 'client' before initialization"
+				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_0059: stloc.1
+				IL_005a: ldloc.1
+				IL_005b: ldstr "encrypted"
+				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 				IL_0065: stloc.1
-				IL_0066: ldstr "client"
+				IL_0066: ldstr "client secure:"
 				IL_006b: ldloc.1
-				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0071: stloc.1
-				IL_0072: ldloc.1
-				IL_0073: ldstr "encrypted"
-				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_007d: stloc.1
-				IL_007e: ldstr "client secure:"
-				IL_0083: ldloc.1
-				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0089: stloc.2
-				IL_008a: ldloc.2
-				IL_008b: ldstr ":"
-				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0095: stloc.2
-				IL_0096: ldarg.0
-				IL_0097: ldc.i4.1
-				IL_0098: ldelem.ref
-				IL_0099: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
-				IL_009e: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-				IL_00a3: ldstr "Cannot access 'client' before initialization"
-				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00ad: stloc.1
-				IL_00ae: ldstr "client"
-				IL_00b3: ldloc.1
-				IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00b9: stloc.1
-				IL_00ba: ldloc.1
-				IL_00bb: ldstr "authorized"
-				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00c5: stloc.1
-				IL_00c6: ldloc.2
-				IL_00c7: ldloc.1
-				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00cd: stloc.2
-				IL_00ce: ldloc.2
-				IL_00cf: ldstr ":"
-				IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00d9: stloc.2
-				IL_00da: ldarg.0
-				IL_00db: ldc.i4.1
-				IL_00dc: ldelem.ref
-				IL_00dd: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
-				IL_00e2: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-				IL_00e7: ldstr "Cannot access 'client' before initialization"
-				IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00f1: stloc.1
-				IL_00f2: ldstr "client"
-				IL_00f7: ldloc.1
-				IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00fd: stloc.1
-				IL_00fe: ldloc.1
-				IL_00ff: ldstr "authorizationError"
-				IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0109: stloc.1
-				IL_010a: ldloc.1
-				IL_010b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0110: ldc.i4.0
-				IL_0111: ceq
-				IL_0113: stloc.3
-				IL_0114: ldloc.3
-				IL_0115: ldc.i4.0
-				IL_0116: ceq
-				IL_0118: stloc.3
-				IL_0119: ldloc.3
-				IL_011a: box [System.Runtime]System.Boolean
-				IL_011f: stloc.s 4
-				IL_0121: ldloc.2
-				IL_0122: ldloc.s 4
-				IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0129: stloc.2
-				IL_012a: ldloc.0
-				IL_012b: ldstr "log"
-				IL_0130: ldloc.2
+				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0071: stloc.2
+				IL_0072: ldloc.2
+				IL_0073: ldstr ":"
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_007d: stloc.2
+				IL_007e: ldarg.0
+				IL_007f: ldc.i4.1
+				IL_0080: ldelem.ref
+				IL_0081: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
+				IL_0086: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+				IL_008b: ldstr "Cannot access 'client' before initialization"
+				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_0095: stloc.1
+				IL_0096: ldloc.1
+				IL_0097: ldstr "authorized"
+				IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00a1: stloc.1
+				IL_00a2: ldloc.2
+				IL_00a3: ldloc.1
+				IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00a9: stloc.2
+				IL_00aa: ldloc.2
+				IL_00ab: ldstr ":"
+				IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00b5: stloc.2
+				IL_00b6: ldarg.0
+				IL_00b7: ldc.i4.1
+				IL_00b8: ldelem.ref
+				IL_00b9: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
+				IL_00be: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+				IL_00c3: ldstr "Cannot access 'client' before initialization"
+				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_00cd: stloc.1
+				IL_00ce: ldloc.1
+				IL_00cf: ldstr "authorizationError"
+				IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00d9: stloc.1
+				IL_00da: ldloc.1
+				IL_00db: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_00e0: ldc.i4.0
+				IL_00e1: ceq
+				IL_00e3: stloc.3
+				IL_00e4: ldloc.3
+				IL_00e5: ldc.i4.0
+				IL_00e6: ceq
+				IL_00e8: stloc.3
+				IL_00e9: ldloc.3
+				IL_00ea: box [System.Runtime]System.Boolean
+				IL_00ef: stloc.s 4
+				IL_00f1: ldloc.2
+				IL_00f2: ldloc.s 4
+				IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00f9: stloc.2
+				IL_00fa: ldloc.0
+				IL_00fb: ldstr "log"
+				IL_0100: ldloc.2
+				IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0106: pop
+				IL_0107: ldarg.0
+				IL_0108: ldc.i4.1
+				IL_0109: ldelem.ref
+				IL_010a: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
+				IL_010f: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+				IL_0114: ldstr "Cannot access 'client' before initialization"
+				IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_011e: stloc.0
+				IL_011f: ldloc.0
+				IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0125: stloc.0
+				IL_0126: ldloc.0
+				IL_0127: ldstr "write"
+				IL_012c: ldstr "ping"
 				IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 				IL_0136: pop
-				IL_0137: ldarg.0
-				IL_0138: ldc.i4.1
-				IL_0139: ldelem.ref
-				IL_013a: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
-				IL_013f: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-				IL_0144: ldstr "Cannot access 'client' before initialization"
-				IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_014e: stloc.0
-				IL_014f: ldstr "client"
-				IL_0154: ldloc.0
-				IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_015a: stloc.0
-				IL_015b: ldloc.0
-				IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0161: stloc.0
-				IL_0162: ldloc.0
-				IL_0163: ldstr "write"
-				IL_0168: ldstr "ping"
-				IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0172: pop
-				IL_0173: ldnull
-				IL_0174: ret
+				IL_0137: ldnull
+				IL_0138: ret
 			} // end of method ArrowFunction_L17C5::__js_call__
 
 		} // end of class ArrowFunction_L17C5
@@ -285,7 +265,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26b0
+					// Method begins at RVA 0x264c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -309,7 +289,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x259c
+				// Method begins at RVA 0x2544
 				// Header size: 12
 				// Code size: 45 (0x2d)
 				.maxstack 8
@@ -354,7 +334,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26c2
+						// Method begins at RVA 0x265e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -377,7 +357,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2650
+					// Method begins at RVA 0x25ec
 					// Header size: 12
 					// Code size: 37 (0x25)
 					.maxstack 8
@@ -409,7 +389,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26b9
+					// Method begins at RVA 0x2655
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -433,9 +413,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25d8
+				// Method begins at RVA 0x2580
 				// Header size: 12
-				// Code size: 108 (0x6c)
+				// Code size: 94 (0x5e)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22/Scope,
@@ -450,42 +430,36 @@
 				IL_0008: ldelem.ref
 				IL_0009: castclass Modules.Tls_CreateServer_Connect_Basic/Scope
 				IL_000e: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
-				IL_0013: stloc.1
-				IL_0014: ldstr "server"
-				IL_0019: ldloc.1
-				IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_001f: stloc.1
-				IL_0020: ldloc.1
-				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0026: stloc.1
-				IL_0027: ldnull
-				IL_0028: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22/ArrowFunction_L29C18::__js_call__(object)
-				IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0033: ldc.i4.1
-				IL_0034: newarr [System.Runtime]System.Object
-				IL_0039: dup
-				IL_003a: ldc.i4.0
-				IL_003b: ldarg.0
-				IL_003c: ldc.i4.0
-				IL_003d: ldelem.ref
-				IL_003e: stelem.ref
-				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_0049: ldc.i4.0
-				IL_004a: conv.r8
-				IL_004b: ldstr ""
-				IL_0050: ldc.i4.0
-				IL_0051: ldc.i4.1
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-				IL_005c: stloc.2
-				IL_005d: ldloc.1
-				IL_005e: ldstr "close"
-				IL_0063: ldloc.2
-				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0069: pop
-				IL_006a: ldnull
-				IL_006b: ret
+				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0018: stloc.1
+				IL_0019: ldnull
+				IL_001a: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22/ArrowFunction_L29C18::__js_call__(object)
+				IL_0020: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0025: ldc.i4.1
+				IL_0026: newarr [System.Runtime]System.Object
+				IL_002b: dup
+				IL_002c: ldc.i4.0
+				IL_002d: ldarg.0
+				IL_002e: ldc.i4.0
+				IL_002f: ldelem.ref
+				IL_0030: stelem.ref
+				IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_003b: ldc.i4.0
+				IL_003c: conv.r8
+				IL_003d: ldstr ""
+				IL_0042: ldc.i4.0
+				IL_0043: ldc.i4.1
+				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+				IL_004e: stloc.2
+				IL_004f: ldloc.1
+				IL_0050: ldstr "close"
+				IL_0055: ldloc.2
+				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_005b: pop
+				IL_005c: ldnull
+				IL_005d: ret
 			} // end of method ArrowFunction_L28C22::__js_call__
 
 		} // end of class ArrowFunction_L28C22
@@ -504,7 +478,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2693
+				// Method begins at RVA 0x262f
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -535,7 +509,7 @@
 			)
 			// Method begins at RVA 0x2230
 			// Header size: 12
-			// Code size: 476 (0x1dc)
+			// Code size: 448 (0x1c0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope,
@@ -550,171 +524,159 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
-			IL_000c: stloc.2
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.2
 			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: stloc.1
-			IL_002e: ldstr "console"
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0038: stloc.2
-			IL_0039: ldloc.2
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003f: stloc.2
-			IL_0040: ldstr "listening:"
-			IL_0045: ldloc.1
-			IL_0046: ldstr "address"
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0055: stloc.3
-			IL_0056: ldloc.3
-			IL_0057: ldstr ":ready"
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0061: stloc.3
-			IL_0062: ldloc.2
-			IL_0063: ldstr "log"
-			IL_0068: ldloc.3
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_006e: pop
-			IL_006f: ldarg.0
-			IL_0070: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
-			IL_0075: stloc.2
-			IL_0076: ldstr "tls"
-			IL_007b: ldloc.2
-			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0081: stloc.2
-			IL_0082: ldloc.2
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0088: stloc.2
-			IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_008e: dup
-			IL_008f: ldstr "port"
-			IL_0094: ldloc.1
-			IL_0095: ldstr "port"
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_009f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00a4: dup
-			IL_00a5: ldstr "host"
-			IL_00aa: ldstr "127.0.0.1"
-			IL_00af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00b4: dup
-			IL_00b5: ldstr "rejectUnauthorized"
-			IL_00ba: ldc.i4.0
-			IL_00bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00c0: stloc.s 4
-			IL_00c2: ldnull
-			IL_00c3: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L17C5::__js_call__(object[], object)
-			IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_00ce: ldc.i4.2
-			IL_00cf: newarr [System.Runtime]System.Object
-			IL_00d4: dup
-			IL_00d5: ldc.i4.0
-			IL_00d6: ldarg.0
-			IL_00d7: stelem.ref
-			IL_00d8: dup
-			IL_00d9: ldc.i4.1
-			IL_00da: ldloc.0
-			IL_00db: stelem.ref
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00e6: ldc.i4.0
-			IL_00e7: conv.r8
-			IL_00e8: ldstr ""
-			IL_00ed: ldc.i4.0
-			IL_00ee: ldc.i4.1
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_00f9: stloc.s 5
-			IL_00fb: ldloc.2
-			IL_00fc: ldstr "connect"
-			IL_0101: ldloc.s 4
-			IL_0103: ldloc.s 5
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_010a: stloc.s 5
-			IL_010c: ldloc.0
-			IL_010d: ldloc.s 5
-			IL_010f: stfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-			IL_0114: ldloc.0
-			IL_0115: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-			IL_011a: ldstr "Cannot access 'client' before initialization"
-			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0124: stloc.s 5
-			IL_0126: ldloc.s 5
-			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_012d: stloc.s 5
-			IL_012f: ldnull
-			IL_0130: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L24C21::__js_call__(object, object)
-			IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.2
+			IL_001e: ldloc.2
+			IL_001f: stloc.1
+			IL_0020: ldstr "console"
+			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_002a: stloc.2
+			IL_002b: ldloc.2
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0031: stloc.2
+			IL_0032: ldstr "listening:"
+			IL_0037: ldloc.1
+			IL_0038: ldstr "address"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0047: stloc.3
+			IL_0048: ldloc.3
+			IL_0049: ldstr ":ready"
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0053: stloc.3
+			IL_0054: ldloc.2
+			IL_0055: ldstr "log"
+			IL_005a: ldloc.3
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0060: pop
+			IL_0061: ldarg.0
+			IL_0062: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006c: stloc.2
+			IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0072: dup
+			IL_0073: ldstr "port"
+			IL_0078: ldloc.1
+			IL_0079: ldstr "port"
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0083: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0088: dup
+			IL_0089: ldstr "host"
+			IL_008e: ldstr "127.0.0.1"
+			IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0098: dup
+			IL_0099: ldstr "rejectUnauthorized"
+			IL_009e: ldc.i4.0
+			IL_009f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00a4: stloc.s 4
+			IL_00a6: ldnull
+			IL_00a7: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L17C5::__js_call__(object[], object)
+			IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_00b2: ldc.i4.2
+			IL_00b3: newarr [System.Runtime]System.Object
+			IL_00b8: dup
+			IL_00b9: ldc.i4.0
+			IL_00ba: ldarg.0
+			IL_00bb: stelem.ref
+			IL_00bc: dup
+			IL_00bd: ldc.i4.1
+			IL_00be: ldloc.0
+			IL_00bf: stelem.ref
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00ca: ldc.i4.0
+			IL_00cb: conv.r8
+			IL_00cc: ldstr ""
+			IL_00d1: ldc.i4.0
+			IL_00d2: ldc.i4.1
+			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_00dd: stloc.s 5
+			IL_00df: ldloc.2
+			IL_00e0: ldstr "connect"
+			IL_00e5: ldloc.s 4
+			IL_00e7: ldloc.s 5
+			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00ee: stloc.s 5
+			IL_00f0: ldloc.0
+			IL_00f1: ldloc.s 5
+			IL_00f3: stfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+			IL_00f8: ldloc.0
+			IL_00f9: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+			IL_00fe: ldstr "Cannot access 'client' before initialization"
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0108: stloc.s 5
+			IL_010a: ldloc.s 5
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0111: stloc.s 5
+			IL_0113: ldnull
+			IL_0114: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L24C21::__js_call__(object, object)
+			IL_011a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_011f: ldc.i4.1
+			IL_0120: newarr [System.Runtime]System.Object
+			IL_0125: dup
+			IL_0126: ldc.i4.0
+			IL_0127: ldarg.0
+			IL_0128: stelem.ref
+			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0133: ldc.i4.1
+			IL_0134: conv.r8
+			IL_0135: ldstr ""
+			IL_013a: ldc.i4.0
 			IL_013b: ldc.i4.1
-			IL_013c: newarr [System.Runtime]System.Object
-			IL_0141: dup
-			IL_0142: ldc.i4.0
-			IL_0143: ldarg.0
-			IL_0144: stelem.ref
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_014f: ldc.i4.1
-			IL_0150: conv.r8
-			IL_0151: ldstr ""
-			IL_0156: ldc.i4.0
-			IL_0157: ldc.i4.1
-			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0162: stloc.2
-			IL_0163: ldloc.s 5
-			IL_0165: ldstr "on"
-			IL_016a: ldstr "data"
-			IL_016f: ldloc.2
-			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0175: pop
-			IL_0176: ldloc.0
-			IL_0177: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-			IL_017c: ldstr "Cannot access 'client' before initialization"
-			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0186: stloc.2
-			IL_0187: ldloc.2
-			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018d: stloc.2
-			IL_018e: ldnull
-			IL_018f: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22::__js_call__(object[], object)
-			IL_0195: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_019a: ldc.i4.2
-			IL_019b: newarr [System.Runtime]System.Object
-			IL_01a0: dup
-			IL_01a1: ldc.i4.0
-			IL_01a2: ldarg.0
-			IL_01a3: stelem.ref
-			IL_01a4: dup
-			IL_01a5: ldc.i4.1
-			IL_01a6: ldloc.0
-			IL_01a7: stelem.ref
-			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_01b2: ldc.i4.0
-			IL_01b3: conv.r8
-			IL_01b4: ldstr ""
-			IL_01b9: ldc.i4.0
-			IL_01ba: ldc.i4.1
-			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_01c5: stloc.s 5
-			IL_01c7: ldloc.2
-			IL_01c8: ldstr "on"
-			IL_01cd: ldstr "close"
-			IL_01d2: ldloc.s 5
-			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01d9: pop
-			IL_01da: ldnull
-			IL_01db: ret
+			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0146: stloc.2
+			IL_0147: ldloc.s 5
+			IL_0149: ldstr "on"
+			IL_014e: ldstr "data"
+			IL_0153: ldloc.2
+			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0159: pop
+			IL_015a: ldloc.0
+			IL_015b: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+			IL_0160: ldstr "Cannot access 'client' before initialization"
+			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_016a: stloc.2
+			IL_016b: ldloc.2
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0171: stloc.2
+			IL_0172: ldnull
+			IL_0173: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22::__js_call__(object[], object)
+			IL_0179: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_017e: ldc.i4.2
+			IL_017f: newarr [System.Runtime]System.Object
+			IL_0184: dup
+			IL_0185: ldc.i4.0
+			IL_0186: ldarg.0
+			IL_0187: stelem.ref
+			IL_0188: dup
+			IL_0189: ldc.i4.1
+			IL_018a: ldloc.0
+			IL_018b: stelem.ref
+			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0196: ldc.i4.0
+			IL_0197: conv.r8
+			IL_0198: ldstr ""
+			IL_019d: ldc.i4.0
+			IL_019e: ldc.i4.1
+			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_01a9: stloc.s 5
+			IL_01ab: ldloc.2
+			IL_01ac: ldstr "on"
+			IL_01b1: ldstr "close"
+			IL_01b6: ldloc.s 5
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01bd: pop
+			IL_01be: ldnull
+			IL_01bf: ret
 		} // end of method ArrowFunction_L11C31::__js_call__
 
 	} // end of class ArrowFunction_L11C31
@@ -735,7 +697,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2681
+			// Method begins at RVA 0x261d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -902,7 +864,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26cb
+			// Method begins at RVA 0x2667
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -965,7 +927,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26d4
+		// Method begins at RVA 0x2670
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26eb
+					// Method begins at RVA 0x2653
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,9 +47,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23b4
+				// Method begins at RVA 0x2398
 				// Header size: 12
-				// Code size: 74 (0x4a)
+				// Code size: 62 (0x3e)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -63,30 +63,26 @@
 				IL_0003: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
 				IL_0008: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::received
 				IL_000d: stloc.0
-				IL_000e: ldstr "received"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldarg.2
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldstr "toString"
-				IL_0027: ldstr "utf8"
-				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0031: stloc.1
-				IL_0032: ldloc.0
-				IL_0033: ldloc.1
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0039: stloc.2
-				IL_003a: ldarg.0
-				IL_003b: ldc.i4.1
-				IL_003c: ldelem.ref
-				IL_003d: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
-				IL_0042: ldloc.2
-				IL_0043: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::received
-				IL_0048: ldnull
-				IL_0049: ret
+				IL_000e: ldarg.2
+				IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0014: stloc.1
+				IL_0015: ldloc.1
+				IL_0016: ldstr "toString"
+				IL_001b: ldstr "utf8"
+				IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0025: stloc.1
+				IL_0026: ldloc.0
+				IL_0027: ldloc.1
+				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_002d: stloc.2
+				IL_002e: ldarg.0
+				IL_002f: ldc.i4.1
+				IL_0030: ldelem.ref
+				IL_0031: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
+				IL_0036: ldloc.2
+				IL_0037: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::received
+				IL_003c: ldnull
+				IL_003d: ret
 			} // end of method FunctionExpression_server::__js_call__
 
 		} // end of class FunctionExpression_server
@@ -106,7 +102,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26fd
+						// Method begins at RVA 0x2665
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -130,9 +126,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x25e0
+					// Method begins at RVA 0x2574
 					// Header size: 12
-					// Code size: 186 (0xba)
+					// Code size: 142 (0x8e)
 					.maxstack 8
 					.locals init (
 						[0] object,
@@ -146,70 +142,50 @@
 					IL_000b: ldloc.0
 					IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0011: stloc.0
-					IL_0012: ldarg.0
-					IL_0013: ldc.i4.1
-					IL_0014: ldelem.ref
-					IL_0015: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
-					IL_001a: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::socket
-					IL_001f: stloc.1
-					IL_0020: ldstr "socket"
-					IL_0025: ldloc.1
-					IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_002b: stloc.1
-					IL_002c: ldloc.1
-					IL_002d: ldstr "writable"
-					IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0037: stloc.1
-					IL_0038: ldstr "server writable:"
-					IL_003d: ldloc.1
-					IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0043: stloc.2
-					IL_0044: ldloc.0
-					IL_0045: ldstr "log"
-					IL_004a: ldloc.2
-					IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0050: pop
-					IL_0051: ldarg.0
-					IL_0052: ldc.i4.1
-					IL_0053: ldelem.ref
-					IL_0054: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
-					IL_0059: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::socket
-					IL_005e: stloc.0
-					IL_005f: ldstr "socket"
-					IL_0064: ldloc.0
-					IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_006a: stloc.0
-					IL_006b: ldloc.0
-					IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0071: stloc.0
-					IL_0072: ldarg.0
-					IL_0073: ldc.i4.1
-					IL_0074: ldelem.ref
-					IL_0075: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
-					IL_007a: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::received
-					IL_007f: stloc.1
-					IL_0080: ldstr "received"
+					IL_0012: ldstr "server writable:"
+					IL_0017: ldarg.0
+					IL_0018: ldc.i4.1
+					IL_0019: ldelem.ref
+					IL_001a: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
+					IL_001f: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::socket
+					IL_0024: ldstr "writable"
+					IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0033: stloc.1
+					IL_0034: ldloc.0
+					IL_0035: ldstr "log"
+					IL_003a: ldloc.1
+					IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0040: pop
+					IL_0041: ldarg.0
+					IL_0042: ldc.i4.1
+					IL_0043: ldelem.ref
+					IL_0044: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
+					IL_0049: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::socket
+					IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0053: stloc.0
+					IL_0054: ldarg.0
+					IL_0055: ldc.i4.1
+					IL_0056: ldelem.ref
+					IL_0057: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
+					IL_005c: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::received
+					IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0066: stloc.2
+					IL_0067: ldloc.2
+					IL_0068: ldstr "toUpperCase"
+					IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_0072: stloc.2
+					IL_0073: ldstr "delayed:"
+					IL_0078: ldloc.2
+					IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_007e: stloc.1
+					IL_007f: ldloc.0
+					IL_0080: ldstr "end"
 					IL_0085: ldloc.1
-					IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_008b: stloc.1
-					IL_008c: ldloc.1
-					IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0092: stloc.1
-					IL_0093: ldloc.1
-					IL_0094: ldstr "toUpperCase"
-					IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_009e: stloc.1
-					IL_009f: ldstr "delayed:"
-					IL_00a4: ldloc.1
-					IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_00aa: stloc.2
-					IL_00ab: ldloc.0
-					IL_00ac: ldstr "end"
-					IL_00b1: ldloc.2
-					IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00b7: pop
-					IL_00b8: ldnull
-					IL_00b9: ret
+					IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_008b: pop
+					IL_008c: ldnull
+					IL_008d: ret
 				} // end of method FunctionExpression_server::__js_call__
 
 			} // end of class FunctionExpression_server
@@ -221,7 +197,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26f4
+					// Method begins at RVA 0x265c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -245,15 +221,14 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x240c
+				// Method begins at RVA 0x23e4
 				// Header size: 12
-				// Code size: 152 (0x98)
+				// Code size: 138 (0x8a)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/Scope,
 					[1] object,
-					[2] object,
-					[3] object
+					[2] object
 				)
 
 				IL_0000: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/Scope::.ctor()
@@ -264,61 +239,55 @@
 				IL_0011: ldloc.1
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0017: stloc.1
-				IL_0018: ldarg.0
-				IL_0019: ldc.i4.1
-				IL_001a: ldelem.ref
-				IL_001b: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
-				IL_0020: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::received
-				IL_0025: stloc.2
-				IL_0026: ldstr "received"
-				IL_002b: ldloc.2
-				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0031: stloc.2
-				IL_0032: ldstr "server end:"
-				IL_0037: ldloc.2
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_003d: stloc.3
-				IL_003e: ldloc.1
-				IL_003f: ldstr "log"
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004a: pop
-				IL_004b: ldc.i4.3
-				IL_004c: newarr [System.Runtime]System.Object
-				IL_0051: dup
-				IL_0052: ldc.i4.0
-				IL_0053: ldarg.0
-				IL_0054: ldc.i4.0
-				IL_0055: ldelem.ref
-				IL_0056: stelem.ref
-				IL_0057: dup
-				IL_0058: ldc.i4.1
-				IL_0059: ldarg.0
-				IL_005a: ldc.i4.1
-				IL_005b: ldelem.ref
-				IL_005c: stelem.ref
-				IL_005d: dup
-				IL_005e: ldc.i4.2
-				IL_005f: ldloc.0
-				IL_0060: stelem.ref
-				IL_0061: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server::__js_call__(object[], object)
-				IL_0067: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_006c: ldc.i4.0
-				IL_006d: conv.r8
-				IL_006e: ldstr ""
-				IL_0073: ldc.i4.0
-				IL_0074: ldc.i4.1
-				IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_007a: stloc.1
-				IL_007b: ldloc.1
-				IL_007c: ldc.r8 0.0
-				IL_0085: box [System.Runtime]System.Double
-				IL_008a: ldc.i4.0
-				IL_008b: newarr [System.Runtime]System.Object
-				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
-				IL_0095: pop
-				IL_0096: ldnull
-				IL_0097: ret
+				IL_0018: ldstr "server end:"
+				IL_001d: ldarg.0
+				IL_001e: ldc.i4.1
+				IL_001f: ldelem.ref
+				IL_0020: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
+				IL_0025: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::received
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_002f: stloc.2
+				IL_0030: ldloc.1
+				IL_0031: ldstr "log"
+				IL_0036: ldloc.2
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_003c: pop
+				IL_003d: ldc.i4.3
+				IL_003e: newarr [System.Runtime]System.Object
+				IL_0043: dup
+				IL_0044: ldc.i4.0
+				IL_0045: ldarg.0
+				IL_0046: ldc.i4.0
+				IL_0047: ldelem.ref
+				IL_0048: stelem.ref
+				IL_0049: dup
+				IL_004a: ldc.i4.1
+				IL_004b: ldarg.0
+				IL_004c: ldc.i4.1
+				IL_004d: ldelem.ref
+				IL_004e: stelem.ref
+				IL_004f: dup
+				IL_0050: ldc.i4.2
+				IL_0051: ldloc.0
+				IL_0052: stelem.ref
+				IL_0053: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server::__js_call__(object[], object)
+				IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_005e: ldc.i4.0
+				IL_005f: conv.r8
+				IL_0060: ldstr ""
+				IL_0065: ldc.i4.0
+				IL_0066: ldc.i4.1
+				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_006c: stloc.1
+				IL_006d: ldloc.1
+				IL_006e: ldc.r8 0.0
+				IL_0077: box [System.Runtime]System.Double
+				IL_007c: ldc.i4.0
+				IL_007d: newarr [System.Runtime]System.Object
+				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
+				IL_0087: pop
+				IL_0088: ldnull
+				IL_0089: ret
 			} // end of method FunctionExpression_server_L13C19::__js_call__
 
 		} // end of class FunctionExpression_server_L13C19
@@ -339,7 +308,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26e2
+				// Method begins at RVA 0x264a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -482,7 +451,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x271a
+					// Method begins at RVA 0x2682
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -506,9 +475,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24b0
+				// Method begins at RVA 0x247c
 				// Header size: 12
-				// Code size: 62 (0x3e)
+				// Code size: 50 (0x32)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -522,20 +491,16 @@
 				IL_000d: ldstr "Cannot access 'client' before initialization"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_0017: stloc.0
-				IL_0018: ldstr "client"
-				IL_001d: ldloc.0
-				IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0023: stloc.0
-				IL_0024: ldloc.0
-				IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_002a: stloc.0
-				IL_002b: ldloc.0
-				IL_002c: ldstr "end"
-				IL_0031: ldstr "ping"
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_003b: pop
-				IL_003c: ldnull
-				IL_003d: ret
+				IL_0018: ldloc.0
+				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_001e: stloc.0
+				IL_001f: ldloc.0
+				IL_0020: ldstr "end"
+				IL_0025: ldstr "ping"
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_002f: pop
+				IL_0030: ldnull
+				IL_0031: ret
 			} // end of method FunctionExpression_client::__js_call__
 
 		} // end of class FunctionExpression_client
@@ -551,7 +516,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2723
+					// Method begins at RVA 0x268b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -576,13 +541,12 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24fc
+				// Method begins at RVA 0x24bc
 				// Header size: 12
-				// Code size: 50 (0x32)
+				// Code size: 36 (0x24)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] object
 				)
 
 				IL_0000: ldarg.0
@@ -590,23 +554,17 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
 				IL_0008: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
-				IL_000d: stloc.0
-				IL_000e: ldstr "reply"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: ldarg.2
-				IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0021: stloc.1
-				IL_0022: ldarg.0
-				IL_0023: ldc.i4.1
-				IL_0024: ldelem.ref
-				IL_0025: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
-				IL_002a: ldloc.1
-				IL_002b: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
-				IL_0030: ldnull
-				IL_0031: ret
+				IL_000d: ldarg.2
+				IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0013: stloc.0
+				IL_0014: ldarg.0
+				IL_0015: ldc.i4.1
+				IL_0016: ldelem.ref
+				IL_0017: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
+				IL_001c: ldloc.0
+				IL_001d: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
+				IL_0022: ldnull
+				IL_0023: ret
 			} // end of method FunctionExpression_L30C20::__js_call__
 
 		} // end of class FunctionExpression_L30C20
@@ -626,7 +584,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2735
+						// Method begins at RVA 0x269d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -649,7 +607,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x26a8
+					// Method begins at RVA 0x2610
 					// Header size: 12
 					// Code size: 37 (0x25)
 					.maxstack 8
@@ -681,7 +639,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x272c
+					// Method begins at RVA 0x2694
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -705,9 +663,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x253c
+				// Method begins at RVA 0x24ec
 				// Header size: 12
-				// Code size: 150 (0x96)
+				// Code size: 122 (0x7a)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/Scope,
@@ -724,55 +682,43 @@
 				IL_0011: ldloc.1
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0017: stloc.1
-				IL_0018: ldarg.0
-				IL_0019: ldc.i4.1
-				IL_001a: ldelem.ref
-				IL_001b: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
-				IL_0020: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
-				IL_0025: stloc.2
-				IL_0026: ldstr "reply"
-				IL_002b: ldloc.2
-				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0031: stloc.2
-				IL_0032: ldstr "client recv:"
-				IL_0037: ldloc.2
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_003d: stloc.3
-				IL_003e: ldloc.1
-				IL_003f: ldstr "log"
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004a: pop
-				IL_004b: ldarg.0
-				IL_004c: ldc.i4.0
-				IL_004d: ldelem.ref
-				IL_004e: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
-				IL_0053: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
-				IL_0058: stloc.1
-				IL_0059: ldstr "server"
-				IL_005e: ldloc.1
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0064: stloc.1
-				IL_0065: ldloc.1
-				IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_006b: stloc.1
-				IL_006c: ldnull
-				IL_006d: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17::__js_call__(object)
-				IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0078: ldc.i4.0
-				IL_0079: conv.r8
-				IL_007a: ldstr ""
-				IL_007f: ldc.i4.0
-				IL_0080: ldc.i4.1
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0086: stloc.2
-				IL_0087: ldloc.1
-				IL_0088: ldstr "close"
-				IL_008d: ldloc.2
-				IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0093: pop
-				IL_0094: ldnull
-				IL_0095: ret
+				IL_0018: ldstr "client recv:"
+				IL_001d: ldarg.0
+				IL_001e: ldc.i4.1
+				IL_001f: ldelem.ref
+				IL_0020: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
+				IL_0025: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_002f: stloc.2
+				IL_0030: ldloc.1
+				IL_0031: ldstr "log"
+				IL_0036: ldloc.2
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_003c: pop
+				IL_003d: ldarg.0
+				IL_003e: ldc.i4.0
+				IL_003f: ldelem.ref
+				IL_0040: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
+				IL_0045: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
+				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_004f: stloc.1
+				IL_0050: ldnull
+				IL_0051: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17::__js_call__(object)
+				IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_005c: ldc.i4.0
+				IL_005d: conv.r8
+				IL_005e: ldstr ""
+				IL_0063: ldc.i4.0
+				IL_0064: ldc.i4.1
+				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_006a: stloc.3
+				IL_006b: ldloc.1
+				IL_006c: ldstr "close"
+				IL_0071: ldloc.3
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0077: pop
+				IL_0078: ldnull
+				IL_0079: ret
 			} // end of method FunctionExpression_L34C19::__js_call__
 
 		} // end of class FunctionExpression_L34C19
@@ -793,7 +739,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2706
+				// Method begins at RVA 0x266e
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -824,7 +770,7 @@
 			)
 			// Method begins at RVA 0x2218
 			// Header size: 12
-			// Code size: 398 (0x18e)
+			// Code size: 370 (0x172)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope,
@@ -839,151 +785,139 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
-			IL_000c: stloc.2
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.2
 			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.2
+			IL_001e: ldloc.2
+			IL_001f: stloc.1
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: stloc.1
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
-			IL_0034: stloc.2
-			IL_0035: ldstr "net"
-			IL_003a: ldloc.2
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0040: stloc.2
-			IL_0041: ldloc.2
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0047: stloc.2
-			IL_0048: ldloc.1
-			IL_0049: ldstr "port"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0053: stloc.3
-			IL_0054: ldloc.1
-			IL_0055: ldstr "address"
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005f: stloc.s 4
-			IL_0061: ldc.i4.2
-			IL_0062: newarr [System.Runtime]System.Object
-			IL_0067: dup
-			IL_0068: ldc.i4.0
-			IL_0069: ldarg.0
-			IL_006a: stelem.ref
-			IL_006b: dup
-			IL_006c: ldc.i4.1
-			IL_006d: ldloc.0
-			IL_006e: stelem.ref
-			IL_006f: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_007a: ldc.i4.0
-			IL_007b: conv.r8
-			IL_007c: ldstr ""
-			IL_0081: ldc.i4.0
-			IL_0082: ldc.i4.1
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0088: stloc.s 5
-			IL_008a: ldloc.2
-			IL_008b: ldstr "connect"
-			IL_0090: ldloc.3
-			IL_0091: ldloc.s 4
-			IL_0093: ldloc.s 5
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_009a: stloc.s 5
-			IL_009c: ldloc.0
-			IL_009d: ldloc.s 5
-			IL_009f: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_00a4: ldloc.0
-			IL_00a5: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_00aa: ldstr "Cannot access 'client' before initialization"
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00b4: stloc.s 5
-			IL_00b6: ldloc.s 5
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00bd: stloc.s 5
-			IL_00bf: ldloc.s 5
-			IL_00c1: ldstr "setEncoding"
-			IL_00c6: ldstr "utf8"
-			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00d0: pop
-			IL_00d1: ldloc.0
-			IL_00d2: ldstr ""
-			IL_00d7: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
-			IL_00dc: ldloc.0
-			IL_00dd: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_00e2: ldstr "Cannot access 'client' before initialization"
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00ec: stloc.s 5
-			IL_00ee: ldloc.s 5
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f5: stloc.s 5
-			IL_00f7: ldc.i4.2
-			IL_00f8: newarr [System.Runtime]System.Object
-			IL_00fd: dup
-			IL_00fe: ldc.i4.0
-			IL_00ff: ldarg.0
-			IL_0100: stelem.ref
-			IL_0101: dup
-			IL_0102: ldc.i4.1
-			IL_0103: ldloc.0
-			IL_0104: stelem.ref
-			IL_0105: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-			IL_010b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0110: ldc.i4.1
-			IL_0111: conv.r8
-			IL_0112: ldstr ""
-			IL_0117: ldc.i4.0
-			IL_0118: ldc.i4.1
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_011e: stloc.s 4
-			IL_0120: ldloc.s 5
-			IL_0122: ldstr "on"
-			IL_0127: ldstr "data"
-			IL_012c: ldloc.s 4
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0133: pop
-			IL_0134: ldloc.0
-			IL_0135: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_013a: ldstr "Cannot access 'client' before initialization"
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0144: stloc.s 4
-			IL_0146: ldloc.s 4
-			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014d: stloc.s 4
-			IL_014f: ldc.i4.2
-			IL_0150: newarr [System.Runtime]System.Object
-			IL_0155: dup
-			IL_0156: ldc.i4.0
-			IL_0157: ldarg.0
-			IL_0158: stelem.ref
-			IL_0159: dup
-			IL_015a: ldc.i4.1
-			IL_015b: ldloc.0
-			IL_015c: stelem.ref
-			IL_015d: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19::__js_call__(object[], object)
-			IL_0163: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0168: ldc.i4.0
-			IL_0169: conv.r8
-			IL_016a: ldstr ""
-			IL_016f: ldc.i4.0
-			IL_0170: ldc.i4.1
-			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0176: stloc.s 5
-			IL_0178: ldloc.s 4
-			IL_017a: ldstr "on"
-			IL_017f: ldstr "end"
-			IL_0184: ldloc.s 5
-			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_018b: pop
-			IL_018c: ldnull
-			IL_018d: ret
+			IL_002c: ldloc.1
+			IL_002d: ldstr "port"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.3
+			IL_0038: ldloc.1
+			IL_0039: ldstr "address"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0043: stloc.s 4
+			IL_0045: ldc.i4.2
+			IL_0046: newarr [System.Runtime]System.Object
+			IL_004b: dup
+			IL_004c: ldc.i4.0
+			IL_004d: ldarg.0
+			IL_004e: stelem.ref
+			IL_004f: dup
+			IL_0050: ldc.i4.1
+			IL_0051: ldloc.0
+			IL_0052: stelem.ref
+			IL_0053: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_005e: ldc.i4.0
+			IL_005f: conv.r8
+			IL_0060: ldstr ""
+			IL_0065: ldc.i4.0
+			IL_0066: ldc.i4.1
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_006c: stloc.s 5
+			IL_006e: ldloc.2
+			IL_006f: ldstr "connect"
+			IL_0074: ldloc.3
+			IL_0075: ldloc.s 4
+			IL_0077: ldloc.s 5
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_007e: stloc.s 5
+			IL_0080: ldloc.0
+			IL_0081: ldloc.s 5
+			IL_0083: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_0088: ldloc.0
+			IL_0089: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_008e: ldstr "Cannot access 'client' before initialization"
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0098: stloc.s 5
+			IL_009a: ldloc.s 5
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a1: stloc.s 5
+			IL_00a3: ldloc.s 5
+			IL_00a5: ldstr "setEncoding"
+			IL_00aa: ldstr "utf8"
+			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00b4: pop
+			IL_00b5: ldloc.0
+			IL_00b6: ldstr ""
+			IL_00bb: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
+			IL_00c0: ldloc.0
+			IL_00c1: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_00c6: ldstr "Cannot access 'client' before initialization"
+			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00d0: stloc.s 5
+			IL_00d2: ldloc.s 5
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d9: stloc.s 5
+			IL_00db: ldc.i4.2
+			IL_00dc: newarr [System.Runtime]System.Object
+			IL_00e1: dup
+			IL_00e2: ldc.i4.0
+			IL_00e3: ldarg.0
+			IL_00e4: stelem.ref
+			IL_00e5: dup
+			IL_00e6: ldc.i4.1
+			IL_00e7: ldloc.0
+			IL_00e8: stelem.ref
+			IL_00e9: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+			IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00f4: ldc.i4.1
+			IL_00f5: conv.r8
+			IL_00f6: ldstr ""
+			IL_00fb: ldc.i4.0
+			IL_00fc: ldc.i4.1
+			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0102: stloc.s 4
+			IL_0104: ldloc.s 5
+			IL_0106: ldstr "on"
+			IL_010b: ldstr "data"
+			IL_0110: ldloc.s 4
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0117: pop
+			IL_0118: ldloc.0
+			IL_0119: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_011e: ldstr "Cannot access 'client' before initialization"
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0128: stloc.s 4
+			IL_012a: ldloc.s 4
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0131: stloc.s 4
+			IL_0133: ldc.i4.2
+			IL_0134: newarr [System.Runtime]System.Object
+			IL_0139: dup
+			IL_013a: ldc.i4.0
+			IL_013b: ldarg.0
+			IL_013c: stelem.ref
+			IL_013d: dup
+			IL_013e: ldc.i4.1
+			IL_013f: ldloc.0
+			IL_0140: stelem.ref
+			IL_0141: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19::__js_call__(object[], object)
+			IL_0147: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_014c: ldc.i4.0
+			IL_014d: conv.r8
+			IL_014e: ldstr ""
+			IL_0153: ldc.i4.0
+			IL_0154: ldc.i4.1
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_015a: stloc.s 5
+			IL_015c: ldloc.s 4
+			IL_015e: ldstr "on"
+			IL_0163: ldstr "end"
+			IL_0168: ldloc.s 5
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_016f: pop
+			IL_0170: ldnull
+			IL_0171: ret
 		} // end of method FunctionExpression_L22C30::__js_call__
 
 	} // end of class FunctionExpression_L22C30
@@ -1004,7 +938,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26d9
+			// Method begins at RVA 0x2641
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1127,7 +1061,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x273e
+		// Method begins at RVA 0x26a6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x268f
+					// Method begins at RVA 0x25fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,9 +47,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23c4
+				// Method begins at RVA 0x23a8
 				// Header size: 12
-				// Code size: 74 (0x4a)
+				// Code size: 62 (0x3e)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -63,30 +63,26 @@
 				IL_0003: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
 				IL_0008: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::received
 				IL_000d: stloc.0
-				IL_000e: ldstr "received"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldarg.2
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldstr "toString"
-				IL_0027: ldstr "utf8"
-				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0031: stloc.1
-				IL_0032: ldloc.0
-				IL_0033: ldloc.1
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0039: stloc.2
-				IL_003a: ldarg.0
-				IL_003b: ldc.i4.1
-				IL_003c: ldelem.ref
-				IL_003d: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
-				IL_0042: ldloc.2
-				IL_0043: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::received
-				IL_0048: ldnull
-				IL_0049: ret
+				IL_000e: ldarg.2
+				IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0014: stloc.1
+				IL_0015: ldloc.1
+				IL_0016: ldstr "toString"
+				IL_001b: ldstr "utf8"
+				IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0025: stloc.1
+				IL_0026: ldloc.0
+				IL_0027: ldloc.1
+				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_002d: stloc.2
+				IL_002e: ldarg.0
+				IL_002f: ldc.i4.1
+				IL_0030: ldelem.ref
+				IL_0031: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
+				IL_0036: ldloc.2
+				IL_0037: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::received
+				IL_003c: ldnull
+				IL_003d: ret
 			} // end of method FunctionExpression_server::__js_call__
 
 		} // end of class FunctionExpression_server
@@ -102,7 +98,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2698
+					// Method begins at RVA 0x2604
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -126,9 +122,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x241c
+				// Method begins at RVA 0x23f4
 				// Header size: 12
-				// Code size: 219 (0xdb)
+				// Code size: 163 (0xa3)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -142,83 +138,59 @@
 				IL_000b: ldloc.0
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0011: stloc.0
-				IL_0012: ldarg.0
-				IL_0013: ldc.i4.1
-				IL_0014: ldelem.ref
-				IL_0015: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
-				IL_001a: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::received
-				IL_001f: stloc.1
-				IL_0020: ldstr "received"
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002b: stloc.1
-				IL_002c: ldstr "server recv:"
-				IL_0031: ldloc.1
-				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0037: stloc.2
-				IL_0038: ldloc.0
-				IL_0039: ldstr "log"
-				IL_003e: ldloc.2
-				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0044: pop
-				IL_0045: ldarg.0
-				IL_0046: ldc.i4.1
-				IL_0047: ldelem.ref
-				IL_0048: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
-				IL_004d: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::socket
-				IL_0052: stloc.0
-				IL_0053: ldstr "socket"
-				IL_0058: ldloc.0
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005e: stloc.0
-				IL_005f: ldloc.0
-				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0065: stloc.0
-				IL_0066: ldarg.0
-				IL_0067: ldc.i4.1
-				IL_0068: ldelem.ref
-				IL_0069: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
-				IL_006e: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::received
-				IL_0073: stloc.1
-				IL_0074: ldstr "received"
-				IL_0079: ldloc.1
-				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_007f: stloc.1
-				IL_0080: ldloc.1
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0086: stloc.1
-				IL_0087: ldloc.1
-				IL_0088: ldstr "toUpperCase"
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0092: stloc.1
-				IL_0093: ldstr "pong:"
-				IL_0098: ldloc.1
-				IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_009e: stloc.2
-				IL_009f: ldloc.0
-				IL_00a0: ldstr "write"
-				IL_00a5: ldloc.2
-				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00ab: pop
-				IL_00ac: ldarg.0
-				IL_00ad: ldc.i4.1
-				IL_00ae: ldelem.ref
-				IL_00af: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
-				IL_00b4: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::socket
-				IL_00b9: stloc.0
-				IL_00ba: ldstr "socket"
-				IL_00bf: ldloc.0
-				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00c5: stloc.0
-				IL_00c6: ldloc.0
-				IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00cc: stloc.0
-				IL_00cd: ldloc.0
-				IL_00ce: ldstr "end"
-				IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_00d8: pop
-				IL_00d9: ldnull
-				IL_00da: ret
+				IL_0012: ldstr "server recv:"
+				IL_0017: ldarg.0
+				IL_0018: ldc.i4.1
+				IL_0019: ldelem.ref
+				IL_001a: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
+				IL_001f: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::received
+				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0029: stloc.1
+				IL_002a: ldloc.0
+				IL_002b: ldstr "log"
+				IL_0030: ldloc.1
+				IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0036: pop
+				IL_0037: ldarg.0
+				IL_0038: ldc.i4.1
+				IL_0039: ldelem.ref
+				IL_003a: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
+				IL_003f: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::socket
+				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0049: stloc.0
+				IL_004a: ldarg.0
+				IL_004b: ldc.i4.1
+				IL_004c: ldelem.ref
+				IL_004d: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
+				IL_0052: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::received
+				IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_005c: stloc.2
+				IL_005d: ldloc.2
+				IL_005e: ldstr "toUpperCase"
+				IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0068: stloc.2
+				IL_0069: ldstr "pong:"
+				IL_006e: ldloc.2
+				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0074: stloc.1
+				IL_0075: ldloc.0
+				IL_0076: ldstr "write"
+				IL_007b: ldloc.1
+				IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0081: pop
+				IL_0082: ldarg.0
+				IL_0083: ldc.i4.1
+				IL_0084: ldelem.ref
+				IL_0085: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
+				IL_008a: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::socket
+				IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0094: stloc.0
+				IL_0095: ldloc.0
+				IL_0096: ldstr "end"
+				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_00a0: pop
+				IL_00a1: ldnull
+				IL_00a2: ret
 			} // end of method FunctionExpression_server_L12C19::__js_call__
 
 		} // end of class FunctionExpression_server_L12C19
@@ -239,7 +211,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2686
+				// Method begins at RVA 0x25f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -363,7 +335,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26b5
+					// Method begins at RVA 0x2621
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -387,9 +359,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2504
+				// Method begins at RVA 0x24a4
 				// Header size: 12
-				// Code size: 62 (0x3e)
+				// Code size: 50 (0x32)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -403,20 +375,16 @@
 				IL_000d: ldstr "Cannot access 'client' before initialization"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_0017: stloc.0
-				IL_0018: ldstr "client"
-				IL_001d: ldloc.0
-				IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0023: stloc.0
-				IL_0024: ldloc.0
-				IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_002a: stloc.0
-				IL_002b: ldloc.0
-				IL_002c: ldstr "end"
-				IL_0031: ldstr "ping"
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_003b: pop
-				IL_003c: ldnull
-				IL_003d: ret
+				IL_0018: ldloc.0
+				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_001e: stloc.0
+				IL_001f: ldloc.0
+				IL_0020: ldstr "end"
+				IL_0025: ldstr "ping"
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_002f: pop
+				IL_0030: ldnull
+				IL_0031: ret
 			} // end of method FunctionExpression_client::__js_call__
 
 		} // end of class FunctionExpression_client
@@ -432,7 +400,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26be
+					// Method begins at RVA 0x262a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -457,9 +425,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2550
+				// Method begins at RVA 0x24e4
 				// Header size: 12
-				// Code size: 74 (0x4a)
+				// Code size: 62 (0x3e)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -473,30 +441,26 @@
 				IL_0003: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
 				IL_0008: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
 				IL_000d: stloc.0
-				IL_000e: ldstr "reply"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldarg.2
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldstr "toString"
-				IL_0027: ldstr "utf8"
-				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0031: stloc.1
-				IL_0032: ldloc.0
-				IL_0033: ldloc.1
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0039: stloc.2
-				IL_003a: ldarg.0
-				IL_003b: ldc.i4.1
-				IL_003c: ldelem.ref
-				IL_003d: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
-				IL_0042: ldloc.2
-				IL_0043: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
-				IL_0048: ldnull
-				IL_0049: ret
+				IL_000e: ldarg.2
+				IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0014: stloc.1
+				IL_0015: ldloc.1
+				IL_0016: ldstr "toString"
+				IL_001b: ldstr "utf8"
+				IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0025: stloc.1
+				IL_0026: ldloc.0
+				IL_0027: ldloc.1
+				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_002d: stloc.2
+				IL_002e: ldarg.0
+				IL_002f: ldc.i4.1
+				IL_0030: ldelem.ref
+				IL_0031: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
+				IL_0036: ldloc.2
+				IL_0037: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
+				IL_003c: ldnull
+				IL_003d: ret
 			} // end of method FunctionExpression_L28C20::__js_call__
 
 		} // end of class FunctionExpression_L28C20
@@ -516,7 +480,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26d0
+						// Method begins at RVA 0x263c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -539,7 +503,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x264c
+					// Method begins at RVA 0x25b8
 					// Header size: 12
 					// Code size: 37 (0x25)
 					.maxstack 8
@@ -571,7 +535,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26c7
+					// Method begins at RVA 0x2633
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -595,9 +559,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25a8
+				// Method begins at RVA 0x2530
 				// Header size: 12
-				// Code size: 150 (0x96)
+				// Code size: 122 (0x7a)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/Scope,
@@ -614,55 +578,43 @@
 				IL_0011: ldloc.1
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0017: stloc.1
-				IL_0018: ldarg.0
-				IL_0019: ldc.i4.1
-				IL_001a: ldelem.ref
-				IL_001b: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
-				IL_0020: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
-				IL_0025: stloc.2
-				IL_0026: ldstr "reply"
-				IL_002b: ldloc.2
-				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0031: stloc.2
-				IL_0032: ldstr "client recv:"
-				IL_0037: ldloc.2
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_003d: stloc.3
-				IL_003e: ldloc.1
-				IL_003f: ldstr "log"
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004a: pop
-				IL_004b: ldarg.0
-				IL_004c: ldc.i4.0
-				IL_004d: ldelem.ref
-				IL_004e: castclass Modules.Net_CreateServer_Connect_Basic/Scope
-				IL_0053: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
-				IL_0058: stloc.1
-				IL_0059: ldstr "server"
-				IL_005e: ldloc.1
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0064: stloc.1
-				IL_0065: ldloc.1
-				IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_006b: stloc.1
-				IL_006c: ldnull
-				IL_006d: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17::__js_call__(object)
-				IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0078: ldc.i4.0
-				IL_0079: conv.r8
-				IL_007a: ldstr ""
-				IL_007f: ldc.i4.0
-				IL_0080: ldc.i4.1
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0086: stloc.2
-				IL_0087: ldloc.1
-				IL_0088: ldstr "close"
-				IL_008d: ldloc.2
-				IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0093: pop
-				IL_0094: ldnull
-				IL_0095: ret
+				IL_0018: ldstr "client recv:"
+				IL_001d: ldarg.0
+				IL_001e: ldc.i4.1
+				IL_001f: ldelem.ref
+				IL_0020: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
+				IL_0025: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_002f: stloc.2
+				IL_0030: ldloc.1
+				IL_0031: ldstr "log"
+				IL_0036: ldloc.2
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_003c: pop
+				IL_003d: ldarg.0
+				IL_003e: ldc.i4.0
+				IL_003f: ldelem.ref
+				IL_0040: castclass Modules.Net_CreateServer_Connect_Basic/Scope
+				IL_0045: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
+				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_004f: stloc.1
+				IL_0050: ldnull
+				IL_0051: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17::__js_call__(object)
+				IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_005c: ldc.i4.0
+				IL_005d: conv.r8
+				IL_005e: ldstr ""
+				IL_0063: ldc.i4.0
+				IL_0064: ldc.i4.1
+				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_006a: stloc.3
+				IL_006b: ldloc.1
+				IL_006c: ldstr "close"
+				IL_0071: ldloc.3
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0077: pop
+				IL_0078: ldnull
+				IL_0079: ret
 			} // end of method FunctionExpression_L32C19::__js_call__
 
 		} // end of class FunctionExpression_L32C19
@@ -683,7 +635,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26a1
+				// Method begins at RVA 0x260d
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -714,7 +666,7 @@
 			)
 			// Method begins at RVA 0x21cc
 			// Header size: 12
-			// Code size: 489 (0x1e9)
+			// Code size: 461 (0x1cd)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope,
@@ -730,179 +682,167 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
-			IL_000c: stloc.2
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.2
 			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: stloc.1
-			IL_002e: ldstr "console"
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0038: stloc.2
-			IL_0039: ldloc.2
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003f: stloc.2
-			IL_0040: ldstr "listening:"
-			IL_0045: ldloc.1
-			IL_0046: ldstr "family"
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0055: stloc.3
-			IL_0056: ldloc.3
-			IL_0057: ldstr ":"
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0061: stloc.3
-			IL_0062: ldloc.3
-			IL_0063: ldloc.1
-			IL_0064: ldstr "address"
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0073: stloc.3
-			IL_0074: ldloc.3
-			IL_0075: ldstr ":"
-			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_007f: stloc.3
-			IL_0080: ldloc.3
-			IL_0081: ldloc.1
-			IL_0082: ldstr "port"
-			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_008c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0091: ldc.r8 0.0
-			IL_009a: cgt
-			IL_009c: box [System.Runtime]System.Boolean
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a6: stloc.3
-			IL_00a7: ldloc.2
-			IL_00a8: ldstr "log"
-			IL_00ad: ldloc.3
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00b3: pop
-			IL_00b4: ldarg.0
-			IL_00b5: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::net
-			IL_00ba: stloc.2
-			IL_00bb: ldstr "net"
-			IL_00c0: ldloc.2
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c6: stloc.2
-			IL_00c7: ldloc.2
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00cd: stloc.2
-			IL_00ce: ldloc.1
-			IL_00cf: ldstr "port"
-			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d9: stloc.s 4
-			IL_00db: ldloc.1
-			IL_00dc: ldstr "address"
-			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e6: stloc.s 5
-			IL_00e8: ldc.i4.2
-			IL_00e9: newarr [System.Runtime]System.Object
-			IL_00ee: dup
-			IL_00ef: ldc.i4.0
-			IL_00f0: ldarg.0
-			IL_00f1: stelem.ref
-			IL_00f2: dup
-			IL_00f3: ldc.i4.1
-			IL_00f4: ldloc.0
-			IL_00f5: stelem.ref
-			IL_00f6: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_00fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0101: ldc.i4.0
-			IL_0102: conv.r8
-			IL_0103: ldstr ""
-			IL_0108: ldc.i4.0
-			IL_0109: ldc.i4.1
-			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_010f: stloc.s 6
-			IL_0111: ldloc.2
-			IL_0112: ldstr "connect"
-			IL_0117: ldloc.s 4
-			IL_0119: ldloc.s 5
-			IL_011b: ldloc.s 6
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0122: stloc.s 6
-			IL_0124: ldloc.0
-			IL_0125: ldloc.s 6
-			IL_0127: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
-			IL_012c: ldloc.0
-			IL_012d: ldstr ""
-			IL_0132: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
-			IL_0137: ldloc.0
-			IL_0138: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
-			IL_013d: ldstr "Cannot access 'client' before initialization"
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0147: stloc.s 6
-			IL_0149: ldloc.s 6
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0150: stloc.s 6
-			IL_0152: ldc.i4.2
-			IL_0153: newarr [System.Runtime]System.Object
-			IL_0158: dup
-			IL_0159: ldc.i4.0
-			IL_015a: ldarg.0
-			IL_015b: stelem.ref
-			IL_015c: dup
-			IL_015d: ldc.i4.1
-			IL_015e: ldloc.0
-			IL_015f: stelem.ref
-			IL_0160: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20::__js_call__(object[], object, object)
-			IL_0166: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_016b: ldc.i4.1
-			IL_016c: conv.r8
-			IL_016d: ldstr ""
-			IL_0172: ldc.i4.0
-			IL_0173: ldc.i4.1
-			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0179: stloc.s 5
-			IL_017b: ldloc.s 6
-			IL_017d: ldstr "on"
-			IL_0182: ldstr "data"
-			IL_0187: ldloc.s 5
-			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_018e: pop
-			IL_018f: ldloc.0
-			IL_0190: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
-			IL_0195: ldstr "Cannot access 'client' before initialization"
-			IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_019f: stloc.s 5
-			IL_01a1: ldloc.s 5
-			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a8: stloc.s 5
-			IL_01aa: ldc.i4.2
-			IL_01ab: newarr [System.Runtime]System.Object
-			IL_01b0: dup
-			IL_01b1: ldc.i4.0
-			IL_01b2: ldarg.0
-			IL_01b3: stelem.ref
-			IL_01b4: dup
-			IL_01b5: ldc.i4.1
-			IL_01b6: ldloc.0
-			IL_01b7: stelem.ref
-			IL_01b8: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19::__js_call__(object[], object)
-			IL_01be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_01c3: ldc.i4.0
-			IL_01c4: conv.r8
-			IL_01c5: ldstr ""
-			IL_01ca: ldc.i4.0
-			IL_01cb: ldc.i4.1
-			IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_01d1: stloc.s 6
-			IL_01d3: ldloc.s 5
-			IL_01d5: ldstr "on"
-			IL_01da: ldstr "end"
-			IL_01df: ldloc.s 6
-			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01e6: pop
-			IL_01e7: ldnull
-			IL_01e8: ret
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.2
+			IL_001e: ldloc.2
+			IL_001f: stloc.1
+			IL_0020: ldstr "console"
+			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_002a: stloc.2
+			IL_002b: ldloc.2
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0031: stloc.2
+			IL_0032: ldstr "listening:"
+			IL_0037: ldloc.1
+			IL_0038: ldstr "family"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0047: stloc.3
+			IL_0048: ldloc.3
+			IL_0049: ldstr ":"
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0053: stloc.3
+			IL_0054: ldloc.3
+			IL_0055: ldloc.1
+			IL_0056: ldstr "address"
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0065: stloc.3
+			IL_0066: ldloc.3
+			IL_0067: ldstr ":"
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0071: stloc.3
+			IL_0072: ldloc.3
+			IL_0073: ldloc.1
+			IL_0074: ldstr "port"
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0083: ldc.r8 0.0
+			IL_008c: cgt
+			IL_008e: box [System.Runtime]System.Boolean
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0098: stloc.3
+			IL_0099: ldloc.2
+			IL_009a: ldstr "log"
+			IL_009f: ldloc.3
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00a5: pop
+			IL_00a6: ldarg.0
+			IL_00a7: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::net
+			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b1: stloc.2
+			IL_00b2: ldloc.1
+			IL_00b3: ldstr "port"
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00bd: stloc.s 4
+			IL_00bf: ldloc.1
+			IL_00c0: ldstr "address"
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ca: stloc.s 5
+			IL_00cc: ldc.i4.2
+			IL_00cd: newarr [System.Runtime]System.Object
+			IL_00d2: dup
+			IL_00d3: ldc.i4.0
+			IL_00d4: ldarg.0
+			IL_00d5: stelem.ref
+			IL_00d6: dup
+			IL_00d7: ldc.i4.1
+			IL_00d8: ldloc.0
+			IL_00d9: stelem.ref
+			IL_00da: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_00e5: ldc.i4.0
+			IL_00e6: conv.r8
+			IL_00e7: ldstr ""
+			IL_00ec: ldc.i4.0
+			IL_00ed: ldc.i4.1
+			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00f3: stloc.s 6
+			IL_00f5: ldloc.2
+			IL_00f6: ldstr "connect"
+			IL_00fb: ldloc.s 4
+			IL_00fd: ldloc.s 5
+			IL_00ff: ldloc.s 6
+			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0106: stloc.s 6
+			IL_0108: ldloc.0
+			IL_0109: ldloc.s 6
+			IL_010b: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
+			IL_0110: ldloc.0
+			IL_0111: ldstr ""
+			IL_0116: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
+			IL_011b: ldloc.0
+			IL_011c: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
+			IL_0121: ldstr "Cannot access 'client' before initialization"
+			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_012b: stloc.s 6
+			IL_012d: ldloc.s 6
+			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0134: stloc.s 6
+			IL_0136: ldc.i4.2
+			IL_0137: newarr [System.Runtime]System.Object
+			IL_013c: dup
+			IL_013d: ldc.i4.0
+			IL_013e: ldarg.0
+			IL_013f: stelem.ref
+			IL_0140: dup
+			IL_0141: ldc.i4.1
+			IL_0142: ldloc.0
+			IL_0143: stelem.ref
+			IL_0144: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20::__js_call__(object[], object, object)
+			IL_014a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_014f: ldc.i4.1
+			IL_0150: conv.r8
+			IL_0151: ldstr ""
+			IL_0156: ldc.i4.0
+			IL_0157: ldc.i4.1
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_015d: stloc.s 5
+			IL_015f: ldloc.s 6
+			IL_0161: ldstr "on"
+			IL_0166: ldstr "data"
+			IL_016b: ldloc.s 5
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0172: pop
+			IL_0173: ldloc.0
+			IL_0174: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
+			IL_0179: ldstr "Cannot access 'client' before initialization"
+			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0183: stloc.s 5
+			IL_0185: ldloc.s 5
+			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_018c: stloc.s 5
+			IL_018e: ldc.i4.2
+			IL_018f: newarr [System.Runtime]System.Object
+			IL_0194: dup
+			IL_0195: ldc.i4.0
+			IL_0196: ldarg.0
+			IL_0197: stelem.ref
+			IL_0198: dup
+			IL_0199: ldc.i4.1
+			IL_019a: ldloc.0
+			IL_019b: stelem.ref
+			IL_019c: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19::__js_call__(object[], object)
+			IL_01a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_01a7: ldc.i4.0
+			IL_01a8: conv.r8
+			IL_01a9: ldstr ""
+			IL_01ae: ldc.i4.0
+			IL_01af: ldc.i4.1
+			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_01b5: stloc.s 6
+			IL_01b7: ldloc.s 5
+			IL_01b9: ldstr "on"
+			IL_01be: ldstr "end"
+			IL_01c3: ldloc.s 6
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01ca: pop
+			IL_01cb: ldnull
+			IL_01cc: ret
 		} // end of method FunctionExpression_L19C30::__js_call__
 
 	} // end of class FunctionExpression_L19C30
@@ -923,7 +863,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x267d
+			// Method begins at RVA 0x25e9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1038,7 +978,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26d9
+		// Method begins at RVA 0x2645
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Binary_Data_Defaults_To_Buffer.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Binary_Data_Defaults_To_Buffer.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2884
+						// Method begins at RVA 0x27d4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x287b
+					// Method begins at RVA 0x27cb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,24 +69,23 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2304
+				// Method begins at RVA 0x22e8
 				// Header size: 12
-				// Code size: 639 (0x27f)
+				// Code size: 573 (0x23d)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 					[1] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/Scope/Block_L12C39,
-					[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-					[3] object,
-					[4] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-					[5] float64,
-					[6] bool,
+					[2] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+					[3] float64,
+					[4] bool,
+					[5] object,
+					[6] object,
 					[7] object,
 					[8] object,
 					[9] object,
 					[10] object,
-					[11] object,
-					[12] object
+					[11] object
 				)
 
 				IL_0000: ldarg.0
@@ -94,214 +93,186 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
 				IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::received
-				IL_000d: stloc.2
-				IL_000e: ldstr "received"
-				IL_0013: ldloc.2
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.3
-				IL_001a: ldloc.3
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.3
-				IL_0021: ldloc.3
-				IL_0022: ldstr "push"
-				IL_0027: ldarg.2
-				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_002d: pop
-				IL_002e: ldarg.0
-				IL_002f: ldc.i4.1
-				IL_0030: ldelem.ref
-				IL_0031: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
-				IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::received
-				IL_003b: stloc.2
-				IL_003c: ldstr "received"
-				IL_0041: ldloc.2
-				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0047: stloc.3
-				IL_0048: ldloc.3
-				IL_0049: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
+				IL_000d: ldarg.2
+				IL_000e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0013: pop
+				IL_0014: ldarg.0
+				IL_0015: ldc.i4.1
+				IL_0016: ldelem.ref
+				IL_0017: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
+				IL_001c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::received
+				IL_0021: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
+				IL_0026: stloc.2
+				IL_0027: ldloc.2
+				IL_0028: stloc.0
+				IL_0029: ldloc.0
+				IL_002a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+				IL_002f: stloc.3
+				IL_0030: ldloc.3
+				IL_0031: ldc.r8 4
+				IL_003a: clt
+				IL_003c: stloc.s 4
+				IL_003e: ldloc.s 4
+				IL_0040: box [System.Runtime]System.Boolean
+				IL_0045: stloc.s 5
+				IL_0047: ldloc.s 5
+				IL_0049: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_004e: stloc.s 4
 				IL_0050: ldloc.s 4
-				IL_0052: stloc.0
-				IL_0053: ldloc.0
-				IL_0054: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-				IL_0059: stloc.s 5
-				IL_005b: ldloc.s 5
-				IL_005d: ldc.r8 4
-				IL_0066: clt
-				IL_0068: stloc.s 6
-				IL_006a: ldloc.s 6
-				IL_006c: box [System.Runtime]System.Boolean
-				IL_0071: stloc.s 7
-				IL_0073: ldloc.s 7
-				IL_0075: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_007a: stloc.s 6
-				IL_007c: ldloc.s 6
-				IL_007e: brtrue IL_00a5
+				IL_0052: brtrue IL_006b
 
-				IL_0083: ldarg.0
-				IL_0084: ldc.i4.1
-				IL_0085: ldelem.ref
-				IL_0086: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
-				IL_008b: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::replied
-				IL_0090: stloc.3
-				IL_0091: ldstr "replied"
-				IL_0096: ldloc.3
-				IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_009c: stloc.3
-				IL_009d: ldloc.3
-				IL_009e: stloc.s 9
-				IL_00a0: br IL_00a9
+				IL_0057: ldarg.0
+				IL_0058: ldc.i4.1
+				IL_0059: ldelem.ref
+				IL_005a: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
+				IL_005f: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::replied
+				IL_0064: stloc.s 7
+				IL_0066: br IL_006f
 
-				IL_00a5: ldloc.s 7
-				IL_00a7: stloc.s 9
+				IL_006b: ldloc.s 5
+				IL_006d: stloc.s 7
 
-				IL_00a9: ldloc.s 9
-				IL_00ab: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00b0: stloc.s 6
-				IL_00b2: ldloc.s 6
-				IL_00b4: brfalse IL_00c1
+				IL_006f: ldloc.s 7
+				IL_0071: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0076: stloc.s 4
+				IL_0078: ldloc.s 4
+				IL_007a: brfalse IL_0087
 
-				IL_00b9: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/Scope/Block_L12C39::.ctor()
-				IL_00be: stloc.1
-				IL_00bf: ldnull
-				IL_00c0: ret
+				IL_007f: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/Scope/Block_L12C39::.ctor()
+				IL_0084: stloc.1
+				IL_0085: ldnull
+				IL_0086: ret
 
-				IL_00c1: ldarg.0
-				IL_00c2: ldc.i4.1
-				IL_00c3: ldelem.ref
-				IL_00c4: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
-				IL_00c9: ldc.i4.1
-				IL_00ca: box [System.Runtime]System.Boolean
-				IL_00cf: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::replied
-				IL_00d4: ldstr "console"
-				IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00de: stloc.3
-				IL_00df: ldloc.3
-				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00e5: stloc.3
-				IL_00e6: ldloc.0
-				IL_00e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-				IL_00ec: stloc.s 6
-				IL_00ee: ldloc.s 6
-				IL_00f0: box [System.Runtime]System.Boolean
-				IL_00f5: stloc.s 7
-				IL_00f7: ldstr "server buffer:"
-				IL_00fc: ldloc.s 7
-				IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0103: stloc.s 9
-				IL_0105: ldloc.3
-				IL_0106: ldstr "log"
-				IL_010b: ldloc.s 9
-				IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0112: pop
-				IL_0113: ldstr "console"
-				IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_011d: stloc.3
-				IL_011e: ldloc.3
-				IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0124: stloc.3
-				IL_0125: ldloc.0
-				IL_0126: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-				IL_012b: stloc.s 5
-				IL_012d: ldstr "server bytes:"
-				IL_0132: ldloc.s 5
-				IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0139: stloc.s 9
-				IL_013b: ldloc.s 9
-				IL_013d: ldstr ":"
-				IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0147: stloc.s 9
-				IL_0149: ldloc.s 9
-				IL_014b: ldloc.0
-				IL_014c: ldc.r8 0.0
-				IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_015f: stloc.s 9
-				IL_0161: ldloc.s 9
-				IL_0163: ldstr ":"
-				IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_016d: stloc.s 9
-				IL_016f: ldloc.s 9
-				IL_0171: ldloc.0
-				IL_0172: ldc.r8 1
-				IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0185: stloc.s 9
-				IL_0187: ldloc.s 9
-				IL_0189: ldstr ":"
-				IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0193: stloc.s 9
-				IL_0195: ldloc.s 9
-				IL_0197: ldloc.0
-				IL_0198: ldc.r8 2
-				IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_01ab: stloc.s 9
-				IL_01ad: ldloc.s 9
-				IL_01af: ldstr ":"
-				IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_01b9: stloc.s 9
-				IL_01bb: ldloc.s 9
-				IL_01bd: ldloc.0
-				IL_01be: ldc.r8 3
-				IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_01d1: stloc.s 9
-				IL_01d3: ldloc.3
-				IL_01d4: ldstr "log"
-				IL_01d9: ldloc.s 9
-				IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_01e0: pop
-				IL_01e1: ldarg.0
-				IL_01e2: ldc.i4.1
-				IL_01e3: ldelem.ref
-				IL_01e4: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
-				IL_01e9: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::socket
-				IL_01ee: stloc.3
-				IL_01ef: ldstr "socket"
-				IL_01f4: ldloc.3
-				IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_01fa: stloc.3
-				IL_01fb: ldloc.3
-				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0201: stloc.3
-				IL_0202: ldloc.0
-				IL_0203: ldc.r8 3
-				IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0211: stloc.s 10
+				IL_0087: ldarg.0
+				IL_0088: ldc.i4.1
+				IL_0089: ldelem.ref
+				IL_008a: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
+				IL_008f: ldc.i4.1
+				IL_0090: box [System.Runtime]System.Boolean
+				IL_0095: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::replied
+				IL_009a: ldstr "console"
+				IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00a4: stloc.s 8
+				IL_00a6: ldloc.s 8
+				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00ad: stloc.s 8
+				IL_00af: ldloc.0
+				IL_00b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+				IL_00b5: stloc.s 4
+				IL_00b7: ldloc.s 4
+				IL_00b9: box [System.Runtime]System.Boolean
+				IL_00be: stloc.s 5
+				IL_00c0: ldstr "server buffer:"
+				IL_00c5: ldloc.s 5
+				IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00cc: stloc.s 7
+				IL_00ce: ldloc.s 8
+				IL_00d0: ldstr "log"
+				IL_00d5: ldloc.s 7
+				IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00dc: pop
+				IL_00dd: ldstr "console"
+				IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00e7: stloc.s 8
+				IL_00e9: ldloc.s 8
+				IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00f0: stloc.s 8
+				IL_00f2: ldloc.0
+				IL_00f3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+				IL_00f8: stloc.3
+				IL_00f9: ldstr "server bytes:"
+				IL_00fe: ldloc.3
+				IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0104: stloc.s 7
+				IL_0106: ldloc.s 7
+				IL_0108: ldstr ":"
+				IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0112: stloc.s 7
+				IL_0114: ldloc.s 7
+				IL_0116: ldloc.0
+				IL_0117: ldc.r8 0.0
+				IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_012a: stloc.s 7
+				IL_012c: ldloc.s 7
+				IL_012e: ldstr ":"
+				IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0138: stloc.s 7
+				IL_013a: ldloc.s 7
+				IL_013c: ldloc.0
+				IL_013d: ldc.r8 1
+				IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0150: stloc.s 7
+				IL_0152: ldloc.s 7
+				IL_0154: ldstr ":"
+				IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_015e: stloc.s 7
+				IL_0160: ldloc.s 7
+				IL_0162: ldloc.0
+				IL_0163: ldc.r8 2
+				IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0176: stloc.s 7
+				IL_0178: ldloc.s 7
+				IL_017a: ldstr ":"
+				IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0184: stloc.s 7
+				IL_0186: ldloc.s 7
+				IL_0188: ldloc.0
+				IL_0189: ldc.r8 3
+				IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_019c: stloc.s 7
+				IL_019e: ldloc.s 8
+				IL_01a0: ldstr "log"
+				IL_01a5: ldloc.s 7
+				IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_01ac: pop
+				IL_01ad: ldarg.0
+				IL_01ae: ldc.i4.1
+				IL_01af: ldelem.ref
+				IL_01b0: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
+				IL_01b5: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::socket
+				IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01bf: stloc.s 8
+				IL_01c1: ldloc.0
+				IL_01c2: ldc.r8 3
+				IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01d0: stloc.s 9
+				IL_01d2: ldloc.0
+				IL_01d3: ldc.r8 2
+				IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01e1: stloc.s 10
+				IL_01e3: ldloc.0
+				IL_01e4: ldc.r8 1
+				IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01f2: stloc.s 11
+				IL_01f4: ldc.i4.4
+				IL_01f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_01fa: dup
+				IL_01fb: ldloc.s 9
+				IL_01fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0202: dup
+				IL_0203: ldloc.s 10
+				IL_0205: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_020a: dup
+				IL_020b: ldloc.s 11
+				IL_020d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0212: dup
 				IL_0213: ldloc.0
-				IL_0214: ldc.r8 2
+				IL_0214: ldc.r8 0.0
 				IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0222: stloc.s 11
-				IL_0224: ldloc.0
-				IL_0225: ldc.r8 1
-				IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0233: stloc.s 12
-				IL_0235: ldc.i4.4
-				IL_0236: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_023b: dup
-				IL_023c: ldloc.s 10
-				IL_023e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0243: dup
-				IL_0244: ldloc.s 11
-				IL_0246: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_024b: dup
-				IL_024c: ldloc.s 12
-				IL_024e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0253: dup
-				IL_0254: ldloc.0
-				IL_0255: ldc.r8 0.0
-				IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0263: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0268: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_026d: stloc.s 4
-				IL_026f: ldloc.3
-				IL_0270: ldstr "end"
-				IL_0275: ldloc.s 4
-				IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_027c: pop
-				IL_027d: ldnull
-				IL_027e: ret
+				IL_0222: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0227: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_022c: stloc.2
+				IL_022d: ldloc.s 8
+				IL_022f: ldstr "end"
+				IL_0234: ldloc.2
+				IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_023a: pop
+				IL_023b: ldnull
+				IL_023c: ret
 			} // end of method FunctionExpression_server::__js_call__
 
 		} // end of class FunctionExpression_server
@@ -325,7 +296,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2872
+				// Method begins at RVA 0x27c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -425,7 +396,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x28a1
+					// Method begins at RVA 0x27f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -449,9 +420,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2590
+				// Method begins at RVA 0x2534
 				// Header size: 12
-				// Code size: 150 (0x96)
+				// Code size: 138 (0x8a)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -466,40 +437,36 @@
 				IL_000d: ldstr "Cannot access 'client' before initialization"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_0017: stloc.0
-				IL_0018: ldstr "client"
-				IL_001d: ldloc.0
-				IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0023: stloc.0
-				IL_0024: ldloc.0
-				IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_002a: stloc.0
-				IL_002b: ldc.i4.4
-				IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0031: dup
-				IL_0032: ldc.r8 1
-				IL_003b: box [System.Runtime]System.Double
-				IL_0040: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0045: dup
-				IL_0046: ldc.r8 2
-				IL_004f: box [System.Runtime]System.Double
-				IL_0054: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0059: dup
-				IL_005a: ldc.r8 65
-				IL_0063: box [System.Runtime]System.Double
-				IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_006d: dup
-				IL_006e: ldc.r8 66
-				IL_0077: box [System.Runtime]System.Double
-				IL_007c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0081: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_0086: stloc.1
-				IL_0087: ldloc.0
-				IL_0088: ldstr "write"
-				IL_008d: ldloc.1
-				IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0093: pop
-				IL_0094: ldnull
-				IL_0095: ret
+				IL_0018: ldloc.0
+				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_001e: stloc.0
+				IL_001f: ldc.i4.4
+				IL_0020: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_0025: dup
+				IL_0026: ldc.r8 1
+				IL_002f: box [System.Runtime]System.Double
+				IL_0034: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0039: dup
+				IL_003a: ldc.r8 2
+				IL_0043: box [System.Runtime]System.Double
+				IL_0048: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_004d: dup
+				IL_004e: ldc.r8 65
+				IL_0057: box [System.Runtime]System.Double
+				IL_005c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0061: dup
+				IL_0062: ldc.r8 66
+				IL_006b: box [System.Runtime]System.Double
+				IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0075: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_007a: stloc.1
+				IL_007b: ldloc.0
+				IL_007c: ldstr "write"
+				IL_0081: ldloc.1
+				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0087: pop
+				IL_0088: ldnull
+				IL_0089: ret
 			} // end of method FunctionExpression_client::__js_call__
 
 		} // end of class FunctionExpression_client
@@ -515,7 +482,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x28aa
+					// Method begins at RVA 0x27fa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -540,16 +507,15 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2634
+				// Method begins at RVA 0x25cc
 				// Header size: 12
-				// Code size: 162 (0xa2)
+				// Code size: 122 (0x7a)
 				.maxstack 8
 				.locals init (
 					[0] object,
 					[1] bool,
 					[2] object,
-					[3] object,
-					[4] class [JavaScriptRuntime]JavaScriptRuntime.Array
+					[3] object
 				)
 
 				IL_0000: ldstr "console"
@@ -578,40 +544,26 @@
 				IL_003b: ldelem.ref
 				IL_003c: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
 				IL_0041: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
-				IL_0046: stloc.s 4
-				IL_0048: ldstr "reply"
-				IL_004d: ldloc.s 4
-				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0054: stloc.0
-				IL_0055: ldloc.0
-				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_005b: stloc.0
-				IL_005c: ldloc.0
-				IL_005d: ldstr "push"
-				IL_0062: ldarg.2
-				IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0068: pop
-				IL_0069: ldarg.0
-				IL_006a: ldc.i4.1
-				IL_006b: ldelem.ref
-				IL_006c: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
-				IL_0071: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
-				IL_0076: ldstr "Cannot access 'client' before initialization"
-				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0080: stloc.0
-				IL_0081: ldstr "client"
-				IL_0086: ldloc.0
-				IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_008c: stloc.0
-				IL_008d: ldloc.0
-				IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0093: stloc.0
-				IL_0094: ldloc.0
-				IL_0095: ldstr "end"
-				IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_009f: pop
-				IL_00a0: ldnull
-				IL_00a1: ret
+				IL_0046: ldarg.2
+				IL_0047: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_004c: pop
+				IL_004d: ldarg.0
+				IL_004e: ldc.i4.1
+				IL_004f: ldelem.ref
+				IL_0050: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
+				IL_0055: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
+				IL_005a: ldstr "Cannot access 'client' before initialization"
+				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_0064: stloc.0
+				IL_0065: ldloc.0
+				IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_006b: stloc.0
+				IL_006c: ldloc.0
+				IL_006d: ldstr "end"
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0077: pop
+				IL_0078: ldnull
+				IL_0079: ret
 			} // end of method FunctionExpression_L30C20::__js_call__
 
 		} // end of class FunctionExpression_L30C20
@@ -631,7 +583,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x28bc
+						// Method begins at RVA 0x280c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -654,7 +606,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2838
+					// Method begins at RVA 0x2788
 					// Header size: 12
 					// Code size: 37 (0x25)
 					.maxstack 8
@@ -686,7 +638,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x28b3
+					// Method begins at RVA 0x2803
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -710,19 +662,18 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26e4
+				// Method begins at RVA 0x2654
 				// Header size: 12
-				// Code size: 326 (0x146)
+				// Code size: 296 (0x128)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/Scope,
 					[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-					[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+					[2] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 					[3] object,
-					[4] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-					[5] float64,
-					[6] object,
-					[7] object
+					[4] float64,
+					[5] object,
+					[6] object
 				)
 
 				IL_0000: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/Scope::.ctor()
@@ -732,104 +683,92 @@
 				IL_0008: ldelem.ref
 				IL_0009: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
 				IL_000e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
-				IL_0013: stloc.2
-				IL_0014: ldstr "reply"
+				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
+				IL_0018: stloc.2
 				IL_0019: ldloc.2
-				IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_001f: stloc.3
-				IL_0020: ldloc.3
-				IL_0021: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
-				IL_0026: stloc.s 4
-				IL_0028: ldloc.s 4
-				IL_002a: stloc.1
-				IL_002b: ldstr "console"
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0035: stloc.3
-				IL_0036: ldloc.3
-				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003c: stloc.3
-				IL_003d: ldloc.1
-				IL_003e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-				IL_0043: stloc.s 5
-				IL_0045: ldstr "client bytes:"
-				IL_004a: ldloc.s 5
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0051: stloc.s 6
-				IL_0053: ldloc.s 6
-				IL_0055: ldstr ":"
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_005f: stloc.s 6
-				IL_0061: ldloc.s 6
-				IL_0063: ldloc.1
-				IL_0064: ldc.r8 0.0
-				IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0077: stloc.s 6
-				IL_0079: ldloc.s 6
-				IL_007b: ldstr ":"
-				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0085: stloc.s 6
-				IL_0087: ldloc.s 6
-				IL_0089: ldloc.1
-				IL_008a: ldc.r8 1
-				IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_009d: stloc.s 6
-				IL_009f: ldloc.s 6
-				IL_00a1: ldstr ":"
-				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00ab: stloc.s 6
-				IL_00ad: ldloc.s 6
-				IL_00af: ldloc.1
-				IL_00b0: ldc.r8 2
-				IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00c3: stloc.s 6
-				IL_00c5: ldloc.s 6
-				IL_00c7: ldstr ":"
-				IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00d1: stloc.s 6
-				IL_00d3: ldloc.s 6
-				IL_00d5: ldloc.1
-				IL_00d6: ldc.r8 3
-				IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00e9: stloc.s 6
-				IL_00eb: ldloc.3
-				IL_00ec: ldstr "log"
-				IL_00f1: ldloc.s 6
-				IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00f8: pop
-				IL_00f9: ldarg.0
-				IL_00fa: ldc.i4.0
-				IL_00fb: ldelem.ref
-				IL_00fc: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
-				IL_0101: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
-				IL_0106: stloc.3
-				IL_0107: ldstr "server"
-				IL_010c: ldloc.3
-				IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0112: stloc.3
-				IL_0113: ldloc.3
-				IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0119: stloc.3
-				IL_011a: ldnull
-				IL_011b: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17::__js_call__(object)
-				IL_0121: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0126: ldc.i4.0
-				IL_0127: conv.r8
-				IL_0128: ldstr ""
-				IL_012d: ldc.i4.0
-				IL_012e: ldc.i4.1
-				IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0134: stloc.s 7
-				IL_0136: ldloc.3
-				IL_0137: ldstr "close"
-				IL_013c: ldloc.s 7
-				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0143: pop
-				IL_0144: ldnull
-				IL_0145: ret
+				IL_001a: stloc.1
+				IL_001b: ldstr "console"
+				IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0025: stloc.3
+				IL_0026: ldloc.3
+				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_002c: stloc.3
+				IL_002d: ldloc.1
+				IL_002e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+				IL_0033: stloc.s 4
+				IL_0035: ldstr "client bytes:"
+				IL_003a: ldloc.s 4
+				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0041: stloc.s 5
+				IL_0043: ldloc.s 5
+				IL_0045: ldstr ":"
+				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_004f: stloc.s 5
+				IL_0051: ldloc.s 5
+				IL_0053: ldloc.1
+				IL_0054: ldc.r8 0.0
+				IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0067: stloc.s 5
+				IL_0069: ldloc.s 5
+				IL_006b: ldstr ":"
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0075: stloc.s 5
+				IL_0077: ldloc.s 5
+				IL_0079: ldloc.1
+				IL_007a: ldc.r8 1
+				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_008d: stloc.s 5
+				IL_008f: ldloc.s 5
+				IL_0091: ldstr ":"
+				IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_009b: stloc.s 5
+				IL_009d: ldloc.s 5
+				IL_009f: ldloc.1
+				IL_00a0: ldc.r8 2
+				IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00b3: stloc.s 5
+				IL_00b5: ldloc.s 5
+				IL_00b7: ldstr ":"
+				IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00c1: stloc.s 5
+				IL_00c3: ldloc.s 5
+				IL_00c5: ldloc.1
+				IL_00c6: ldc.r8 3
+				IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00d9: stloc.s 5
+				IL_00db: ldloc.3
+				IL_00dc: ldstr "log"
+				IL_00e1: ldloc.s 5
+				IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00e8: pop
+				IL_00e9: ldarg.0
+				IL_00ea: ldc.i4.0
+				IL_00eb: ldelem.ref
+				IL_00ec: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
+				IL_00f1: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
+				IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00fb: stloc.3
+				IL_00fc: ldnull
+				IL_00fd: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17::__js_call__(object)
+				IL_0103: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0108: ldc.i4.0
+				IL_0109: conv.r8
+				IL_010a: ldstr ""
+				IL_010f: ldc.i4.0
+				IL_0110: ldc.i4.1
+				IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0116: stloc.s 6
+				IL_0118: ldloc.3
+				IL_0119: ldstr "close"
+				IL_011e: ldloc.s 6
+				IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0125: pop
+				IL_0126: ldnull
+				IL_0127: ret
 			} // end of method FunctionExpression_L36C19::__js_call__
 
 		} // end of class FunctionExpression_L36C19
@@ -850,7 +789,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x288d
+				// Method begins at RVA 0x27dd
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -881,7 +820,7 @@
 			)
 			// Method begins at RVA 0x2194
 			// Header size: 12
-			// Code size: 354 (0x162)
+			// Code size: 326 (0x146)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope,
@@ -896,139 +835,127 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
-			IL_000c: stloc.2
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.2
 			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.2
+			IL_001e: ldloc.2
+			IL_001f: stloc.1
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: stloc.1
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
-			IL_0034: stloc.2
-			IL_0035: ldstr "net"
-			IL_003a: ldloc.2
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0040: stloc.2
-			IL_0041: ldloc.2
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0047: stloc.2
-			IL_0048: ldloc.1
-			IL_0049: ldstr "port"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0053: stloc.3
-			IL_0054: ldloc.1
-			IL_0055: ldstr "address"
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005f: stloc.s 4
-			IL_0061: ldc.i4.2
-			IL_0062: newarr [System.Runtime]System.Object
-			IL_0067: dup
-			IL_0068: ldc.i4.0
-			IL_0069: ldarg.0
-			IL_006a: stelem.ref
-			IL_006b: dup
-			IL_006c: ldc.i4.1
-			IL_006d: ldloc.0
-			IL_006e: stelem.ref
-			IL_006f: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_007a: ldc.i4.0
-			IL_007b: conv.r8
-			IL_007c: ldstr ""
-			IL_0081: ldc.i4.0
-			IL_0082: ldc.i4.1
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0088: stloc.s 5
-			IL_008a: ldloc.2
-			IL_008b: ldstr "connect"
-			IL_0090: ldloc.3
-			IL_0091: ldloc.s 4
-			IL_0093: ldloc.s 5
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_009a: stloc.s 5
-			IL_009c: ldloc.0
-			IL_009d: ldloc.s 5
-			IL_009f: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
-			IL_00a4: ldloc.0
-			IL_00a5: ldc.i4.0
-			IL_00a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00ab: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
-			IL_00b0: ldloc.0
-			IL_00b1: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
-			IL_00b6: ldstr "Cannot access 'client' before initialization"
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00c0: stloc.s 5
-			IL_00c2: ldloc.s 5
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c9: stloc.s 5
-			IL_00cb: ldc.i4.2
-			IL_00cc: newarr [System.Runtime]System.Object
-			IL_00d1: dup
-			IL_00d2: ldc.i4.0
-			IL_00d3: ldarg.0
-			IL_00d4: stelem.ref
-			IL_00d5: dup
-			IL_00d6: ldc.i4.1
-			IL_00d7: ldloc.0
-			IL_00d8: stelem.ref
-			IL_00d9: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-			IL_00df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00e4: ldc.i4.1
-			IL_00e5: conv.r8
-			IL_00e6: ldstr ""
-			IL_00eb: ldc.i4.0
-			IL_00ec: ldc.i4.1
-			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00f2: stloc.s 4
-			IL_00f4: ldloc.s 5
-			IL_00f6: ldstr "on"
-			IL_00fb: ldstr "data"
-			IL_0100: ldloc.s 4
-			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0107: pop
-			IL_0108: ldloc.0
-			IL_0109: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
-			IL_010e: ldstr "Cannot access 'client' before initialization"
-			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0118: stloc.s 4
-			IL_011a: ldloc.s 4
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0121: stloc.s 4
-			IL_0123: ldc.i4.2
-			IL_0124: newarr [System.Runtime]System.Object
-			IL_0129: dup
-			IL_012a: ldc.i4.0
-			IL_012b: ldarg.0
-			IL_012c: stelem.ref
-			IL_012d: dup
-			IL_012e: ldc.i4.1
-			IL_012f: ldloc.0
-			IL_0130: stelem.ref
-			IL_0131: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19::__js_call__(object[], object)
-			IL_0137: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_013c: ldc.i4.0
-			IL_013d: conv.r8
-			IL_013e: ldstr ""
-			IL_0143: ldc.i4.0
-			IL_0144: ldc.i4.1
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_014a: stloc.s 5
-			IL_014c: ldloc.s 4
-			IL_014e: ldstr "on"
-			IL_0153: ldstr "end"
-			IL_0158: ldloc.s 5
-			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_015f: pop
-			IL_0160: ldnull
-			IL_0161: ret
+			IL_002c: ldloc.1
+			IL_002d: ldstr "port"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.3
+			IL_0038: ldloc.1
+			IL_0039: ldstr "address"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0043: stloc.s 4
+			IL_0045: ldc.i4.2
+			IL_0046: newarr [System.Runtime]System.Object
+			IL_004b: dup
+			IL_004c: ldc.i4.0
+			IL_004d: ldarg.0
+			IL_004e: stelem.ref
+			IL_004f: dup
+			IL_0050: ldc.i4.1
+			IL_0051: ldloc.0
+			IL_0052: stelem.ref
+			IL_0053: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_005e: ldc.i4.0
+			IL_005f: conv.r8
+			IL_0060: ldstr ""
+			IL_0065: ldc.i4.0
+			IL_0066: ldc.i4.1
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_006c: stloc.s 5
+			IL_006e: ldloc.2
+			IL_006f: ldstr "connect"
+			IL_0074: ldloc.3
+			IL_0075: ldloc.s 4
+			IL_0077: ldloc.s 5
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_007e: stloc.s 5
+			IL_0080: ldloc.0
+			IL_0081: ldloc.s 5
+			IL_0083: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
+			IL_0088: ldloc.0
+			IL_0089: ldc.i4.0
+			IL_008a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_008f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
+			IL_0094: ldloc.0
+			IL_0095: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
+			IL_009a: ldstr "Cannot access 'client' before initialization"
+			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00a4: stloc.s 5
+			IL_00a6: ldloc.s 5
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ad: stloc.s 5
+			IL_00af: ldc.i4.2
+			IL_00b0: newarr [System.Runtime]System.Object
+			IL_00b5: dup
+			IL_00b6: ldc.i4.0
+			IL_00b7: ldarg.0
+			IL_00b8: stelem.ref
+			IL_00b9: dup
+			IL_00ba: ldc.i4.1
+			IL_00bb: ldloc.0
+			IL_00bc: stelem.ref
+			IL_00bd: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+			IL_00c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00c8: ldc.i4.1
+			IL_00c9: conv.r8
+			IL_00ca: ldstr ""
+			IL_00cf: ldc.i4.0
+			IL_00d0: ldc.i4.1
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00d6: stloc.s 4
+			IL_00d8: ldloc.s 5
+			IL_00da: ldstr "on"
+			IL_00df: ldstr "data"
+			IL_00e4: ldloc.s 4
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00eb: pop
+			IL_00ec: ldloc.0
+			IL_00ed: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
+			IL_00f2: ldstr "Cannot access 'client' before initialization"
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00fc: stloc.s 4
+			IL_00fe: ldloc.s 4
+			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0105: stloc.s 4
+			IL_0107: ldc.i4.2
+			IL_0108: newarr [System.Runtime]System.Object
+			IL_010d: dup
+			IL_010e: ldc.i4.0
+			IL_010f: ldarg.0
+			IL_0110: stelem.ref
+			IL_0111: dup
+			IL_0112: ldc.i4.1
+			IL_0113: ldloc.0
+			IL_0114: stelem.ref
+			IL_0115: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19::__js_call__(object[], object)
+			IL_011b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0120: ldc.i4.0
+			IL_0121: conv.r8
+			IL_0122: ldstr ""
+			IL_0127: ldc.i4.0
+			IL_0128: ldc.i4.1
+			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_012e: stloc.s 5
+			IL_0130: ldloc.s 4
+			IL_0132: ldstr "on"
+			IL_0137: ldstr "end"
+			IL_013c: ldloc.s 5
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0143: pop
+			IL_0144: ldnull
+			IL_0145: ret
 		} // end of method FunctionExpression_L23C30::__js_call__
 
 	} // end of class FunctionExpression_L23C30
@@ -1049,7 +976,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2869
+			// Method begins at RVA 0x27b9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1164,7 +1091,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x28c5
+		// Method begins at RVA 0x2815
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x273a
+				// Method begins at RVA 0x2682
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -112,7 +112,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2760
+						// Method begins at RVA 0x26a8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -132,7 +132,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2769
+						// Method begins at RVA 0x26b1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -150,7 +150,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2757
+					// Method begins at RVA 0x269f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -174,9 +174,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2348
+				// Method begins at RVA 0x232c
 				// Header size: 12
-				// Code size: 501 (0x1f5)
+				// Code size: 431 (0x1af)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/Scope/Block_L22C8,
@@ -200,173 +200,153 @@
 				IL_000d: ldstr "Cannot access 'client' before initialization"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_0017: stloc.s 6
-				IL_0019: ldstr "client"
-				IL_001e: ldloc.s 6
-				IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0025: stloc.s 6
-				IL_0027: ldloc.s 6
-				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_002e: stloc.s 6
-				IL_0030: ldloc.s 6
-				IL_0032: ldstr "setKeepAlive"
+				IL_0019: ldloc.s 6
+				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0020: stloc.s 6
+				IL_0022: ldloc.s 6
+				IL_0024: ldstr "setKeepAlive"
+				IL_0029: ldc.i4.1
+				IL_002a: box [System.Runtime]System.Boolean
+				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0034: stloc.s 6
+				IL_0036: ldarg.0
 				IL_0037: ldc.i4.1
-				IL_0038: box [System.Runtime]System.Boolean
-				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0042: stloc.s 6
-				IL_0044: ldarg.0
-				IL_0045: ldc.i4.1
-				IL_0046: ldelem.ref
-				IL_0047: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
-				IL_004c: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-				IL_0051: ldstr "Cannot access 'client' before initialization"
-				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_005b: stloc.s 7
-				IL_005d: ldstr "client"
-				IL_0062: ldloc.s 7
-				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0069: stloc.s 7
-				IL_006b: ldloc.s 6
-				IL_006d: ldloc.s 7
-				IL_006f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0074: stloc.s 8
-				IL_0076: ldloc.s 8
-				IL_0078: box [System.Runtime]System.Boolean
-				IL_007d: stloc.s 9
-				IL_007f: ldstr "client keepalive same:"
-				IL_0084: ldloc.s 9
-				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_008b: stloc.s 10
-				IL_008d: ldarg.0
-				IL_008e: ldc.i4.0
-				IL_008f: ldelem.ref
-				IL_0090: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_0095: ldloc.s 10
-				IL_0097: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveLine
-				IL_009c: ldarg.0
-				IL_009d: ldc.i4.1
-				IL_009e: ldelem.ref
-				IL_009f: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
-				IL_00a4: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-				IL_00a9: ldstr "Cannot access 'client' before initialization"
-				IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00b3: stloc.s 7
-				IL_00b5: ldstr "client"
-				IL_00ba: ldloc.s 7
-				IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00c1: stloc.s 7
-				IL_00c3: ldloc.s 7
-				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ca: stloc.s 7
-				IL_00cc: ldloc.s 7
-				IL_00ce: ldstr "setNoDelay"
-				IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_00d8: stloc.s 7
-				IL_00da: ldarg.0
-				IL_00db: ldc.i4.1
-				IL_00dc: ldelem.ref
-				IL_00dd: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
-				IL_00e2: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-				IL_00e7: ldstr "Cannot access 'client' before initialization"
-				IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00f1: stloc.s 6
-				IL_00f3: ldstr "client"
-				IL_00f8: ldloc.s 6
-				IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00ff: stloc.s 6
-				IL_0101: ldloc.s 7
-				IL_0103: ldloc.s 6
-				IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_010a: stloc.s 8
-				IL_010c: ldloc.s 8
-				IL_010e: box [System.Runtime]System.Boolean
-				IL_0113: stloc.s 9
-				IL_0115: ldstr "client nodelay same:"
-				IL_011a: ldloc.s 9
-				IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0121: stloc.s 10
-				IL_0123: ldarg.0
-				IL_0124: ldc.i4.0
-				IL_0125: ldelem.ref
-				IL_0126: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_012b: ldloc.s 10
-				IL_012d: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientNoDelayLine
+				IL_0038: ldelem.ref
+				IL_0039: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
+				IL_003e: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+				IL_0043: ldstr "Cannot access 'client' before initialization"
+				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_004d: stloc.s 7
+				IL_004f: ldloc.s 6
+				IL_0051: ldloc.s 7
+				IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0058: stloc.s 8
+				IL_005a: ldloc.s 8
+				IL_005c: box [System.Runtime]System.Boolean
+				IL_0061: stloc.s 9
+				IL_0063: ldstr "client keepalive same:"
+				IL_0068: ldloc.s 9
+				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_006f: stloc.s 10
+				IL_0071: ldarg.0
+				IL_0072: ldc.i4.0
+				IL_0073: ldelem.ref
+				IL_0074: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+				IL_0079: ldloc.s 10
+				IL_007b: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveLine
+				IL_0080: ldarg.0
+				IL_0081: ldc.i4.1
+				IL_0082: ldelem.ref
+				IL_0083: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
+				IL_0088: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+				IL_008d: ldstr "Cannot access 'client' before initialization"
+				IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_0097: stloc.s 7
+				IL_0099: ldloc.s 7
+				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00a0: stloc.s 7
+				IL_00a2: ldloc.s 7
+				IL_00a4: ldstr "setNoDelay"
+				IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_00ae: stloc.s 7
+				IL_00b0: ldarg.0
+				IL_00b1: ldc.i4.1
+				IL_00b2: ldelem.ref
+				IL_00b3: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
+				IL_00b8: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+				IL_00bd: ldstr "Cannot access 'client' before initialization"
+				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_00c7: stloc.s 6
+				IL_00c9: ldloc.s 7
+				IL_00cb: ldloc.s 6
+				IL_00cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00d2: stloc.s 8
+				IL_00d4: ldloc.s 8
+				IL_00d6: box [System.Runtime]System.Boolean
+				IL_00db: stloc.s 9
+				IL_00dd: ldstr "client nodelay same:"
+				IL_00e2: ldloc.s 9
+				IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00e9: stloc.s 10
+				IL_00eb: ldarg.0
+				IL_00ec: ldc.i4.0
+				IL_00ed: ldelem.ref
+				IL_00ee: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+				IL_00f3: ldloc.s 10
+				IL_00f5: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientNoDelayLine
 				.try
 				{
-					IL_0132: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/Scope/Block_L22C8::.ctor()
-					IL_0137: stloc.0
-					IL_0138: ldarg.0
-					IL_0139: ldc.i4.1
-					IL_013a: ldelem.ref
-					IL_013b: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
-					IL_0140: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-					IL_0145: ldstr "Cannot access 'client' before initialization"
-					IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_014f: stloc.s 6
-					IL_0151: ldstr "client"
-					IL_0156: ldloc.s 6
-					IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_015d: stloc.s 6
-					IL_015f: ldloc.s 6
-					IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0166: stloc.s 6
-					IL_0168: ldloc.s 6
-					IL_016a: ldstr "setKeepAlive"
-					IL_016f: ldc.i4.1
-					IL_0170: box [System.Runtime]System.Boolean
-					IL_0175: ldc.r8 25
-					IL_017e: box [System.Runtime]System.Double
-					IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0188: pop
-					IL_0189: leave IL_01ef
+					IL_00fa: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/Scope/Block_L22C8::.ctor()
+					IL_00ff: stloc.0
+					IL_0100: ldarg.0
+					IL_0101: ldc.i4.1
+					IL_0102: ldelem.ref
+					IL_0103: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
+					IL_0108: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+					IL_010d: ldstr "Cannot access 'client' before initialization"
+					IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+					IL_0117: stloc.s 6
+					IL_0119: ldloc.s 6
+					IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0120: stloc.s 6
+					IL_0122: ldloc.s 6
+					IL_0124: ldstr "setKeepAlive"
+					IL_0129: ldc.i4.1
+					IL_012a: box [System.Runtime]System.Boolean
+					IL_012f: ldc.r8 25
+					IL_0138: box [System.Runtime]System.Double
+					IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0142: pop
+					IL_0143: leave IL_01a9
 				} // end .try
 				catch [System.Runtime]System.Exception
 				{
-					IL_018e: stloc.1
-					IL_018f: ldloc.1
-					IL_0190: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-					IL_0195: dup
-					IL_0196: brtrue IL_01ab
+					IL_0148: stloc.1
+					IL_0149: ldloc.1
+					IL_014a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+					IL_014f: dup
+					IL_0150: brtrue IL_0165
 
-					IL_019b: pop
-					IL_019c: ldloc.1
-					IL_019d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-					IL_01a2: dup
-					IL_01a3: brtrue IL_01b6
+					IL_0155: pop
+					IL_0156: ldloc.1
+					IL_0157: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+					IL_015c: dup
+					IL_015d: brtrue IL_0170
 
-					IL_01a8: pop
-					IL_01a9: rethrow
+					IL_0162: pop
+					IL_0163: rethrow
 
-					IL_01ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-					IL_01b0: stloc.2
-					IL_01b1: br IL_01b7
+					IL_0165: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+					IL_016a: stloc.2
+					IL_016b: br IL_0171
 
-					IL_01b6: stloc.2
+					IL_0170: stloc.2
 
-					IL_01b7: ldloc.2
-					IL_01b8: stloc.s 6
-					IL_01ba: ldloc.s 6
-					IL_01bc: stloc.3
-					IL_01bd: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/Scope/Block_L24C18::.ctor()
-					IL_01c2: stloc.s 4
-					IL_01c4: ldstr "client keepalive delay:"
-					IL_01c9: ldloc.3
-					IL_01ca: ldstr "message"
-					IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_01d9: stloc.s 10
-					IL_01db: ldarg.0
-					IL_01dc: ldc.i4.0
-					IL_01dd: ldelem.ref
-					IL_01de: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-					IL_01e3: ldloc.s 10
-					IL_01e5: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveDelayLine
-					IL_01ea: leave IL_01ef
+					IL_0171: ldloc.2
+					IL_0172: stloc.s 6
+					IL_0174: ldloc.s 6
+					IL_0176: stloc.3
+					IL_0177: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/Scope/Block_L24C18::.ctor()
+					IL_017c: stloc.s 4
+					IL_017e: ldstr "client keepalive delay:"
+					IL_0183: ldloc.3
+					IL_0184: ldstr "message"
+					IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0193: stloc.s 10
+					IL_0195: ldarg.0
+					IL_0196: ldc.i4.0
+					IL_0197: ldelem.ref
+					IL_0198: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+					IL_019d: ldloc.s 10
+					IL_019f: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveDelayLine
+					IL_01a4: leave IL_01a9
 				} // end handler
 
-				IL_01ef: ldnull
-				IL_01f0: stloc.s 5
-				IL_01f2: ldloc.s 5
-				IL_01f4: ret
+				IL_01a9: ldnull
+				IL_01aa: stloc.s 5
+				IL_01ac: ldloc.s 5
+				IL_01ae: ret
 			} // end of method FunctionExpression_client::__js_call__
 
 		} // end of class FunctionExpression_client
@@ -382,7 +362,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2772
+					// Method begins at RVA 0x26ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -407,7 +387,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x255c
+				// Method begins at RVA 0x24f8
 				// Header size: 12
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -446,7 +426,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2784
+						// Method begins at RVA 0x26cc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -469,7 +449,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2700
+					// Method begins at RVA 0x2648
 					// Header size: 12
 					// Code size: 37 (0x25)
 					.maxstack 8
@@ -501,7 +481,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x277b
+					// Method begins at RVA 0x26c3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -525,9 +505,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2584
+				// Method begins at RVA 0x2520
 				// Header size: 12
-				// Code size: 366 (0x16e)
+				// Code size: 282 (0x11a)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/Scope,
@@ -543,135 +523,99 @@
 				IL_0011: ldloc.1
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0017: stloc.1
-				IL_0018: ldarg.0
-				IL_0019: ldc.i4.0
-				IL_001a: ldelem.ref
-				IL_001b: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_0020: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveLine
-				IL_0025: stloc.2
-				IL_0026: ldstr "clientKeepAliveLine"
-				IL_002b: ldloc.2
-				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0031: stloc.2
-				IL_0032: ldloc.1
-				IL_0033: ldstr "log"
-				IL_0038: ldloc.2
-				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_003e: pop
-				IL_003f: ldstr "console"
-				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0049: stloc.2
-				IL_004a: ldloc.2
-				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0050: stloc.2
-				IL_0051: ldarg.0
-				IL_0052: ldc.i4.0
-				IL_0053: ldelem.ref
-				IL_0054: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_0059: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientNoDelayLine
-				IL_005e: stloc.1
-				IL_005f: ldstr "clientNoDelayLine"
-				IL_0064: ldloc.1
-				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006a: stloc.1
-				IL_006b: ldloc.2
-				IL_006c: ldstr "log"
-				IL_0071: ldloc.1
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0077: pop
-				IL_0078: ldstr "console"
-				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0082: stloc.1
-				IL_0083: ldloc.1
-				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0089: stloc.1
-				IL_008a: ldarg.0
-				IL_008b: ldc.i4.0
-				IL_008c: ldelem.ref
-				IL_008d: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_0092: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveDelayLine
-				IL_0097: stloc.2
-				IL_0098: ldstr "clientKeepAliveDelayLine"
-				IL_009d: ldloc.2
-				IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00a3: stloc.2
-				IL_00a4: ldloc.1
-				IL_00a5: ldstr "log"
-				IL_00aa: ldloc.2
-				IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00b0: pop
-				IL_00b1: ldstr "console"
-				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00bb: stloc.2
-				IL_00bc: ldloc.2
-				IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00c2: stloc.2
-				IL_00c3: ldarg.0
-				IL_00c4: ldc.i4.0
-				IL_00c5: ldelem.ref
-				IL_00c6: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_00cb: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::serverKeepAliveLine
-				IL_00d0: stloc.1
-				IL_00d1: ldstr "serverKeepAliveLine"
-				IL_00d6: ldloc.1
-				IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00dc: stloc.1
-				IL_00dd: ldloc.2
-				IL_00de: ldstr "log"
-				IL_00e3: ldloc.1
-				IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00e9: pop
-				IL_00ea: ldstr "console"
-				IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00f4: stloc.1
-				IL_00f5: ldloc.1
-				IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00fb: stloc.1
-				IL_00fc: ldarg.0
-				IL_00fd: ldc.i4.0
-				IL_00fe: ldelem.ref
-				IL_00ff: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_0104: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientDataLine
-				IL_0109: stloc.2
-				IL_010a: ldstr "clientDataLine"
-				IL_010f: ldloc.2
-				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0115: stloc.2
-				IL_0116: ldloc.1
-				IL_0117: ldstr "log"
-				IL_011c: ldloc.2
-				IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0122: pop
-				IL_0123: ldarg.0
-				IL_0124: ldc.i4.0
-				IL_0125: ldelem.ref
-				IL_0126: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_012b: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
-				IL_0130: stloc.2
-				IL_0131: ldstr "server"
-				IL_0136: ldloc.2
-				IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_013c: stloc.2
-				IL_013d: ldloc.2
-				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0143: stloc.2
-				IL_0144: ldnull
-				IL_0145: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17::__js_call__(object)
-				IL_014b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0150: ldc.i4.0
-				IL_0151: conv.r8
-				IL_0152: ldstr ""
-				IL_0157: ldc.i4.0
-				IL_0158: ldc.i4.1
-				IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_015e: stloc.1
-				IL_015f: ldloc.2
-				IL_0160: ldstr "close"
-				IL_0165: ldloc.1
-				IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_016b: pop
-				IL_016c: ldnull
-				IL_016d: ret
+				IL_0018: ldloc.1
+				IL_0019: ldstr "log"
+				IL_001e: ldarg.0
+				IL_001f: ldc.i4.0
+				IL_0020: ldelem.ref
+				IL_0021: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+				IL_0026: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveLine
+				IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0030: pop
+				IL_0031: ldstr "console"
+				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_003b: stloc.1
+				IL_003c: ldloc.1
+				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0042: stloc.1
+				IL_0043: ldloc.1
+				IL_0044: ldstr "log"
+				IL_0049: ldarg.0
+				IL_004a: ldc.i4.0
+				IL_004b: ldelem.ref
+				IL_004c: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+				IL_0051: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientNoDelayLine
+				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_005b: pop
+				IL_005c: ldstr "console"
+				IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0066: stloc.1
+				IL_0067: ldloc.1
+				IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: ldstr "log"
+				IL_0074: ldarg.0
+				IL_0075: ldc.i4.0
+				IL_0076: ldelem.ref
+				IL_0077: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+				IL_007c: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveDelayLine
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0086: pop
+				IL_0087: ldstr "console"
+				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0091: stloc.1
+				IL_0092: ldloc.1
+				IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0098: stloc.1
+				IL_0099: ldloc.1
+				IL_009a: ldstr "log"
+				IL_009f: ldarg.0
+				IL_00a0: ldc.i4.0
+				IL_00a1: ldelem.ref
+				IL_00a2: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+				IL_00a7: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::serverKeepAliveLine
+				IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00b1: pop
+				IL_00b2: ldstr "console"
+				IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00bc: stloc.1
+				IL_00bd: ldloc.1
+				IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00c3: stloc.1
+				IL_00c4: ldloc.1
+				IL_00c5: ldstr "log"
+				IL_00ca: ldarg.0
+				IL_00cb: ldc.i4.0
+				IL_00cc: ldelem.ref
+				IL_00cd: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+				IL_00d2: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientDataLine
+				IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00dc: pop
+				IL_00dd: ldarg.0
+				IL_00de: ldc.i4.0
+				IL_00df: ldelem.ref
+				IL_00e0: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+				IL_00e5: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
+				IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00ef: stloc.1
+				IL_00f0: ldnull
+				IL_00f1: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17::__js_call__(object)
+				IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_00fc: ldc.i4.0
+				IL_00fd: conv.r8
+				IL_00fe: ldstr ""
+				IL_0103: ldc.i4.0
+				IL_0104: ldc.i4.1
+				IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_010a: stloc.2
+				IL_010b: ldloc.1
+				IL_010c: ldstr "close"
+				IL_0111: ldloc.2
+				IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0117: pop
+				IL_0118: ldnull
+				IL_0119: ret
 			} // end of method FunctionExpression_L34C19::__js_call__
 
 		} // end of class FunctionExpression_L34C19
@@ -690,7 +634,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2743
+				// Method begins at RVA 0x268b
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -721,7 +665,7 @@
 			)
 			// Method begins at RVA 0x21b8
 			// Header size: 12
-			// Code size: 387 (0x183)
+			// Code size: 359 (0x167)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope,
@@ -736,148 +680,136 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
-			IL_000c: stloc.2
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.2
 			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.2
+			IL_001e: ldloc.2
+			IL_001f: stloc.1
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: stloc.1
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
-			IL_0034: stloc.2
-			IL_0035: ldstr "net"
-			IL_003a: ldloc.2
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0040: stloc.2
-			IL_0041: ldloc.2
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0047: stloc.2
-			IL_0048: ldloc.1
-			IL_0049: ldstr "port"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0053: stloc.3
-			IL_0054: ldloc.1
-			IL_0055: ldstr "address"
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005f: stloc.s 4
-			IL_0061: ldc.i4.2
-			IL_0062: newarr [System.Runtime]System.Object
-			IL_0067: dup
-			IL_0068: ldc.i4.0
-			IL_0069: ldarg.0
-			IL_006a: stelem.ref
-			IL_006b: dup
-			IL_006c: ldc.i4.1
-			IL_006d: ldloc.0
-			IL_006e: stelem.ref
-			IL_006f: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_007a: ldc.i4.0
-			IL_007b: conv.r8
-			IL_007c: ldstr ""
-			IL_0081: ldc.i4.0
-			IL_0082: ldc.i4.1
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0088: stloc.s 5
-			IL_008a: ldloc.2
-			IL_008b: ldstr "connect"
-			IL_0090: ldloc.3
-			IL_0091: ldloc.s 4
-			IL_0093: ldloc.s 5
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_009a: stloc.s 5
-			IL_009c: ldloc.0
-			IL_009d: ldloc.s 5
-			IL_009f: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_00a4: ldloc.0
-			IL_00a5: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_00aa: ldstr "Cannot access 'client' before initialization"
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00b4: stloc.s 5
-			IL_00b6: ldloc.s 5
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00bd: stloc.s 5
-			IL_00bf: ldloc.s 5
-			IL_00c1: ldstr "setEncoding"
-			IL_00c6: ldstr "utf8"
-			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00d0: pop
-			IL_00d1: ldloc.0
-			IL_00d2: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_00d7: ldstr "Cannot access 'client' before initialization"
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00e1: stloc.s 5
-			IL_00e3: ldloc.s 5
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ea: stloc.s 5
-			IL_00ec: ldc.i4.2
-			IL_00ed: newarr [System.Runtime]System.Object
-			IL_00f2: dup
-			IL_00f3: ldc.i4.0
-			IL_00f4: ldarg.0
-			IL_00f5: stelem.ref
-			IL_00f6: dup
-			IL_00f7: ldc.i4.1
-			IL_00f8: ldloc.0
-			IL_00f9: stelem.ref
-			IL_00fa: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-			IL_0100: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0105: ldc.i4.1
-			IL_0106: conv.r8
-			IL_0107: ldstr ""
-			IL_010c: ldc.i4.0
-			IL_010d: ldc.i4.1
-			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0113: stloc.s 4
-			IL_0115: ldloc.s 5
-			IL_0117: ldstr "on"
-			IL_011c: ldstr "data"
-			IL_0121: ldloc.s 4
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0128: pop
-			IL_0129: ldloc.0
-			IL_012a: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_012f: ldstr "Cannot access 'client' before initialization"
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0139: stloc.s 4
-			IL_013b: ldloc.s 4
-			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0142: stloc.s 4
-			IL_0144: ldc.i4.2
-			IL_0145: newarr [System.Runtime]System.Object
-			IL_014a: dup
-			IL_014b: ldc.i4.0
-			IL_014c: ldarg.0
-			IL_014d: stelem.ref
-			IL_014e: dup
-			IL_014f: ldc.i4.1
-			IL_0150: ldloc.0
-			IL_0151: stelem.ref
-			IL_0152: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19::__js_call__(object[], object)
-			IL_0158: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_015d: ldc.i4.0
-			IL_015e: conv.r8
-			IL_015f: ldstr ""
-			IL_0164: ldc.i4.0
-			IL_0165: ldc.i4.1
-			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_016b: stloc.s 5
-			IL_016d: ldloc.s 4
-			IL_016f: ldstr "on"
-			IL_0174: ldstr "end"
-			IL_0179: ldloc.s 5
-			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0180: pop
-			IL_0181: ldnull
-			IL_0182: ret
+			IL_002c: ldloc.1
+			IL_002d: ldstr "port"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.3
+			IL_0038: ldloc.1
+			IL_0039: ldstr "address"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0043: stloc.s 4
+			IL_0045: ldc.i4.2
+			IL_0046: newarr [System.Runtime]System.Object
+			IL_004b: dup
+			IL_004c: ldc.i4.0
+			IL_004d: ldarg.0
+			IL_004e: stelem.ref
+			IL_004f: dup
+			IL_0050: ldc.i4.1
+			IL_0051: ldloc.0
+			IL_0052: stelem.ref
+			IL_0053: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_005e: ldc.i4.0
+			IL_005f: conv.r8
+			IL_0060: ldstr ""
+			IL_0065: ldc.i4.0
+			IL_0066: ldc.i4.1
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_006c: stloc.s 5
+			IL_006e: ldloc.2
+			IL_006f: ldstr "connect"
+			IL_0074: ldloc.3
+			IL_0075: ldloc.s 4
+			IL_0077: ldloc.s 5
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_007e: stloc.s 5
+			IL_0080: ldloc.0
+			IL_0081: ldloc.s 5
+			IL_0083: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_0088: ldloc.0
+			IL_0089: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_008e: ldstr "Cannot access 'client' before initialization"
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0098: stloc.s 5
+			IL_009a: ldloc.s 5
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a1: stloc.s 5
+			IL_00a3: ldloc.s 5
+			IL_00a5: ldstr "setEncoding"
+			IL_00aa: ldstr "utf8"
+			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00b4: pop
+			IL_00b5: ldloc.0
+			IL_00b6: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_00bb: ldstr "Cannot access 'client' before initialization"
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00c5: stloc.s 5
+			IL_00c7: ldloc.s 5
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ce: stloc.s 5
+			IL_00d0: ldc.i4.2
+			IL_00d1: newarr [System.Runtime]System.Object
+			IL_00d6: dup
+			IL_00d7: ldc.i4.0
+			IL_00d8: ldarg.0
+			IL_00d9: stelem.ref
+			IL_00da: dup
+			IL_00db: ldc.i4.1
+			IL_00dc: ldloc.0
+			IL_00dd: stelem.ref
+			IL_00de: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+			IL_00e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00e9: ldc.i4.1
+			IL_00ea: conv.r8
+			IL_00eb: ldstr ""
+			IL_00f0: ldc.i4.0
+			IL_00f1: ldc.i4.1
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00f7: stloc.s 4
+			IL_00f9: ldloc.s 5
+			IL_00fb: ldstr "on"
+			IL_0100: ldstr "data"
+			IL_0105: ldloc.s 4
+			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_010c: pop
+			IL_010d: ldloc.0
+			IL_010e: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_0113: ldstr "Cannot access 'client' before initialization"
+			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_011d: stloc.s 4
+			IL_011f: ldloc.s 4
+			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0126: stloc.s 4
+			IL_0128: ldc.i4.2
+			IL_0129: newarr [System.Runtime]System.Object
+			IL_012e: dup
+			IL_012f: ldc.i4.0
+			IL_0130: ldarg.0
+			IL_0131: stelem.ref
+			IL_0132: dup
+			IL_0133: ldc.i4.1
+			IL_0134: ldloc.0
+			IL_0135: stelem.ref
+			IL_0136: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19::__js_call__(object[], object)
+			IL_013c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0141: ldc.i4.0
+			IL_0142: conv.r8
+			IL_0143: ldstr ""
+			IL_0148: ldc.i4.0
+			IL_0149: ldc.i4.1
+			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_014f: stloc.s 5
+			IL_0151: ldloc.s 4
+			IL_0153: ldstr "on"
+			IL_0158: ldstr "end"
+			IL_015d: ldloc.s 5
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0164: pop
+			IL_0165: ldnull
+			IL_0166: ret
 		} // end of method FunctionExpression_L16C30::__js_call__
 
 	} // end of class FunctionExpression_L16C30
@@ -916,7 +848,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2731
+			// Method begins at RVA 0x2679
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1051,7 +983,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x278d
+		// Method begins at RVA 0x26d5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_SetEncoding_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_SetEncoding_Utf8.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x275b
+					// Method begins at RVA 0x26c3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,9 +47,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2384
+				// Method begins at RVA 0x2368
 				// Header size: 12
-				// Code size: 114 (0x72)
+				// Code size: 100 (0x64)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -81,23 +81,17 @@
 				IL_0042: ldelem.ref
 				IL_0043: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
 				IL_0048: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::received
-				IL_004d: stloc.0
-				IL_004e: ldstr "received"
-				IL_0053: ldloc.0
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0059: stloc.0
-				IL_005a: ldloc.0
-				IL_005b: ldarg.2
-				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0061: stloc.1
-				IL_0062: ldarg.0
-				IL_0063: ldc.i4.1
-				IL_0064: ldelem.ref
-				IL_0065: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
-				IL_006a: ldloc.1
-				IL_006b: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::received
-				IL_0070: ldnull
-				IL_0071: ret
+				IL_004d: ldarg.2
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0053: stloc.1
+				IL_0054: ldarg.0
+				IL_0055: ldc.i4.1
+				IL_0056: ldelem.ref
+				IL_0057: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
+				IL_005c: ldloc.1
+				IL_005d: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::received
+				IL_0062: ldnull
+				IL_0063: ret
 			} // end of method FunctionExpression_server::__js_call__
 
 		} // end of class FunctionExpression_server
@@ -113,7 +107,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2764
+					// Method begins at RVA 0x26cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -137,14 +131,13 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2404
+				// Method begins at RVA 0x23d8
 				// Header size: 12
-				// Code size: 155 (0x9b)
+				// Code size: 113 (0x71)
 				.maxstack 8
 				.locals init (
 					[0] object,
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: ldstr "console"
@@ -153,59 +146,41 @@
 				IL_000b: ldloc.0
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0011: stloc.0
-				IL_0012: ldarg.0
-				IL_0013: ldc.i4.1
-				IL_0014: ldelem.ref
-				IL_0015: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
-				IL_001a: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::received
-				IL_001f: stloc.1
-				IL_0020: ldstr "received"
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002b: stloc.1
-				IL_002c: ldstr "server recv:"
-				IL_0031: ldloc.1
-				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0037: stloc.2
-				IL_0038: ldloc.0
-				IL_0039: ldstr "log"
-				IL_003e: ldloc.2
-				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0044: pop
-				IL_0045: ldarg.0
-				IL_0046: ldc.i4.1
-				IL_0047: ldelem.ref
-				IL_0048: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
-				IL_004d: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::socket
-				IL_0052: stloc.0
-				IL_0053: ldstr "socket"
-				IL_0058: ldloc.0
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005e: stloc.0
-				IL_005f: ldloc.0
-				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0065: stloc.0
-				IL_0066: ldarg.0
-				IL_0067: ldc.i4.1
-				IL_0068: ldelem.ref
-				IL_0069: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
-				IL_006e: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::received
-				IL_0073: stloc.1
-				IL_0074: ldstr "received"
-				IL_0079: ldloc.1
-				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_007f: stloc.1
-				IL_0080: ldstr "done:"
-				IL_0085: ldloc.1
-				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_008b: stloc.2
-				IL_008c: ldloc.0
-				IL_008d: ldstr "end"
-				IL_0092: ldloc.2
-				IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0098: pop
-				IL_0099: ldnull
-				IL_009a: ret
+				IL_0012: ldstr "server recv:"
+				IL_0017: ldarg.0
+				IL_0018: ldc.i4.1
+				IL_0019: ldelem.ref
+				IL_001a: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
+				IL_001f: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::received
+				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0029: stloc.1
+				IL_002a: ldloc.0
+				IL_002b: ldstr "log"
+				IL_0030: ldloc.1
+				IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0036: pop
+				IL_0037: ldarg.0
+				IL_0038: ldc.i4.1
+				IL_0039: ldelem.ref
+				IL_003a: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
+				IL_003f: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::socket
+				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0049: stloc.0
+				IL_004a: ldstr "done:"
+				IL_004f: ldarg.0
+				IL_0050: ldc.i4.1
+				IL_0051: ldelem.ref
+				IL_0052: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
+				IL_0057: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::received
+				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0061: stloc.1
+				IL_0062: ldloc.0
+				IL_0063: ldstr "end"
+				IL_0068: ldloc.1
+				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_006e: pop
+				IL_006f: ldnull
+				IL_0070: ret
 			} // end of method FunctionExpression_server_L14C19::__js_call__
 
 		} // end of class FunctionExpression_server_L14C19
@@ -226,7 +201,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2752
+				// Method begins at RVA 0x26ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -363,7 +338,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x278a
+						// Method begins at RVA 0x26f2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -387,9 +362,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x269c
+					// Method begins at RVA 0x2610
 					// Header size: 12
-					// Code size: 110 (0x6e)
+					// Code size: 98 (0x62)
 					.maxstack 8
 					.locals init (
 						[0] object,
@@ -404,32 +379,28 @@
 					IL_000d: ldstr "Cannot access 'client' before initialization"
 					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 					IL_0017: stloc.0
-					IL_0018: ldstr "client"
-					IL_001d: ldloc.0
-					IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-					IL_0023: stloc.0
-					IL_0024: ldloc.0
-					IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_002a: stloc.0
-					IL_002b: ldc.i4.2
-					IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_0031: dup
-					IL_0032: ldc.r8 172
-					IL_003b: box [System.Runtime]System.Double
-					IL_0040: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_0045: dup
-					IL_0046: ldc.r8 33
-					IL_004f: box [System.Runtime]System.Double
-					IL_0054: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-					IL_005e: stloc.1
-					IL_005f: ldloc.0
-					IL_0060: ldstr "end"
-					IL_0065: ldloc.1
-					IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_006b: pop
-					IL_006c: ldnull
-					IL_006d: ret
+					IL_0018: ldloc.0
+					IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_001e: stloc.0
+					IL_001f: ldc.i4.2
+					IL_0020: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_0025: dup
+					IL_0026: ldc.r8 172
+					IL_002f: box [System.Runtime]System.Double
+					IL_0034: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_0039: dup
+					IL_003a: ldc.r8 33
+					IL_0043: box [System.Runtime]System.Double
+					IL_0048: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+					IL_0052: stloc.1
+					IL_0053: ldloc.0
+					IL_0054: ldstr "end"
+					IL_0059: ldloc.1
+					IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_005f: pop
+					IL_0060: ldnull
+					IL_0061: ret
 				} // end of method FunctionExpression_client::__js_call__
 
 			} // end of class FunctionExpression_client
@@ -441,7 +412,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2781
+					// Method begins at RVA 0x26e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -465,9 +436,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24ac
+				// Method begins at RVA 0x2458
 				// Header size: 12
-				// Code size: 191 (0xbf)
+				// Code size: 179 (0xb3)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/Scope,
@@ -485,66 +456,62 @@
 				IL_0013: ldstr "Cannot access 'client' before initialization"
 				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_001d: stloc.1
-				IL_001e: ldstr "client"
-				IL_0023: ldloc.1
-				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0029: stloc.1
-				IL_002a: ldloc.1
-				IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0030: stloc.1
-				IL_0031: ldc.i4.2
-				IL_0032: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0037: dup
-				IL_0038: ldc.r8 226
-				IL_0041: box [System.Runtime]System.Double
-				IL_0046: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_004b: dup
-				IL_004c: ldc.r8 130
-				IL_0055: box [System.Runtime]System.Double
-				IL_005a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_005f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-				IL_0064: stloc.2
-				IL_0065: ldloc.1
-				IL_0066: ldstr "write"
-				IL_006b: ldloc.2
-				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0071: pop
-				IL_0072: ldc.i4.3
-				IL_0073: newarr [System.Runtime]System.Object
+				IL_001e: ldloc.1
+				IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0024: stloc.1
+				IL_0025: ldc.i4.2
+				IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_002b: dup
+				IL_002c: ldc.r8 226
+				IL_0035: box [System.Runtime]System.Double
+				IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_003f: dup
+				IL_0040: ldc.r8 130
+				IL_0049: box [System.Runtime]System.Double
+				IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+				IL_0058: stloc.2
+				IL_0059: ldloc.1
+				IL_005a: ldstr "write"
+				IL_005f: ldloc.2
+				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0065: pop
+				IL_0066: ldc.i4.3
+				IL_0067: newarr [System.Runtime]System.Object
+				IL_006c: dup
+				IL_006d: ldc.i4.0
+				IL_006e: ldarg.0
+				IL_006f: ldc.i4.0
+				IL_0070: ldelem.ref
+				IL_0071: stelem.ref
+				IL_0072: dup
+				IL_0073: ldc.i4.1
+				IL_0074: ldarg.0
+				IL_0075: ldc.i4.1
+				IL_0076: ldelem.ref
+				IL_0077: stelem.ref
 				IL_0078: dup
-				IL_0079: ldc.i4.0
-				IL_007a: ldarg.0
-				IL_007b: ldc.i4.0
-				IL_007c: ldelem.ref
-				IL_007d: stelem.ref
-				IL_007e: dup
-				IL_007f: ldc.i4.1
-				IL_0080: ldarg.0
-				IL_0081: ldc.i4.1
-				IL_0082: ldelem.ref
-				IL_0083: stelem.ref
-				IL_0084: dup
-				IL_0085: ldc.i4.2
-				IL_0086: ldloc.0
-				IL_0087: stelem.ref
-				IL_0088: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client::__js_call__(object[], object)
-				IL_008e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0093: ldc.i4.0
-				IL_0094: conv.r8
-				IL_0095: ldstr ""
-				IL_009a: ldc.i4.0
-				IL_009b: ldc.i4.1
-				IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_00a1: stloc.1
-				IL_00a2: ldloc.1
-				IL_00a3: ldc.r8 0.0
-				IL_00ac: box [System.Runtime]System.Double
-				IL_00b1: ldc.i4.0
-				IL_00b2: newarr [System.Runtime]System.Object
-				IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
-				IL_00bc: pop
-				IL_00bd: ldnull
-				IL_00be: ret
+				IL_0079: ldc.i4.2
+				IL_007a: ldloc.0
+				IL_007b: stelem.ref
+				IL_007c: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client::__js_call__(object[], object)
+				IL_0082: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0087: ldc.i4.0
+				IL_0088: conv.r8
+				IL_0089: ldstr ""
+				IL_008e: ldc.i4.0
+				IL_008f: ldc.i4.1
+				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0095: stloc.1
+				IL_0096: ldloc.1
+				IL_0097: ldc.r8 0.0
+				IL_00a0: box [System.Runtime]System.Double
+				IL_00a5: ldc.i4.0
+				IL_00a6: newarr [System.Runtime]System.Object
+				IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
+				IL_00b0: pop
+				IL_00b1: ldnull
+				IL_00b2: ret
 			} // end of method FunctionExpression_client::__js_call__
 
 		} // end of class FunctionExpression_client
@@ -560,7 +527,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2793
+					// Method begins at RVA 0x26fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -585,9 +552,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2578
+				// Method begins at RVA 0x2518
 				// Header size: 12
-				// Code size: 114 (0x72)
+				// Code size: 100 (0x64)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -619,23 +586,17 @@
 				IL_0042: ldelem.ref
 				IL_0043: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
 				IL_0048: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
-				IL_004d: stloc.0
-				IL_004e: ldstr "reply"
-				IL_0053: ldloc.0
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0059: stloc.0
-				IL_005a: ldloc.0
-				IL_005b: ldarg.2
-				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0061: stloc.1
-				IL_0062: ldarg.0
-				IL_0063: ldc.i4.1
-				IL_0064: ldelem.ref
-				IL_0065: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
-				IL_006a: ldloc.1
-				IL_006b: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
-				IL_0070: ldnull
-				IL_0071: ret
+				IL_004d: ldarg.2
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0053: stloc.1
+				IL_0054: ldarg.0
+				IL_0055: ldc.i4.1
+				IL_0056: ldelem.ref
+				IL_0057: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
+				IL_005c: ldloc.1
+				IL_005d: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
+				IL_0062: ldnull
+				IL_0063: ret
 			} // end of method FunctionExpression_L31C20::__js_call__
 
 		} // end of class FunctionExpression_L31C20
@@ -655,7 +616,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27a5
+						// Method begins at RVA 0x270d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -678,7 +639,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2718
+					// Method begins at RVA 0x2680
 					// Header size: 12
 					// Code size: 37 (0x25)
 					.maxstack 8
@@ -710,7 +671,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x279c
+					// Method begins at RVA 0x2704
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -734,9 +695,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25f8
+				// Method begins at RVA 0x2588
 				// Header size: 12
-				// Code size: 150 (0x96)
+				// Code size: 122 (0x7a)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/Scope,
@@ -753,55 +714,43 @@
 				IL_0011: ldloc.1
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0017: stloc.1
-				IL_0018: ldarg.0
-				IL_0019: ldc.i4.1
-				IL_001a: ldelem.ref
-				IL_001b: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
-				IL_0020: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
-				IL_0025: stloc.2
-				IL_0026: ldstr "reply"
-				IL_002b: ldloc.2
-				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0031: stloc.2
-				IL_0032: ldstr "client recv:"
-				IL_0037: ldloc.2
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_003d: stloc.3
-				IL_003e: ldloc.1
-				IL_003f: ldstr "log"
-				IL_0044: ldloc.3
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004a: pop
-				IL_004b: ldarg.0
-				IL_004c: ldc.i4.0
-				IL_004d: ldelem.ref
-				IL_004e: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-				IL_0053: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
-				IL_0058: stloc.1
-				IL_0059: ldstr "server"
-				IL_005e: ldloc.1
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0064: stloc.1
-				IL_0065: ldloc.1
-				IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_006b: stloc.1
-				IL_006c: ldnull
-				IL_006d: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17::__js_call__(object)
-				IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0078: ldc.i4.0
-				IL_0079: conv.r8
-				IL_007a: ldstr ""
-				IL_007f: ldc.i4.0
-				IL_0080: ldc.i4.1
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0086: stloc.2
-				IL_0087: ldloc.1
-				IL_0088: ldstr "close"
-				IL_008d: ldloc.2
-				IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0093: pop
-				IL_0094: ldnull
-				IL_0095: ret
+				IL_0018: ldstr "client recv:"
+				IL_001d: ldarg.0
+				IL_001e: ldc.i4.1
+				IL_001f: ldelem.ref
+				IL_0020: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
+				IL_0025: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_002f: stloc.2
+				IL_0030: ldloc.1
+				IL_0031: ldstr "log"
+				IL_0036: ldloc.2
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_003c: pop
+				IL_003d: ldarg.0
+				IL_003e: ldc.i4.0
+				IL_003f: ldelem.ref
+				IL_0040: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
+				IL_0045: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
+				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_004f: stloc.1
+				IL_0050: ldnull
+				IL_0051: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17::__js_call__(object)
+				IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_005c: ldc.i4.0
+				IL_005d: conv.r8
+				IL_005e: ldstr ""
+				IL_0063: ldc.i4.0
+				IL_0064: ldc.i4.1
+				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_006a: stloc.3
+				IL_006b: ldloc.1
+				IL_006c: ldstr "close"
+				IL_0071: ldloc.3
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0077: pop
+				IL_0078: ldnull
+				IL_0079: ret
 			} // end of method FunctionExpression_L36C19::__js_call__
 
 		} // end of class FunctionExpression_L36C19
@@ -822,7 +771,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x276d
+				// Method begins at RVA 0x26d5
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -853,7 +802,7 @@
 			)
 			// Method begins at RVA 0x21e8
 			// Header size: 12
-			// Code size: 398 (0x18e)
+			// Code size: 370 (0x172)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope,
@@ -868,151 +817,139 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
-			IL_000c: stloc.2
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.2
 			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.2
+			IL_001e: ldloc.2
+			IL_001f: stloc.1
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::net
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: stloc.1
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::net
-			IL_0034: stloc.2
-			IL_0035: ldstr "net"
-			IL_003a: ldloc.2
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0040: stloc.2
-			IL_0041: ldloc.2
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0047: stloc.2
-			IL_0048: ldloc.1
-			IL_0049: ldstr "port"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0053: stloc.3
-			IL_0054: ldloc.1
-			IL_0055: ldstr "address"
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005f: stloc.s 4
-			IL_0061: ldc.i4.2
-			IL_0062: newarr [System.Runtime]System.Object
-			IL_0067: dup
-			IL_0068: ldc.i4.0
-			IL_0069: ldarg.0
-			IL_006a: stelem.ref
-			IL_006b: dup
-			IL_006c: ldc.i4.1
-			IL_006d: ldloc.0
-			IL_006e: stelem.ref
-			IL_006f: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_007a: ldc.i4.0
-			IL_007b: conv.r8
-			IL_007c: ldstr ""
-			IL_0081: ldc.i4.0
-			IL_0082: ldc.i4.1
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0088: stloc.s 5
-			IL_008a: ldloc.2
-			IL_008b: ldstr "connect"
-			IL_0090: ldloc.3
-			IL_0091: ldloc.s 4
-			IL_0093: ldloc.s 5
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_009a: stloc.s 5
-			IL_009c: ldloc.0
-			IL_009d: ldloc.s 5
-			IL_009f: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_00a4: ldloc.0
-			IL_00a5: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_00aa: ldstr "Cannot access 'client' before initialization"
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00b4: stloc.s 5
-			IL_00b6: ldloc.s 5
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00bd: stloc.s 5
-			IL_00bf: ldloc.s 5
-			IL_00c1: ldstr "setEncoding"
-			IL_00c6: ldstr "utf8"
-			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00d0: pop
-			IL_00d1: ldloc.0
-			IL_00d2: ldstr ""
-			IL_00d7: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
-			IL_00dc: ldloc.0
-			IL_00dd: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_00e2: ldstr "Cannot access 'client' before initialization"
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00ec: stloc.s 5
-			IL_00ee: ldloc.s 5
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f5: stloc.s 5
-			IL_00f7: ldc.i4.2
-			IL_00f8: newarr [System.Runtime]System.Object
-			IL_00fd: dup
-			IL_00fe: ldc.i4.0
-			IL_00ff: ldarg.0
-			IL_0100: stelem.ref
-			IL_0101: dup
-			IL_0102: ldc.i4.1
-			IL_0103: ldloc.0
-			IL_0104: stelem.ref
-			IL_0105: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20::__js_call__(object[], object, object)
-			IL_010b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0110: ldc.i4.1
-			IL_0111: conv.r8
-			IL_0112: ldstr ""
-			IL_0117: ldc.i4.0
-			IL_0118: ldc.i4.1
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_011e: stloc.s 4
-			IL_0120: ldloc.s 5
-			IL_0122: ldstr "on"
-			IL_0127: ldstr "data"
-			IL_012c: ldloc.s 4
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0133: pop
-			IL_0134: ldloc.0
-			IL_0135: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_013a: ldstr "Cannot access 'client' before initialization"
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0144: stloc.s 4
-			IL_0146: ldloc.s 4
-			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014d: stloc.s 4
-			IL_014f: ldc.i4.2
-			IL_0150: newarr [System.Runtime]System.Object
-			IL_0155: dup
-			IL_0156: ldc.i4.0
-			IL_0157: ldarg.0
-			IL_0158: stelem.ref
-			IL_0159: dup
-			IL_015a: ldc.i4.1
-			IL_015b: ldloc.0
-			IL_015c: stelem.ref
-			IL_015d: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19::__js_call__(object[], object)
-			IL_0163: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0168: ldc.i4.0
-			IL_0169: conv.r8
-			IL_016a: ldstr ""
-			IL_016f: ldc.i4.0
-			IL_0170: ldc.i4.1
-			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0176: stloc.s 5
-			IL_0178: ldloc.s 4
-			IL_017a: ldstr "on"
-			IL_017f: ldstr "end"
-			IL_0184: ldloc.s 5
-			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_018b: pop
-			IL_018c: ldnull
-			IL_018d: ret
+			IL_002c: ldloc.1
+			IL_002d: ldstr "port"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.3
+			IL_0038: ldloc.1
+			IL_0039: ldstr "address"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0043: stloc.s 4
+			IL_0045: ldc.i4.2
+			IL_0046: newarr [System.Runtime]System.Object
+			IL_004b: dup
+			IL_004c: ldc.i4.0
+			IL_004d: ldarg.0
+			IL_004e: stelem.ref
+			IL_004f: dup
+			IL_0050: ldc.i4.1
+			IL_0051: ldloc.0
+			IL_0052: stelem.ref
+			IL_0053: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_005e: ldc.i4.0
+			IL_005f: conv.r8
+			IL_0060: ldstr ""
+			IL_0065: ldc.i4.0
+			IL_0066: ldc.i4.1
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_006c: stloc.s 5
+			IL_006e: ldloc.2
+			IL_006f: ldstr "connect"
+			IL_0074: ldloc.3
+			IL_0075: ldloc.s 4
+			IL_0077: ldloc.s 5
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_007e: stloc.s 5
+			IL_0080: ldloc.0
+			IL_0081: ldloc.s 5
+			IL_0083: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_0088: ldloc.0
+			IL_0089: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_008e: ldstr "Cannot access 'client' before initialization"
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0098: stloc.s 5
+			IL_009a: ldloc.s 5
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a1: stloc.s 5
+			IL_00a3: ldloc.s 5
+			IL_00a5: ldstr "setEncoding"
+			IL_00aa: ldstr "utf8"
+			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00b4: pop
+			IL_00b5: ldloc.0
+			IL_00b6: ldstr ""
+			IL_00bb: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
+			IL_00c0: ldloc.0
+			IL_00c1: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_00c6: ldstr "Cannot access 'client' before initialization"
+			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00d0: stloc.s 5
+			IL_00d2: ldloc.s 5
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d9: stloc.s 5
+			IL_00db: ldc.i4.2
+			IL_00dc: newarr [System.Runtime]System.Object
+			IL_00e1: dup
+			IL_00e2: ldc.i4.0
+			IL_00e3: ldarg.0
+			IL_00e4: stelem.ref
+			IL_00e5: dup
+			IL_00e6: ldc.i4.1
+			IL_00e7: ldloc.0
+			IL_00e8: stelem.ref
+			IL_00e9: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20::__js_call__(object[], object, object)
+			IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00f4: ldc.i4.1
+			IL_00f5: conv.r8
+			IL_00f6: ldstr ""
+			IL_00fb: ldc.i4.0
+			IL_00fc: ldc.i4.1
+			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0102: stloc.s 4
+			IL_0104: ldloc.s 5
+			IL_0106: ldstr "on"
+			IL_010b: ldstr "data"
+			IL_0110: ldloc.s 4
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0117: pop
+			IL_0118: ldloc.0
+			IL_0119: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_011e: ldstr "Cannot access 'client' before initialization"
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0128: stloc.s 4
+			IL_012a: ldloc.s 4
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0131: stloc.s 4
+			IL_0133: ldc.i4.2
+			IL_0134: newarr [System.Runtime]System.Object
+			IL_0139: dup
+			IL_013a: ldc.i4.0
+			IL_013b: ldarg.0
+			IL_013c: stelem.ref
+			IL_013d: dup
+			IL_013e: ldc.i4.1
+			IL_013f: ldloc.0
+			IL_0140: stelem.ref
+			IL_0141: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19::__js_call__(object[], object)
+			IL_0147: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_014c: ldc.i4.0
+			IL_014d: conv.r8
+			IL_014e: ldstr ""
+			IL_0153: ldc.i4.0
+			IL_0154: ldc.i4.1
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_015a: stloc.s 5
+			IL_015c: ldloc.s 4
+			IL_015e: ldstr "on"
+			IL_0163: ldstr "end"
+			IL_0168: ldloc.s 5
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_016f: pop
+			IL_0170: ldnull
+			IL_0171: ret
 		} // end of method FunctionExpression_L20C30::__js_call__
 
 	} // end of class FunctionExpression_L20C30
@@ -1033,7 +970,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2749
+			// Method begins at RVA 0x26b1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1148,7 +1085,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27ae
+		// Method begins at RVA 0x2716
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Timeout_Allows_Graceful_End.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Timeout_Allows_Graceful_End.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24c8
+					// Method begins at RVA 0x2482
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,14 +46,13 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22f8
+				// Method begins at RVA 0x22dc
 				// Header size: 12
-				// Code size: 168 (0xa8)
+				// Code size: 138 (0x8a)
 				.maxstack 8
 				.locals init (
 					[0] object,
-					[1] object,
-					[2] object
+					[1] object
 				)
 
 				IL_0000: ldstr "console"
@@ -73,49 +72,35 @@
 				IL_002e: ldloc.0
 				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0034: stloc.0
-				IL_0035: ldarg.0
-				IL_0036: ldc.i4.1
-				IL_0037: ldelem.ref
-				IL_0038: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope
-				IL_003d: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope::socket
-				IL_0042: stloc.1
-				IL_0043: ldstr "socket"
-				IL_0048: ldloc.1
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_004e: stloc.1
-				IL_004f: ldloc.1
-				IL_0050: ldstr "writable"
-				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_005a: stloc.1
-				IL_005b: ldstr "server writable:"
-				IL_0060: ldloc.1
-				IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0066: stloc.2
-				IL_0067: ldloc.0
-				IL_0068: ldstr "log"
-				IL_006d: ldloc.2
-				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0073: pop
-				IL_0074: ldarg.0
-				IL_0075: ldc.i4.1
-				IL_0076: ldelem.ref
-				IL_0077: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope
-				IL_007c: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope::socket
-				IL_0081: stloc.0
-				IL_0082: ldstr "socket"
-				IL_0087: ldloc.0
-				IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_008d: stloc.0
-				IL_008e: ldloc.0
-				IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0094: stloc.0
-				IL_0095: ldloc.0
-				IL_0096: ldstr "end"
-				IL_009b: ldstr "timeout-response"
-				IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00a5: pop
-				IL_00a6: ldnull
-				IL_00a7: ret
+				IL_0035: ldstr "server writable:"
+				IL_003a: ldarg.0
+				IL_003b: ldc.i4.1
+				IL_003c: ldelem.ref
+				IL_003d: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope
+				IL_0042: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope::socket
+				IL_0047: ldstr "writable"
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0056: stloc.1
+				IL_0057: ldloc.0
+				IL_0058: ldstr "log"
+				IL_005d: ldloc.1
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0063: pop
+				IL_0064: ldarg.0
+				IL_0065: ldc.i4.1
+				IL_0066: ldelem.ref
+				IL_0067: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope
+				IL_006c: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope::socket
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0076: stloc.0
+				IL_0077: ldloc.0
+				IL_0078: ldstr "end"
+				IL_007d: ldstr "timeout-response"
+				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0087: pop
+				IL_0088: ldnull
+				IL_0089: ret
 			} // end of method FunctionExpression_server::__js_call__
 
 		} // end of class FunctionExpression_server
@@ -131,7 +116,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24d1
+					// Method begins at RVA 0x248b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -155,7 +140,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23ac
+				// Method begins at RVA 0x2374
 				// Header size: 12
 				// Code size: 45 (0x2d)
 				.maxstack 8
@@ -199,7 +184,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24bf
+				// Method begins at RVA 0x2479
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -312,7 +297,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24e3
+					// Method begins at RVA 0x249d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -335,7 +320,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23e8
+				// Method begins at RVA 0x23b0
 				// Header size: 12
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -371,7 +356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24ec
+					// Method begins at RVA 0x24a6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -395,7 +380,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x241c
+				// Method begins at RVA 0x23e4
 				// Header size: 12
 				// Code size: 45 (0x2d)
 				.maxstack 8
@@ -436,7 +421,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24f5
+					// Method begins at RVA 0x24af
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -460,9 +445,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2458
+				// Method begins at RVA 0x2420
 				// Header size: 12
-				// Code size: 82 (0x52)
+				// Code size: 68 (0x44)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -484,20 +469,14 @@
 				IL_0025: ldelem.ref
 				IL_0026: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
 				IL_002b: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
-				IL_0030: stloc.0
-				IL_0031: ldstr "server"
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0035: stloc.0
 				IL_0036: ldloc.0
-				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_003c: stloc.0
-				IL_003d: ldloc.0
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0043: stloc.0
-				IL_0044: ldloc.0
-				IL_0045: ldstr "close"
-				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_004f: pop
-				IL_0050: ldnull
-				IL_0051: ret
+				IL_0037: ldstr "close"
+				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0041: pop
+				IL_0042: ldnull
+				IL_0043: ret
 			} // end of method FunctionExpression_L28C19::__js_call__
 
 		} // end of class FunctionExpression_L28C19
@@ -509,7 +488,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24da
+				// Method begins at RVA 0x2494
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -537,7 +516,7 @@
 			)
 			// Method begins at RVA 0x21bc
 			// Header size: 12
-			// Code size: 301 (0x12d)
+			// Code size: 273 (0x111)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/Scope,
@@ -553,114 +532,102 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
-			IL_000c: stloc.3
-			IL_000d: ldstr "server"
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0011: stloc.3
 			IL_0012: ldloc.3
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.3
-			IL_0019: ldloc.3
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.3
-			IL_0020: ldloc.3
-			IL_0021: ldstr "address"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0013: ldstr "address"
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_001d: stloc.3
+			IL_001e: ldloc.3
+			IL_001f: stloc.1
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002b: stloc.3
-			IL_002c: ldloc.3
-			IL_002d: stloc.1
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
-			IL_0034: stloc.3
-			IL_0035: ldstr "net"
-			IL_003a: ldloc.3
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0040: stloc.3
-			IL_0041: ldloc.3
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0047: stloc.3
-			IL_0048: ldloc.1
-			IL_0049: ldstr "port"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0053: stloc.s 4
-			IL_0055: ldloc.1
-			IL_0056: ldstr "address"
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0060: stloc.s 5
-			IL_0062: ldnull
-			IL_0063: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client::__js_call__(object)
-			IL_0069: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_006e: ldc.i4.0
-			IL_006f: conv.r8
-			IL_0070: ldstr ""
-			IL_0075: ldc.i4.0
-			IL_0076: ldc.i4.1
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_007c: stloc.s 6
-			IL_007e: ldloc.3
-			IL_007f: ldstr "connect"
-			IL_0084: ldloc.s 4
-			IL_0086: ldloc.s 5
-			IL_0088: ldloc.s 6
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_008f: stloc.s 6
-			IL_0091: ldloc.s 6
-			IL_0093: stloc.2
-			IL_0094: ldloc.2
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009a: stloc.s 6
-			IL_009c: ldloc.s 6
-			IL_009e: ldstr "setEncoding"
-			IL_00a3: ldstr "utf8"
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ad: pop
-			IL_00ae: ldloc.2
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b4: stloc.s 6
-			IL_00b6: ldnull
-			IL_00b7: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20::__js_call__(object, object)
-			IL_00bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00c2: ldc.i4.1
-			IL_00c3: conv.r8
-			IL_00c4: ldstr ""
-			IL_00c9: ldc.i4.0
-			IL_00ca: ldc.i4.1
-			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_002c: ldloc.1
+			IL_002d: ldstr "port"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: stloc.s 4
+			IL_0039: ldloc.1
+			IL_003a: ldstr "address"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0044: stloc.s 5
+			IL_0046: ldnull
+			IL_0047: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client::__js_call__(object)
+			IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0052: ldc.i4.0
+			IL_0053: conv.r8
+			IL_0054: ldstr ""
+			IL_0059: ldc.i4.0
+			IL_005a: ldc.i4.1
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0060: stloc.s 6
+			IL_0062: ldloc.3
+			IL_0063: ldstr "connect"
+			IL_0068: ldloc.s 4
+			IL_006a: ldloc.s 5
+			IL_006c: ldloc.s 6
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0073: stloc.s 6
+			IL_0075: ldloc.s 6
+			IL_0077: stloc.2
+			IL_0078: ldloc.2
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_007e: stloc.s 6
+			IL_0080: ldloc.s 6
+			IL_0082: ldstr "setEncoding"
+			IL_0087: ldstr "utf8"
+			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0091: pop
+			IL_0092: ldloc.2
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0098: stloc.s 6
+			IL_009a: ldnull
+			IL_009b: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20::__js_call__(object, object)
+			IL_00a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00a6: ldc.i4.1
+			IL_00a7: conv.r8
+			IL_00a8: ldstr ""
+			IL_00ad: ldc.i4.0
+			IL_00ae: ldc.i4.1
+			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00b4: stloc.s 5
+			IL_00b6: ldloc.s 6
+			IL_00b8: ldstr "on"
+			IL_00bd: ldstr "data"
+			IL_00c2: ldloc.s 5
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00c9: pop
+			IL_00ca: ldloc.2
+			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00d0: stloc.s 5
-			IL_00d2: ldloc.s 6
-			IL_00d4: ldstr "on"
-			IL_00d9: ldstr "data"
-			IL_00de: ldloc.s 5
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00e5: pop
-			IL_00e6: ldloc.2
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ec: stloc.s 5
-			IL_00ee: ldc.i4.2
-			IL_00ef: newarr [System.Runtime]System.Object
-			IL_00f4: dup
-			IL_00f5: ldc.i4.0
-			IL_00f6: ldarg.0
-			IL_00f7: stelem.ref
-			IL_00f8: dup
-			IL_00f9: ldc.i4.1
-			IL_00fa: ldloc.0
-			IL_00fb: stelem.ref
-			IL_00fc: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19::__js_call__(object[], object)
-			IL_0102: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0107: ldc.i4.0
-			IL_0108: conv.r8
-			IL_0109: ldstr ""
-			IL_010e: ldc.i4.0
-			IL_010f: ldc.i4.1
-			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0115: stloc.s 6
-			IL_0117: ldloc.s 5
-			IL_0119: ldstr "on"
-			IL_011e: ldstr "end"
-			IL_0123: ldloc.s 6
-			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_012a: pop
-			IL_012b: ldnull
-			IL_012c: ret
+			IL_00d2: ldc.i4.2
+			IL_00d3: newarr [System.Runtime]System.Object
+			IL_00d8: dup
+			IL_00d9: ldc.i4.0
+			IL_00da: ldarg.0
+			IL_00db: stelem.ref
+			IL_00dc: dup
+			IL_00dd: ldc.i4.1
+			IL_00de: ldloc.0
+			IL_00df: stelem.ref
+			IL_00e0: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19::__js_call__(object[], object)
+			IL_00e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_00eb: ldc.i4.0
+			IL_00ec: conv.r8
+			IL_00ed: ldstr ""
+			IL_00f2: ldc.i4.0
+			IL_00f3: ldc.i4.1
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00f9: stloc.s 6
+			IL_00fb: ldloc.s 5
+			IL_00fd: ldstr "on"
+			IL_0102: ldstr "end"
+			IL_0107: ldloc.s 6
+			IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_010e: pop
+			IL_010f: ldnull
+			IL_0110: ret
 		} // end of method FunctionExpression_L17C30::__js_call__
 
 	} // end of class FunctionExpression_L17C30
@@ -681,7 +648,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24b6
+			// Method begins at RVA 0x2470
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -796,7 +763,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24fe
+		// Method begins at RVA 0x24b8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x213b
+				// Method begins at RVA 0x212d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,7 +48,7 @@
 			)
 			// Method begins at RVA 0x20fc
 			// Header size: 12
-			// Code size: 42 (0x2a)
+			// Code size: 28 (0x1c)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -56,22 +56,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Path_Join_NestedFunction/Scope::path
-			IL_0006: stloc.0
-			IL_0007: ldstr "path"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000d: ldstr "join"
+			IL_0012: ldarg.2
+			IL_0013: ldarg.3
+			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 			IL_0019: stloc.0
 			IL_001a: ldloc.0
-			IL_001b: ldstr "join"
-			IL_0020: ldarg.2
-			IL_0021: ldarg.3
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0027: stloc.0
-			IL_0028: ldloc.0
-			IL_0029: ret
+			IL_001b: ret
 		} // end of method joinWrapper::__js_call__
 
 	} // end of class joinWrapper
@@ -92,7 +86,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2132
+			// Method begins at RVA 0x2124
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -199,7 +193,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2144
+		// Method begins at RVA 0x2136
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Chdir_And_NextTick_Basics.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Chdir_And_NextTick_Basics.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230d
+				// Method begins at RVA 0x22ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,30 +46,23 @@
 			)
 			// Method begins at RVA 0x2240
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] float64,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "tick"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
+			IL_0006: ldstr "tick"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L10C18::__js_call__
 
 	} // end of class ArrowFunction_L10C18
@@ -85,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2316
+				// Method begins at RVA 0x22d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,60 +104,44 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x227c
+			// Method begins at RVA 0x2268
 			// Header size: 12
-			// Code size: 124 (0x7c)
+			// Code size: 81 (0x51)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object,
-				[2] object
+				[0] object,
+				[1] string
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "immediate"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldstr "console"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0035: stloc.1
-			IL_0036: ldloc.1
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0006: ldstr "immediate"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldstr "console"
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_001b: stloc.0
+			IL_001c: ldloc.0
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0022: stloc.0
+			IL_0023: ldarg.0
+			IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
+			IL_0029: ldc.i4.1
+			IL_002a: newarr [System.Runtime]System.Object
+			IL_002f: dup
+			IL_0030: ldc.i4.0
+			IL_0031: ldstr ","
+			IL_0036: stelem.ref
+			IL_0037: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
 			IL_003c: stloc.1
-			IL_003d: ldarg.0
-			IL_003e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
-			IL_0043: stloc.0
-			IL_0044: ldstr "order"
-			IL_0049: ldloc.0
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_004f: stloc.2
-			IL_0050: ldloc.2
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.2
-			IL_0057: ldloc.2
-			IL_0058: ldstr "join"
-			IL_005d: ldstr ","
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: stloc.2
-			IL_0068: ldloc.1
-			IL_0069: ldstr "log"
-			IL_006e: ldstr "order"
-			IL_0073: ldloc.2
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0079: pop
-			IL_007a: ldnull
-			IL_007b: ret
+			IL_003d: ldloc.0
+			IL_003e: ldstr "log"
+			IL_0043: ldstr "order"
+			IL_0048: ldloc.1
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_004e: pop
+			IL_004f: ldnull
+			IL_0050: ret
 		} // end of method ArrowFunction_L12C14::__js_call__
 
 	} // end of class ArrowFunction_L12C14
@@ -183,7 +160,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2304
+			// Method begins at RVA 0x22c5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -405,7 +382,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x231f
+		// Method begins at RVA 0x22e0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_And_Promise_Ordering.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_And_Promise_Ordering.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24fe
+				// Method begins at RVA 0x2450
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,30 +46,23 @@
 			)
 			// Method begins at RVA 0x220c
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] float64,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "nextTick1"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
+			IL_0006: ldstr "nextTick1"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L7C18::__js_call__
 
 	} // end of class ArrowFunction_L7C18
@@ -89,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2510
+					// Method begins at RVA 0x2462
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -113,12 +106,12 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23b0
+				// Method begins at RVA 0x2350
 				// Header size: 12
-				// Code size: 52 (0x34)
+				// Code size: 33 (0x21)
 				.maxstack 8
 				.locals init (
-					[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+					[0] float64,
 					[1] object
 				)
 
@@ -127,21 +120,14 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
 				IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-				IL_000d: stloc.0
-				IL_000e: ldstr "order"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldloc.1
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldstr "push"
-				IL_0027: ldstr "nextTickFromPromise"
-				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0031: stloc.1
-				IL_0032: ldloc.1
-				IL_0033: ret
+				IL_000d: ldstr "nextTickFromPromise"
+				IL_0012: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0017: stloc.0
+				IL_0018: ldloc.0
+				IL_0019: box [System.Runtime]System.Double
+				IL_001e: stloc.1
+				IL_001f: ldloc.1
+				IL_0020: ret
 			} // end of method ArrowFunction_L11C20::__js_call__
 
 		} // end of class ArrowFunction_L11C20
@@ -153,7 +139,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2507
+				// Method begins at RVA 0x2459
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -179,70 +165,59 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2248
+			// Method begins at RVA 0x2234
 			// Header size: 12
-			// Code size: 138 (0x8a)
+			// Code size: 112 (0x70)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/Scope,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object,
-				[3] object
+				[1] object,
+				[2] object
 			)
 
 			IL_0000: newobj instance void Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-			IL_000c: stloc.1
-			IL_000d: ldstr "order"
-			IL_0012: ldloc.1
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "push"
-			IL_0026: ldstr "promise1"
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0030: pop
-			IL_0031: ldstr "process"
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_003b: stloc.2
-			IL_003c: ldloc.2
-			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0042: stloc.2
-			IL_0043: ldnull
-			IL_0044: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/ArrowFunction_L11C20::__js_call__(object[], object)
-			IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_004f: ldc.i4.2
-			IL_0050: newarr [System.Runtime]System.Object
-			IL_0055: dup
-			IL_0056: ldc.i4.0
-			IL_0057: ldarg.0
-			IL_0058: stelem.ref
-			IL_0059: dup
-			IL_005a: ldc.i4.1
-			IL_005b: ldloc.0
-			IL_005c: stelem.ref
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0067: ldc.i4.0
-			IL_0068: conv.r8
-			IL_0069: ldstr ""
-			IL_006e: ldc.i4.0
-			IL_006f: ldc.i4.1
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_007a: stloc.3
-			IL_007b: ldloc.2
-			IL_007c: ldstr "nextTick"
-			IL_0081: ldloc.3
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0087: pop
-			IL_0088: ldnull
-			IL_0089: ret
+			IL_000c: ldstr "promise1"
+			IL_0011: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0016: pop
+			IL_0017: ldstr "process"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0021: stloc.1
+			IL_0022: ldloc.1
+			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0028: stloc.1
+			IL_0029: ldnull
+			IL_002a: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/ArrowFunction_L11C20::__js_call__(object[], object)
+			IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0035: ldc.i4.2
+			IL_0036: newarr [System.Runtime]System.Object
+			IL_003b: dup
+			IL_003c: ldc.i4.0
+			IL_003d: ldarg.0
+			IL_003e: stelem.ref
+			IL_003f: dup
+			IL_0040: ldc.i4.1
+			IL_0041: ldloc.0
+			IL_0042: stelem.ref
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_004d: ldc.i4.0
+			IL_004e: conv.r8
+			IL_004f: ldstr ""
+			IL_0054: ldc.i4.0
+			IL_0055: ldc.i4.1
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0060: stloc.2
+			IL_0061: ldloc.1
+			IL_0062: ldstr "nextTick"
+			IL_0067: ldloc.2
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_006d: pop
+			IL_006e: ldnull
+			IL_006f: ret
 		} // end of method ArrowFunction_L9C25::__js_call__
 
 	} // end of class ArrowFunction_L9C25
@@ -258,7 +233,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2519
+				// Method begins at RVA 0x246b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -284,32 +259,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x22e0
+			// Method begins at RVA 0x22b0
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] float64,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "promise2"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
+			IL_0006: ldstr "promise2"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L14C25::__js_call__
 
 	} // end of class ArrowFunction_L14C25
@@ -329,7 +297,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x252b
+					// Method begins at RVA 0x247d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -353,17 +321,16 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23f0
+				// Method begins at RVA 0x2380
 				// Header size: 12
-				// Code size: 249 (0xf9)
+				// Code size: 187 (0xbb)
 				.maxstack 8
 				.locals init (
 					[0] string,
-					[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-					[2] object,
-					[3] object,
-					[4] bool,
-					[5] object
+					[1] object,
+					[2] string,
+					[3] bool,
+					[4] object
 				)
 
 				IL_0000: ldarg.0
@@ -371,90 +338,70 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
 				IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-				IL_000d: stloc.1
-				IL_000e: ldstr "order"
-				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.2
-				IL_001a: ldloc.2
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.2
-				IL_0021: ldloc.2
-				IL_0022: ldstr "push"
-				IL_0027: ldstr "setTimeout"
-				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0031: pop
-				IL_0032: ldstr "console"
-				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_003c: stloc.2
-				IL_003d: ldloc.2
-				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0043: stloc.2
-				IL_0044: ldarg.0
-				IL_0045: ldc.i4.0
-				IL_0046: ldelem.ref
-				IL_0047: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-				IL_0051: stloc.1
-				IL_0052: ldstr "order"
-				IL_0057: ldloc.1
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_005d: stloc.3
-				IL_005e: ldloc.3
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0064: stloc.3
-				IL_0065: ldloc.3
-				IL_0066: ldstr "join"
-				IL_006b: ldstr ","
-				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0075: stloc.3
-				IL_0076: ldloc.2
-				IL_0077: ldstr "log"
-				IL_007c: ldstr "order"
-				IL_0081: ldloc.3
-				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0087: pop
-				IL_0088: ldstr "sync,nextTick1,promise1,nextTickFromPromise,promise2,setImmediate,setTimeout"
-				IL_008d: stloc.0
-				IL_008e: ldstr "console"
-				IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0098: stloc.3
-				IL_0099: ldloc.3
-				IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_009f: stloc.3
-				IL_00a0: ldarg.0
-				IL_00a1: ldc.i4.0
-				IL_00a2: ldelem.ref
-				IL_00a3: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-				IL_00a8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-				IL_00ad: stloc.1
-				IL_00ae: ldstr "order"
-				IL_00b3: ldloc.1
-				IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00b9: stloc.2
-				IL_00ba: ldloc.2
-				IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00c0: stloc.2
-				IL_00c1: ldloc.2
-				IL_00c2: ldstr "join"
-				IL_00c7: ldstr ","
-				IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00d1: stloc.2
-				IL_00d2: ldloc.2
-				IL_00d3: ldloc.0
-				IL_00d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00d9: stloc.s 4
-				IL_00db: ldloc.s 4
-				IL_00dd: box [System.Runtime]System.Boolean
-				IL_00e2: stloc.s 5
-				IL_00e4: ldloc.3
-				IL_00e5: ldstr "log"
-				IL_00ea: ldstr "correct order"
-				IL_00ef: ldloc.s 5
-				IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00f6: pop
-				IL_00f7: ldnull
-				IL_00f8: ret
+				IL_000d: ldstr "setTimeout"
+				IL_0012: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0017: pop
+				IL_0018: ldstr "console"
+				IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0022: stloc.1
+				IL_0023: ldloc.1
+				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0029: stloc.1
+				IL_002a: ldarg.0
+				IL_002b: ldc.i4.0
+				IL_002c: ldelem.ref
+				IL_002d: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
+				IL_0032: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
+				IL_0037: ldc.i4.1
+				IL_0038: newarr [System.Runtime]System.Object
+				IL_003d: dup
+				IL_003e: ldc.i4.0
+				IL_003f: ldstr ","
+				IL_0044: stelem.ref
+				IL_0045: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+				IL_004a: stloc.2
+				IL_004b: ldloc.1
+				IL_004c: ldstr "log"
+				IL_0051: ldstr "order"
+				IL_0056: ldloc.2
+				IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_005c: pop
+				IL_005d: ldstr "sync,nextTick1,promise1,nextTickFromPromise,promise2,setImmediate,setTimeout"
+				IL_0062: stloc.0
+				IL_0063: ldstr "console"
+				IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_006d: stloc.1
+				IL_006e: ldloc.1
+				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0074: stloc.1
+				IL_0075: ldarg.0
+				IL_0076: ldc.i4.0
+				IL_0077: ldelem.ref
+				IL_0078: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
+				IL_007d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
+				IL_0082: ldc.i4.1
+				IL_0083: newarr [System.Runtime]System.Object
+				IL_0088: dup
+				IL_0089: ldc.i4.0
+				IL_008a: ldstr ","
+				IL_008f: stelem.ref
+				IL_0090: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+				IL_0095: stloc.2
+				IL_0096: ldloc.2
+				IL_0097: ldloc.0
+				IL_0098: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_009d: stloc.3
+				IL_009e: ldloc.3
+				IL_009f: box [System.Runtime]System.Boolean
+				IL_00a4: stloc.s 4
+				IL_00a6: ldloc.1
+				IL_00a7: ldstr "log"
+				IL_00ac: ldstr "correct order"
+				IL_00b1: ldloc.s 4
+				IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00b8: pop
+				IL_00b9: ldnull
+				IL_00ba: ret
 			} // end of method ArrowFunction_L18C14::__js_call__
 
 		} // end of class ArrowFunction_L18C14
@@ -466,7 +413,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2522
+				// Method begins at RVA 0x2474
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -492,65 +439,54 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x231c
+			// Method begins at RVA 0x22d8
 			// Header size: 12
-			// Code size: 134 (0x86)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/Scope,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object
+				[1] object
 			)
 
 			IL_0000: newobj instance void Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_And_Promise_Ordering/Scope::order
-			IL_000c: stloc.1
-			IL_000d: ldstr "order"
-			IL_0012: ldloc.1
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "push"
-			IL_0026: ldstr "setImmediate"
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0030: pop
-			IL_0031: ldnull
-			IL_0032: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/ArrowFunction_L18C14::__js_call__(object[], object)
-			IL_0038: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_003d: ldc.i4.2
-			IL_003e: newarr [System.Runtime]System.Object
-			IL_0043: dup
-			IL_0044: ldc.i4.0
-			IL_0045: ldarg.0
-			IL_0046: stelem.ref
-			IL_0047: dup
-			IL_0048: ldc.i4.1
-			IL_0049: ldloc.0
-			IL_004a: stelem.ref
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0055: ldc.i4.0
-			IL_0056: conv.r8
-			IL_0057: ldstr ""
-			IL_005c: ldc.i4.0
-			IL_005d: ldc.i4.1
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0068: stloc.2
-			IL_0069: ldloc.2
-			IL_006a: ldc.r8 0.0
-			IL_0073: box [System.Runtime]System.Double
-			IL_0078: ldc.i4.0
-			IL_0079: newarr [System.Runtime]System.Object
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
-			IL_0083: pop
-			IL_0084: ldnull
-			IL_0085: ret
+			IL_000c: ldstr "setImmediate"
+			IL_0011: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0016: pop
+			IL_0017: ldnull
+			IL_0018: ldftn object Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/ArrowFunction_L18C14::__js_call__(object[], object)
+			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0023: ldc.i4.2
+			IL_0024: newarr [System.Runtime]System.Object
+			IL_0029: dup
+			IL_002a: ldc.i4.0
+			IL_002b: ldarg.0
+			IL_002c: stelem.ref
+			IL_002d: dup
+			IL_002e: ldc.i4.1
+			IL_002f: ldloc.0
+			IL_0030: stelem.ref
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_003b: ldc.i4.0
+			IL_003c: conv.r8
+			IL_003d: ldstr ""
+			IL_0042: ldc.i4.0
+			IL_0043: ldc.i4.1
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_004e: stloc.1
+			IL_004f: ldloc.1
+			IL_0050: ldc.r8 0.0
+			IL_0059: box [System.Runtime]System.Double
+			IL_005e: ldc.i4.0
+			IL_005f: newarr [System.Runtime]System.Object
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
+			IL_0069: pop
+			IL_006a: ldnull
+			IL_006b: ret
 		} // end of method ArrowFunction_L16C14::__js_call__
 
 	} // end of class ArrowFunction_L16C14
@@ -569,7 +505,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24f5
+			// Method begins at RVA 0x2447
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -774,7 +710,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2534
+		// Method begins at RVA 0x2486
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_Precedes_SetImmediate_When_Queued_Later.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_Precedes_SetImmediate_When_Queued_Later.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e9
+				// Method begins at RVA 0x2284
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,30 +46,23 @@
 			)
 			// Method begins at RVA 0x2184
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] float64,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "setImmediate"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
+			IL_0006: ldstr "setImmediate"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L5C14::__js_call__
 
 	} // end of class ArrowFunction_L5C14
@@ -85,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f2
+				// Method begins at RVA 0x228d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,32 +104,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x21c0
+			// Method begins at RVA 0x21ac
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] float64,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "nextTick"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
+			IL_0006: ldstr "nextTick"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L6C18::__js_call__
 
 	} // end of class ArrowFunction_L6C18
@@ -152,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22fb
+				// Method begins at RVA 0x2296
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -178,92 +164,68 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x21fc
+			// Method begins at RVA 0x21d4
 			// Header size: 12
-			// Code size: 216 (0xd8)
+			// Code size: 155 (0x9b)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object,
-				[2] object,
-				[3] bool,
-				[4] object
+				[0] object,
+				[1] string,
+				[2] bool,
+				[3] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "setTimeout"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldstr "console"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0035: stloc.1
-			IL_0036: ldloc.1
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0006: ldstr "setTimeout"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldstr "console"
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_001b: stloc.0
+			IL_001c: ldloc.0
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0022: stloc.0
+			IL_0023: ldarg.0
+			IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
+			IL_0029: ldc.i4.1
+			IL_002a: newarr [System.Runtime]System.Object
+			IL_002f: dup
+			IL_0030: ldc.i4.0
+			IL_0031: ldstr ","
+			IL_0036: stelem.ref
+			IL_0037: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
 			IL_003c: stloc.1
-			IL_003d: ldarg.0
-			IL_003e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
-			IL_0043: stloc.0
-			IL_0044: ldstr "order"
-			IL_0049: ldloc.0
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_004f: stloc.2
-			IL_0050: ldloc.2
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.2
-			IL_0057: ldloc.2
-			IL_0058: ldstr "join"
-			IL_005d: ldstr ","
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: stloc.2
-			IL_0068: ldloc.1
-			IL_0069: ldstr "log"
-			IL_006e: ldstr "order"
-			IL_0073: ldloc.2
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0079: pop
-			IL_007a: ldstr "console"
-			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0084: stloc.2
-			IL_0085: ldloc.2
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_008b: stloc.2
-			IL_008c: ldarg.0
-			IL_008d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
-			IL_0092: stloc.0
-			IL_0093: ldstr "order"
-			IL_0098: ldloc.0
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_009e: stloc.1
-			IL_009f: ldloc.1
-			IL_00a0: ldc.r8 0.0
-			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00ae: stloc.1
-			IL_00af: ldloc.1
-			IL_00b0: ldstr "nextTick"
-			IL_00b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00ba: stloc.3
-			IL_00bb: ldloc.3
-			IL_00bc: box [System.Runtime]System.Boolean
-			IL_00c1: stloc.s 4
-			IL_00c3: ldloc.2
-			IL_00c4: ldstr "log"
-			IL_00c9: ldstr "nextTick first"
-			IL_00ce: ldloc.s 4
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00d5: pop
-			IL_00d6: ldnull
-			IL_00d7: ret
+			IL_003d: ldloc.0
+			IL_003e: ldstr "log"
+			IL_0043: ldstr "order"
+			IL_0048: ldloc.1
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_004e: pop
+			IL_004f: ldstr "console"
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0059: stloc.0
+			IL_005a: ldloc.0
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0060: stloc.0
+			IL_0061: ldarg.0
+			IL_0062: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope::order
+			IL_0067: ldc.r8 0.0
+			IL_0070: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0075: ldstr "nextTick"
+			IL_007a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_007f: stloc.2
+			IL_0080: ldloc.2
+			IL_0081: box [System.Runtime]System.Boolean
+			IL_0086: stloc.3
+			IL_0087: ldloc.0
+			IL_0088: ldstr "log"
+			IL_008d: ldstr "nextTick first"
+			IL_0092: ldloc.3
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0098: pop
+			IL_0099: ldnull
+			IL_009a: ret
 		} // end of method ArrowFunction_L8C12::__js_call__
 
 	} // end of class ArrowFunction_L8C12
@@ -282,7 +244,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e0
+			// Method begins at RVA 0x227b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -438,7 +400,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2304
+		// Method begins at RVA 0x229f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_Queue_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_Queue_Semantics.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a9
+				// Method begins at RVA 0x232f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,30 +46,23 @@
 			)
 			// Method begins at RVA 0x21fc
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] float64,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "nextTick1"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
+			IL_0006: ldstr "nextTick1"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L6C18::__js_call__
 
 	} // end of class ArrowFunction_L6C18
@@ -85,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b2
+				// Method begins at RVA 0x2338
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,32 +104,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2238
+			// Method begins at RVA 0x2224
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] float64,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "nextTick2"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
+			IL_0006: ldstr "nextTick2"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L7C18::__js_call__
 
 	} // end of class ArrowFunction_L7C18
@@ -152,7 +138,67 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23bb
+				// Method begins at RVA 0x2341
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Process_NextTick_Queue_Semantics/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 07 00 00 02
+			)
+			// Method begins at RVA 0x224c
+			// Header size: 12
+			// Code size: 26 (0x1a)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
+			IL_0006: ldstr "nextTick3"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
+		} // end of method ArrowFunction_L11C18::__js_call__
+
+	} // end of class ArrowFunction_L11C18
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L13C14
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x234a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,164 +226,76 @@
 			)
 			// Method begins at RVA 0x2274
 			// Header size: 12
-			// Code size: 45 (0x2d)
-			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
-
-			IL_0000: ldarg.0
-			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "nextTick3"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
-		} // end of method ArrowFunction_L11C18::__js_call__
-
-	} // end of class ArrowFunction_L11C18
-
-	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L13C14
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x23c4
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Process_NextTick_Queue_Semantics/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 07 00 00 02
-			)
-			// Method begins at RVA 0x22b0
-			// Header size: 12
-			// Code size: 228 (0xe4)
+			// Code size: 166 (0xa6)
 			.maxstack 8
 			.locals init (
 				[0] string,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object,
-				[3] object,
-				[4] bool,
-				[5] object
+				[1] object,
+				[2] string,
+				[3] bool,
+				[4] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0006: stloc.1
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.2
-			IL_0013: ldloc.2
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.2
-			IL_001a: ldloc.2
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "setImmediate"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldstr "console"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0035: stloc.2
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0006: ldstr "setImmediate"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldstr "console"
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_001b: stloc.1
+			IL_001c: ldloc.1
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0022: stloc.1
+			IL_0023: ldarg.0
+			IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
+			IL_0029: ldc.i4.1
+			IL_002a: newarr [System.Runtime]System.Object
+			IL_002f: dup
+			IL_0030: ldc.i4.0
+			IL_0031: ldstr ","
+			IL_0036: stelem.ref
+			IL_0037: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
 			IL_003c: stloc.2
-			IL_003d: ldarg.0
-			IL_003e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0043: stloc.1
-			IL_0044: ldstr "order"
-			IL_0049: ldloc.1
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_004f: stloc.3
-			IL_0050: ldloc.3
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.3
-			IL_0057: ldloc.3
-			IL_0058: ldstr "join"
-			IL_005d: ldstr ","
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: stloc.3
-			IL_0068: ldloc.2
-			IL_0069: ldstr "log"
-			IL_006e: ldstr "order"
-			IL_0073: ldloc.3
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0079: pop
-			IL_007a: ldstr "sync,nextTick1,nextTick2,nextTick3,setImmediate"
-			IL_007f: stloc.0
-			IL_0080: ldstr "console"
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_008a: stloc.3
-			IL_008b: ldloc.3
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0091: stloc.3
-			IL_0092: ldarg.0
-			IL_0093: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
-			IL_0098: stloc.1
-			IL_0099: ldstr "order"
-			IL_009e: ldloc.1
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a4: stloc.2
-			IL_00a5: ldloc.2
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ab: stloc.2
-			IL_00ac: ldloc.2
-			IL_00ad: ldstr "join"
-			IL_00b2: ldstr ","
-			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00bc: stloc.2
-			IL_00bd: ldloc.2
-			IL_00be: ldloc.0
-			IL_00bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00c4: stloc.s 4
-			IL_00c6: ldloc.s 4
-			IL_00c8: box [System.Runtime]System.Boolean
-			IL_00cd: stloc.s 5
-			IL_00cf: ldloc.3
-			IL_00d0: ldstr "log"
-			IL_00d5: ldstr "correct order"
-			IL_00da: ldloc.s 5
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00e1: pop
-			IL_00e2: ldnull
-			IL_00e3: ret
+			IL_003d: ldloc.1
+			IL_003e: ldstr "log"
+			IL_0043: ldstr "order"
+			IL_0048: ldloc.2
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_004e: pop
+			IL_004f: ldstr "sync,nextTick1,nextTick2,nextTick3,setImmediate"
+			IL_0054: stloc.0
+			IL_0055: ldstr "console"
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_005f: stloc.1
+			IL_0060: ldloc.1
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0066: stloc.1
+			IL_0067: ldarg.0
+			IL_0068: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
+			IL_006d: ldc.i4.1
+			IL_006e: newarr [System.Runtime]System.Object
+			IL_0073: dup
+			IL_0074: ldc.i4.0
+			IL_0075: ldstr ","
+			IL_007a: stelem.ref
+			IL_007b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0080: stloc.2
+			IL_0081: ldloc.2
+			IL_0082: ldloc.0
+			IL_0083: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0088: stloc.3
+			IL_0089: ldloc.3
+			IL_008a: box [System.Runtime]System.Boolean
+			IL_008f: stloc.s 4
+			IL_0091: ldloc.1
+			IL_0092: ldstr "log"
+			IL_0097: ldstr "correct order"
+			IL_009c: ldloc.s 4
+			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00a3: pop
+			IL_00a4: ldnull
+			IL_00a5: ret
 		} // end of method ArrowFunction_L13C14::__js_call__
 
 	} // end of class ArrowFunction_L13C14
@@ -356,7 +314,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23a0
+			// Method begins at RVA 0x2326
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -559,7 +517,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23cd
+		// Method begins at RVA 0x2353
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Versions_Expanded.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Versions_Expanded.verified.txt
@@ -449,9 +449,9 @@
 		IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_04d2: stloc.s 19
 		IL_04d4: ldloc.s 19
-		IL_04d6: ldstr "test"
+		IL_04d6: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_04db: ldloc.s 6
-		IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_04dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
 		IL_04e2: stloc.s 19
 		IL_04e4: ldloc.s 7
 		IL_04e6: ldstr "log"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x221e
+				// Method begins at RVA 0x2208
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2227
+				// Method begins at RVA 0x2211
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -92,14 +92,13 @@
 			)
 			// Method begins at RVA 0x2168
 			// Header size: 12
-			// Code size: 161 (0xa1)
+			// Code size: 139 (0x8b)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] bool,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldstr "console"
@@ -138,28 +137,20 @@
 			IL_005a: ldloc.1
 			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0060: stloc.1
-			IL_0061: ldarg.0
-			IL_0062: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
-			IL_0067: stloc.s 4
-			IL_0069: ldstr "writable"
-			IL_006e: ldloc.s 4
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0075: stloc.s 4
-			IL_0077: ldloc.s 4
-			IL_0079: ldstr "destroyed"
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0083: stloc.s 4
-			IL_0085: ldstr "destroyed:"
-			IL_008a: ldloc.s 4
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0091: stloc.3
-			IL_0092: ldloc.1
-			IL_0093: ldstr "log"
-			IL_0098: ldloc.3
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_009e: pop
-			IL_009f: ldnull
-			IL_00a0: ret
+			IL_0061: ldstr "destroyed:"
+			IL_0066: ldarg.0
+			IL_0067: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
+			IL_006c: ldstr "destroyed"
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_007b: stloc.3
+			IL_007c: ldloc.1
+			IL_007d: ldstr "log"
+			IL_0082: ldloc.3
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0088: pop
+			IL_0089: ldnull
+			IL_008a: ret
 		} // end of method FunctionExpression_L8C26::__js_call__
 
 	} // end of class FunctionExpression_L8C26
@@ -178,7 +169,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2215
+			// Method begins at RVA 0x21ff
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -319,7 +310,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2230
+		// Method begins at RVA 0x221a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_DestroyError.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_DestroyError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ba
+				// Method begins at RVA 0x21a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,14 +47,13 @@
 			)
 			// Method begins at RVA 0x2104
 			// Header size: 12
-			// Code size: 161 (0xa1)
+			// Code size: 139 (0x8b)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] bool,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldstr "console"
@@ -93,28 +92,20 @@
 			IL_005a: ldloc.1
 			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0060: stloc.1
-			IL_0061: ldarg.0
-			IL_0062: ldfld object Modules.Stream_Finished_Callback_DestroyError/Scope::readable
-			IL_0067: stloc.s 4
-			IL_0069: ldstr "readable"
-			IL_006e: ldloc.s 4
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0075: stloc.s 4
-			IL_0077: ldloc.s 4
-			IL_0079: ldstr "destroyed"
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0083: stloc.s 4
-			IL_0085: ldstr "destroyed:"
-			IL_008a: ldloc.s 4
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0091: stloc.3
-			IL_0092: ldloc.1
-			IL_0093: ldstr "log"
-			IL_0098: ldloc.3
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_009e: pop
-			IL_009f: ldnull
-			IL_00a0: ret
+			IL_0061: ldstr "destroyed:"
+			IL_0066: ldarg.0
+			IL_0067: ldfld object Modules.Stream_Finished_Callback_DestroyError/Scope::readable
+			IL_006c: ldstr "destroyed"
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_007b: stloc.3
+			IL_007c: ldloc.1
+			IL_007d: ldstr "log"
+			IL_0082: ldloc.3
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0088: pop
+			IL_0089: ldnull
+			IL_008a: ret
 		} // end of method FunctionExpression_L7C26::__js_call__
 
 	} // end of class FunctionExpression_L7C26
@@ -133,7 +124,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b1
+			// Method begins at RVA 0x219b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -242,7 +233,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c3
+		// Method begins at RVA 0x21ad
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c17
+					// Method begins at RVA 0x2b2f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bfc
+				// Method begins at RVA 0x2b14
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c0e
+				// Method begins at RVA 0x2b26
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -92,7 +92,7 @@
 			)
 			// Method begins at RVA 0x2120
 			// Header size: 12
-			// Code size: 115 (0x73)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/Scope,
@@ -104,48 +104,42 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-			IL_000c: stloc.2
-			IL_000d: ldstr "stream"
-			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: ldstr "Writable"
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0024: stloc.2
-			IL_0025: ldloc.2
-			IL_0026: ldc.i4.1
-			IL_0027: newarr [System.Runtime]System.Object
-			IL_002c: dup
-			IL_002d: ldc.i4.0
-			IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0033: dup
-			IL_0034: ldstr "objectMode"
-			IL_0039: ldc.i4.1
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003f: stelem.ref
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0045: stloc.2
-			IL_0046: ldloc.2
-			IL_0047: stloc.1
-			IL_0048: ldnull
-			IL_0049: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20::__js_call__(object, object)
-			IL_004f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0054: ldc.i4.1
-			IL_0055: conv.r8
-			IL_0056: ldstr ""
-			IL_005b: ldc.i4.0
+			IL_000c: ldstr "Writable"
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0016: stloc.2
+			IL_0017: ldloc.2
+			IL_0018: ldc.i4.1
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: dup
+			IL_001f: ldc.i4.0
+			IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0025: dup
+			IL_0026: ldstr "objectMode"
+			IL_002b: ldc.i4.1
+			IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0031: stelem.ref
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0037: stloc.2
+			IL_0038: ldloc.2
+			IL_0039: stloc.1
+			IL_003a: ldnull
+			IL_003b: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20::__js_call__(object, object)
+			IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0046: ldc.i4.1
+			IL_0047: conv.r8
+			IL_0048: ldstr ""
+			IL_004d: ldc.i4.0
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0054: stloc.2
+			IL_0055: ldloc.1
+			IL_0056: ldstr "_write"
+			IL_005b: ldloc.2
 			IL_005c: ldc.i4.1
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0062: stloc.2
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0062: pop
 			IL_0063: ldloc.1
-			IL_0064: ldstr "_write"
-			IL_0069: ldloc.2
-			IL_006a: ldc.i4.1
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0070: pop
-			IL_0071: ldloc.1
-			IL_0072: ret
+			IL_0064: ret
 		} // end of method createWritable::__js_call__
 
 	} // end of class createWritable
@@ -161,7 +155,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c20
+				// Method begins at RVA 0x2b38
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -187,9 +181,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x21a0
+			// Method begins at RVA 0x2194
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 52 (0x34)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -197,30 +191,24 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-			IL_0006: stloc.0
-			IL_0007: ldstr "stream"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "Readable"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: ldc.i4.1
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_002d: dup
-			IL_002e: ldstr "objectMode"
-			IL_0033: ldc.i4.1
-			IL_0034: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0039: stelem.ref
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_003f: stloc.0
-			IL_0040: ldloc.0
-			IL_0041: ret
+			IL_0006: ldstr "Readable"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: ldc.i4.1
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001f: dup
+			IL_0020: ldstr "objectMode"
+			IL_0025: ldc.i4.1
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_002b: stelem.ref
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0031: stloc.0
+			IL_0032: ldloc.0
+			IL_0033: ret
 		} // end of method createReadable::__js_call__
 
 	} // end of class createReadable
@@ -240,7 +228,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c3b
+					// Method begins at RVA 0x2b53
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -263,7 +251,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bff
+				// Method begins at RVA 0x2b17
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -285,7 +273,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c56
+					// Method begins at RVA 0x2b6e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -308,7 +296,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c02
+				// Method begins at RVA 0x2b1a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -345,7 +333,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c32
+					// Method begins at RVA 0x2b4a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -365,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c44
+					// Method begins at RVA 0x2b5c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -385,7 +373,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c4d
+					// Method begins at RVA 0x2b65
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -405,7 +393,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c5f
+					// Method begins at RVA 0x2b77
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -425,7 +413,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c68
+					// Method begins at RVA 0x2b80
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -445,7 +433,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c71
+					// Method begins at RVA 0x2b89
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -465,7 +453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c7a
+					// Method begins at RVA 0x2b92
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -485,7 +473,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c83
+					// Method begins at RVA 0x2b9b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -513,7 +501,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c29
+				// Method begins at RVA 0x2b41
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -537,9 +525,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f0
+			// Method begins at RVA 0x21d4
 			// Header size: 12
-			// Code size: 2506 (0x9ca)
+			// Code size: 2326 (0x916)
 			.maxstack 10
 			.locals init (
 				[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope,
@@ -732,7 +720,7 @@
 
 			IL_0133: ldloc.0
 			IL_0134: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0139: switch (IL_0152, IL_065a, IL_0627, IL_08e6, IL_08b3)
+			IL_0139: switch (IL_0152, IL_05dc, IL_05a9, IL_0832, IL_07ff)
 			.try
 			{
 				IL_0152: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L17C6::.ctor()
@@ -742,870 +730,810 @@
 				IL_015a: ldelem.ref
 				IL_015b: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
 				IL_0160: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-				IL_0165: stloc.s 20
-				IL_0167: ldstr "stream"
-				IL_016c: ldloc.s 20
-				IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0173: stloc.s 20
-				IL_0175: ldloc.s 20
-				IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_017c: stloc.s 20
-				IL_017e: ldarg.0
-				IL_017f: ldc.i4.1
-				IL_0180: ldelem.ref
-				IL_0181: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0186: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-				IL_018b: stloc.s 21
-				IL_018d: ldstr "createWritable"
-				IL_0192: ldloc.s 21
-				IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0199: stloc.s 21
-				IL_019b: ldloc.s 21
-				IL_019d: ldc.i4.1
-				IL_019e: newarr [System.Runtime]System.Object
-				IL_01a3: dup
-				IL_01a4: ldc.i4.0
-				IL_01a5: ldarg.0
-				IL_01a6: ldc.i4.1
-				IL_01a7: ldelem.ref
-				IL_01a8: stelem.ref
-				IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_01ae: stloc.s 21
-				IL_01b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_01b5: dup
-				IL_01b6: ldstr "signal"
-				IL_01bb: ldc.i4.0
-				IL_01bc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_01c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_01c6: stloc.s 22
-				IL_01c8: ldnull
-				IL_01c9: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
-				IL_01cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_01d4: ldc.i4.0
-				IL_01d5: conv.r8
-				IL_01d6: ldstr ""
-				IL_01db: ldc.i4.0
-				IL_01dc: ldc.i4.1
-				IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_01e2: stloc.s 23
-				IL_01e4: ldloc.s 20
-				IL_01e6: ldstr "finished"
-				IL_01eb: ldloc.s 21
-				IL_01ed: ldloc.s 22
-				IL_01ef: ldloc.s 23
-				IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_01f6: pop
-				IL_01f7: ldstr "console"
-				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0201: stloc.s 23
-				IL_0203: ldloc.s 23
-				IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_020a: stloc.s 23
-				IL_020c: ldloc.s 23
-				IL_020e: ldstr "log"
-				IL_0213: ldstr "callback-finished:ok"
-				IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_021d: pop
-				IL_021e: leave IL_02ec
+				IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_016a: stloc.s 20
+				IL_016c: ldarg.0
+				IL_016d: ldc.i4.1
+				IL_016e: ldelem.ref
+				IL_016f: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0174: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+				IL_0179: ldc.i4.1
+				IL_017a: newarr [System.Runtime]System.Object
+				IL_017f: dup
+				IL_0180: ldc.i4.0
+				IL_0181: ldarg.0
+				IL_0182: ldc.i4.1
+				IL_0183: ldelem.ref
+				IL_0184: stelem.ref
+				IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_018a: stloc.s 21
+				IL_018c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0191: dup
+				IL_0192: ldstr "signal"
+				IL_0197: ldc.i4.0
+				IL_0198: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_019d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_01a2: stloc.s 22
+				IL_01a4: ldnull
+				IL_01a5: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
+				IL_01ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_01b0: ldc.i4.0
+				IL_01b1: conv.r8
+				IL_01b2: ldstr ""
+				IL_01b7: ldc.i4.0
+				IL_01b8: ldc.i4.1
+				IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_01be: stloc.s 23
+				IL_01c0: ldloc.s 20
+				IL_01c2: ldstr "finished"
+				IL_01c7: ldloc.s 21
+				IL_01c9: ldloc.s 22
+				IL_01cb: ldloc.s 23
+				IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_01d2: pop
+				IL_01d3: ldstr "console"
+				IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_01dd: stloc.s 23
+				IL_01df: ldloc.s 23
+				IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01e6: stloc.s 23
+				IL_01e8: ldloc.s 23
+				IL_01ea: ldstr "log"
+				IL_01ef: ldstr "callback-finished:ok"
+				IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_01f9: pop
+				IL_01fa: leave IL_02c8
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0223: stloc.2
-				IL_0224: ldloc.2
-				IL_0225: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_022a: dup
-				IL_022b: brtrue IL_0240
+				IL_01ff: stloc.2
+				IL_0200: ldloc.2
+				IL_0201: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0206: dup
+				IL_0207: brtrue IL_021c
 
-				IL_0230: pop
-				IL_0231: ldloc.2
-				IL_0232: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0237: dup
-				IL_0238: brtrue IL_024b
+				IL_020c: pop
+				IL_020d: ldloc.2
+				IL_020e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0213: dup
+				IL_0214: brtrue IL_0227
 
-				IL_023d: pop
-				IL_023e: rethrow
+				IL_0219: pop
+				IL_021a: rethrow
 
-				IL_0240: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0245: stloc.3
-				IL_0246: br IL_024c
+				IL_021c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0221: stloc.3
+				IL_0222: br IL_0228
 
-				IL_024b: stloc.3
+				IL_0227: stloc.3
 
-				IL_024c: ldloc.3
-				IL_024d: stloc.s 23
-				IL_024f: ldloc.s 23
-				IL_0251: stloc.s 4
-				IL_0253: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L20C18::.ctor()
-				IL_0258: stloc.s 5
-				IL_025a: ldstr "console"
-				IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0264: stloc.s 23
-				IL_0266: ldloc.s 23
-				IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_026d: stloc.s 23
-				IL_026f: ldstr "callback-finished:"
-				IL_0274: ldloc.s 4
-				IL_0276: ldstr "name"
-				IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0285: stloc.s 24
-				IL_0287: ldloc.s 24
-				IL_0289: ldstr ":"
-				IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0293: stloc.s 24
-				IL_0295: ldloc.s 24
-				IL_0297: ldloc.s 4
-				IL_0299: ldstr "code"
-				IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_02a8: stloc.s 24
+				IL_0228: ldloc.3
+				IL_0229: stloc.s 23
+				IL_022b: ldloc.s 23
+				IL_022d: stloc.s 4
+				IL_022f: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L20C18::.ctor()
+				IL_0234: stloc.s 5
+				IL_0236: ldstr "console"
+				IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0240: stloc.s 23
+				IL_0242: ldloc.s 23
+				IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0249: stloc.s 23
+				IL_024b: ldstr "callback-finished:"
+				IL_0250: ldloc.s 4
+				IL_0252: ldstr "name"
+				IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0261: stloc.s 24
+				IL_0263: ldloc.s 24
+				IL_0265: ldstr ":"
+				IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_026f: stloc.s 24
+				IL_0271: ldloc.s 24
+				IL_0273: ldloc.s 4
+				IL_0275: ldstr "code"
+				IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0284: stloc.s 24
+				IL_0286: ldloc.s 23
+				IL_0288: ldstr "log"
+				IL_028d: ldloc.s 24
+				IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0294: pop
+				IL_0295: ldstr "console"
+				IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_029f: stloc.s 23
+				IL_02a1: ldloc.s 23
+				IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02a8: stloc.s 23
 				IL_02aa: ldloc.s 23
 				IL_02ac: ldstr "log"
-				IL_02b1: ldloc.s 24
-				IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02b8: pop
-				IL_02b9: ldstr "console"
-				IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02c3: stloc.s 23
-				IL_02c5: ldloc.s 23
-				IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02cc: stloc.s 23
-				IL_02ce: ldloc.s 23
-				IL_02d0: ldstr "log"
-				IL_02d5: ldloc.s 4
-				IL_02d7: ldstr "message"
-				IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02e6: pop
-				IL_02e7: leave IL_02ec
+				IL_02b1: ldloc.s 4
+				IL_02b3: ldstr "message"
+				IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02c2: pop
+				IL_02c3: leave IL_02c8
 			} // end handler
 			.try
 			{
-				IL_02ec: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L25C6::.ctor()
-				IL_02f1: stloc.s 6
-				IL_02f3: ldarg.0
-				IL_02f4: ldc.i4.1
-				IL_02f5: ldelem.ref
-				IL_02f6: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_02fb: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-				IL_0300: stloc.s 23
-				IL_0302: ldstr "stream"
-				IL_0307: ldloc.s 23
-				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_030e: stloc.s 23
-				IL_0310: ldloc.s 23
-				IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0317: stloc.s 23
-				IL_0319: ldarg.0
-				IL_031a: ldc.i4.1
-				IL_031b: ldelem.ref
-				IL_031c: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0321: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
-				IL_0326: stloc.s 21
-				IL_0328: ldstr "createReadable"
-				IL_032d: ldloc.s 21
-				IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0334: stloc.s 21
-				IL_0336: ldloc.s 21
-				IL_0338: ldc.i4.1
-				IL_0339: newarr [System.Runtime]System.Object
-				IL_033e: dup
-				IL_033f: ldc.i4.0
-				IL_0340: ldarg.0
-				IL_0341: ldc.i4.1
-				IL_0342: ldelem.ref
-				IL_0343: stelem.ref
-				IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0349: stloc.s 21
-				IL_034b: ldarg.0
-				IL_034c: ldc.i4.1
-				IL_034d: ldelem.ref
-				IL_034e: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0353: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-				IL_0358: stloc.s 20
-				IL_035a: ldstr "createWritable"
-				IL_035f: ldloc.s 20
-				IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0366: stloc.s 20
-				IL_0368: ldloc.s 20
-				IL_036a: ldc.i4.1
-				IL_036b: newarr [System.Runtime]System.Object
-				IL_0370: dup
-				IL_0371: ldc.i4.0
-				IL_0372: ldarg.0
-				IL_0373: ldc.i4.1
-				IL_0374: ldelem.ref
-				IL_0375: stelem.ref
-				IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_037b: stloc.s 20
-				IL_037d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0382: dup
-				IL_0383: ldstr "signal"
-				IL_0388: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_038d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0392: stloc.s 22
-				IL_0394: ldnull
-				IL_0395: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
-				IL_039b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_03a0: ldc.i4.0
-				IL_03a1: conv.r8
-				IL_03a2: ldstr ""
-				IL_03a7: ldc.i4.0
-				IL_03a8: ldc.i4.1
-				IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_03ae: stloc.s 25
-				IL_03b0: ldc.i4.4
-				IL_03b1: newarr [System.Runtime]System.Object
-				IL_03b6: dup
-				IL_03b7: ldc.i4.0
-				IL_03b8: ldloc.s 21
-				IL_03ba: stelem.ref
-				IL_03bb: dup
-				IL_03bc: ldc.i4.1
-				IL_03bd: ldloc.s 20
-				IL_03bf: stelem.ref
-				IL_03c0: dup
-				IL_03c1: ldc.i4.2
-				IL_03c2: ldloc.s 22
-				IL_03c4: stelem.ref
-				IL_03c5: dup
-				IL_03c6: ldc.i4.3
-				IL_03c7: ldloc.s 25
-				IL_03c9: stelem.ref
-				IL_03ca: stloc.s 26
-				IL_03cc: ldloc.s 23
-				IL_03ce: ldstr "pipeline"
-				IL_03d3: ldloc.s 26
-				IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_03da: pop
-				IL_03db: ldstr "console"
-				IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_03e5: stloc.s 23
-				IL_03e7: ldloc.s 23
-				IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03ee: stloc.s 23
-				IL_03f0: ldloc.s 23
-				IL_03f2: ldstr "log"
-				IL_03f7: ldstr "callback-pipeline:ok"
-				IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0401: pop
-				IL_0402: leave IL_04d6
+				IL_02c8: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L25C6::.ctor()
+				IL_02cd: stloc.s 6
+				IL_02cf: ldarg.0
+				IL_02d0: ldc.i4.1
+				IL_02d1: ldelem.ref
+				IL_02d2: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_02d7: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
+				IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02e1: stloc.s 23
+				IL_02e3: ldarg.0
+				IL_02e4: ldc.i4.1
+				IL_02e5: ldelem.ref
+				IL_02e6: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_02eb: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
+				IL_02f0: ldc.i4.1
+				IL_02f1: newarr [System.Runtime]System.Object
+				IL_02f6: dup
+				IL_02f7: ldc.i4.0
+				IL_02f8: ldarg.0
+				IL_02f9: ldc.i4.1
+				IL_02fa: ldelem.ref
+				IL_02fb: stelem.ref
+				IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0301: stloc.s 21
+				IL_0303: ldarg.0
+				IL_0304: ldc.i4.1
+				IL_0305: ldelem.ref
+				IL_0306: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_030b: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+				IL_0310: ldc.i4.1
+				IL_0311: newarr [System.Runtime]System.Object
+				IL_0316: dup
+				IL_0317: ldc.i4.0
+				IL_0318: ldarg.0
+				IL_0319: ldc.i4.1
+				IL_031a: ldelem.ref
+				IL_031b: stelem.ref
+				IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0321: stloc.s 20
+				IL_0323: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0328: dup
+				IL_0329: ldstr "signal"
+				IL_032e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0333: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0338: stloc.s 22
+				IL_033a: ldnull
+				IL_033b: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
+				IL_0341: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0346: ldc.i4.0
+				IL_0347: conv.r8
+				IL_0348: ldstr ""
+				IL_034d: ldc.i4.0
+				IL_034e: ldc.i4.1
+				IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0354: stloc.s 25
+				IL_0356: ldc.i4.4
+				IL_0357: newarr [System.Runtime]System.Object
+				IL_035c: dup
+				IL_035d: ldc.i4.0
+				IL_035e: ldloc.s 21
+				IL_0360: stelem.ref
+				IL_0361: dup
+				IL_0362: ldc.i4.1
+				IL_0363: ldloc.s 20
+				IL_0365: stelem.ref
+				IL_0366: dup
+				IL_0367: ldc.i4.2
+				IL_0368: ldloc.s 22
+				IL_036a: stelem.ref
+				IL_036b: dup
+				IL_036c: ldc.i4.3
+				IL_036d: ldloc.s 25
+				IL_036f: stelem.ref
+				IL_0370: stloc.s 26
+				IL_0372: ldloc.s 23
+				IL_0374: ldstr "pipeline"
+				IL_0379: ldloc.s 26
+				IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0380: pop
+				IL_0381: ldstr "console"
+				IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_038b: stloc.s 23
+				IL_038d: ldloc.s 23
+				IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0394: stloc.s 23
+				IL_0396: ldloc.s 23
+				IL_0398: ldstr "log"
+				IL_039d: ldstr "callback-pipeline:ok"
+				IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_03a7: pop
+				IL_03a8: leave IL_047c
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0407: stloc.s 7
-				IL_0409: ldloc.s 7
-				IL_040b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0410: dup
-				IL_0411: brtrue IL_0427
+				IL_03ad: stloc.s 7
+				IL_03af: ldloc.s 7
+				IL_03b1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_03b6: dup
+				IL_03b7: brtrue IL_03cd
 
-				IL_0416: pop
-				IL_0417: ldloc.s 7
-				IL_0419: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_041e: dup
-				IL_041f: brtrue IL_0433
+				IL_03bc: pop
+				IL_03bd: ldloc.s 7
+				IL_03bf: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_03c4: dup
+				IL_03c5: brtrue IL_03d9
 
-				IL_0424: pop
-				IL_0425: rethrow
+				IL_03ca: pop
+				IL_03cb: rethrow
 
-				IL_0427: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_042c: stloc.s 8
-				IL_042e: br IL_0435
+				IL_03cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_03d2: stloc.s 8
+				IL_03d4: br IL_03db
 
-				IL_0433: stloc.s 8
+				IL_03d9: stloc.s 8
 
-				IL_0435: ldloc.s 8
-				IL_0437: stloc.s 23
-				IL_0439: ldloc.s 23
-				IL_043b: stloc.s 9
-				IL_043d: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L28C18::.ctor()
-				IL_0442: stloc.s 10
-				IL_0444: ldstr "console"
-				IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_044e: stloc.s 23
-				IL_0450: ldloc.s 23
-				IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0457: stloc.s 23
-				IL_0459: ldstr "callback-pipeline:"
-				IL_045e: ldloc.s 9
-				IL_0460: ldstr "name"
-				IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_046f: stloc.s 24
-				IL_0471: ldloc.s 24
-				IL_0473: ldstr ":"
-				IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_047d: stloc.s 24
-				IL_047f: ldloc.s 24
-				IL_0481: ldloc.s 9
-				IL_0483: ldstr "code"
-				IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0492: stloc.s 24
-				IL_0494: ldloc.s 23
-				IL_0496: ldstr "log"
-				IL_049b: ldloc.s 24
-				IL_049d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_04a2: pop
-				IL_04a3: ldstr "console"
-				IL_04a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_04ad: stloc.s 23
-				IL_04af: ldloc.s 23
-				IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_04b6: stloc.s 23
-				IL_04b8: ldloc.s 23
-				IL_04ba: ldstr "log"
-				IL_04bf: ldloc.s 9
-				IL_04c1: ldstr "message"
-				IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_04d0: pop
-				IL_04d1: leave IL_04d6
+				IL_03db: ldloc.s 8
+				IL_03dd: stloc.s 23
+				IL_03df: ldloc.s 23
+				IL_03e1: stloc.s 9
+				IL_03e3: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L28C18::.ctor()
+				IL_03e8: stloc.s 10
+				IL_03ea: ldstr "console"
+				IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_03f4: stloc.s 23
+				IL_03f6: ldloc.s 23
+				IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03fd: stloc.s 23
+				IL_03ff: ldstr "callback-pipeline:"
+				IL_0404: ldloc.s 9
+				IL_0406: ldstr "name"
+				IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0415: stloc.s 24
+				IL_0417: ldloc.s 24
+				IL_0419: ldstr ":"
+				IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0423: stloc.s 24
+				IL_0425: ldloc.s 24
+				IL_0427: ldloc.s 9
+				IL_0429: ldstr "code"
+				IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0438: stloc.s 24
+				IL_043a: ldloc.s 23
+				IL_043c: ldstr "log"
+				IL_0441: ldloc.s 24
+				IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0448: pop
+				IL_0449: ldstr "console"
+				IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0453: stloc.s 23
+				IL_0455: ldloc.s 23
+				IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_045c: stloc.s 23
+				IL_045e: ldloc.s 23
+				IL_0460: ldstr "log"
+				IL_0465: ldloc.s 9
+				IL_0467: ldstr "message"
+				IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0476: pop
+				IL_0477: leave IL_047c
 			} // end handler
 
-			IL_04d6: ldloc.0
+			IL_047c: ldloc.0
+			IL_047d: ldc.i4.0
+			IL_047e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0483: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0488: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L33C6::.ctor()
+			IL_048d: stloc.s 11
+			IL_048f: ldarg.0
+			IL_0490: ldc.i4.1
+			IL_0491: ldelem.ref
+			IL_0492: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_0497: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04a1: stloc.s 23
+			IL_04a3: ldarg.0
+			IL_04a4: ldc.i4.1
+			IL_04a5: ldelem.ref
+			IL_04a6: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_04ab: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+			IL_04b0: ldc.i4.1
+			IL_04b1: newarr [System.Runtime]System.Object
+			IL_04b6: dup
+			IL_04b7: ldc.i4.0
+			IL_04b8: ldarg.0
+			IL_04b9: ldc.i4.1
+			IL_04ba: ldelem.ref
+			IL_04bb: stelem.ref
+			IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_04c1: stloc.s 25
+			IL_04c3: ldloc.s 23
+			IL_04c5: ldstr "finished"
+			IL_04ca: ldloc.s 25
+			IL_04cc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_04d1: dup
+			IL_04d2: ldstr "signal"
 			IL_04d7: ldc.i4.0
 			IL_04d8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_04dd: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_04e2: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L33C6::.ctor()
-			IL_04e7: stloc.s 11
-			IL_04e9: ldarg.0
-			IL_04ea: ldc.i4.1
-			IL_04eb: ldelem.ref
-			IL_04ec: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_04f1: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_04f6: stloc.s 23
-			IL_04f8: ldstr "streamPromises"
-			IL_04fd: ldloc.s 23
-			IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0504: stloc.s 23
-			IL_0506: ldloc.s 23
-			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_050d: stloc.s 23
-			IL_050f: ldarg.0
-			IL_0510: ldc.i4.1
-			IL_0511: ldelem.ref
-			IL_0512: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0517: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-			IL_051c: stloc.s 25
-			IL_051e: ldstr "createWritable"
-			IL_0523: ldloc.s 25
-			IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_052a: stloc.s 25
-			IL_052c: ldloc.s 25
-			IL_052e: ldc.i4.1
-			IL_052f: newarr [System.Runtime]System.Object
-			IL_0534: dup
-			IL_0535: ldc.i4.0
-			IL_0536: ldarg.0
-			IL_0537: ldc.i4.1
-			IL_0538: ldelem.ref
-			IL_0539: stelem.ref
-			IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_053f: stloc.s 25
-			IL_0541: ldloc.s 23
-			IL_0543: ldstr "finished"
-			IL_0548: ldloc.s 25
-			IL_054a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_054f: dup
-			IL_0550: ldstr "signal"
-			IL_0555: ldc.i4.0
-			IL_0556: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_055b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0560: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0565: stloc.s 25
-			IL_0567: ldloc.0
-			IL_0568: ldc.i4.2
-			IL_0569: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_056e: ldloc.0
-			IL_056f: ldloc.s 25
-			IL_0571: ldarg.0
-			IL_0572: ldc.i4.1
-			IL_0573: ldloc.0
-			IL_0574: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0579: ldc.i4.1
-			IL_057a: ldstr "_pendingException"
-			IL_057f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0584: ldloc.0
-			IL_0585: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_04dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04e7: stloc.s 25
+			IL_04e9: ldloc.0
+			IL_04ea: ldc.i4.2
+			IL_04eb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04f0: ldloc.0
+			IL_04f1: ldloc.s 25
+			IL_04f3: ldarg.0
+			IL_04f4: ldc.i4.1
+			IL_04f5: ldloc.0
+			IL_04f6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04fb: ldc.i4.1
+			IL_04fc: ldstr "_pendingException"
+			IL_0501: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0506: ldloc.0
+			IL_0507: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_050c: dup
+			IL_050d: ldc.i4.0
+			IL_050e: ldloc.1
+			IL_050f: stelem.ref
+			IL_0510: dup
+			IL_0511: ldc.i4.1
+			IL_0512: ldloc.2
+			IL_0513: stelem.ref
+			IL_0514: dup
+			IL_0515: ldc.i4.2
+			IL_0516: ldloc.3
+			IL_0517: stelem.ref
+			IL_0518: dup
+			IL_0519: ldc.i4.3
+			IL_051a: ldloc.s 4
+			IL_051c: stelem.ref
+			IL_051d: dup
+			IL_051e: ldc.i4.4
+			IL_051f: ldloc.s 5
+			IL_0521: stelem.ref
+			IL_0522: dup
+			IL_0523: ldc.i4.5
+			IL_0524: ldloc.s 6
+			IL_0526: stelem.ref
+			IL_0527: dup
+			IL_0528: ldc.i4.6
+			IL_0529: ldloc.s 7
+			IL_052b: stelem.ref
+			IL_052c: dup
+			IL_052d: ldc.i4.7
+			IL_052e: ldloc.s 8
+			IL_0530: stelem.ref
+			IL_0531: dup
+			IL_0532: ldc.i4.8
+			IL_0533: ldloc.s 9
+			IL_0535: stelem.ref
+			IL_0536: dup
+			IL_0537: ldc.i4.s 9
+			IL_0539: ldloc.s 10
+			IL_053b: stelem.ref
+			IL_053c: dup
+			IL_053d: ldc.i4.s 10
+			IL_053f: ldloc.s 11
+			IL_0541: stelem.ref
+			IL_0542: dup
+			IL_0543: ldc.i4.s 11
+			IL_0545: ldloc.s 12
+			IL_0547: stelem.ref
+			IL_0548: dup
+			IL_0549: ldc.i4.s 12
+			IL_054b: ldloc.s 13
+			IL_054d: stelem.ref
+			IL_054e: dup
+			IL_054f: ldc.i4.s 13
+			IL_0551: ldloc.s 14
+			IL_0553: stelem.ref
+			IL_0554: dup
+			IL_0555: ldc.i4.s 14
+			IL_0557: ldloc.s 15
+			IL_0559: stelem.ref
+			IL_055a: dup
+			IL_055b: ldc.i4.s 15
+			IL_055d: ldloc.s 16
+			IL_055f: stelem.ref
+			IL_0560: dup
+			IL_0561: ldc.i4.s 16
+			IL_0563: ldloc.s 17
+			IL_0565: stelem.ref
+			IL_0566: dup
+			IL_0567: ldc.i4.s 17
+			IL_0569: ldloc.s 18
+			IL_056b: stelem.ref
+			IL_056c: dup
+			IL_056d: ldc.i4.s 18
+			IL_056f: ldloc.s 19
+			IL_0571: stelem.ref
+			IL_0572: dup
+			IL_0573: ldc.i4.s 19
+			IL_0575: ldloc.s 20
+			IL_0577: stelem.ref
+			IL_0578: dup
+			IL_0579: ldc.i4.s 20
+			IL_057b: ldloc.s 21
+			IL_057d: stelem.ref
+			IL_057e: dup
+			IL_057f: ldc.i4.s 21
+			IL_0581: ldloc.s 22
+			IL_0583: stelem.ref
+			IL_0584: dup
+			IL_0585: ldc.i4.s 22
+			IL_0587: ldloc.s 23
+			IL_0589: stelem.ref
 			IL_058a: dup
-			IL_058b: ldc.i4.0
-			IL_058c: ldloc.1
-			IL_058d: stelem.ref
-			IL_058e: dup
-			IL_058f: ldc.i4.1
-			IL_0590: ldloc.2
-			IL_0591: stelem.ref
-			IL_0592: dup
-			IL_0593: ldc.i4.2
-			IL_0594: ldloc.3
+			IL_058b: ldc.i4.s 23
+			IL_058d: ldloc.s 24
+			IL_058f: stelem.ref
+			IL_0590: dup
+			IL_0591: ldc.i4.s 24
+			IL_0593: ldloc.s 25
 			IL_0595: stelem.ref
 			IL_0596: dup
-			IL_0597: ldc.i4.3
-			IL_0598: ldloc.s 4
-			IL_059a: stelem.ref
-			IL_059b: dup
-			IL_059c: ldc.i4.4
-			IL_059d: ldloc.s 5
-			IL_059f: stelem.ref
-			IL_05a0: dup
-			IL_05a1: ldc.i4.5
-			IL_05a2: ldloc.s 6
-			IL_05a4: stelem.ref
-			IL_05a5: dup
-			IL_05a6: ldc.i4.6
-			IL_05a7: ldloc.s 7
-			IL_05a9: stelem.ref
-			IL_05aa: dup
-			IL_05ab: ldc.i4.7
-			IL_05ac: ldloc.s 8
-			IL_05ae: stelem.ref
-			IL_05af: dup
-			IL_05b0: ldc.i4.8
-			IL_05b1: ldloc.s 9
-			IL_05b3: stelem.ref
-			IL_05b4: dup
-			IL_05b5: ldc.i4.s 9
-			IL_05b7: ldloc.s 10
-			IL_05b9: stelem.ref
-			IL_05ba: dup
-			IL_05bb: ldc.i4.s 10
-			IL_05bd: ldloc.s 11
-			IL_05bf: stelem.ref
-			IL_05c0: dup
-			IL_05c1: ldc.i4.s 11
-			IL_05c3: ldloc.s 12
-			IL_05c5: stelem.ref
-			IL_05c6: dup
-			IL_05c7: ldc.i4.s 12
-			IL_05c9: ldloc.s 13
-			IL_05cb: stelem.ref
-			IL_05cc: dup
-			IL_05cd: ldc.i4.s 13
-			IL_05cf: ldloc.s 14
-			IL_05d1: stelem.ref
-			IL_05d2: dup
-			IL_05d3: ldc.i4.s 14
-			IL_05d5: ldloc.s 15
-			IL_05d7: stelem.ref
-			IL_05d8: dup
-			IL_05d9: ldc.i4.s 15
-			IL_05db: ldloc.s 16
-			IL_05dd: stelem.ref
-			IL_05de: dup
-			IL_05df: ldc.i4.s 16
-			IL_05e1: ldloc.s 17
-			IL_05e3: stelem.ref
-			IL_05e4: dup
-			IL_05e5: ldc.i4.s 17
-			IL_05e7: ldloc.s 18
-			IL_05e9: stelem.ref
-			IL_05ea: dup
-			IL_05eb: ldc.i4.s 18
-			IL_05ed: ldloc.s 19
-			IL_05ef: stelem.ref
-			IL_05f0: dup
-			IL_05f1: ldc.i4.s 19
-			IL_05f3: ldloc.s 20
-			IL_05f5: stelem.ref
-			IL_05f6: dup
-			IL_05f7: ldc.i4.s 20
-			IL_05f9: ldloc.s 21
-			IL_05fb: stelem.ref
-			IL_05fc: dup
-			IL_05fd: ldc.i4.s 21
-			IL_05ff: ldloc.s 22
-			IL_0601: stelem.ref
-			IL_0602: dup
-			IL_0603: ldc.i4.s 22
-			IL_0605: ldloc.s 23
-			IL_0607: stelem.ref
-			IL_0608: dup
-			IL_0609: ldc.i4.s 23
-			IL_060b: ldloc.s 24
-			IL_060d: stelem.ref
-			IL_060e: dup
-			IL_060f: ldc.i4.s 24
-			IL_0611: ldloc.s 25
-			IL_0613: stelem.ref
-			IL_0614: dup
-			IL_0615: ldc.i4.s 25
-			IL_0617: ldloc.s 26
-			IL_0619: stelem.ref
-			IL_061a: pop
-			IL_061b: ldloc.0
-			IL_061c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0621: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0626: ret
+			IL_0597: ldc.i4.s 25
+			IL_0599: ldloc.s 26
+			IL_059b: stelem.ref
+			IL_059c: pop
+			IL_059d: ldloc.0
+			IL_059e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05a3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05a8: ret
 
-			IL_0627: ldloc.0
-			IL_0628: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
-			IL_062d: pop
-			IL_062e: ldstr "console"
-			IL_0633: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0638: stloc.s 25
-			IL_063a: ldloc.s 25
-			IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0641: stloc.s 25
-			IL_0643: ldloc.s 25
-			IL_0645: ldstr "log"
-			IL_064a: ldstr "promise-finished:ok"
-			IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0654: pop
-			IL_0655: br IL_070b
+			IL_05a9: ldloc.0
+			IL_05aa: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
+			IL_05af: pop
+			IL_05b0: ldstr "console"
+			IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05ba: stloc.s 25
+			IL_05bc: ldloc.s 25
+			IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05c3: stloc.s 25
+			IL_05c5: ldloc.s 25
+			IL_05c7: ldstr "log"
+			IL_05cc: ldstr "promise-finished:ok"
+			IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05d6: pop
+			IL_05d7: br IL_068d
 
-			IL_065a: ldloc.0
-			IL_065b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0660: stloc.s 25
-			IL_0662: ldloc.0
-			IL_0663: ldc.i4.0
-			IL_0664: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0669: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_066e: ldloc.s 25
-			IL_0670: stloc.s 12
-			IL_0672: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L36C18::.ctor()
-			IL_0677: stloc.s 13
-			IL_0679: ldstr "console"
-			IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0683: stloc.s 25
-			IL_0685: ldloc.s 25
-			IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_068c: stloc.s 25
-			IL_068e: ldstr "promise-finished:"
-			IL_0693: ldloc.s 12
-			IL_0695: ldstr "name"
-			IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06a4: stloc.s 24
-			IL_06a6: ldloc.s 24
-			IL_06a8: ldstr ":"
-			IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06b2: stloc.s 24
-			IL_06b4: ldloc.s 24
-			IL_06b6: ldloc.s 12
-			IL_06b8: ldstr "code"
-			IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06c7: stloc.s 24
-			IL_06c9: ldloc.s 25
-			IL_06cb: ldstr "log"
-			IL_06d0: ldloc.s 24
-			IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_06d7: pop
-			IL_06d8: ldstr "console"
-			IL_06dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06e2: stloc.s 25
-			IL_06e4: ldloc.s 25
-			IL_06e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06eb: stloc.s 25
-			IL_06ed: ldloc.s 25
-			IL_06ef: ldstr "log"
-			IL_06f4: ldloc.s 12
-			IL_06f6: ldstr "message"
-			IL_06fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0705: pop
-			IL_0706: br IL_070b
+			IL_05dc: ldloc.0
+			IL_05dd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_05e2: stloc.s 25
+			IL_05e4: ldloc.0
+			IL_05e5: ldc.i4.0
+			IL_05e6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_05eb: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_05f0: ldloc.s 25
+			IL_05f2: stloc.s 12
+			IL_05f4: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L36C18::.ctor()
+			IL_05f9: stloc.s 13
+			IL_05fb: ldstr "console"
+			IL_0600: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0605: stloc.s 25
+			IL_0607: ldloc.s 25
+			IL_0609: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_060e: stloc.s 25
+			IL_0610: ldstr "promise-finished:"
+			IL_0615: ldloc.s 12
+			IL_0617: ldstr "name"
+			IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0626: stloc.s 24
+			IL_0628: ldloc.s 24
+			IL_062a: ldstr ":"
+			IL_062f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0634: stloc.s 24
+			IL_0636: ldloc.s 24
+			IL_0638: ldloc.s 12
+			IL_063a: ldstr "code"
+			IL_063f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0644: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0649: stloc.s 24
+			IL_064b: ldloc.s 25
+			IL_064d: ldstr "log"
+			IL_0652: ldloc.s 24
+			IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0659: pop
+			IL_065a: ldstr "console"
+			IL_065f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0664: stloc.s 25
+			IL_0666: ldloc.s 25
+			IL_0668: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_066d: stloc.s 25
+			IL_066f: ldloc.s 25
+			IL_0671: ldstr "log"
+			IL_0676: ldloc.s 12
+			IL_0678: ldstr "message"
+			IL_067d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0687: pop
+			IL_0688: br IL_068d
 
-			IL_070b: ldloc.0
-			IL_070c: ldc.i4.0
-			IL_070d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0712: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0717: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L41C6::.ctor()
-			IL_071c: stloc.s 14
-			IL_071e: ldarg.0
-			IL_071f: ldc.i4.1
-			IL_0720: ldelem.ref
-			IL_0721: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0726: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
-			IL_072b: stloc.s 25
-			IL_072d: ldstr "createReadable"
-			IL_0732: ldloc.s 25
-			IL_0734: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0739: stloc.s 25
-			IL_073b: ldloc.s 25
-			IL_073d: ldc.i4.1
-			IL_073e: newarr [System.Runtime]System.Object
-			IL_0743: dup
-			IL_0744: ldc.i4.0
-			IL_0745: ldarg.0
-			IL_0746: ldc.i4.1
-			IL_0747: ldelem.ref
-			IL_0748: stelem.ref
-			IL_0749: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_074e: stloc.s 25
-			IL_0750: ldloc.s 25
-			IL_0752: stloc.s 15
-			IL_0754: ldarg.0
-			IL_0755: ldc.i4.1
-			IL_0756: ldelem.ref
-			IL_0757: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_075c: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_0761: stloc.s 25
-			IL_0763: ldstr "streamPromises"
-			IL_0768: ldloc.s 25
-			IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_076f: stloc.s 25
-			IL_0771: ldloc.s 25
-			IL_0773: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0778: stloc.s 25
-			IL_077a: ldarg.0
-			IL_077b: ldc.i4.1
-			IL_077c: ldelem.ref
-			IL_077d: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0782: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-			IL_0787: stloc.s 23
-			IL_0789: ldstr "createWritable"
-			IL_078e: ldloc.s 23
-			IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0795: stloc.s 23
-			IL_0797: ldloc.s 23
-			IL_0799: ldc.i4.1
-			IL_079a: newarr [System.Runtime]System.Object
-			IL_079f: dup
-			IL_07a0: ldc.i4.0
-			IL_07a1: ldarg.0
-			IL_07a2: ldc.i4.1
-			IL_07a3: ldelem.ref
-			IL_07a4: stelem.ref
-			IL_07a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_07aa: stloc.s 23
-			IL_07ac: ldloc.s 25
-			IL_07ae: ldstr "pipeline"
-			IL_07b3: ldloc.s 15
-			IL_07b5: ldloc.s 23
-			IL_07b7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_068d: ldloc.0
+			IL_068e: ldc.i4.0
+			IL_068f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0694: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0699: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L41C6::.ctor()
+			IL_069e: stloc.s 14
+			IL_06a0: ldarg.0
+			IL_06a1: ldc.i4.1
+			IL_06a2: ldelem.ref
+			IL_06a3: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_06a8: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
+			IL_06ad: ldc.i4.1
+			IL_06ae: newarr [System.Runtime]System.Object
+			IL_06b3: dup
+			IL_06b4: ldc.i4.0
+			IL_06b5: ldarg.0
+			IL_06b6: ldc.i4.1
+			IL_06b7: ldelem.ref
+			IL_06b8: stelem.ref
+			IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_06be: stloc.s 25
+			IL_06c0: ldloc.s 25
+			IL_06c2: stloc.s 15
+			IL_06c4: ldarg.0
+			IL_06c5: ldc.i4.1
+			IL_06c6: ldelem.ref
+			IL_06c7: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_06cc: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_06d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06d6: stloc.s 25
+			IL_06d8: ldarg.0
+			IL_06d9: ldc.i4.1
+			IL_06da: ldelem.ref
+			IL_06db: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_06e0: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+			IL_06e5: ldc.i4.1
+			IL_06e6: newarr [System.Runtime]System.Object
+			IL_06eb: dup
+			IL_06ec: ldc.i4.0
+			IL_06ed: ldarg.0
+			IL_06ee: ldc.i4.1
+			IL_06ef: ldelem.ref
+			IL_06f0: stelem.ref
+			IL_06f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_06f6: stloc.s 23
+			IL_06f8: ldloc.s 25
+			IL_06fa: ldstr "pipeline"
+			IL_06ff: ldloc.s 15
+			IL_0701: ldloc.s 23
+			IL_0703: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0708: dup
+			IL_0709: ldstr "signal"
+			IL_070e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0713: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_071d: stloc.s 23
+			IL_071f: ldloc.s 23
+			IL_0721: stloc.s 16
+			IL_0723: ldloc.s 15
+			IL_0725: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_072a: stloc.s 23
+			IL_072c: ldloc.s 23
+			IL_072e: ldstr "push"
+			IL_0733: ldc.i4.0
+			IL_0734: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_073e: pop
+			IL_073f: ldloc.0
+			IL_0740: ldc.i4.4
+			IL_0741: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0746: ldloc.0
+			IL_0747: ldloc.s 16
+			IL_0749: ldarg.0
+			IL_074a: ldc.i4.2
+			IL_074b: ldloc.0
+			IL_074c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0751: ldc.i4.3
+			IL_0752: ldstr "_pendingException"
+			IL_0757: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_075c: ldloc.0
+			IL_075d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0762: dup
+			IL_0763: ldc.i4.0
+			IL_0764: ldloc.1
+			IL_0765: stelem.ref
+			IL_0766: dup
+			IL_0767: ldc.i4.1
+			IL_0768: ldloc.2
+			IL_0769: stelem.ref
+			IL_076a: dup
+			IL_076b: ldc.i4.2
+			IL_076c: ldloc.3
+			IL_076d: stelem.ref
+			IL_076e: dup
+			IL_076f: ldc.i4.3
+			IL_0770: ldloc.s 4
+			IL_0772: stelem.ref
+			IL_0773: dup
+			IL_0774: ldc.i4.4
+			IL_0775: ldloc.s 5
+			IL_0777: stelem.ref
+			IL_0778: dup
+			IL_0779: ldc.i4.5
+			IL_077a: ldloc.s 6
+			IL_077c: stelem.ref
+			IL_077d: dup
+			IL_077e: ldc.i4.6
+			IL_077f: ldloc.s 7
+			IL_0781: stelem.ref
+			IL_0782: dup
+			IL_0783: ldc.i4.7
+			IL_0784: ldloc.s 8
+			IL_0786: stelem.ref
+			IL_0787: dup
+			IL_0788: ldc.i4.8
+			IL_0789: ldloc.s 9
+			IL_078b: stelem.ref
+			IL_078c: dup
+			IL_078d: ldc.i4.s 9
+			IL_078f: ldloc.s 10
+			IL_0791: stelem.ref
+			IL_0792: dup
+			IL_0793: ldc.i4.s 10
+			IL_0795: ldloc.s 11
+			IL_0797: stelem.ref
+			IL_0798: dup
+			IL_0799: ldc.i4.s 11
+			IL_079b: ldloc.s 12
+			IL_079d: stelem.ref
+			IL_079e: dup
+			IL_079f: ldc.i4.s 12
+			IL_07a1: ldloc.s 13
+			IL_07a3: stelem.ref
+			IL_07a4: dup
+			IL_07a5: ldc.i4.s 13
+			IL_07a7: ldloc.s 14
+			IL_07a9: stelem.ref
+			IL_07aa: dup
+			IL_07ab: ldc.i4.s 14
+			IL_07ad: ldloc.s 15
+			IL_07af: stelem.ref
+			IL_07b0: dup
+			IL_07b1: ldc.i4.s 15
+			IL_07b3: ldloc.s 16
+			IL_07b5: stelem.ref
+			IL_07b6: dup
+			IL_07b7: ldc.i4.s 16
+			IL_07b9: ldloc.s 17
+			IL_07bb: stelem.ref
 			IL_07bc: dup
-			IL_07bd: ldstr "signal"
-			IL_07c2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_07c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_07cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_07d1: stloc.s 23
-			IL_07d3: ldloc.s 23
-			IL_07d5: stloc.s 16
-			IL_07d7: ldloc.s 15
-			IL_07d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07de: stloc.s 23
-			IL_07e0: ldloc.s 23
-			IL_07e2: ldstr "push"
-			IL_07e7: ldc.i4.0
-			IL_07e8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_07bd: ldc.i4.s 17
+			IL_07bf: ldloc.s 18
+			IL_07c1: stelem.ref
+			IL_07c2: dup
+			IL_07c3: ldc.i4.s 18
+			IL_07c5: ldloc.s 19
+			IL_07c7: stelem.ref
+			IL_07c8: dup
+			IL_07c9: ldc.i4.s 19
+			IL_07cb: ldloc.s 20
+			IL_07cd: stelem.ref
+			IL_07ce: dup
+			IL_07cf: ldc.i4.s 20
+			IL_07d1: ldloc.s 21
+			IL_07d3: stelem.ref
+			IL_07d4: dup
+			IL_07d5: ldc.i4.s 21
+			IL_07d7: ldloc.s 22
+			IL_07d9: stelem.ref
+			IL_07da: dup
+			IL_07db: ldc.i4.s 22
+			IL_07dd: ldloc.s 23
+			IL_07df: stelem.ref
+			IL_07e0: dup
+			IL_07e1: ldc.i4.s 23
+			IL_07e3: ldloc.s 24
+			IL_07e5: stelem.ref
+			IL_07e6: dup
+			IL_07e7: ldc.i4.s 24
+			IL_07e9: ldloc.s 25
+			IL_07eb: stelem.ref
+			IL_07ec: dup
+			IL_07ed: ldc.i4.s 25
+			IL_07ef: ldloc.s 26
+			IL_07f1: stelem.ref
 			IL_07f2: pop
 			IL_07f3: ldloc.0
-			IL_07f4: ldc.i4.4
-			IL_07f5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07fa: ldloc.0
-			IL_07fb: ldloc.s 16
-			IL_07fd: ldarg.0
-			IL_07fe: ldc.i4.2
+			IL_07f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07f9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07fe: ret
+
 			IL_07ff: ldloc.0
-			IL_0800: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0805: ldc.i4.3
-			IL_0806: ldstr "_pendingException"
-			IL_080b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0810: ldloc.0
-			IL_0811: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0816: dup
-			IL_0817: ldc.i4.0
-			IL_0818: ldloc.1
-			IL_0819: stelem.ref
-			IL_081a: dup
-			IL_081b: ldc.i4.1
-			IL_081c: ldloc.2
-			IL_081d: stelem.ref
-			IL_081e: dup
-			IL_081f: ldc.i4.2
-			IL_0820: ldloc.3
-			IL_0821: stelem.ref
-			IL_0822: dup
-			IL_0823: ldc.i4.3
-			IL_0824: ldloc.s 4
-			IL_0826: stelem.ref
-			IL_0827: dup
-			IL_0828: ldc.i4.4
-			IL_0829: ldloc.s 5
-			IL_082b: stelem.ref
-			IL_082c: dup
-			IL_082d: ldc.i4.5
-			IL_082e: ldloc.s 6
-			IL_0830: stelem.ref
-			IL_0831: dup
-			IL_0832: ldc.i4.6
-			IL_0833: ldloc.s 7
-			IL_0835: stelem.ref
-			IL_0836: dup
-			IL_0837: ldc.i4.7
-			IL_0838: ldloc.s 8
-			IL_083a: stelem.ref
-			IL_083b: dup
-			IL_083c: ldc.i4.8
-			IL_083d: ldloc.s 9
-			IL_083f: stelem.ref
-			IL_0840: dup
-			IL_0841: ldc.i4.s 9
-			IL_0843: ldloc.s 10
-			IL_0845: stelem.ref
-			IL_0846: dup
-			IL_0847: ldc.i4.s 10
-			IL_0849: ldloc.s 11
-			IL_084b: stelem.ref
-			IL_084c: dup
-			IL_084d: ldc.i4.s 11
-			IL_084f: ldloc.s 12
-			IL_0851: stelem.ref
-			IL_0852: dup
-			IL_0853: ldc.i4.s 12
-			IL_0855: ldloc.s 13
-			IL_0857: stelem.ref
-			IL_0858: dup
-			IL_0859: ldc.i4.s 13
-			IL_085b: ldloc.s 14
-			IL_085d: stelem.ref
-			IL_085e: dup
-			IL_085f: ldc.i4.s 14
-			IL_0861: ldloc.s 15
-			IL_0863: stelem.ref
-			IL_0864: dup
-			IL_0865: ldc.i4.s 15
-			IL_0867: ldloc.s 16
-			IL_0869: stelem.ref
-			IL_086a: dup
-			IL_086b: ldc.i4.s 16
-			IL_086d: ldloc.s 17
-			IL_086f: stelem.ref
-			IL_0870: dup
-			IL_0871: ldc.i4.s 17
-			IL_0873: ldloc.s 18
-			IL_0875: stelem.ref
-			IL_0876: dup
-			IL_0877: ldc.i4.s 18
-			IL_0879: ldloc.s 19
-			IL_087b: stelem.ref
-			IL_087c: dup
-			IL_087d: ldc.i4.s 19
-			IL_087f: ldloc.s 20
-			IL_0881: stelem.ref
-			IL_0882: dup
-			IL_0883: ldc.i4.s 20
-			IL_0885: ldloc.s 21
-			IL_0887: stelem.ref
-			IL_0888: dup
-			IL_0889: ldc.i4.s 21
-			IL_088b: ldloc.s 22
-			IL_088d: stelem.ref
-			IL_088e: dup
-			IL_088f: ldc.i4.s 22
-			IL_0891: ldloc.s 23
-			IL_0893: stelem.ref
-			IL_0894: dup
-			IL_0895: ldc.i4.s 23
-			IL_0897: ldloc.s 24
-			IL_0899: stelem.ref
-			IL_089a: dup
-			IL_089b: ldc.i4.s 24
-			IL_089d: ldloc.s 25
-			IL_089f: stelem.ref
-			IL_08a0: dup
-			IL_08a1: ldc.i4.s 25
-			IL_08a3: ldloc.s 26
-			IL_08a5: stelem.ref
-			IL_08a6: pop
-			IL_08a7: ldloc.0
-			IL_08a8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08ad: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08b2: ret
+			IL_0800: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
+			IL_0805: pop
+			IL_0806: ldstr "console"
+			IL_080b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0810: stloc.s 23
+			IL_0812: ldloc.s 23
+			IL_0814: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0819: stloc.s 23
+			IL_081b: ldloc.s 23
+			IL_081d: ldstr "log"
+			IL_0822: ldstr "promise-pipeline:ok"
+			IL_0827: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_082c: pop
+			IL_082d: br IL_08e3
 
-			IL_08b3: ldloc.0
-			IL_08b4: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
-			IL_08b9: pop
-			IL_08ba: ldstr "console"
-			IL_08bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_08c4: stloc.s 23
-			IL_08c6: ldloc.s 23
-			IL_08c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_08cd: stloc.s 23
-			IL_08cf: ldloc.s 23
-			IL_08d1: ldstr "log"
-			IL_08d6: ldstr "promise-pipeline:ok"
-			IL_08db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_08e0: pop
-			IL_08e1: br IL_0997
+			IL_0832: ldloc.0
+			IL_0833: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0838: stloc.s 23
+			IL_083a: ldloc.0
+			IL_083b: ldc.i4.0
+			IL_083c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0841: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0846: ldloc.s 23
+			IL_0848: stloc.s 17
+			IL_084a: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L47C18::.ctor()
+			IL_084f: stloc.s 18
+			IL_0851: ldstr "console"
+			IL_0856: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_085b: stloc.s 23
+			IL_085d: ldloc.s 23
+			IL_085f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0864: stloc.s 23
+			IL_0866: ldstr "promise-pipeline:"
+			IL_086b: ldloc.s 17
+			IL_086d: ldstr "name"
+			IL_0872: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0877: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_087c: stloc.s 24
+			IL_087e: ldloc.s 24
+			IL_0880: ldstr ":"
+			IL_0885: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_088a: stloc.s 24
+			IL_088c: ldloc.s 24
+			IL_088e: ldloc.s 17
+			IL_0890: ldstr "code"
+			IL_0895: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_089a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_089f: stloc.s 24
+			IL_08a1: ldloc.s 23
+			IL_08a3: ldstr "log"
+			IL_08a8: ldloc.s 24
+			IL_08aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_08af: pop
+			IL_08b0: ldstr "console"
+			IL_08b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08ba: stloc.s 23
+			IL_08bc: ldloc.s 23
+			IL_08be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08c3: stloc.s 23
+			IL_08c5: ldloc.s 23
+			IL_08c7: ldstr "log"
+			IL_08cc: ldloc.s 17
+			IL_08ce: ldstr "message"
+			IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_08dd: pop
+			IL_08de: br IL_08e3
 
+			IL_08e3: ldnull
+			IL_08e4: stloc.s 19
 			IL_08e6: ldloc.0
-			IL_08e7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_08ec: stloc.s 23
-			IL_08ee: ldloc.0
-			IL_08ef: ldc.i4.0
-			IL_08f0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_08f5: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_08fa: ldloc.s 23
-			IL_08fc: stloc.s 17
-			IL_08fe: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L47C18::.ctor()
-			IL_0903: stloc.s 18
-			IL_0905: ldstr "console"
-			IL_090a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_090f: stloc.s 23
-			IL_0911: ldloc.s 23
-			IL_0913: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0918: stloc.s 23
-			IL_091a: ldstr "promise-pipeline:"
-			IL_091f: ldloc.s 17
-			IL_0921: ldstr "name"
-			IL_0926: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_092b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0930: stloc.s 24
-			IL_0932: ldloc.s 24
-			IL_0934: ldstr ":"
-			IL_0939: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_093e: stloc.s 24
-			IL_0940: ldloc.s 24
-			IL_0942: ldloc.s 17
-			IL_0944: ldstr "code"
-			IL_0949: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_094e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0953: stloc.s 24
-			IL_0955: ldloc.s 23
-			IL_0957: ldstr "log"
-			IL_095c: ldloc.s 24
-			IL_095e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0963: pop
-			IL_0964: ldstr "console"
-			IL_0969: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_096e: stloc.s 23
-			IL_0970: ldloc.s 23
-			IL_0972: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0977: stloc.s 23
-			IL_0979: ldloc.s 23
-			IL_097b: ldstr "log"
-			IL_0980: ldloc.s 17
-			IL_0982: ldstr "message"
-			IL_0987: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_098c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0991: pop
-			IL_0992: br IL_0997
-
-			IL_0997: ldnull
-			IL_0998: stloc.s 19
-			IL_099a: ldloc.0
-			IL_099b: ldc.i4.m1
-			IL_099c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_09a1: ldloc.0
-			IL_09a2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_09ac: ldarg.0
-			IL_09ad: ldc.i4.1
-			IL_09ae: newarr [System.Runtime]System.Object
-			IL_09b3: dup
-			IL_09b4: ldc.i4.0
-			IL_09b5: ldloc.s 19
-			IL_09b7: stelem.ref
-			IL_09b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_09bd: pop
-			IL_09be: ldloc.0
-			IL_09bf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09c4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_09c9: ret
+			IL_08e7: ldc.i4.m1
+			IL_08e8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08ed: ldloc.0
+			IL_08ee: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_08f8: ldarg.0
+			IL_08f9: ldc.i4.1
+			IL_08fa: newarr [System.Runtime]System.Object
+			IL_08ff: dup
+			IL_0900: ldc.i4.0
+			IL_0901: ldloc.s 19
+			IL_0903: stelem.ref
+			IL_0904: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0909: pop
+			IL_090a: ldloc.0
+			IL_090b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0910: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0915: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1635,7 +1563,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2c05
+			// Method begins at RVA 0x2b1d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1760,7 +1688,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2c8c
+		// Method begins at RVA 0x2ba4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_PassThrough_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_PassThrough_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230c
+				// Method begins at RVA 0x22b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,31 +46,17 @@
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
 			// Method begins at RVA 0x21d4
-			// Header size: 12
-			// Code size: 41 (0x29)
+			// Header size: 1
+			// Code size: 15 (0xf)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_PassThrough_Basic/Scope::written
-			IL_0006: stloc.0
-			IL_0007: ldstr "written"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0026: pop
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldnull
+			IL_000e: ret
 		} // end of method FunctionExpression_L10C18::__js_call__
 
 	} // end of class FunctionExpression_L10C18
@@ -86,7 +72,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2315
+				// Method begins at RVA 0x22ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -112,16 +98,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x220c
+			// Method begins at RVA 0x21e4
 			// Header size: 12
-			// Code size: 235 (0xeb)
+			// Code size: 184 (0xb8)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object,
-				[3] float64,
-				[4] object
+				[0] object
 			)
 
 			IL_0000: ldstr "console"
@@ -141,70 +123,45 @@
 			IL_002e: ldloc.0
 			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0034: stloc.0
-			IL_0035: ldarg.0
-			IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_PassThrough_Basic/Scope::written
-			IL_003b: stloc.1
-			IL_003c: ldstr "written"
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0047: stloc.2
-			IL_0048: ldloc.2
-			IL_0049: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_004e: stloc.3
-			IL_004f: ldloc.3
-			IL_0050: box [System.Runtime]System.Double
-			IL_0055: stloc.s 4
-			IL_0057: ldloc.0
-			IL_0058: ldstr "log"
-			IL_005d: ldloc.s 4
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0064: pop
-			IL_0065: ldstr "console"
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_006f: stloc.0
-			IL_0070: ldloc.0
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0076: stloc.0
-			IL_0077: ldarg.0
-			IL_0078: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_PassThrough_Basic/Scope::written
-			IL_007d: stloc.1
-			IL_007e: ldstr "written"
-			IL_0083: ldloc.1
-			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0089: stloc.2
-			IL_008a: ldloc.2
-			IL_008b: ldc.r8 0.0
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0099: stloc.2
-			IL_009a: ldloc.0
-			IL_009b: ldstr "log"
-			IL_00a0: ldloc.2
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00a6: pop
-			IL_00a7: ldstr "console"
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b1: stloc.2
-			IL_00b2: ldloc.2
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b8: stloc.2
-			IL_00b9: ldarg.0
-			IL_00ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_PassThrough_Basic/Scope::written
-			IL_00bf: stloc.1
-			IL_00c0: ldstr "written"
-			IL_00c5: ldloc.1
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00cb: stloc.0
-			IL_00cc: ldloc.0
-			IL_00cd: ldc.r8 1
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00db: stloc.0
-			IL_00dc: ldloc.2
-			IL_00dd: ldstr "log"
-			IL_00e2: ldloc.0
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00e8: pop
-			IL_00e9: ldnull
-			IL_00ea: ret
+			IL_0035: ldloc.0
+			IL_0036: ldstr "log"
+			IL_003b: ldarg.0
+			IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_PassThrough_Basic/Scope::written
+			IL_0041: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0046: conv.r8
+			IL_0047: box [System.Runtime]System.Double
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0051: pop
+			IL_0052: ldstr "console"
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_005c: stloc.0
+			IL_005d: ldloc.0
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0063: stloc.0
+			IL_0064: ldloc.0
+			IL_0065: ldstr "log"
+			IL_006a: ldarg.0
+			IL_006b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_PassThrough_Basic/Scope::written
+			IL_0070: ldc.r8 0.0
+			IL_0079: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0083: pop
+			IL_0084: ldstr "console"
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_008e: stloc.0
+			IL_008f: ldloc.0
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0095: stloc.0
+			IL_0096: ldloc.0
+			IL_0097: ldstr "log"
+			IL_009c: ldarg.0
+			IL_009d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_PassThrough_Basic/Scope::written
+			IL_00a2: ldc.r8 1
+			IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00b5: pop
+			IL_00b6: ldnull
+			IL_00b7: ret
 		} // end of method FunctionExpression_L14C22::__js_call__
 
 	} // end of class FunctionExpression_L14C22
@@ -223,7 +180,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2303
+			// Method begins at RVA 0x22a8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -404,7 +361,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x231e
+		// Method begins at RVA 0x22c3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Backpressure_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Backpressure_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x247a
+				// Method begins at RVA 0x23c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,31 +46,17 @@
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
 			// Method begins at RVA 0x2254
-			// Header size: 12
-			// Code size: 41 (0x29)
+			// Header size: 1
+			// Code size: 15 (0xf)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Backpressure_Basic/Scope::written
-			IL_0006: stloc.0
-			IL_0007: ldstr "written"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0026: pop
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldnull
+			IL_000e: ret
 		} // end of method FunctionExpression_L11C18::__js_call__
 
 	} // end of class FunctionExpression_L11C18
@@ -86,7 +72,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2483
+				// Method begins at RVA 0x23ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -109,7 +95,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x228c
+			// Method begins at RVA 0x2264
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -145,7 +131,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x248c
+				// Method begins at RVA 0x23d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -171,15 +157,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x22c0
+			// Method begins at RVA 0x2298
 			// Header size: 12
-			// Code size: 123 (0x7b)
+			// Code size: 106 (0x6a)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object,
-				[3] object
+				[1] string
 			)
 
 			IL_0000: ldstr "console"
@@ -201,30 +185,25 @@
 			IL_0034: stloc.0
 			IL_0035: ldarg.0
 			IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Backpressure_Basic/Scope::written
-			IL_003b: stloc.1
-			IL_003c: ldstr "written"
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0047: stloc.2
-			IL_0048: ldloc.2
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: ldstr "join"
-			IL_0055: ldstr ","
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005f: stloc.2
-			IL_0060: ldstr "written:"
-			IL_0065: ldloc.2
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006b: stloc.3
-			IL_006c: ldloc.0
-			IL_006d: ldstr "log"
-			IL_0072: ldloc.3
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0078: pop
-			IL_0079: ldnull
-			IL_007a: ret
+			IL_003b: ldc.i4.1
+			IL_003c: newarr [System.Runtime]System.Object
+			IL_0041: dup
+			IL_0042: ldc.i4.0
+			IL_0043: ldstr ","
+			IL_0048: stelem.ref
+			IL_0049: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_004e: stloc.1
+			IL_004f: ldstr "written:"
+			IL_0054: ldloc.1
+			IL_0055: call string [System.Runtime]System.String::Concat(string, string)
+			IL_005a: stloc.1
+			IL_005b: ldloc.0
+			IL_005c: ldstr "log"
+			IL_0061: ldloc.1
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0067: pop
+			IL_0068: ldnull
+			IL_0069: ret
 		} // end of method FunctionExpression_L19C22::__js_call__
 
 	} // end of class FunctionExpression_L19C22
@@ -244,7 +223,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x249e
+					// Method begins at RVA 0x23e5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -264,7 +243,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24a7
+					// Method begins at RVA 0x23ee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -282,7 +261,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2495
+				// Method begins at RVA 0x23dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -308,125 +287,71 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2348
+			// Method begins at RVA 0x2310
 			// Header size: 12
-			// Code size: 285 (0x11d)
+			// Code size: 156 (0x9c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/Scope/Block_L29C29,
 				[1] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/Scope/Block_L31C9,
 				[2] object,
-				[3] float64,
-				[4] object,
-				[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[6] object,
-				[7] float64,
-				[8] object
+				[3] float64
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::index
-			IL_0006: stloc.2
-			IL_0007: ldstr "index"
-			IL_000c: ldloc.2
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.2
-			IL_0013: ldloc.2
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.3
-			IL_001a: ldloc.3
-			IL_001b: ldc.r8 1
-			IL_0024: add
-			IL_0025: stloc.3
-			IL_0026: ldloc.3
-			IL_0027: box [System.Runtime]System.Double
-			IL_002c: stloc.s 4
-			IL_002e: ldarg.0
-			IL_002f: ldloc.s 4
-			IL_0031: stfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::index
-			IL_0036: ldarg.0
-			IL_0037: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::index
-			IL_003c: stloc.2
-			IL_003d: ldstr "index"
-			IL_0042: ldloc.2
-			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0048: stloc.2
-			IL_0049: ldarg.0
-			IL_004a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
-			IL_004f: stloc.s 5
-			IL_0051: ldstr "chunks"
-			IL_0056: ldloc.s 5
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_005d: stloc.s 6
-			IL_005f: ldloc.s 6
-			IL_0061: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_0066: stloc.3
-			IL_0067: ldloc.2
-			IL_0068: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_006d: stloc.s 7
-			IL_006f: ldloc.s 7
-			IL_0071: ldloc.3
-			IL_0072: clt
-			IL_0074: brfalse IL_00e3
+			IL_0001: ldarg.0
+			IL_0002: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::index
+			IL_0007: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000c: ldc.r8 1
+			IL_0015: add
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: stfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::index
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::index
+			IL_0026: stloc.2
+			IL_0027: ldarg.0
+			IL_0028: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
+			IL_002d: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0032: conv.r8
+			IL_0033: stloc.3
+			IL_0034: ldloc.2
+			IL_0035: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_003a: ldloc.3
+			IL_003b: clt
+			IL_003d: brfalse IL_0076
 
-			IL_0079: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/Scope/Block_L29C29::.ctor()
-			IL_007e: stloc.0
-			IL_007f: ldarg.0
-			IL_0080: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
-			IL_0085: stloc.2
-			IL_0086: ldstr "readable"
-			IL_008b: ldloc.2
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0091: stloc.2
-			IL_0092: ldloc.2
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0098: stloc.2
-			IL_0099: ldarg.0
-			IL_009a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
-			IL_009f: stloc.s 5
-			IL_00a1: ldstr "chunks"
-			IL_00a6: ldloc.s 5
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ad: stloc.s 6
-			IL_00af: ldarg.0
-			IL_00b0: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::index
-			IL_00b5: stloc.s 8
-			IL_00b7: ldstr "index"
-			IL_00bc: ldloc.s 8
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c3: stloc.s 8
-			IL_00c5: ldloc.s 6
-			IL_00c7: ldloc.s 8
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_00ce: stloc.s 8
-			IL_00d0: ldloc.2
-			IL_00d1: ldstr "push"
-			IL_00d6: ldloc.s 8
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00dd: pop
-			IL_00de: br IL_011b
+			IL_0042: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/Scope/Block_L29C29::.ctor()
+			IL_0047: stloc.0
+			IL_0048: ldarg.0
+			IL_0049: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0053: stloc.2
+			IL_0054: ldloc.2
+			IL_0055: ldstr "push"
+			IL_005a: ldarg.0
+			IL_005b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
+			IL_0060: ldarg.0
+			IL_0061: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::index
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0070: pop
+			IL_0071: br IL_009a
 
-			IL_00e3: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/Scope/Block_L31C9::.ctor()
-			IL_00e8: stloc.1
-			IL_00e9: ldarg.0
-			IL_00ea: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
-			IL_00ef: stloc.s 8
-			IL_00f1: ldstr "readable"
-			IL_00f6: ldloc.s 8
-			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00fd: stloc.s 8
-			IL_00ff: ldloc.s 8
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0106: stloc.s 8
-			IL_0108: ldloc.s 8
-			IL_010a: ldstr "push"
-			IL_010f: ldc.i4.0
-			IL_0110: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_011a: pop
+			IL_0076: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/Scope/Block_L31C9::.ctor()
+			IL_007b: stloc.1
+			IL_007c: ldarg.0
+			IL_007d: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0087: stloc.2
+			IL_0088: ldloc.2
+			IL_0089: ldstr "push"
+			IL_008e: ldc.i4.0
+			IL_008f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0099: pop
 
-			IL_011b: ldnull
-			IL_011c: ret
+			IL_009a: ldnull
+			IL_009b: ret
 		} // end of method FunctionExpression_L27C21::__js_call__
 
 	} // end of class FunctionExpression_L27C21
@@ -451,7 +376,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2471
+			// Method begins at RVA 0x23b8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -672,7 +597,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24b0
+		// Method begins at RVA 0x23f7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a6
+				// Method begins at RVA 0x2280
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,32 +45,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2268
-			// Header size: 12
-			// Code size: 41 (0x29)
+			// Method begins at RVA 0x2267
+			// Header size: 1
+			// Code size: 15 (0xf)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Basic/Scope::writtenData
-			IL_0006: stloc.0
-			IL_0007: ldstr "writtenData"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0026: pop
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldnull
+			IL_000e: ret
 		} // end of method FunctionExpression_L13C18::__js_call__
 
 	} // end of class FunctionExpression_L13C18
@@ -90,7 +76,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x229d
+			// Method begins at RVA 0x2277
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -114,7 +100,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b8
+				// Method begins at RVA 0x2292
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -132,7 +118,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22af
+			// Method begins at RVA 0x2289
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -362,7 +348,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22c1
+		// Method begins at RVA 0x229b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2310
+				// Method begins at RVA 0x22bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,31 +46,17 @@
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
 			// Method begins at RVA 0x21c4
-			// Header size: 12
-			// Code size: 41 (0x29)
+			// Header size: 1
+			// Code size: 15 (0xf)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipeline_Basic/Scope::written
-			IL_0006: stloc.0
-			IL_0007: ldstr "written"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0026: pop
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldnull
+			IL_000e: ret
 		} // end of method FunctionExpression_L10C18::__js_call__
 
 	} // end of class FunctionExpression_L10C18
@@ -86,7 +72,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2319
+				// Method begins at RVA 0x22c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -113,17 +99,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21fc
+			// Method begins at RVA 0x21d4
 			// Header size: 12
-			// Code size: 255 (0xff)
+			// Code size: 212 (0xd4)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] bool,
 				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[5] object
+				[4] string
 			)
 
 			IL_0000: ldstr "console"
@@ -164,56 +149,43 @@
 			IL_0060: stloc.1
 			IL_0061: ldarg.0
 			IL_0062: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipeline_Basic/Scope::written
-			IL_0067: stloc.s 4
-			IL_0069: ldstr "written"
-			IL_006e: ldloc.s 4
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0075: stloc.s 5
-			IL_0077: ldloc.s 5
-			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007e: stloc.s 5
-			IL_0080: ldloc.s 5
-			IL_0082: ldstr "join"
-			IL_0087: ldstr ","
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0091: stloc.s 5
-			IL_0093: ldstr "written:"
-			IL_0098: ldloc.s 5
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_009f: stloc.3
-			IL_00a0: ldloc.1
-			IL_00a1: ldstr "log"
-			IL_00a6: ldloc.3
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ac: pop
-			IL_00ad: ldstr "console"
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b7: stloc.1
-			IL_00b8: ldloc.1
-			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00be: stloc.1
-			IL_00bf: ldarg.0
-			IL_00c0: ldfld object Modules.Stream_Pipeline_Basic/Scope::pass
-			IL_00c5: stloc.s 5
-			IL_00c7: ldstr "pass"
-			IL_00cc: ldloc.s 5
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00d3: stloc.s 5
-			IL_00d5: ldloc.s 5
-			IL_00d7: ldstr "destroyed"
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e1: stloc.s 5
-			IL_00e3: ldstr "pass-destroyed:"
-			IL_00e8: ldloc.s 5
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00ef: stloc.3
-			IL_00f0: ldloc.1
-			IL_00f1: ldstr "log"
-			IL_00f6: ldloc.3
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00fc: pop
-			IL_00fd: ldnull
-			IL_00fe: ret
+			IL_0067: ldc.i4.1
+			IL_0068: newarr [System.Runtime]System.Object
+			IL_006d: dup
+			IL_006e: ldc.i4.0
+			IL_006f: ldstr ","
+			IL_0074: stelem.ref
+			IL_0075: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_007a: stloc.s 4
+			IL_007c: ldstr "written:"
+			IL_0081: ldloc.s 4
+			IL_0083: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0088: stloc.s 4
+			IL_008a: ldloc.1
+			IL_008b: ldstr "log"
+			IL_0090: ldloc.s 4
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0097: pop
+			IL_0098: ldstr "console"
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00a2: stloc.1
+			IL_00a3: ldloc.1
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a9: stloc.1
+			IL_00aa: ldstr "pass-destroyed:"
+			IL_00af: ldarg.0
+			IL_00b0: ldfld object Modules.Stream_Pipeline_Basic/Scope::pass
+			IL_00b5: ldstr "destroyed"
+			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00c4: stloc.3
+			IL_00c5: ldloc.1
+			IL_00c6: ldstr "log"
+			IL_00cb: ldloc.3
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00d1: pop
+			IL_00d2: ldnull
+			IL_00d3: ret
 		} // end of method FunctionExpression_L14C42::__js_call__
 
 	} // end of class FunctionExpression_L14C42
@@ -234,7 +206,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2307
+			// Method begins at RVA 0x22b4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -422,7 +394,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2322
+		// Method begins at RVA 0x22cf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2342
+				// Method begins at RVA 0x2300
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x234b
+				// Method begins at RVA 0x2309
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -130,7 +130,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2354
+				// Method begins at RVA 0x2312
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -159,14 +159,13 @@
 			)
 			// Method begins at RVA 0x21ec
 			// Header size: 12
-			// Code size: 321 (0x141)
+			// Code size: 255 (0xff)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] bool,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldstr "console"
@@ -205,80 +204,56 @@
 			IL_005a: ldloc.1
 			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0060: stloc.1
-			IL_0061: ldarg.0
-			IL_0062: ldfld object Modules.Stream_Pipeline_Error/Scope::readable
-			IL_0067: stloc.s 4
-			IL_0069: ldstr "readable"
-			IL_006e: ldloc.s 4
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0075: stloc.s 4
-			IL_0077: ldloc.s 4
-			IL_0079: ldstr "destroyed"
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0083: stloc.s 4
-			IL_0085: ldstr "source-destroyed:"
-			IL_008a: ldloc.s 4
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0091: stloc.3
-			IL_0092: ldloc.1
-			IL_0093: ldstr "log"
-			IL_0098: ldloc.3
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_009e: pop
-			IL_009f: ldstr "console"
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00a9: stloc.1
-			IL_00aa: ldloc.1
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b0: stloc.1
-			IL_00b1: ldarg.0
-			IL_00b2: ldfld object Modules.Stream_Pipeline_Error/Scope::transform
-			IL_00b7: stloc.s 4
-			IL_00b9: ldstr "transform"
-			IL_00be: ldloc.s 4
-			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c5: stloc.s 4
-			IL_00c7: ldloc.s 4
-			IL_00c9: ldstr "destroyed"
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d3: stloc.s 4
-			IL_00d5: ldstr "transform-destroyed:"
-			IL_00da: ldloc.s 4
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00e1: stloc.3
-			IL_00e2: ldloc.1
-			IL_00e3: ldstr "log"
-			IL_00e8: ldloc.3
-			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ee: pop
-			IL_00ef: ldstr "console"
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00f9: stloc.1
-			IL_00fa: ldloc.1
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0100: stloc.1
-			IL_0101: ldarg.0
-			IL_0102: ldfld object Modules.Stream_Pipeline_Error/Scope::writable
-			IL_0107: stloc.s 4
-			IL_0109: ldstr "writable"
-			IL_010e: ldloc.s 4
-			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0115: stloc.s 4
-			IL_0117: ldloc.s 4
-			IL_0119: ldstr "destroyed"
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0123: stloc.s 4
-			IL_0125: ldstr "writable-destroyed:"
-			IL_012a: ldloc.s 4
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0131: stloc.3
-			IL_0132: ldloc.1
-			IL_0133: ldstr "log"
-			IL_0138: ldloc.3
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_013e: pop
-			IL_013f: ldnull
-			IL_0140: ret
+			IL_0061: ldstr "source-destroyed:"
+			IL_0066: ldarg.0
+			IL_0067: ldfld object Modules.Stream_Pipeline_Error/Scope::readable
+			IL_006c: ldstr "destroyed"
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_007b: stloc.3
+			IL_007c: ldloc.1
+			IL_007d: ldstr "log"
+			IL_0082: ldloc.3
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0088: pop
+			IL_0089: ldstr "console"
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0093: stloc.1
+			IL_0094: ldloc.1
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009a: stloc.1
+			IL_009b: ldstr "transform-destroyed:"
+			IL_00a0: ldarg.0
+			IL_00a1: ldfld object Modules.Stream_Pipeline_Error/Scope::transform
+			IL_00a6: ldstr "destroyed"
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00b5: stloc.3
+			IL_00b6: ldloc.1
+			IL_00b7: ldstr "log"
+			IL_00bc: ldloc.3
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00c2: pop
+			IL_00c3: ldstr "console"
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00cd: stloc.1
+			IL_00ce: ldloc.1
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d4: stloc.1
+			IL_00d5: ldstr "writable-destroyed:"
+			IL_00da: ldarg.0
+			IL_00db: ldfld object Modules.Stream_Pipeline_Error/Scope::writable
+			IL_00e0: ldstr "destroyed"
+			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00ef: stloc.3
+			IL_00f0: ldloc.1
+			IL_00f1: ldstr "log"
+			IL_00f6: ldloc.3
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00fc: pop
+			IL_00fd: ldnull
+			IL_00fe: ret
 		} // end of method FunctionExpression_L15C47::__js_call__
 
 	} // end of class FunctionExpression_L15C47
@@ -302,7 +277,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2339
+			// Method begins at RVA 0x22f7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -485,7 +460,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x235d
+		// Method begins at RVA 0x231b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error_PropagatesToPeers.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error_PropagatesToPeers.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x248a
+				// Method begins at RVA 0x2448
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2493
+				// Method begins at RVA 0x2451
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -152,7 +152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x249c
+				// Method begins at RVA 0x245a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -219,7 +219,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a5
+				// Method begins at RVA 0x2463
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +286,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ae
+				// Method begins at RVA 0x246c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -315,14 +315,13 @@
 			)
 			// Method begins at RVA 0x2334
 			// Header size: 12
-			// Code size: 321 (0x141)
+			// Code size: 255 (0xff)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] bool,
-				[3] object,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldstr "console"
@@ -361,80 +360,56 @@
 			IL_005a: ldloc.1
 			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0060: stloc.1
-			IL_0061: ldarg.0
-			IL_0062: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
-			IL_0067: stloc.s 4
-			IL_0069: ldstr "readable"
-			IL_006e: ldloc.s 4
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0075: stloc.s 4
-			IL_0077: ldloc.s 4
-			IL_0079: ldstr "destroyed"
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0083: stloc.s 4
-			IL_0085: ldstr "source-destroyed:"
-			IL_008a: ldloc.s 4
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0091: stloc.3
-			IL_0092: ldloc.1
-			IL_0093: ldstr "log"
-			IL_0098: ldloc.3
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_009e: pop
-			IL_009f: ldstr "console"
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00a9: stloc.1
-			IL_00aa: ldloc.1
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b0: stloc.1
-			IL_00b1: ldarg.0
-			IL_00b2: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::pass
-			IL_00b7: stloc.s 4
-			IL_00b9: ldstr "pass"
-			IL_00be: ldloc.s 4
-			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c5: stloc.s 4
-			IL_00c7: ldloc.s 4
-			IL_00c9: ldstr "destroyed"
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d3: stloc.s 4
-			IL_00d5: ldstr "pass-destroyed:"
-			IL_00da: ldloc.s 4
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00e1: stloc.3
-			IL_00e2: ldloc.1
-			IL_00e3: ldstr "log"
-			IL_00e8: ldloc.3
-			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ee: pop
-			IL_00ef: ldstr "console"
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00f9: stloc.1
-			IL_00fa: ldloc.1
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0100: stloc.1
-			IL_0101: ldarg.0
-			IL_0102: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::writable
-			IL_0107: stloc.s 4
-			IL_0109: ldstr "writable"
-			IL_010e: ldloc.s 4
-			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0115: stloc.s 4
-			IL_0117: ldloc.s 4
-			IL_0119: ldstr "destroyed"
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0123: stloc.s 4
-			IL_0125: ldstr "writable-destroyed:"
-			IL_012a: ldloc.s 4
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0131: stloc.3
-			IL_0132: ldloc.1
-			IL_0133: ldstr "log"
-			IL_0138: ldloc.3
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_013e: pop
-			IL_013f: ldnull
-			IL_0140: ret
+			IL_0061: ldstr "source-destroyed:"
+			IL_0066: ldarg.0
+			IL_0067: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
+			IL_006c: ldstr "destroyed"
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_007b: stloc.3
+			IL_007c: ldloc.1
+			IL_007d: ldstr "log"
+			IL_0082: ldloc.3
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0088: pop
+			IL_0089: ldstr "console"
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0093: stloc.1
+			IL_0094: ldloc.1
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009a: stloc.1
+			IL_009b: ldstr "pass-destroyed:"
+			IL_00a0: ldarg.0
+			IL_00a1: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::pass
+			IL_00a6: ldstr "destroyed"
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00b5: stloc.3
+			IL_00b6: ldloc.1
+			IL_00b7: ldstr "log"
+			IL_00bc: ldloc.3
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00c2: pop
+			IL_00c3: ldstr "console"
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00cd: stloc.1
+			IL_00ce: ldloc.1
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d4: stloc.1
+			IL_00d5: ldstr "writable-destroyed:"
+			IL_00da: ldarg.0
+			IL_00db: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::writable
+			IL_00e0: ldstr "destroyed"
+			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00ef: stloc.3
+			IL_00f0: ldloc.1
+			IL_00f1: ldstr "log"
+			IL_00f6: ldloc.3
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00fc: pop
+			IL_00fd: ldnull
+			IL_00fe: ret
 		} // end of method FunctionExpression_L25C42::__js_call__
 
 	} // end of class FunctionExpression_L25C42
@@ -457,7 +432,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2481
+			// Method begins at RVA 0x243f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -683,7 +658,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24b7
+		// Method begins at RVA 0x2475
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22e7
+					// Method begins at RVA 0x22c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22d2
+				// Method begins at RVA 0x22b4
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22de
+				// Method begins at RVA 0x22c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			)
 			// Method begins at RVA 0x20bc
 			// Header size: 12
-			// Code size: 522 (0x20a)
+			// Code size: 492 (0x1ec)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Promises_Finished_Basic/main/Scope,
@@ -170,159 +170,145 @@
 
 			IL_0077: ldloc.0
 			IL_0078: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_007d: switch (IL_008a, IL_016a)
+			IL_007d: switch (IL_008a, IL_014c)
 
 			IL_008a: ldarg.0
 			IL_008b: ldc.i4.1
 			IL_008c: ldelem.ref
 			IL_008d: castclass Modules.Stream_Promises_Finished_Basic/Scope
 			IL_0092: ldfld object Modules.Stream_Promises_Finished_Basic/Scope::'stream'
-			IL_0097: stloc.3
-			IL_0098: ldstr "stream"
-			IL_009d: ldloc.3
-			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a3: stloc.3
-			IL_00a4: ldloc.3
-			IL_00a5: ldstr "Writable"
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00af: stloc.3
-			IL_00b0: ldloc.3
-			IL_00b1: ldc.i4.0
-			IL_00b2: newarr [System.Runtime]System.Object
-			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_00bc: stloc.3
-			IL_00bd: ldloc.3
-			IL_00be: stloc.1
-			IL_00bf: ldnull
-			IL_00c0: ldftn object Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20::__js_call__(object)
-			IL_00c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_00cb: ldc.i4.0
-			IL_00cc: conv.r8
-			IL_00cd: ldstr ""
-			IL_00d2: ldc.i4.0
-			IL_00d3: ldc.i4.1
-			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00d9: stloc.3
-			IL_00da: ldloc.1
-			IL_00db: ldstr "_write"
-			IL_00e0: ldloc.3
-			IL_00e1: ldc.i4.1
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_00e7: pop
-			IL_00e8: ldarg.0
-			IL_00e9: ldc.i4.1
-			IL_00ea: ldelem.ref
-			IL_00eb: castclass Modules.Stream_Promises_Finished_Basic/Scope
-			IL_00f0: ldfld object Modules.Stream_Promises_Finished_Basic/Scope::streamPromises
-			IL_00f5: stloc.3
-			IL_00f6: ldstr "streamPromises"
-			IL_00fb: ldloc.3
-			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0101: stloc.3
-			IL_0102: ldloc.3
-			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0108: stloc.3
-			IL_0109: ldloc.3
-			IL_010a: ldstr "finished"
-			IL_010f: ldloc.1
-			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0115: stloc.3
-			IL_0116: ldloc.3
-			IL_0117: stloc.2
-			IL_0118: ldloc.1
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011e: stloc.3
-			IL_011f: ldloc.3
-			IL_0120: ldstr "end"
-			IL_0125: ldstr "done"
-			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_012f: pop
-			IL_0130: ldloc.0
-			IL_0131: ldc.i4.1
-			IL_0132: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0137: ldloc.0
-			IL_0138: ldloc.2
-			IL_0139: ldarg.0
-			IL_013a: ldc.i4.1
-			IL_013b: ldloc.0
-			IL_013c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0141: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0146: ldloc.0
-			IL_0147: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_014c: dup
-			IL_014d: ldc.i4.0
-			IL_014e: ldloc.1
-			IL_014f: stelem.ref
-			IL_0150: dup
-			IL_0151: ldc.i4.1
-			IL_0152: ldloc.2
-			IL_0153: stelem.ref
-			IL_0154: dup
-			IL_0155: ldc.i4.2
-			IL_0156: ldloc.3
-			IL_0157: stelem.ref
-			IL_0158: dup
-			IL_0159: ldc.i4.3
-			IL_015a: ldloc.s 4
-			IL_015c: stelem.ref
-			IL_015d: pop
-			IL_015e: ldloc.0
-			IL_015f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0164: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0169: ret
+			IL_0097: ldstr "Writable"
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a1: ldc.i4.0
+			IL_00a2: newarr [System.Runtime]System.Object
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_00ac: stloc.3
+			IL_00ad: ldloc.3
+			IL_00ae: stloc.1
+			IL_00af: ldnull
+			IL_00b0: ldftn object Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20::__js_call__(object)
+			IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_00bb: ldc.i4.0
+			IL_00bc: conv.r8
+			IL_00bd: ldstr ""
+			IL_00c2: ldc.i4.0
+			IL_00c3: ldc.i4.1
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00c9: stloc.3
+			IL_00ca: ldloc.1
+			IL_00cb: ldstr "_write"
+			IL_00d0: ldloc.3
+			IL_00d1: ldc.i4.1
+			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_00d7: pop
+			IL_00d8: ldarg.0
+			IL_00d9: ldc.i4.1
+			IL_00da: ldelem.ref
+			IL_00db: castclass Modules.Stream_Promises_Finished_Basic/Scope
+			IL_00e0: ldfld object Modules.Stream_Promises_Finished_Basic/Scope::streamPromises
+			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ea: stloc.3
+			IL_00eb: ldloc.3
+			IL_00ec: ldstr "finished"
+			IL_00f1: ldloc.1
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f7: stloc.3
+			IL_00f8: ldloc.3
+			IL_00f9: stloc.2
+			IL_00fa: ldloc.1
+			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0100: stloc.3
+			IL_0101: ldloc.3
+			IL_0102: ldstr "end"
+			IL_0107: ldstr "done"
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0111: pop
+			IL_0112: ldloc.0
+			IL_0113: ldc.i4.1
+			IL_0114: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0119: ldloc.0
+			IL_011a: ldloc.2
+			IL_011b: ldarg.0
+			IL_011c: ldc.i4.1
+			IL_011d: ldloc.0
+			IL_011e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0123: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0128: ldloc.0
+			IL_0129: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_012e: dup
+			IL_012f: ldc.i4.0
+			IL_0130: ldloc.1
+			IL_0131: stelem.ref
+			IL_0132: dup
+			IL_0133: ldc.i4.1
+			IL_0134: ldloc.2
+			IL_0135: stelem.ref
+			IL_0136: dup
+			IL_0137: ldc.i4.2
+			IL_0138: ldloc.3
+			IL_0139: stelem.ref
+			IL_013a: dup
+			IL_013b: ldc.i4.3
+			IL_013c: ldloc.s 4
+			IL_013e: stelem.ref
+			IL_013f: pop
+			IL_0140: ldloc.0
+			IL_0141: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0146: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_014b: ret
 
-			IL_016a: ldloc.0
-			IL_016b: ldfld object Modules.Stream_Promises_Finished_Basic/main/Scope::_awaited1
-			IL_0170: pop
-			IL_0171: ldstr "console"
-			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_017b: stloc.3
+			IL_014c: ldloc.0
+			IL_014d: ldfld object Modules.Stream_Promises_Finished_Basic/main/Scope::_awaited1
+			IL_0152: pop
+			IL_0153: ldstr "console"
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_015d: stloc.3
+			IL_015e: ldloc.3
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0164: stloc.3
+			IL_0165: ldstr "destroyed:"
+			IL_016a: ldloc.1
+			IL_016b: ldstr "destroyed"
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_017a: stloc.s 4
 			IL_017c: ldloc.3
-			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0182: stloc.3
-			IL_0183: ldstr "destroyed:"
-			IL_0188: ldloc.1
-			IL_0189: ldstr "destroyed"
-			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0198: stloc.s 4
-			IL_019a: ldloc.3
-			IL_019b: ldstr "log"
-			IL_01a0: ldloc.s 4
-			IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01a7: pop
-			IL_01a8: ldstr "console"
-			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01b2: stloc.3
+			IL_017d: ldstr "log"
+			IL_0182: ldloc.s 4
+			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0189: pop
+			IL_018a: ldstr "console"
+			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0194: stloc.3
+			IL_0195: ldloc.3
+			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_019b: stloc.3
+			IL_019c: ldstr "writable:"
+			IL_01a1: ldloc.1
+			IL_01a2: ldstr "writable"
+			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01b1: stloc.s 4
 			IL_01b3: ldloc.3
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b9: stloc.3
-			IL_01ba: ldstr "writable:"
-			IL_01bf: ldloc.1
-			IL_01c0: ldstr "writable"
-			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01cf: stloc.s 4
-			IL_01d1: ldloc.3
-			IL_01d2: ldstr "log"
-			IL_01d7: ldloc.s 4
-			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01de: pop
-			IL_01df: ldloc.0
-			IL_01e0: ldc.i4.m1
-			IL_01e1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01e6: ldloc.0
-			IL_01e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_01f1: ldarg.0
-			IL_01f2: ldc.i4.1
-			IL_01f3: newarr [System.Runtime]System.Object
-			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01fd: pop
-			IL_01fe: ldloc.0
-			IL_01ff: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0204: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0209: ret
+			IL_01b4: ldstr "log"
+			IL_01b9: ldloc.s 4
+			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01c0: pop
+			IL_01c1: ldloc.0
+			IL_01c2: ldc.i4.m1
+			IL_01c3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01c8: ldloc.0
+			IL_01c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_01d3: ldarg.0
+			IL_01d4: ldc.i4.1
+			IL_01d5: newarr [System.Runtime]System.Object
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01df: pop
+			IL_01e0: ldloc.0
+			IL_01e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01e6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01eb: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -346,7 +332,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22d5
+			// Method begins at RVA 0x22b7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -429,7 +415,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22f0
+		// Method begins at RVA 0x22d2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_AbortSignal.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x254f
+				// Method begins at RVA 0x24f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,32 +47,23 @@
 			)
 			// Method begins at RVA 0x2304
 			// Header size: 12
-			// Code size: 51 (0x33)
+			// Code size: 27 (0x1b)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_AbortSignal/Scope::written
 			IL_0006: stloc.0
-			IL_0007: ldstr "written"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldarg.2
-			IL_0021: ldstr "value"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0030: pop
-			IL_0031: ldnull
-			IL_0032: ret
+			IL_0007: ldloc.0
+			IL_0008: ldarg.2
+			IL_0009: ldstr "value"
+			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0013: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0018: pop
+			IL_0019: ldnull
+			IL_001a: ret
 		} // end of method FunctionExpression_L12C18::__js_call__
 
 	} // end of class FunctionExpression_L12C18
@@ -88,7 +79,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2558
+				// Method begins at RVA 0x24ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,7 +102,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2344
+			// Method begins at RVA 0x232c
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -147,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2561
+				// Method begins at RVA 0x2508
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -171,7 +162,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2378
+			// Method begins at RVA 0x2360
 			// Header size: 12
 			// Code size: 125 (0x7d)
 			.maxstack 8
@@ -235,7 +226,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x256a
+				// Method begins at RVA 0x2511
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -261,15 +252,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2404
+			// Method begins at RVA 0x23ec
 			// Header size: 12
-			// Code size: 310 (0x136)
+			// Code size: 245 (0xf5)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object,
-				[3] object
+				[1] string,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -280,108 +270,79 @@
 			IL_0011: stloc.0
 			IL_0012: ldarg.0
 			IL_0013: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_AbortSignal/Scope::written
-			IL_0018: stloc.1
-			IL_0019: ldstr "written"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.2
-			IL_0025: ldloc.2
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: ldstr "join"
-			IL_0032: ldstr ","
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003c: stloc.2
-			IL_003d: ldstr "written:"
-			IL_0042: ldloc.2
-			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0048: stloc.3
-			IL_0049: ldloc.0
-			IL_004a: ldstr "log"
-			IL_004f: ldloc.3
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0055: pop
-			IL_0056: ldstr "console"
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0060: stloc.0
-			IL_0061: ldloc.0
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0067: stloc.0
-			IL_0068: ldarg.0
-			IL_0069: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::readable
-			IL_006e: stloc.2
-			IL_006f: ldstr "readable"
-			IL_0074: ldloc.2
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_007a: stloc.2
-			IL_007b: ldloc.2
-			IL_007c: ldstr "destroyed"
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0086: stloc.2
-			IL_0087: ldstr "readable-destroyed:"
-			IL_008c: ldloc.2
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0092: stloc.3
-			IL_0093: ldloc.0
-			IL_0094: ldstr "log"
-			IL_0099: ldloc.3
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_009f: pop
-			IL_00a0: ldstr "console"
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00aa: stloc.0
-			IL_00ab: ldloc.0
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b1: stloc.0
-			IL_00b2: ldarg.0
-			IL_00b3: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::pass
-			IL_00b8: stloc.2
-			IL_00b9: ldstr "pass"
-			IL_00be: ldloc.2
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00c4: stloc.2
-			IL_00c5: ldloc.2
-			IL_00c6: ldstr "destroyed"
-			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d0: stloc.2
-			IL_00d1: ldstr "pass-destroyed:"
-			IL_00d6: ldloc.2
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00dc: stloc.3
-			IL_00dd: ldloc.0
-			IL_00de: ldstr "log"
-			IL_00e3: ldloc.3
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00e9: pop
-			IL_00ea: ldstr "console"
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00f4: stloc.0
-			IL_00f5: ldloc.0
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fb: stloc.0
-			IL_00fc: ldarg.0
-			IL_00fd: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::writable
-			IL_0102: stloc.2
-			IL_0103: ldstr "writable"
-			IL_0108: ldloc.2
-			IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_010e: stloc.2
-			IL_010f: ldloc.2
-			IL_0110: ldstr "destroyed"
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_011a: stloc.2
-			IL_011b: ldstr "writable-destroyed:"
-			IL_0120: ldloc.2
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0126: stloc.3
-			IL_0127: ldloc.0
-			IL_0128: ldstr "log"
-			IL_012d: ldloc.3
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0133: pop
-			IL_0134: ldnull
-			IL_0135: ret
+			IL_0018: ldc.i4.1
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: dup
+			IL_001f: ldc.i4.0
+			IL_0020: ldstr ","
+			IL_0025: stelem.ref
+			IL_0026: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_002b: stloc.1
+			IL_002c: ldstr "written:"
+			IL_0031: ldloc.1
+			IL_0032: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0037: stloc.1
+			IL_0038: ldloc.0
+			IL_0039: ldstr "log"
+			IL_003e: ldloc.1
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0044: pop
+			IL_0045: ldstr "console"
+			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_004f: stloc.0
+			IL_0050: ldloc.0
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0056: stloc.0
+			IL_0057: ldstr "readable-destroyed:"
+			IL_005c: ldarg.0
+			IL_005d: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::readable
+			IL_0062: ldstr "destroyed"
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0071: stloc.2
+			IL_0072: ldloc.0
+			IL_0073: ldstr "log"
+			IL_0078: ldloc.2
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_007e: pop
+			IL_007f: ldstr "console"
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0089: stloc.0
+			IL_008a: ldloc.0
+			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0090: stloc.0
+			IL_0091: ldstr "pass-destroyed:"
+			IL_0096: ldarg.0
+			IL_0097: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::pass
+			IL_009c: ldstr "destroyed"
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00ab: stloc.2
+			IL_00ac: ldloc.0
+			IL_00ad: ldstr "log"
+			IL_00b2: ldloc.2
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00b8: pop
+			IL_00b9: ldstr "console"
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c3: stloc.0
+			IL_00c4: ldloc.0
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ca: stloc.0
+			IL_00cb: ldstr "writable-destroyed:"
+			IL_00d0: ldarg.0
+			IL_00d1: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::writable
+			IL_00d6: ldstr "destroyed"
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00e5: stloc.2
+			IL_00e6: ldloc.0
+			IL_00e7: ldstr "log"
+			IL_00ec: ldloc.2
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f2: pop
+			IL_00f3: ldnull
+			IL_00f4: ret
 		} // end of method FunctionExpression_L30C8::__js_call__
 
 	} // end of class FunctionExpression_L30C8
@@ -407,7 +368,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2546
+			// Method begins at RVA 0x24ed
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -701,7 +662,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2573
+		// Method begins at RVA 0x251a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25ec
+					// Method begins at RVA 0x258c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2540
+				// Method begins at RVA 0x24f8
 				// Header size: 12
 				// Code size: 70 (0x46)
 				.maxstack 8
@@ -94,7 +94,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25f5
+					// Method begins at RVA 0x2595
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -119,13 +119,12 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2594
+				// Method begins at RVA 0x254c
 				// Header size: 12
-				// Code size: 58 (0x3a)
+				// Code size: 34 (0x22)
 				.maxstack 8
 				.locals init (
-					[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-					[1] object
+					[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 				)
 
 				IL_0000: ldarg.0
@@ -134,22 +133,14 @@
 				IL_0003: castclass Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope
 				IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
 				IL_000d: stloc.0
-				IL_000e: ldstr "written"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldloc.1
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldstr "push"
-				IL_0027: ldarg.2
-				IL_0028: ldstr "value"
-				IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0037: pop
-				IL_0038: ldnull
-				IL_0039: ret
+				IL_000e: ldloc.0
+				IL_000f: ldarg.2
+				IL_0010: ldstr "value"
+				IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_001a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_001f: pop
+				IL_0020: ldnull
+				IL_0021: ret
 			} // end of method FunctionExpression_L16C20::__js_call__
 
 		} // end of class FunctionExpression_L16C20
@@ -170,7 +161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25e3
+				// Method begins at RVA 0x2583
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +187,7 @@
 			)
 			// Method begins at RVA 0x20bc
 			// Header size: 12
-			// Code size: 1144 (0x478)
+			// Code size: 1072 (0x430)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope,
@@ -283,365 +274,341 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0091: switch (IL_009e, IL_030d)
+			IL_0091: switch (IL_009e, IL_02c5)
 
 			IL_009e: ldarg.0
 			IL_009f: ldc.i4.1
 			IL_00a0: ldelem.ref
 			IL_00a1: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
 			IL_00a6: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
-			IL_00ab: stloc.s 5
-			IL_00ad: ldstr "stream"
-			IL_00b2: ldloc.s 5
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00b9: stloc.s 5
-			IL_00bb: ldloc.s 5
-			IL_00bd: ldstr "Readable"
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c7: stloc.s 5
-			IL_00c9: ldloc.s 5
-			IL_00cb: ldc.i4.1
-			IL_00cc: newarr [System.Runtime]System.Object
-			IL_00d1: dup
-			IL_00d2: ldc.i4.0
-			IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00d8: dup
-			IL_00d9: ldstr "objectMode"
+			IL_00ab: ldstr "Readable"
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b5: stloc.s 5
+			IL_00b7: ldloc.s 5
+			IL_00b9: ldc.i4.1
+			IL_00ba: newarr [System.Runtime]System.Object
+			IL_00bf: dup
+			IL_00c0: ldc.i4.0
+			IL_00c1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00c6: dup
+			IL_00c7: ldstr "objectMode"
+			IL_00cc: ldc.i4.1
+			IL_00cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00d2: stelem.ref
+			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_00d8: stloc.s 5
+			IL_00da: ldloc.s 5
+			IL_00dc: stloc.1
+			IL_00dd: ldarg.0
 			IL_00de: ldc.i4.1
-			IL_00df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00e4: stelem.ref
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_00ea: stloc.s 5
-			IL_00ec: ldloc.s 5
-			IL_00ee: stloc.1
-			IL_00ef: ldarg.0
-			IL_00f0: ldc.i4.1
-			IL_00f1: ldelem.ref
-			IL_00f2: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
-			IL_00f7: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
-			IL_00fc: stloc.s 5
-			IL_00fe: ldstr "stream"
-			IL_0103: ldloc.s 5
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_010a: stloc.s 5
-			IL_010c: ldloc.s 5
-			IL_010e: ldstr "Transform"
-			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0118: stloc.s 5
-			IL_011a: ldloc.s 5
-			IL_011c: ldc.i4.1
-			IL_011d: newarr [System.Runtime]System.Object
-			IL_0122: dup
-			IL_0123: ldc.i4.0
-			IL_0124: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0129: dup
-			IL_012a: ldstr "objectMode"
-			IL_012f: ldc.i4.1
-			IL_0130: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0135: stelem.ref
-			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_013b: stloc.s 5
-			IL_013d: ldloc.s 5
-			IL_013f: stloc.2
-			IL_0140: ldarg.0
-			IL_0141: ldc.i4.1
-			IL_0142: ldelem.ref
-			IL_0143: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
-			IL_0148: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
-			IL_014d: stloc.s 5
-			IL_014f: ldstr "stream"
-			IL_0154: ldloc.s 5
-			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_015b: stloc.s 5
-			IL_015d: ldloc.s 5
-			IL_015f: ldstr "Writable"
-			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0169: stloc.s 5
-			IL_016b: ldloc.s 5
-			IL_016d: ldc.i4.1
-			IL_016e: newarr [System.Runtime]System.Object
+			IL_00df: ldelem.ref
+			IL_00e0: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
+			IL_00e5: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
+			IL_00ea: ldstr "Transform"
+			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f4: stloc.s 5
+			IL_00f6: ldloc.s 5
+			IL_00f8: ldc.i4.1
+			IL_00f9: newarr [System.Runtime]System.Object
+			IL_00fe: dup
+			IL_00ff: ldc.i4.0
+			IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0105: dup
+			IL_0106: ldstr "objectMode"
+			IL_010b: ldc.i4.1
+			IL_010c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0111: stelem.ref
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0117: stloc.s 5
+			IL_0119: ldloc.s 5
+			IL_011b: stloc.2
+			IL_011c: ldarg.0
+			IL_011d: ldc.i4.1
+			IL_011e: ldelem.ref
+			IL_011f: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
+			IL_0124: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
+			IL_0129: ldstr "Writable"
+			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0133: stloc.s 5
+			IL_0135: ldloc.s 5
+			IL_0137: ldc.i4.1
+			IL_0138: newarr [System.Runtime]System.Object
+			IL_013d: dup
+			IL_013e: ldc.i4.0
+			IL_013f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0144: dup
+			IL_0145: ldstr "objectMode"
+			IL_014a: ldc.i4.1
+			IL_014b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0150: stelem.ref
+			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0156: stloc.s 5
+			IL_0158: ldloc.s 5
+			IL_015a: stloc.3
+			IL_015b: ldloc.0
+			IL_015c: ldc.i4.0
+			IL_015d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0162: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
+			IL_0167: ldc.i4.2
+			IL_0168: newarr [System.Runtime]System.Object
+			IL_016d: dup
+			IL_016e: ldc.i4.0
+			IL_016f: ldarg.0
+			IL_0170: ldc.i4.1
+			IL_0171: ldelem.ref
+			IL_0172: stelem.ref
 			IL_0173: dup
-			IL_0174: ldc.i4.0
-			IL_0175: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_017a: dup
-			IL_017b: ldstr "objectMode"
-			IL_0180: ldc.i4.1
-			IL_0181: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0186: stelem.ref
-			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_018c: stloc.s 5
-			IL_018e: ldloc.s 5
-			IL_0190: stloc.3
-			IL_0191: ldloc.0
-			IL_0192: ldc.i4.0
-			IL_0193: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0198: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
-			IL_019d: ldc.i4.2
-			IL_019e: newarr [System.Runtime]System.Object
-			IL_01a3: dup
-			IL_01a4: ldc.i4.0
-			IL_01a5: ldarg.0
-			IL_01a6: ldc.i4.1
-			IL_01a7: ldelem.ref
-			IL_01a8: stelem.ref
-			IL_01a9: dup
+			IL_0174: ldc.i4.1
+			IL_0175: ldloc.0
+			IL_0176: stelem.ref
+			IL_0177: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25::__js_call__(object[], object, object)
+			IL_017d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0182: ldc.i4.1
+			IL_0183: conv.r8
+			IL_0184: ldstr ""
+			IL_0189: ldc.i4.0
+			IL_018a: ldc.i4.1
+			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0190: stloc.s 5
+			IL_0192: ldloc.2
+			IL_0193: ldstr "_transform"
+			IL_0198: ldloc.s 5
+			IL_019a: ldc.i4.1
+			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_01a0: pop
+			IL_01a1: ldc.i4.2
+			IL_01a2: newarr [System.Runtime]System.Object
+			IL_01a7: dup
+			IL_01a8: ldc.i4.0
+			IL_01a9: ldarg.0
 			IL_01aa: ldc.i4.1
-			IL_01ab: ldloc.0
+			IL_01ab: ldelem.ref
 			IL_01ac: stelem.ref
-			IL_01ad: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25::__js_call__(object[], object, object)
-			IL_01b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_01b8: ldc.i4.1
-			IL_01b9: conv.r8
-			IL_01ba: ldstr ""
-			IL_01bf: ldc.i4.0
-			IL_01c0: ldc.i4.1
-			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_01c6: stloc.s 5
-			IL_01c8: ldloc.2
-			IL_01c9: ldstr "_transform"
-			IL_01ce: ldloc.s 5
-			IL_01d0: ldc.i4.1
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_01d6: pop
-			IL_01d7: ldc.i4.2
-			IL_01d8: newarr [System.Runtime]System.Object
-			IL_01dd: dup
-			IL_01de: ldc.i4.0
-			IL_01df: ldarg.0
-			IL_01e0: ldc.i4.1
-			IL_01e1: ldelem.ref
-			IL_01e2: stelem.ref
-			IL_01e3: dup
-			IL_01e4: ldc.i4.1
-			IL_01e5: ldloc.0
-			IL_01e6: stelem.ref
-			IL_01e7: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20::__js_call__(object[], object, object)
-			IL_01ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_01f2: ldc.i4.1
-			IL_01f3: conv.r8
-			IL_01f4: ldstr ""
-			IL_01f9: ldc.i4.0
-			IL_01fa: ldc.i4.1
-			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0200: stloc.s 5
-			IL_0202: ldloc.3
-			IL_0203: ldstr "_write"
-			IL_0208: ldloc.s 5
-			IL_020a: ldc.i4.1
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0210: pop
-			IL_0211: ldarg.0
-			IL_0212: ldc.i4.1
-			IL_0213: ldelem.ref
-			IL_0214: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
-			IL_0219: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::streamPromises
-			IL_021e: stloc.s 5
-			IL_0220: ldstr "streamPromises"
-			IL_0225: ldloc.s 5
-			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_022c: stloc.s 5
-			IL_022e: ldloc.s 5
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0235: stloc.s 5
-			IL_0237: ldloc.s 5
-			IL_0239: ldstr "pipeline"
-			IL_023e: ldloc.1
-			IL_023f: ldloc.2
-			IL_0240: ldloc.3
-			IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0246: stloc.s 5
-			IL_0248: ldloc.s 5
-			IL_024a: stloc.s 4
-			IL_024c: ldloc.1
-			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0252: stloc.s 5
-			IL_0254: ldloc.s 5
-			IL_0256: ldstr "push"
-			IL_025b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0260: dup
-			IL_0261: ldstr "value"
-			IL_0266: ldc.r8 1
-			IL_026f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0279: pop
-			IL_027a: ldloc.1
-			IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0280: stloc.s 5
-			IL_0282: ldloc.s 5
-			IL_0284: ldstr "push"
-			IL_0289: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_028e: dup
-			IL_028f: ldstr "value"
-			IL_0294: ldc.r8 2
-			IL_029d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02a7: pop
-			IL_02a8: ldloc.1
-			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ae: stloc.s 5
-			IL_02b0: ldloc.s 5
-			IL_02b2: ldstr "push"
-			IL_02b7: ldc.i4.0
-			IL_02b8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02c2: pop
-			IL_02c3: ldloc.0
-			IL_02c4: ldc.i4.1
-			IL_02c5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02ca: ldloc.0
-			IL_02cb: ldloc.s 4
-			IL_02cd: ldarg.0
-			IL_02ce: ldc.i4.1
-			IL_02cf: ldloc.0
-			IL_02d0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02da: ldloc.0
-			IL_02db: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02e0: dup
-			IL_02e1: ldc.i4.0
-			IL_02e2: ldloc.1
-			IL_02e3: stelem.ref
-			IL_02e4: dup
-			IL_02e5: ldc.i4.1
-			IL_02e6: ldloc.2
-			IL_02e7: stelem.ref
-			IL_02e8: dup
-			IL_02e9: ldc.i4.2
-			IL_02ea: ldloc.3
-			IL_02eb: stelem.ref
-			IL_02ec: dup
-			IL_02ed: ldc.i4.3
-			IL_02ee: ldloc.s 4
-			IL_02f0: stelem.ref
-			IL_02f1: dup
-			IL_02f2: ldc.i4.4
-			IL_02f3: ldloc.s 5
-			IL_02f5: stelem.ref
-			IL_02f6: dup
-			IL_02f7: ldc.i4.5
-			IL_02f8: ldloc.s 6
-			IL_02fa: stelem.ref
-			IL_02fb: dup
-			IL_02fc: ldc.i4.6
-			IL_02fd: ldloc.s 7
-			IL_02ff: stelem.ref
-			IL_0300: pop
-			IL_0301: ldloc.0
-			IL_0302: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0307: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_030c: ret
+			IL_01ad: dup
+			IL_01ae: ldc.i4.1
+			IL_01af: ldloc.0
+			IL_01b0: stelem.ref
+			IL_01b1: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20::__js_call__(object[], object, object)
+			IL_01b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_01bc: ldc.i4.1
+			IL_01bd: conv.r8
+			IL_01be: ldstr ""
+			IL_01c3: ldc.i4.0
+			IL_01c4: ldc.i4.1
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_01ca: stloc.s 5
+			IL_01cc: ldloc.3
+			IL_01cd: ldstr "_write"
+			IL_01d2: ldloc.s 5
+			IL_01d4: ldc.i4.1
+			IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_01da: pop
+			IL_01db: ldarg.0
+			IL_01dc: ldc.i4.1
+			IL_01dd: ldelem.ref
+			IL_01de: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
+			IL_01e3: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::streamPromises
+			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ed: stloc.s 5
+			IL_01ef: ldloc.s 5
+			IL_01f1: ldstr "pipeline"
+			IL_01f6: ldloc.1
+			IL_01f7: ldloc.2
+			IL_01f8: ldloc.3
+			IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01fe: stloc.s 5
+			IL_0200: ldloc.s 5
+			IL_0202: stloc.s 4
+			IL_0204: ldloc.1
+			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_020a: stloc.s 5
+			IL_020c: ldloc.s 5
+			IL_020e: ldstr "push"
+			IL_0213: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0218: dup
+			IL_0219: ldstr "value"
+			IL_021e: ldc.r8 1
+			IL_0227: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0231: pop
+			IL_0232: ldloc.1
+			IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0238: stloc.s 5
+			IL_023a: ldloc.s 5
+			IL_023c: ldstr "push"
+			IL_0241: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0246: dup
+			IL_0247: ldstr "value"
+			IL_024c: ldc.r8 2
+			IL_0255: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_025f: pop
+			IL_0260: ldloc.1
+			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0266: stloc.s 5
+			IL_0268: ldloc.s 5
+			IL_026a: ldstr "push"
+			IL_026f: ldc.i4.0
+			IL_0270: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_027a: pop
+			IL_027b: ldloc.0
+			IL_027c: ldc.i4.1
+			IL_027d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0282: ldloc.0
+			IL_0283: ldloc.s 4
+			IL_0285: ldarg.0
+			IL_0286: ldc.i4.1
+			IL_0287: ldloc.0
+			IL_0288: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_028d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0292: ldloc.0
+			IL_0293: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0298: dup
+			IL_0299: ldc.i4.0
+			IL_029a: ldloc.1
+			IL_029b: stelem.ref
+			IL_029c: dup
+			IL_029d: ldc.i4.1
+			IL_029e: ldloc.2
+			IL_029f: stelem.ref
+			IL_02a0: dup
+			IL_02a1: ldc.i4.2
+			IL_02a2: ldloc.3
+			IL_02a3: stelem.ref
+			IL_02a4: dup
+			IL_02a5: ldc.i4.3
+			IL_02a6: ldloc.s 4
+			IL_02a8: stelem.ref
+			IL_02a9: dup
+			IL_02aa: ldc.i4.4
+			IL_02ab: ldloc.s 5
+			IL_02ad: stelem.ref
+			IL_02ae: dup
+			IL_02af: ldc.i4.5
+			IL_02b0: ldloc.s 6
+			IL_02b2: stelem.ref
+			IL_02b3: dup
+			IL_02b4: ldc.i4.6
+			IL_02b5: ldloc.s 7
+			IL_02b7: stelem.ref
+			IL_02b8: pop
+			IL_02b9: ldloc.0
+			IL_02ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02bf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02c4: ret
 
-			IL_030d: ldloc.0
-			IL_030e: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::_awaited1
-			IL_0313: pop
-			IL_0314: ldstr "console"
-			IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_031e: stloc.s 5
-			IL_0320: ldloc.s 5
-			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0327: stloc.s 5
-			IL_0329: ldstr "readableObjectMode:"
-			IL_032e: ldloc.1
-			IL_032f: ldstr "readableObjectMode"
-			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_033e: stloc.s 6
-			IL_0340: ldloc.s 5
-			IL_0342: ldstr "log"
-			IL_0347: ldloc.s 6
-			IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_034e: pop
-			IL_034f: ldstr "console"
-			IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0359: stloc.s 5
-			IL_035b: ldloc.s 5
-			IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0362: stloc.s 5
-			IL_0364: ldstr "transformReadableObjectMode:"
-			IL_0369: ldloc.2
-			IL_036a: ldstr "readableObjectMode"
-			IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0379: stloc.s 6
-			IL_037b: ldloc.s 5
-			IL_037d: ldstr "log"
-			IL_0382: ldloc.s 6
-			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0389: pop
-			IL_038a: ldstr "console"
-			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0394: stloc.s 5
-			IL_0396: ldloc.s 5
-			IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_039d: stloc.s 5
-			IL_039f: ldstr "transformWritableObjectMode:"
-			IL_03a4: ldloc.2
-			IL_03a5: ldstr "writableObjectMode"
-			IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03b4: stloc.s 6
-			IL_03b6: ldloc.s 5
-			IL_03b8: ldstr "log"
-			IL_03bd: ldloc.s 6
-			IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03c4: pop
-			IL_03c5: ldstr "console"
-			IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03cf: stloc.s 5
-			IL_03d1: ldloc.s 5
-			IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03d8: stloc.s 5
-			IL_03da: ldstr "writableObjectMode:"
-			IL_03df: ldloc.3
-			IL_03e0: ldstr "writableObjectMode"
-			IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03ef: stloc.s 6
-			IL_03f1: ldloc.s 5
-			IL_03f3: ldstr "log"
-			IL_03f8: ldloc.s 6
-			IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03ff: pop
-			IL_0400: ldstr "console"
-			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_040a: stloc.s 5
-			IL_040c: ldloc.s 5
-			IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0413: stloc.s 5
-			IL_0415: ldloc.0
-			IL_0416: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
-			IL_041b: ldc.i4.1
-			IL_041c: newarr [System.Runtime]System.Object
-			IL_0421: dup
-			IL_0422: ldc.i4.0
-			IL_0423: ldstr ","
-			IL_0428: stelem.ref
-			IL_0429: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_042e: stloc.s 7
-			IL_0430: ldstr "written:"
-			IL_0435: ldloc.s 7
-			IL_0437: call string [System.Runtime]System.String::Concat(string, string)
-			IL_043c: stloc.s 7
-			IL_043e: ldloc.s 5
-			IL_0440: ldstr "log"
-			IL_0445: ldloc.s 7
-			IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_044c: pop
-			IL_044d: ldloc.0
-			IL_044e: ldc.i4.m1
-			IL_044f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0454: ldloc.0
-			IL_0455: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_045a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_045f: ldarg.0
-			IL_0460: ldc.i4.1
-			IL_0461: newarr [System.Runtime]System.Object
-			IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_046b: pop
-			IL_046c: ldloc.0
-			IL_046d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0472: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0477: ret
+			IL_02c5: ldloc.0
+			IL_02c6: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::_awaited1
+			IL_02cb: pop
+			IL_02cc: ldstr "console"
+			IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02d6: stloc.s 5
+			IL_02d8: ldloc.s 5
+			IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02df: stloc.s 5
+			IL_02e1: ldstr "readableObjectMode:"
+			IL_02e6: ldloc.1
+			IL_02e7: ldstr "readableObjectMode"
+			IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02f6: stloc.s 6
+			IL_02f8: ldloc.s 5
+			IL_02fa: ldstr "log"
+			IL_02ff: ldloc.s 6
+			IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0306: pop
+			IL_0307: ldstr "console"
+			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0311: stloc.s 5
+			IL_0313: ldloc.s 5
+			IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_031a: stloc.s 5
+			IL_031c: ldstr "transformReadableObjectMode:"
+			IL_0321: ldloc.2
+			IL_0322: ldstr "readableObjectMode"
+			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0331: stloc.s 6
+			IL_0333: ldloc.s 5
+			IL_0335: ldstr "log"
+			IL_033a: ldloc.s 6
+			IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0341: pop
+			IL_0342: ldstr "console"
+			IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_034c: stloc.s 5
+			IL_034e: ldloc.s 5
+			IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0355: stloc.s 5
+			IL_0357: ldstr "transformWritableObjectMode:"
+			IL_035c: ldloc.2
+			IL_035d: ldstr "writableObjectMode"
+			IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_036c: stloc.s 6
+			IL_036e: ldloc.s 5
+			IL_0370: ldstr "log"
+			IL_0375: ldloc.s 6
+			IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_037c: pop
+			IL_037d: ldstr "console"
+			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0387: stloc.s 5
+			IL_0389: ldloc.s 5
+			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0390: stloc.s 5
+			IL_0392: ldstr "writableObjectMode:"
+			IL_0397: ldloc.3
+			IL_0398: ldstr "writableObjectMode"
+			IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_03a7: stloc.s 6
+			IL_03a9: ldloc.s 5
+			IL_03ab: ldstr "log"
+			IL_03b0: ldloc.s 6
+			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03b7: pop
+			IL_03b8: ldstr "console"
+			IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03c2: stloc.s 5
+			IL_03c4: ldloc.s 5
+			IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03cb: stloc.s 5
+			IL_03cd: ldloc.0
+			IL_03ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
+			IL_03d3: ldc.i4.1
+			IL_03d4: newarr [System.Runtime]System.Object
+			IL_03d9: dup
+			IL_03da: ldc.i4.0
+			IL_03db: ldstr ","
+			IL_03e0: stelem.ref
+			IL_03e1: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_03e6: stloc.s 7
+			IL_03e8: ldstr "written:"
+			IL_03ed: ldloc.s 7
+			IL_03ef: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03f4: stloc.s 7
+			IL_03f6: ldloc.s 5
+			IL_03f8: ldstr "log"
+			IL_03fd: ldloc.s 7
+			IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0404: pop
+			IL_0405: ldloc.0
+			IL_0406: ldc.i4.m1
+			IL_0407: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_040c: ldloc.0
+			IL_040d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0412: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0417: ldarg.0
+			IL_0418: ldc.i4.1
+			IL_0419: newarr [System.Runtime]System.Object
+			IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0423: pop
+			IL_0424: ldloc.0
+			IL_0425: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_042a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_042f: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -665,7 +632,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25da
+			// Method begins at RVA 0x257a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -748,7 +715,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25fe
+		// Method begins at RVA 0x259e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a2
+				// Method begins at RVA 0x228e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,12 +47,10 @@
 			)
 			// Method begins at RVA 0x2200
 			// Header size: 12
-			// Code size: 90 (0x5a)
+			// Code size: 70 (0x46)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] float64,
-				[2] object
+				[0] object
 			)
 
 			IL_0000: ldstr "console"
@@ -68,27 +66,15 @@
 			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 			IL_0023: pop
 			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.Stream_Readable_Basic/Scope::dataReceived
-			IL_002a: stloc.0
-			IL_002b: ldstr "dataReceived"
-			IL_0030: ldloc.0
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0036: stloc.0
-			IL_0037: ldloc.0
-			IL_0038: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_003d: stloc.1
-			IL_003e: ldloc.1
-			IL_003f: ldc.r8 1
-			IL_0048: add
-			IL_0049: stloc.1
-			IL_004a: ldloc.1
-			IL_004b: box [System.Runtime]System.Double
-			IL_0050: stloc.2
-			IL_0051: ldarg.0
-			IL_0052: ldloc.2
-			IL_0053: stfld object Modules.Stream_Readable_Basic/Scope::dataReceived
-			IL_0058: ldnull
-			IL_0059: ret
+			IL_0025: ldarg.0
+			IL_0026: ldfld object Modules.Stream_Readable_Basic/Scope::dataReceived
+			IL_002b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0030: ldc.r8 1
+			IL_0039: add
+			IL_003a: box [System.Runtime]System.Double
+			IL_003f: stfld object Modules.Stream_Readable_Basic/Scope::dataReceived
+			IL_0044: ldnull
+			IL_0045: ret
 		} // end of method FunctionExpression_L13C20::__js_call__
 
 	} // end of class FunctionExpression_L13C20
@@ -104,7 +90,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ab
+				// Method begins at RVA 0x2297
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -127,7 +113,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2268
+			// Method begins at RVA 0x2254
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -167,7 +153,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2299
+			// Method begins at RVA 0x2285
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -350,7 +336,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22b4
+		// Method begins at RVA 0x22a0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Pause_Resume.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Pause_Resume.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x238c
+				// Method begins at RVA 0x232b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,31 +45,17 @@
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
 			// Method begins at RVA 0x2248
-			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Readable_Pause_Resume/Scope::events
-			IL_0006: stloc.0
-			IL_0007: ldstr "events"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "pause"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldnull
-			IL_002c: ret
+			IL_0006: ldstr "pause"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
 		} // end of method FunctionExpression_L8C21::__js_call__
 
 	} // end of class FunctionExpression_L8C21
@@ -85,7 +71,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2395
+				// Method begins at RVA 0x2334
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,32 +97,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2284
-			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Method begins at RVA 0x225c
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Readable_Pause_Resume/Scope::events
-			IL_0006: stloc.0
-			IL_0007: ldstr "events"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "resume"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldnull
-			IL_002c: ret
+			IL_0006: ldstr "resume"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
 		} // end of method FunctionExpression_L12C22::__js_call__
 
 	} // end of class FunctionExpression_L12C22
@@ -152,7 +124,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x239e
+				// Method begins at RVA 0x233d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -176,7 +148,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22c0
+			// Method begins at RVA 0x2270
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -217,7 +189,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a7
+				// Method begins at RVA 0x2346
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -243,15 +215,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x22fc
+			// Method begins at RVA 0x22ac
 			// Header size: 12
-			// Code size: 123 (0x7b)
+			// Code size: 106 (0x6a)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object,
-				[3] object
+				[1] string
 			)
 
 			IL_0000: ldstr "console"
@@ -273,30 +243,25 @@
 			IL_0034: stloc.0
 			IL_0035: ldarg.0
 			IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Readable_Pause_Resume/Scope::events
-			IL_003b: stloc.1
-			IL_003c: ldstr "events"
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0047: stloc.2
-			IL_0048: ldloc.2
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: ldstr "join"
-			IL_0055: ldstr ","
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005f: stloc.2
-			IL_0060: ldstr "events:"
-			IL_0065: ldloc.2
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006b: stloc.3
-			IL_006c: ldloc.0
-			IL_006d: ldstr "log"
-			IL_0072: ldloc.3
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0078: pop
-			IL_0079: ldnull
-			IL_007a: ret
+			IL_003b: ldc.i4.1
+			IL_003c: newarr [System.Runtime]System.Object
+			IL_0041: dup
+			IL_0042: ldc.i4.0
+			IL_0043: ldstr ","
+			IL_0048: stelem.ref
+			IL_0049: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_004e: stloc.1
+			IL_004f: ldstr "events:"
+			IL_0054: ldloc.1
+			IL_0055: call string [System.Runtime]System.String::Concat(string, string)
+			IL_005a: stloc.1
+			IL_005b: ldloc.0
+			IL_005c: ldstr "log"
+			IL_0061: ldloc.1
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0067: pop
+			IL_0068: ldnull
+			IL_0069: ret
 		} // end of method FunctionExpression_L20C19::__js_call__
 
 	} // end of class FunctionExpression_L20C19
@@ -315,7 +280,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2383
+			// Method begins at RVA 0x2322
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -542,7 +507,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23b0
+		// Method begins at RVA 0x234f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_SetEncoding_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_SetEncoding_Utf8.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x232d
+				// Method begins at RVA 0x231d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2336
+				// Method begins at RVA 0x2326
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -120,12 +120,11 @@
 			)
 			// Method begins at RVA 0x22cc
 			// Header size: 12
-			// Code size: 76 (0x4c)
+			// Code size: 60 (0x3c)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] object
+				[1] object
 			)
 
 			IL_0000: ldstr "console"
@@ -134,28 +133,20 @@
 			IL_000b: ldloc.0
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
-			IL_0012: ldarg.0
-			IL_0013: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-			IL_0018: stloc.1
-			IL_0019: ldstr "readable"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: ldloc.1
-			IL_0026: ldstr "readableEncoding"
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0030: stloc.1
-			IL_0031: ldstr "encoding:"
-			IL_0036: ldloc.1
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_003c: stloc.2
-			IL_003d: ldloc.0
-			IL_003e: ldstr "log"
-			IL_0043: ldloc.2
-			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0049: pop
-			IL_004a: ldnull
-			IL_004b: ret
+			IL_0012: ldstr "encoding:"
+			IL_0017: ldarg.0
+			IL_0018: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+			IL_001d: ldstr "readableEncoding"
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_002c: stloc.1
+			IL_002d: ldloc.0
+			IL_002e: ldstr "log"
+			IL_0033: ldloc.1
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0039: pop
+			IL_003a: ldnull
+			IL_003b: ret
 		} // end of method FunctionExpression_L19C19::__js_call__
 
 	} // end of class FunctionExpression_L19C19
@@ -174,7 +165,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2324
+			// Method begins at RVA 0x2314
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -398,7 +389,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x233f
+		// Method begins at RVA 0x232f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Transform_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Transform_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2304
+				// Method begins at RVA 0x22cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230d
+				// Method begins at RVA 0x22d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -110,32 +110,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x223c
-			// Header size: 12
-			// Code size: 41 (0x29)
+			// Method begins at RVA 0x2239
+			// Header size: 1
+			// Code size: 15 (0xf)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Transform_Basic/Scope::written
-			IL_0006: stloc.0
-			IL_0007: ldstr "written"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0026: pop
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldnull
+			IL_000e: ret
 		} // end of method FunctionExpression_L14C18::__js_call__
 
 	} // end of class FunctionExpression_L14C18
@@ -151,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2316
+				// Method begins at RVA 0x22dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -177,15 +163,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2274
+			// Method begins at RVA 0x224c
 			// Header size: 12
-			// Code size: 123 (0x7b)
+			// Code size: 106 (0x6a)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object,
-				[3] object
+				[1] string
 			)
 
 			IL_0000: ldstr "console"
@@ -207,30 +191,25 @@
 			IL_0034: stloc.0
 			IL_0035: ldarg.0
 			IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Transform_Basic/Scope::written
-			IL_003b: stloc.1
-			IL_003c: ldstr "written"
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0047: stloc.2
-			IL_0048: ldloc.2
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004e: stloc.2
-			IL_004f: ldloc.2
-			IL_0050: ldstr "join"
-			IL_0055: ldstr ","
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005f: stloc.2
-			IL_0060: ldstr "written:"
-			IL_0065: ldloc.2
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006b: stloc.3
-			IL_006c: ldloc.0
-			IL_006d: ldstr "log"
-			IL_0072: ldloc.3
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0078: pop
-			IL_0079: ldnull
-			IL_007a: ret
+			IL_003b: ldc.i4.1
+			IL_003c: newarr [System.Runtime]System.Object
+			IL_0041: dup
+			IL_0042: ldc.i4.0
+			IL_0043: ldstr ","
+			IL_0048: stelem.ref
+			IL_0049: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_004e: stloc.1
+			IL_004f: ldstr "written:"
+			IL_0054: ldloc.1
+			IL_0055: call string [System.Runtime]System.String::Concat(string, string)
+			IL_005a: stloc.1
+			IL_005b: ldloc.0
+			IL_005c: ldstr "log"
+			IL_0061: ldloc.1
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0067: pop
+			IL_0068: ldnull
+			IL_0069: ret
 		} // end of method FunctionExpression_L18C22::__js_call__
 
 	} // end of class FunctionExpression_L18C22
@@ -249,7 +228,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22fb
+			// Method begins at RVA 0x22c2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -446,7 +425,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x231f
+		// Method begins at RVA 0x22e6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_CustomWrite.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_CustomWrite.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x226e
+				// Method begins at RVA 0x2254
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,42 +47,31 @@
 			)
 			// Method begins at RVA 0x220c
 			// Header size: 12
-			// Code size: 77 (0x4d)
+			// Code size: 51 (0x33)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_CustomWrite/Scope::writtenData
-			IL_0006: stloc.0
-			IL_0007: ldstr "writtenData"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0026: pop
-			IL_0027: ldstr "console"
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0031: stloc.1
-			IL_0032: ldloc.1
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0038: stloc.1
-			IL_0039: ldloc.1
-			IL_003a: ldstr "log"
-			IL_003f: ldstr "_write called with:"
-			IL_0044: ldarg.2
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_004a: pop
-			IL_004b: ldnull
-			IL_004c: ret
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldstr "console"
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0017: stloc.0
+			IL_0018: ldloc.0
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001e: stloc.0
+			IL_001f: ldloc.0
+			IL_0020: ldstr "log"
+			IL_0025: ldstr "_write called with:"
+			IL_002a: ldarg.2
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0030: pop
+			IL_0031: ldnull
+			IL_0032: ret
 		} // end of method FunctionExpression_L11C18::__js_call__
 
 	} // end of class FunctionExpression_L11C18
@@ -102,7 +91,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2265
+			// Method begins at RVA 0x224b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -126,7 +115,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2280
+				// Method begins at RVA 0x2266
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -144,7 +133,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2277
+			// Method begins at RVA 0x225d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -343,7 +332,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2289
+		// Method begins at RVA 0x226f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Destroy_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Destroy_Error.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x238e
+				// Method begins at RVA 0x2313
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2397
+				// Method begins at RVA 0x231c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -120,37 +120,28 @@
 			)
 			// Method begins at RVA 0x2230
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 39 (0x27)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object,
-				[2] object
+				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Destroy_Error/Scope::sequence
 			IL_0006: stloc.0
-			IL_0007: ldstr "sequence"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldstr "error:"
-			IL_001f: ldarg.2
-			IL_0020: ldstr "message"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_002f: stloc.2
-			IL_0030: ldloc.1
-			IL_0031: ldstr "push"
-			IL_0036: ldloc.2
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003c: pop
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0007: ldstr "error:"
+			IL_000c: ldarg.2
+			IL_000d: ldstr "message"
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_001c: stloc.1
+			IL_001d: ldloc.0
+			IL_001e: ldloc.1
+			IL_001f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0024: pop
+			IL_0025: ldnull
+			IL_0026: ret
 		} // end of method FunctionExpression_L12C21::__js_call__
 
 	} // end of class FunctionExpression_L12C21
@@ -166,7 +157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a0
+				// Method begins at RVA 0x2325
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -192,32 +183,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x227c
-			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Method begins at RVA 0x2263
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Destroy_Error/Scope::sequence
-			IL_0006: stloc.0
-			IL_0007: ldstr "sequence"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "finish"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldnull
-			IL_002c: ret
+			IL_0006: ldstr "finish"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
 		} // end of method FunctionExpression_L16C22::__js_call__
 
 	} // end of class FunctionExpression_L16C22
@@ -233,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a9
+				// Method begins at RVA 0x232e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -259,86 +236,62 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x22b8
+			// Method begins at RVA 0x2278
 			// Header size: 12
-			// Code size: 193 (0xc1)
+			// Code size: 134 (0x86)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object,
-				[2] object,
-				[3] object
+				[0] object,
+				[1] string,
+				[2] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Destroy_Error/Scope::sequence
-			IL_0006: stloc.0
-			IL_0007: ldstr "sequence"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "close"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldstr "console"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0035: stloc.1
-			IL_0036: ldloc.1
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0006: ldstr "close"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldstr "console"
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_001b: stloc.0
+			IL_001c: ldloc.0
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0022: stloc.0
+			IL_0023: ldarg.0
+			IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Destroy_Error/Scope::sequence
+			IL_0029: ldc.i4.1
+			IL_002a: newarr [System.Runtime]System.Object
+			IL_002f: dup
+			IL_0030: ldc.i4.0
+			IL_0031: ldstr ","
+			IL_0036: stelem.ref
+			IL_0037: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
 			IL_003c: stloc.1
-			IL_003d: ldarg.0
-			IL_003e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Destroy_Error/Scope::sequence
-			IL_0043: stloc.0
-			IL_0044: ldstr "sequence"
-			IL_0049: ldloc.0
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_004f: stloc.2
-			IL_0050: ldloc.2
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.2
-			IL_0057: ldloc.2
-			IL_0058: ldstr "join"
-			IL_005d: ldstr ","
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: stloc.2
-			IL_0068: ldloc.1
-			IL_0069: ldstr "log"
-			IL_006e: ldloc.2
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0074: pop
-			IL_0075: ldstr "console"
-			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_007f: stloc.2
-			IL_0080: ldloc.2
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0086: stloc.2
-			IL_0087: ldarg.0
-			IL_0088: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
-			IL_008d: stloc.1
-			IL_008e: ldstr "writable"
-			IL_0093: ldloc.1
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0099: stloc.1
-			IL_009a: ldloc.1
-			IL_009b: ldstr "destroyed"
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00a5: stloc.1
-			IL_00a6: ldstr "destroyed:"
-			IL_00ab: ldloc.1
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00b1: stloc.3
-			IL_00b2: ldloc.2
-			IL_00b3: ldstr "log"
-			IL_00b8: ldloc.3
-			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00be: pop
-			IL_00bf: ldnull
-			IL_00c0: ret
+			IL_003d: ldloc.0
+			IL_003e: ldstr "log"
+			IL_0043: ldloc.1
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0049: pop
+			IL_004a: ldstr "console"
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0054: stloc.0
+			IL_0055: ldloc.0
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005b: stloc.0
+			IL_005c: ldstr "destroyed:"
+			IL_0061: ldarg.0
+			IL_0062: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
+			IL_0067: ldstr "destroyed"
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0076: stloc.2
+			IL_0077: ldloc.0
+			IL_0078: ldstr "log"
+			IL_007d: ldloc.2
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0083: pop
+			IL_0084: ldnull
+			IL_0085: ret
 		} // end of method FunctionExpression_L20C21::__js_call__
 
 	} // end of class FunctionExpression_L20C21
@@ -360,7 +313,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2385
+			// Method begins at RVA 0x230a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -555,7 +508,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23b2
+		// Method begins at RVA 0x2337
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Drain_Finish_Order.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Drain_Finish_Order.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x237a
+				// Method begins at RVA 0x22ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,32 +45,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2218
-			// Header size: 12
-			// Code size: 41 (0x29)
+			// Method begins at RVA 0x2215
+			// Header size: 1
+			// Code size: 15 (0xf)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::written
-			IL_0006: stloc.0
-			IL_0007: ldstr "written"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0026: pop
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldnull
+			IL_000e: ret
 		} // end of method FunctionExpression_L10C18::__js_call__
 
 	} // end of class FunctionExpression_L10C18
@@ -86,7 +72,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2383
+				// Method begins at RVA 0x22f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -112,32 +98,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2250
-			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Method begins at RVA 0x2225
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
-			IL_0006: stloc.0
-			IL_0007: ldstr "sequence"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "drain"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldnull
-			IL_002c: ret
+			IL_0006: ldstr "drain"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
 		} // end of method FunctionExpression_L14C21::__js_call__
 
 	} // end of class FunctionExpression_L14C21
@@ -153,7 +125,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x238c
+				// Method begins at RVA 0x2300
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -179,94 +151,72 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x228c
+			// Method begins at RVA 0x223c
 			// Header size: 12
-			// Code size: 217 (0xd9)
+			// Code size: 157 (0x9d)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object,
-				[2] object,
-				[3] object
+				[0] object,
+				[1] string
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
-			IL_0006: stloc.0
-			IL_0007: ldstr "sequence"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "finish"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldstr "console"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0035: stloc.1
-			IL_0036: ldloc.1
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0006: ldstr "finish"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldstr "console"
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_001b: stloc.0
+			IL_001c: ldloc.0
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0022: stloc.0
+			IL_0023: ldarg.0
+			IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
+			IL_0029: ldc.i4.1
+			IL_002a: newarr [System.Runtime]System.Object
+			IL_002f: dup
+			IL_0030: ldc.i4.0
+			IL_0031: ldstr ","
+			IL_0036: stelem.ref
+			IL_0037: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
 			IL_003c: stloc.1
-			IL_003d: ldarg.0
-			IL_003e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::sequence
-			IL_0043: stloc.0
-			IL_0044: ldstr "sequence"
+			IL_003d: ldstr "sequence:"
+			IL_0042: ldloc.1
+			IL_0043: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0048: stloc.1
 			IL_0049: ldloc.0
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_004f: stloc.2
-			IL_0050: ldloc.2
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.2
-			IL_0057: ldloc.2
-			IL_0058: ldstr "join"
-			IL_005d: ldstr ","
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: stloc.2
-			IL_0068: ldstr "sequence:"
-			IL_006d: ldloc.2
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0073: stloc.3
-			IL_0074: ldloc.1
-			IL_0075: ldstr "log"
-			IL_007a: ldloc.3
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0080: pop
-			IL_0081: ldstr "console"
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_008b: stloc.1
-			IL_008c: ldloc.1
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0092: stloc.1
-			IL_0093: ldarg.0
-			IL_0094: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::written
-			IL_0099: stloc.0
-			IL_009a: ldstr "written"
-			IL_009f: ldloc.0
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a5: stloc.2
-			IL_00a6: ldloc.2
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ac: stloc.2
-			IL_00ad: ldloc.2
-			IL_00ae: ldstr "join"
-			IL_00b3: ldstr ","
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00bd: stloc.2
-			IL_00be: ldstr "written:"
-			IL_00c3: ldloc.2
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00c9: stloc.3
-			IL_00ca: ldloc.1
-			IL_00cb: ldstr "log"
-			IL_00d0: ldloc.3
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00d6: pop
-			IL_00d7: ldnull
-			IL_00d8: ret
+			IL_004a: ldstr "log"
+			IL_004f: ldloc.1
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0055: pop
+			IL_0056: ldstr "console"
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0060: stloc.0
+			IL_0061: ldloc.0
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0067: stloc.0
+			IL_0068: ldarg.0
+			IL_0069: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Drain_Finish_Order/Scope::written
+			IL_006e: ldc.i4.1
+			IL_006f: newarr [System.Runtime]System.Object
+			IL_0074: dup
+			IL_0075: ldc.i4.0
+			IL_0076: ldstr ","
+			IL_007b: stelem.ref
+			IL_007c: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0081: stloc.1
+			IL_0082: ldstr "written:"
+			IL_0087: ldloc.1
+			IL_0088: call string [System.Runtime]System.String::Concat(string, string)
+			IL_008d: stloc.1
+			IL_008e: ldloc.0
+			IL_008f: ldstr "log"
+			IL_0094: ldloc.1
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_009a: pop
+			IL_009b: ldnull
+			IL_009c: ret
 		} // end of method FunctionExpression_L18C22::__js_call__
 
 	} // end of class FunctionExpression_L18C22
@@ -287,7 +237,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2371
+			// Method begins at RVA 0x22e5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -493,7 +443,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2395
+		// Method begins at RVA 0x2309
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_MemoryStreamStyle.verified.txt
+++ b/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_MemoryStreamStyle.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228d
+				// Method begins at RVA 0x2281
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2296
+				// Method begins at RVA 0x228a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -100,7 +100,7 @@
 			)
 			// Method begins at RVA 0x21c8
 			// Header size: 12
-			// Code size: 176 (0xb0)
+			// Code size: 164 (0xa4)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -133,64 +133,60 @@
 			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_002f: stloc.3
 			IL_0030: ldloc.3
-			IL_0031: brfalse IL_0061
+			IL_0031: brfalse IL_0055
 
 			IL_0036: ldarg.0
 			IL_0037: ldfld object Modules.Require_StringDecoder_MemoryStreamStyle/Scope::StringDecoder
 			IL_003c: stloc.2
-			IL_003d: ldstr "StringDecoder"
-			IL_0042: ldloc.2
-			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0048: stloc.2
-			IL_0049: ldloc.2
-			IL_004a: ldc.i4.1
-			IL_004b: newarr [System.Runtime]System.Object
-			IL_0050: dup
-			IL_0051: ldc.i4.0
-			IL_0052: ldarg.3
-			IL_0053: stelem.ref
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0059: stloc.2
-			IL_005a: ldloc.2
+			IL_003d: ldloc.2
+			IL_003e: ldc.i4.1
+			IL_003f: newarr [System.Runtime]System.Object
+			IL_0044: dup
+			IL_0045: ldc.i4.0
+			IL_0046: ldarg.3
+			IL_0047: stelem.ref
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_004d: stloc.2
+			IL_004e: ldloc.2
+			IL_004f: stloc.0
+			IL_0050: br IL_005c
+
+			IL_0055: ldc.i4.0
+			IL_0056: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_005b: stloc.0
-			IL_005c: br IL_0068
 
-			IL_0061: ldc.i4.0
-			IL_0062: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0067: stloc.0
+			IL_005c: ldloc.0
+			IL_005d: stloc.1
+			IL_005e: ldloc.1
+			IL_005f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0064: stloc.3
+			IL_0065: ldloc.3
+			IL_0066: brfalse IL_00a2
 
-			IL_0068: ldloc.0
-			IL_0069: stloc.1
-			IL_006a: ldloc.1
-			IL_006b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0070: stloc.3
-			IL_0071: ldloc.3
-			IL_0072: brfalse IL_00ae
+			IL_006b: ldloc.1
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0071: stloc.2
+			IL_0072: ldloc.2
+			IL_0073: ldstr "write"
+			IL_0078: ldarg.2
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_007e: stloc.2
+			IL_007f: ldloc.1
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0085: stloc.s 6
+			IL_0087: ldloc.s 6
+			IL_0089: ldstr "end"
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0093: stloc.s 6
+			IL_0095: ldloc.2
+			IL_0096: ldloc.s 6
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_009d: stloc.s 5
+			IL_009f: ldloc.s 5
+			IL_00a1: ret
 
-			IL_0077: ldloc.1
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007d: stloc.2
-			IL_007e: ldloc.2
-			IL_007f: ldstr "write"
-			IL_0084: ldarg.2
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_008a: stloc.2
-			IL_008b: ldloc.1
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0091: stloc.s 6
-			IL_0093: ldloc.s 6
-			IL_0095: ldstr "end"
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_009f: stloc.s 6
-			IL_00a1: ldloc.2
-			IL_00a2: ldloc.s 6
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a9: stloc.s 5
-			IL_00ab: ldloc.s 5
-			IL_00ad: ret
-
-			IL_00ae: ldarg.2
-			IL_00af: ret
+			IL_00a2: ldarg.2
+			IL_00a3: ret
 		} // end of method FunctionExpression_L9C40::__js_call__
 
 	} // end of class FunctionExpression_L9C40
@@ -214,7 +210,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2284
+			// Method begins at RVA 0x2278
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -379,7 +375,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x229f
+		// Method begins at RVA 0x2293
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.SetInterval_ExecutesThreeTimes_ThenClears.verified.txt
+++ b/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.SetInterval_ExecutesThreeTimes_ThenClears.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2220
+					// Method begins at RVA 0x21de
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2217
+				// Method begins at RVA 0x21d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -68,103 +68,74 @@
 			)
 			// Method begins at RVA 0x2100
 			// Header size: 12
-			// Code size: 247 (0xf7)
+			// Code size: 181 (0xb5)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.SetInterval_ExecutesThreeTimes_ThenClears/ArrowFunction_L5C24/Scope/Block_L9C21,
 				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object,
-				[5] object,
-				[6] bool
+				[2] object,
+				[3] bool
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.SetInterval_ExecutesThreeTimes_ThenClears/Scope::count
-			IL_0006: stloc.1
-			IL_0007: ldstr "count"
-			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.2
-			IL_001a: ldloc.2
-			IL_001b: ldc.r8 1
-			IL_0024: add
-			IL_0025: stloc.2
-			IL_0026: ldloc.2
-			IL_0027: box [System.Runtime]System.Double
-			IL_002c: stloc.3
-			IL_002d: ldarg.0
-			IL_002e: ldloc.3
-			IL_002f: stfld object Modules.SetInterval_ExecutesThreeTimes_ThenClears/Scope::count
-			IL_0034: ldstr "console"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_003e: stloc.1
-			IL_003f: ldloc.1
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0045: stloc.1
-			IL_0046: ldarg.0
-			IL_0047: ldfld object Modules.SetInterval_ExecutesThreeTimes_ThenClears/Scope::count
-			IL_004c: stloc.s 4
-			IL_004e: ldstr "count"
-			IL_0053: ldloc.s 4
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_005a: stloc.s 4
-			IL_005c: ldstr "tick "
-			IL_0061: ldloc.s 4
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0068: stloc.s 5
-			IL_006a: ldloc.1
-			IL_006b: ldstr "log"
-			IL_0070: ldloc.s 5
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0077: pop
+			IL_0001: ldarg.0
+			IL_0002: ldfld object Modules.SetInterval_ExecutesThreeTimes_ThenClears/Scope::count
+			IL_0007: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000c: ldc.r8 1
+			IL_0015: add
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: stfld object Modules.SetInterval_ExecutesThreeTimes_ThenClears/Scope::count
+			IL_0020: ldstr "console"
+			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_002a: stloc.1
+			IL_002b: ldloc.1
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0031: stloc.1
+			IL_0032: ldstr "tick "
+			IL_0037: ldarg.0
+			IL_0038: ldfld object Modules.SetInterval_ExecutesThreeTimes_ThenClears/Scope::count
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0042: stloc.2
+			IL_0043: ldloc.1
+			IL_0044: ldstr "log"
+			IL_0049: ldloc.2
+			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004f: pop
+			IL_0050: ldarg.0
+			IL_0051: ldfld object Modules.SetInterval_ExecutesThreeTimes_ThenClears/Scope::count
+			IL_0056: stloc.1
+			IL_0057: ldloc.1
+			IL_0058: ldc.r8 3
+			IL_0061: box [System.Runtime]System.Double
+			IL_0066: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_006b: stloc.3
+			IL_006c: ldloc.3
+			IL_006d: brfalse IL_00b3
+
+			IL_0072: newobj instance void Modules.SetInterval_ExecutesThreeTimes_ThenClears/ArrowFunction_L5C24/Scope/Block_L9C21::.ctor()
+			IL_0077: stloc.0
 			IL_0078: ldarg.0
-			IL_0079: ldfld object Modules.SetInterval_ExecutesThreeTimes_ThenClears/Scope::count
-			IL_007e: stloc.1
-			IL_007f: ldstr "count"
-			IL_0084: ldloc.1
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_008a: stloc.1
-			IL_008b: ldloc.1
-			IL_008c: ldc.r8 3
-			IL_0095: box [System.Runtime]System.Double
-			IL_009a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_009f: stloc.s 6
-			IL_00a1: ldloc.s 6
-			IL_00a3: brfalse IL_00f5
+			IL_0079: ldfld object Modules.SetInterval_ExecutesThreeTimes_ThenClears/Scope::id
+			IL_007e: ldstr "Cannot access 'id' before initialization"
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0088: stloc.1
+			IL_0089: ldloc.1
+			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::clearInterval(object)
+			IL_008f: pop
+			IL_0090: ldstr "console"
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_009a: stloc.1
+			IL_009b: ldloc.1
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a1: stloc.1
+			IL_00a2: ldloc.1
+			IL_00a3: ldstr "log"
+			IL_00a8: ldstr "cleared"
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00b2: pop
 
-			IL_00a8: newobj instance void Modules.SetInterval_ExecutesThreeTimes_ThenClears/ArrowFunction_L5C24/Scope/Block_L9C21::.ctor()
-			IL_00ad: stloc.0
-			IL_00ae: ldarg.0
-			IL_00af: ldfld object Modules.SetInterval_ExecutesThreeTimes_ThenClears/Scope::id
-			IL_00b4: ldstr "Cannot access 'id' before initialization"
-			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00be: stloc.1
-			IL_00bf: ldstr "id"
-			IL_00c4: ldloc.1
-			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ca: stloc.1
-			IL_00cb: ldloc.1
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::clearInterval(object)
-			IL_00d1: pop
-			IL_00d2: ldstr "console"
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00dc: stloc.1
-			IL_00dd: ldloc.1
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e3: stloc.1
-			IL_00e4: ldloc.1
-			IL_00e5: ldstr "log"
-			IL_00ea: ldstr "cleared"
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00f4: pop
-
-			IL_00f5: ldnull
-			IL_00f6: ret
+			IL_00b3: ldnull
+			IL_00b4: ret
 		} // end of method ArrowFunction_L5C24::__js_call__
 
 	} // end of class ArrowFunction_L5C24
@@ -184,7 +155,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2203
+			// Method begins at RVA 0x21c1
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -286,7 +257,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2229
+		// Method begins at RVA 0x21e7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2486
+				// Method begins at RVA 0x2472
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x248f
+				// Method begins at RVA 0x247b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -144,7 +144,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2498
+				// Method begins at RVA 0x2484
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -223,7 +223,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24aa
+					// Method begins at RVA 0x2496
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -246,7 +246,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2444
+				// Method begins at RVA 0x2430
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -268,7 +268,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24b3
+					// Method begins at RVA 0x249f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -291,7 +291,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2448
+				// Method begins at RVA 0x2434
 				// Header size: 12
 				// Code size: 41 (0x29)
 				.maxstack 8
@@ -335,7 +335,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24bc
+					// Method begins at RVA 0x24a8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -355,7 +355,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24c5
+					// Method begins at RVA 0x24b1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -373,7 +373,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a1
+				// Method begins at RVA 0x248d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -401,7 +401,7 @@
 			)
 			// Method begins at RVA 0x2288
 			// Header size: 12
-			// Code size: 414 (0x19e)
+			// Code size: 396 (0x18c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/Scope,
@@ -463,103 +463,97 @@
 				IL_007c: stloc.2
 				IL_007d: ldarg.0
 				IL_007e: ldfld object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::timersPromises
-				IL_0083: stloc.s 8
-				IL_0085: ldstr "timersPromises"
-				IL_008a: ldloc.s 8
-				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0091: stloc.s 8
-				IL_0093: ldloc.s 8
-				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_009a: stloc.s 8
-				IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00a1: dup
-				IL_00a2: ldstr "signal"
-				IL_00a7: ldloc.1
-				IL_00a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_00ad: stloc.s 9
-				IL_00af: ldloc.s 8
-				IL_00b1: ldstr "setTimeout"
-				IL_00b6: ldc.r8 0.0
-				IL_00bf: box [System.Runtime]System.Double
-				IL_00c4: ldstr "value"
-				IL_00c9: ldloc.s 9
-				IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_00d0: pop
-				IL_00d1: ldstr "console"
-				IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00db: stloc.s 8
-				IL_00dd: ldloc.s 8
-				IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00e4: stloc.s 8
-				IL_00e6: ldloc.s 8
-				IL_00e8: ldstr "log"
-				IL_00ed: ldstr "aborted-getter-no-throw"
-				IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00f7: pop
-				IL_00f8: leave IL_0198
+				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0088: stloc.s 8
+				IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_008f: dup
+				IL_0090: ldstr "signal"
+				IL_0095: ldloc.1
+				IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_009b: stloc.s 9
+				IL_009d: ldloc.s 8
+				IL_009f: ldstr "setTimeout"
+				IL_00a4: ldc.r8 0.0
+				IL_00ad: box [System.Runtime]System.Double
+				IL_00b2: ldstr "value"
+				IL_00b7: ldloc.s 9
+				IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_00be: pop
+				IL_00bf: ldstr "console"
+				IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00c9: stloc.s 8
+				IL_00cb: ldloc.s 8
+				IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00d2: stloc.s 8
+				IL_00d4: ldloc.s 8
+				IL_00d6: ldstr "log"
+				IL_00db: ldstr "aborted-getter-no-throw"
+				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00e5: pop
+				IL_00e6: leave IL_0186
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_00fd: stloc.3
-				IL_00fe: ldloc.3
-				IL_00ff: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0104: dup
-				IL_0105: brtrue IL_011a
+				IL_00eb: stloc.3
+				IL_00ec: ldloc.3
+				IL_00ed: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_00f2: dup
+				IL_00f3: brtrue IL_0108
 
-				IL_010a: pop
-				IL_010b: ldloc.3
-				IL_010c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0111: dup
-				IL_0112: brtrue IL_0126
+				IL_00f8: pop
+				IL_00f9: ldloc.3
+				IL_00fa: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_00ff: dup
+				IL_0100: brtrue IL_0114
 
-				IL_0117: pop
-				IL_0118: rethrow
+				IL_0105: pop
+				IL_0106: rethrow
 
-				IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_011f: stloc.s 4
-				IL_0121: br IL_0128
+				IL_0108: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_010d: stloc.s 4
+				IL_010f: br IL_0116
 
-				IL_0126: stloc.s 4
+				IL_0114: stloc.s 4
 
-				IL_0128: ldloc.s 4
-				IL_012a: stloc.s 8
-				IL_012c: ldloc.s 8
-				IL_012e: stloc.s 5
-				IL_0130: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/Scope/Block_L40C20::.ctor()
-				IL_0135: stloc.s 6
-				IL_0137: ldstr "console"
-				IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0141: stloc.s 8
-				IL_0143: ldloc.s 8
-				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_014a: stloc.s 8
-				IL_014c: ldloc.s 8
-				IL_014e: ldstr "log"
-				IL_0153: ldloc.s 5
-				IL_0155: ldstr "name"
-				IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0164: pop
-				IL_0165: ldstr "console"
-				IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_016f: stloc.s 8
-				IL_0171: ldloc.s 8
-				IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0178: stloc.s 8
-				IL_017a: ldloc.s 8
-				IL_017c: ldstr "log"
-				IL_0181: ldloc.s 5
-				IL_0183: ldstr "message"
-				IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0192: pop
-				IL_0193: leave IL_0198
+				IL_0116: ldloc.s 4
+				IL_0118: stloc.s 8
+				IL_011a: ldloc.s 8
+				IL_011c: stloc.s 5
+				IL_011e: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/Scope/Block_L40C20::.ctor()
+				IL_0123: stloc.s 6
+				IL_0125: ldstr "console"
+				IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_012f: stloc.s 8
+				IL_0131: ldloc.s 8
+				IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0138: stloc.s 8
+				IL_013a: ldloc.s 8
+				IL_013c: ldstr "log"
+				IL_0141: ldloc.s 5
+				IL_0143: ldstr "name"
+				IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0152: pop
+				IL_0153: ldstr "console"
+				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_015d: stloc.s 8
+				IL_015f: ldloc.s 8
+				IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0166: stloc.s 8
+				IL_0168: ldloc.s 8
+				IL_016a: ldstr "log"
+				IL_016f: ldloc.s 5
+				IL_0171: ldstr "message"
+				IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0180: pop
+				IL_0181: leave IL_0186
 			} // end handler
 
-			IL_0198: ldnull
-			IL_0199: stloc.s 7
-			IL_019b: ldloc.s 7
-			IL_019d: ret
+			IL_0186: ldnull
+			IL_0187: stloc.s 7
+			IL_0189: ldloc.s 7
+			IL_018b: ret
 		} // end of method FunctionExpression_L24C8::__js_call__
 
 	} // end of class FunctionExpression_L24C8
@@ -579,7 +573,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x247d
+			// Method begins at RVA 0x2469
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -750,7 +744,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24ce
+		// Method begins at RVA 0x24ba
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26a3
+						// Method begins at RVA 0x263d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x269a
+					// Method begins at RVA 0x2634
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24b0
+				// Method begins at RVA 0x2484
 				// Header size: 12
 				// Code size: 44 (0x2c)
 				.maxstack 8
@@ -115,7 +115,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26b5
+						// Method begins at RVA 0x264f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26ac
+					// Method begins at RVA 0x2646
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -158,7 +158,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24e8
+				// Method begins at RVA 0x24bc
 				// Header size: 12
 				// Code size: 117 (0x75)
 				.maxstack 8
@@ -237,7 +237,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26c7
+						// Method begins at RVA 0x2661
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -255,7 +255,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26be
+					// Method begins at RVA 0x2658
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -279,9 +279,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x256c
+				// Method begins at RVA 0x2540
 				// Header size: 12
-				// Code size: 149 (0x95)
+				// Code size: 107 (0x6b)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/Scope/Block_L24C27,
@@ -295,59 +295,41 @@
 				IL_0003: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
 				IL_0008: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
 				IL_000d: stloc.1
-				IL_000e: ldstr "signal"
-				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldloc.1
-				IL_001b: ldstr "aborted"
-				IL_0020: ldc.i4.1
-				IL_0021: box [System.Runtime]System.Boolean
-				IL_0026: ldc.i4.1
-				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_002c: pop
-				IL_002d: ldarg.0
-				IL_002e: ldc.i4.1
-				IL_002f: ldelem.ref
-				IL_0030: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
-				IL_0035: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
-				IL_003a: stloc.1
-				IL_003b: ldstr "signal"
-				IL_0040: ldloc.1
-				IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0046: stloc.1
-				IL_0047: ldloc.1
-				IL_0048: ldstr "listener"
-				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0052: stloc.1
-				IL_0053: ldloc.1
-				IL_0054: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0059: stloc.2
-				IL_005a: ldloc.2
-				IL_005b: brfalse IL_0093
+				IL_000e: ldloc.1
+				IL_000f: ldstr "aborted"
+				IL_0014: ldc.i4.1
+				IL_0015: box [System.Runtime]System.Boolean
+				IL_001a: ldc.i4.1
+				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0020: pop
+				IL_0021: ldarg.0
+				IL_0022: ldc.i4.1
+				IL_0023: ldelem.ref
+				IL_0024: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
+				IL_0029: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
+				IL_002e: ldstr "listener"
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0038: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_003d: stloc.2
+				IL_003e: ldloc.2
+				IL_003f: brfalse IL_0069
 
-				IL_0060: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/Scope/Block_L24C27::.ctor()
-				IL_0065: stloc.0
-				IL_0066: ldarg.0
-				IL_0067: ldc.i4.1
-				IL_0068: ldelem.ref
-				IL_0069: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
-				IL_006e: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
-				IL_0073: stloc.1
-				IL_0074: ldstr "signal"
-				IL_0079: ldloc.1
-				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_007f: stloc.1
-				IL_0080: ldloc.1
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0086: stloc.1
-				IL_0087: ldloc.1
-				IL_0088: ldstr "listener"
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0092: pop
+				IL_0044: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/Scope/Block_L24C27::.ctor()
+				IL_0049: stloc.0
+				IL_004a: ldarg.0
+				IL_004b: ldc.i4.1
+				IL_004c: ldelem.ref
+				IL_004d: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
+				IL_0052: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
+				IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_005c: stloc.1
+				IL_005d: ldloc.1
+				IL_005e: ldstr "listener"
+				IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0068: pop
 
-				IL_0093: ldnull
-				IL_0094: ret
+				IL_0069: ldnull
+				IL_006a: ret
 			} // end of method FunctionExpression_L22C11::__js_call__
 
 		} // end of class FunctionExpression_L22C11
@@ -366,7 +348,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2691
+				// Method begins at RVA 0x262b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -489,7 +471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26d0
+				// Method begins at RVA 0x266a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -577,7 +559,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26d9
+				// Method begins at RVA 0x2673
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -636,7 +618,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26e2
+				// Method begins at RVA 0x267c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -665,34 +647,27 @@
 			)
 			// Method begins at RVA 0x2378
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 27 (0x1b)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object[]
+				[0] object[]
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::logAbort
-			IL_0006: stloc.0
-			IL_0007: ldstr "logAbort"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldc.i4.1
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0026: pop
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.0
+			IL_000b: ldarg.0
+			IL_000c: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::logAbort
+			IL_0011: ldloc.0
+			IL_0012: ldarg.2
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0018: pop
+			IL_0019: ldnull
+			IL_001a: ret
 		} // end of method FunctionExpression_L45C9::__js_call__
 
 	} // end of class FunctionExpression_L45C9
@@ -712,7 +687,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26f4
+					// Method begins at RVA 0x268e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -735,7 +710,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2610
+				// Method begins at RVA 0x25b8
 				// Header size: 12
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -771,7 +746,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26fd
+					// Method begins at RVA 0x2697
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -796,47 +771,40 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2644
+				// Method begins at RVA 0x25ec
 				// Header size: 12
-				// Code size: 56 (0x38)
+				// Code size: 42 (0x2a)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object[]
+					[0] object[]
 				)
 
-				IL_0000: ldarg.0
-				IL_0001: ldc.i4.0
-				IL_0002: ldelem.ref
-				IL_0003: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-				IL_0008: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::logAbort
-				IL_000d: stloc.0
-				IL_000e: ldstr "logAbort"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldc.i4.2
-				IL_001b: newarr [System.Runtime]System.Object
-				IL_0020: dup
-				IL_0021: ldc.i4.0
-				IL_0022: ldarg.0
-				IL_0023: ldc.i4.0
-				IL_0024: ldelem.ref
-				IL_0025: stelem.ref
-				IL_0026: dup
-				IL_0027: ldc.i4.1
-				IL_0028: ldarg.0
-				IL_0029: ldc.i4.1
-				IL_002a: ldelem.ref
-				IL_002b: stelem.ref
-				IL_002c: stloc.1
-				IL_002d: ldloc.0
-				IL_002e: ldloc.1
-				IL_002f: ldarg.2
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0035: pop
-				IL_0036: ldnull
-				IL_0037: ret
+				IL_0000: ldc.i4.2
+				IL_0001: newarr [System.Runtime]System.Object
+				IL_0006: dup
+				IL_0007: ldc.i4.0
+				IL_0008: ldarg.0
+				IL_0009: ldc.i4.0
+				IL_000a: ldelem.ref
+				IL_000b: stelem.ref
+				IL_000c: dup
+				IL_000d: ldc.i4.1
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: stelem.ref
+				IL_0012: stloc.0
+				IL_0013: ldarg.0
+				IL_0014: ldc.i4.0
+				IL_0015: ldelem.ref
+				IL_0016: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+				IL_001b: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::logAbort
+				IL_0020: ldloc.0
+				IL_0021: ldarg.2
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0027: pop
+				IL_0028: ldnull
+				IL_0029: ret
 			} // end of method FunctionExpression_L56C13::__js_call__
 
 		} // end of class FunctionExpression_L56C13
@@ -848,7 +816,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26eb
+				// Method begins at RVA 0x2685
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -874,9 +842,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x23b0
+			// Method begins at RVA 0x23a0
 			// Header size: 12
-			// Code size: 242 (0xf2)
+			// Code size: 214 (0xd6)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/Scope,
@@ -889,98 +857,86 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::createController
-			IL_000c: stloc.2
-			IL_000d: ldstr "createController"
-			IL_0012: ldloc.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: ldc.i4.1
-			IL_001b: newarr [System.Runtime]System.Object
-			IL_0020: dup
-			IL_0021: ldc.i4.0
-			IL_0022: ldarg.0
-			IL_0023: stelem.ref
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0029: stloc.2
-			IL_002a: ldloc.2
-			IL_002b: stloc.1
-			IL_002c: ldloc.1
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0032: stloc.2
-			IL_0033: ldloc.2
-			IL_0034: ldstr "abort"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_003e: pop
-			IL_003f: ldarg.0
-			IL_0040: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-			IL_0045: stloc.2
-			IL_0046: ldstr "timersPromises"
-			IL_004b: ldloc.2
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0051: stloc.2
-			IL_0052: ldloc.2
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0058: stloc.2
-			IL_0059: ldloc.2
-			IL_005a: ldstr "setImmediate"
-			IL_005f: ldstr "immediate-value"
-			IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0069: dup
-			IL_006a: ldstr "signal"
-			IL_006f: ldloc.1
-			IL_0070: ldstr "signal"
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0084: stloc.2
-			IL_0085: ldloc.2
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_008b: stloc.2
-			IL_008c: ldnull
-			IL_008d: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
-			IL_0093: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0098: ldc.i4.0
-			IL_0099: conv.r8
-			IL_009a: ldstr ""
-			IL_009f: ldc.i4.0
-			IL_00a0: ldc.i4.1
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00a6: stloc.3
-			IL_00a7: ldloc.2
-			IL_00a8: ldstr "then"
-			IL_00ad: ldloc.3
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00b3: stloc.3
-			IL_00b4: ldloc.3
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ba: stloc.3
-			IL_00bb: ldc.i4.2
-			IL_00bc: newarr [System.Runtime]System.Object
-			IL_00c1: dup
-			IL_00c2: ldc.i4.0
-			IL_00c3: ldarg.0
-			IL_00c4: stelem.ref
-			IL_00c5: dup
-			IL_00c6: ldc.i4.1
-			IL_00c7: ldloc.0
-			IL_00c8: stelem.ref
-			IL_00c9: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
-			IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00d4: ldc.i4.1
-			IL_00d5: conv.r8
-			IL_00d6: ldstr ""
-			IL_00db: ldc.i4.0
-			IL_00dc: ldc.i4.1
-			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00e2: stloc.2
-			IL_00e3: ldloc.3
-			IL_00e4: ldstr "catch"
-			IL_00e9: ldloc.2
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ef: stloc.2
-			IL_00f0: ldloc.2
-			IL_00f1: ret
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: stelem.ref
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_001b: stloc.2
+			IL_001c: ldloc.2
+			IL_001d: stloc.1
+			IL_001e: ldloc.1
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0024: stloc.2
+			IL_0025: ldloc.2
+			IL_0026: ldstr "abort"
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0030: pop
+			IL_0031: ldarg.0
+			IL_0032: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003c: stloc.2
+			IL_003d: ldloc.2
+			IL_003e: ldstr "setImmediate"
+			IL_0043: ldstr "immediate-value"
+			IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_004d: dup
+			IL_004e: ldstr "signal"
+			IL_0053: ldloc.1
+			IL_0054: ldstr "signal"
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0068: stloc.2
+			IL_0069: ldloc.2
+			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006f: stloc.2
+			IL_0070: ldnull
+			IL_0071: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
+			IL_0077: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_007c: ldc.i4.0
+			IL_007d: conv.r8
+			IL_007e: ldstr ""
+			IL_0083: ldc.i4.0
+			IL_0084: ldc.i4.1
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_008a: stloc.3
+			IL_008b: ldloc.2
+			IL_008c: ldstr "then"
+			IL_0091: ldloc.3
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0097: stloc.3
+			IL_0098: ldloc.3
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009e: stloc.3
+			IL_009f: ldc.i4.2
+			IL_00a0: newarr [System.Runtime]System.Object
+			IL_00a5: dup
+			IL_00a6: ldc.i4.0
+			IL_00a7: ldarg.0
+			IL_00a8: stelem.ref
+			IL_00a9: dup
+			IL_00aa: ldc.i4.1
+			IL_00ab: ldloc.0
+			IL_00ac: stelem.ref
+			IL_00ad: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
+			IL_00b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00b8: ldc.i4.1
+			IL_00b9: conv.r8
+			IL_00ba: ldstr ""
+			IL_00bf: ldc.i4.0
+			IL_00c0: ldc.i4.1
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00c6: stloc.2
+			IL_00c7: ldloc.3
+			IL_00c8: ldstr "catch"
+			IL_00cd: ldloc.2
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00d3: stloc.2
+			IL_00d4: ldloc.2
+			IL_00d5: ret
 		} // end of method FunctionExpression_L48C8::__js_call__
 
 	} // end of class FunctionExpression_L48C8
@@ -1006,7 +962,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2688
+			// Method begins at RVA 0x2622
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1201,7 +1157,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2706
+		// Method begins at RVA 0x26a0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ba
+				// Method begins at RVA 0x2304
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,31 +45,17 @@
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
 			// Method begins at RVA 0x218c
-			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "nextTick"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldnull
-			IL_002c: ret
+			IL_0006: ldstr "nextTick"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
 		} // end of method FunctionExpression_L8C17::__js_call__
 
 	} // end of class FunctionExpression_L8C17
@@ -85,7 +71,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c3
+				// Method begins at RVA 0x230d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,32 +97,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x21c8
-			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Method begins at RVA 0x21a0
+			// Header size: 1
+			// Code size: 19 (0x13)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-			IL_0006: stloc.0
-			IL_0007: ldstr "order"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "promise"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldnull
-			IL_002c: ret
+			IL_0006: ldstr "promise"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldnull
+			IL_0012: ret
 		} // end of method FunctionExpression_L12C24::__js_call__
 
 	} // end of class FunctionExpression_L12C24
@@ -156,7 +128,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23d5
+					// Method begins at RVA 0x231f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -181,16 +153,15 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22b4
+				// Method begins at RVA 0x223c
 				// Header size: 12
-				// Code size: 241 (0xf1)
+				// Code size: 179 (0xb3)
 				.maxstack 8
 				.locals init (
-					[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-					[1] object,
-					[2] object,
-					[3] bool,
-					[4] object
+					[0] object,
+					[1] string,
+					[2] bool,
+					[3] object
 				)
 
 				IL_0000: ldarg.0
@@ -198,88 +169,68 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
 				IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-				IL_000d: stloc.0
-				IL_000e: ldstr "order"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldloc.1
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldstr "push"
-				IL_0027: ldarg.2
-				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_002d: pop
-				IL_002e: ldstr "console"
-				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0038: stloc.1
-				IL_0039: ldloc.1
-				IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003f: stloc.1
-				IL_0040: ldarg.0
-				IL_0041: ldc.i4.0
-				IL_0042: ldelem.ref
-				IL_0043: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-				IL_0048: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-				IL_004d: stloc.0
-				IL_004e: ldstr "order"
-				IL_0053: ldloc.0
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0059: stloc.2
-				IL_005a: ldloc.2
-				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0060: stloc.2
-				IL_0061: ldloc.2
-				IL_0062: ldstr "join"
-				IL_0067: ldstr ","
-				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0071: stloc.2
-				IL_0072: ldloc.1
-				IL_0073: ldstr "log"
-				IL_0078: ldstr "order"
-				IL_007d: ldloc.2
-				IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0083: pop
-				IL_0084: ldstr "console"
-				IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_008e: stloc.2
-				IL_008f: ldloc.2
-				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0095: stloc.2
-				IL_0096: ldarg.0
-				IL_0097: ldc.i4.0
-				IL_0098: ldelem.ref
-				IL_0099: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-				IL_009e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-				IL_00a3: stloc.0
-				IL_00a4: ldstr "order"
-				IL_00a9: ldloc.0
-				IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00af: stloc.1
-				IL_00b0: ldloc.1
-				IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00b6: stloc.1
-				IL_00b7: ldloc.1
-				IL_00b8: ldstr "join"
-				IL_00bd: ldstr ","
-				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00c7: stloc.1
-				IL_00c8: ldloc.1
-				IL_00c9: ldstr "sync,nextTick,promise,immediate,timeout"
-				IL_00ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00d3: stloc.3
-				IL_00d4: ldloc.3
-				IL_00d5: box [System.Runtime]System.Boolean
-				IL_00da: stloc.s 4
-				IL_00dc: ldloc.2
-				IL_00dd: ldstr "log"
-				IL_00e2: ldstr "correct"
-				IL_00e7: ldloc.s 4
-				IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00ee: pop
-				IL_00ef: ldnull
-				IL_00f0: ret
+				IL_000d: ldarg.2
+				IL_000e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0013: pop
+				IL_0014: ldstr "console"
+				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_001e: stloc.0
+				IL_001f: ldloc.0
+				IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0025: stloc.0
+				IL_0026: ldarg.0
+				IL_0027: ldc.i4.0
+				IL_0028: ldelem.ref
+				IL_0029: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
+				IL_002e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
+				IL_0033: ldc.i4.1
+				IL_0034: newarr [System.Runtime]System.Object
+				IL_0039: dup
+				IL_003a: ldc.i4.0
+				IL_003b: ldstr ","
+				IL_0040: stelem.ref
+				IL_0041: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+				IL_0046: stloc.1
+				IL_0047: ldloc.0
+				IL_0048: ldstr "log"
+				IL_004d: ldstr "order"
+				IL_0052: ldloc.1
+				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0058: pop
+				IL_0059: ldstr "console"
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0063: stloc.0
+				IL_0064: ldloc.0
+				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_006a: stloc.0
+				IL_006b: ldarg.0
+				IL_006c: ldc.i4.0
+				IL_006d: ldelem.ref
+				IL_006e: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
+				IL_0073: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
+				IL_0078: ldc.i4.1
+				IL_0079: newarr [System.Runtime]System.Object
+				IL_007e: dup
+				IL_007f: ldc.i4.0
+				IL_0080: ldstr ","
+				IL_0085: stelem.ref
+				IL_0086: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+				IL_008b: stloc.1
+				IL_008c: ldloc.1
+				IL_008d: ldstr "sync,nextTick,promise,immediate,timeout"
+				IL_0092: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0097: stloc.2
+				IL_0098: ldloc.2
+				IL_0099: box [System.Runtime]System.Boolean
+				IL_009e: stloc.3
+				IL_009f: ldloc.0
+				IL_00a0: ldstr "log"
+				IL_00a5: ldstr "correct"
+				IL_00aa: ldloc.3
+				IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00b0: pop
+				IL_00b1: ldnull
+				IL_00b2: ret
 			} // end of method FunctionExpression_L19C54::__js_call__
 
 		} // end of class FunctionExpression_L19C54
@@ -291,7 +242,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23cc
+				// Method begins at RVA 0x2316
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -318,80 +269,63 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2204
+			// Method begins at RVA 0x21b4
 			// Header size: 12
-			// Code size: 164 (0xa4)
+			// Code size: 124 (0x7c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/Scope,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object,
-				[3] object
+				[1] object,
+				[2] object
 			)
 
 			IL_0000: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
 			IL_0007: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::order
-			IL_000c: stloc.1
-			IL_000d: ldstr "order"
-			IL_0012: ldloc.1
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "push"
-			IL_0026: ldarg.2
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002c: pop
-			IL_002d: ldarg.0
-			IL_002e: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
-			IL_0033: stloc.2
-			IL_0034: ldstr "timersPromises"
-			IL_0039: ldloc.2
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003f: stloc.2
-			IL_0040: ldloc.2
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0046: stloc.2
-			IL_0047: ldloc.2
-			IL_0048: ldstr "setTimeout"
-			IL_004d: ldc.r8 0.0
-			IL_0056: box [System.Runtime]System.Double
-			IL_005b: ldstr "timeout"
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0065: stloc.2
-			IL_0066: ldloc.2
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000c: ldarg.2
+			IL_000d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0012: pop
+			IL_0013: ldarg.0
+			IL_0014: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001e: stloc.1
+			IL_001f: ldloc.1
+			IL_0020: ldstr "setTimeout"
+			IL_0025: ldc.r8 0.0
+			IL_002e: box [System.Runtime]System.Double
+			IL_0033: ldstr "timeout"
+			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_003d: stloc.1
+			IL_003e: ldloc.1
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0044: stloc.1
+			IL_0045: ldc.i4.2
+			IL_0046: newarr [System.Runtime]System.Object
+			IL_004b: dup
+			IL_004c: ldc.i4.0
+			IL_004d: ldarg.0
+			IL_004e: stelem.ref
+			IL_004f: dup
+			IL_0050: ldc.i4.1
+			IL_0051: ldloc.0
+			IL_0052: stelem.ref
+			IL_0053: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54::__js_call__(object[], object, object)
+			IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_005e: ldc.i4.1
+			IL_005f: conv.r8
+			IL_0060: ldstr ""
+			IL_0065: ldc.i4.0
+			IL_0066: ldc.i4.1
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 			IL_006c: stloc.2
-			IL_006d: ldc.i4.2
-			IL_006e: newarr [System.Runtime]System.Object
-			IL_0073: dup
-			IL_0074: ldc.i4.0
-			IL_0075: ldarg.0
-			IL_0076: stelem.ref
-			IL_0077: dup
-			IL_0078: ldc.i4.1
-			IL_0079: ldloc.0
-			IL_007a: stelem.ref
-			IL_007b: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54::__js_call__(object[], object, object)
-			IL_0081: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0086: ldc.i4.1
-			IL_0087: conv.r8
-			IL_0088: ldstr ""
-			IL_008d: ldc.i4.0
-			IL_008e: ldc.i4.1
-			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0094: stloc.3
-			IL_0095: ldloc.2
-			IL_0096: ldstr "then"
-			IL_009b: ldloc.3
-			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00a1: stloc.3
-			IL_00a2: ldloc.3
-			IL_00a3: ret
+			IL_006d: ldloc.1
+			IL_006e: ldstr "then"
+			IL_0073: ldloc.2
+			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0079: stloc.2
+			IL_007a: ldloc.2
+			IL_007b: ret
 		} // end of method FunctionExpression_L16C46::__js_call__
 
 	} // end of class FunctionExpression_L16C46
@@ -413,7 +347,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23b1
+			// Method begins at RVA 0x22fb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -571,7 +505,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23de
+		// Method begins at RVA 0x2328
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27ba
+						// Method begins at RVA 0x275e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27b1
+					// Method begins at RVA 0x2755
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24f4
+				// Method begins at RVA 0x24d0
 				// Header size: 12
 				// Code size: 44 (0x2c)
 				.maxstack 8
@@ -115,7 +115,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27cc
+						// Method begins at RVA 0x2770
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27c3
+					// Method begins at RVA 0x2767
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -158,7 +158,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x252c
+				// Method begins at RVA 0x2508
 				// Header size: 12
 				// Code size: 117 (0x75)
 				.maxstack 8
@@ -237,7 +237,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27de
+						// Method begins at RVA 0x2782
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -255,7 +255,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27d5
+					// Method begins at RVA 0x2779
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -280,9 +280,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25b0
+				// Method begins at RVA 0x258c
 				// Header size: 12
-				// Code size: 189 (0xbd)
+				// Code size: 133 (0x85)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/Scope/Block_L26C27,
@@ -296,75 +296,51 @@
 				IL_0003: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
 				IL_0008: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
 				IL_000d: stloc.1
-				IL_000e: ldstr "signal"
-				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldloc.1
-				IL_001b: ldstr "aborted"
-				IL_0020: ldc.i4.1
-				IL_0021: box [System.Runtime]System.Boolean
-				IL_0026: ldc.i4.1
-				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_002c: pop
-				IL_002d: ldarg.0
-				IL_002e: ldc.i4.1
-				IL_002f: ldelem.ref
-				IL_0030: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
-				IL_0035: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
-				IL_003a: stloc.1
-				IL_003b: ldstr "signal"
-				IL_0040: ldloc.1
-				IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0046: stloc.1
-				IL_0047: ldloc.1
-				IL_0048: ldstr "reason"
-				IL_004d: ldarg.2
-				IL_004e: ldc.i4.1
-				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0054: pop
-				IL_0055: ldarg.0
-				IL_0056: ldc.i4.1
-				IL_0057: ldelem.ref
-				IL_0058: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
-				IL_005d: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
-				IL_0062: stloc.1
-				IL_0063: ldstr "signal"
-				IL_0068: ldloc.1
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006e: stloc.1
-				IL_006f: ldloc.1
-				IL_0070: ldstr "listener"
-				IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_007a: stloc.1
-				IL_007b: ldloc.1
-				IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0081: stloc.2
-				IL_0082: ldloc.2
-				IL_0083: brfalse IL_00bb
+				IL_000e: ldloc.1
+				IL_000f: ldstr "aborted"
+				IL_0014: ldc.i4.1
+				IL_0015: box [System.Runtime]System.Boolean
+				IL_001a: ldc.i4.1
+				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0020: pop
+				IL_0021: ldarg.0
+				IL_0022: ldc.i4.1
+				IL_0023: ldelem.ref
+				IL_0024: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
+				IL_0029: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
+				IL_002e: ldstr "reason"
+				IL_0033: ldarg.2
+				IL_0034: ldc.i4.1
+				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_003a: pop
+				IL_003b: ldarg.0
+				IL_003c: ldc.i4.1
+				IL_003d: ldelem.ref
+				IL_003e: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
+				IL_0043: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
+				IL_0048: ldstr "listener"
+				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0057: stloc.2
+				IL_0058: ldloc.2
+				IL_0059: brfalse IL_0083
 
-				IL_0088: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/Scope/Block_L26C27::.ctor()
-				IL_008d: stloc.0
-				IL_008e: ldarg.0
-				IL_008f: ldc.i4.1
-				IL_0090: ldelem.ref
-				IL_0091: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
-				IL_0096: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
-				IL_009b: stloc.1
-				IL_009c: ldstr "signal"
-				IL_00a1: ldloc.1
-				IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00a7: stloc.1
-				IL_00a8: ldloc.1
-				IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ae: stloc.1
-				IL_00af: ldloc.1
-				IL_00b0: ldstr "listener"
-				IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_00ba: pop
+				IL_005e: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/Scope/Block_L26C27::.ctor()
+				IL_0063: stloc.0
+				IL_0064: ldarg.0
+				IL_0065: ldc.i4.1
+				IL_0066: ldelem.ref
+				IL_0067: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
+				IL_006c: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0076: stloc.1
+				IL_0077: ldloc.1
+				IL_0078: ldstr "listener"
+				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0082: pop
 
-				IL_00bb: ldnull
-				IL_00bc: ret
+				IL_0083: ldnull
+				IL_0084: ret
 			} // end of method FunctionExpression_L23C11::__js_call__
 
 		} // end of class FunctionExpression_L23C11
@@ -383,7 +359,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27a8
+				// Method begins at RVA 0x274c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -515,7 +491,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27f0
+					// Method begins at RVA 0x2794
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -538,7 +514,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x267c
+				// Method begins at RVA 0x2620
 				// Header size: 12
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -574,7 +550,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27f9
+					// Method begins at RVA 0x279d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -598,7 +574,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26b0
+				// Method begins at RVA 0x2654
 				// Header size: 12
 				// Code size: 227 (0xe3)
 				.maxstack 8
@@ -703,7 +679,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27e7
+				// Method begins at RVA 0x278b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -729,7 +705,7 @@
 			)
 			// Method begins at RVA 0x21b4
 			// Header size: 12
-			// Code size: 818 (0x332)
+			// Code size: 782 (0x30e)
 			.maxstack 9
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope,
@@ -810,268 +786,256 @@
 
 			IL_0081: ldloc.0
 			IL_0082: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0087: switch (IL_0098, IL_018d, IL_0220)
+			IL_0087: switch (IL_0098, IL_0169, IL_01fc)
 
 			IL_0098: ldarg.0
 			IL_0099: ldc.i4.1
 			IL_009a: ldelem.ref
 			IL_009b: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
 			IL_00a0: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::createController
-			IL_00a5: stloc.s 5
-			IL_00a7: ldstr "createController"
-			IL_00ac: ldloc.s 5
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00b3: stloc.s 5
-			IL_00b5: ldloc.s 5
-			IL_00b7: ldc.i4.1
-			IL_00b8: newarr [System.Runtime]System.Object
-			IL_00bd: dup
-			IL_00be: ldc.i4.0
-			IL_00bf: ldarg.0
-			IL_00c0: ldc.i4.1
-			IL_00c1: ldelem.ref
-			IL_00c2: stelem.ref
-			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00c8: stloc.s 5
-			IL_00ca: ldloc.s 5
-			IL_00cc: stloc.1
-			IL_00cd: ldarg.0
-			IL_00ce: ldc.i4.1
-			IL_00cf: ldelem.ref
-			IL_00d0: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
-			IL_00d5: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
-			IL_00da: stloc.s 5
-			IL_00dc: ldstr "timersPromises"
-			IL_00e1: ldloc.s 5
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00e8: stloc.s 5
-			IL_00ea: ldloc.s 5
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f1: stloc.s 5
-			IL_00f3: ldloc.s 5
-			IL_00f5: ldstr "setInterval"
-			IL_00fa: ldc.r8 0.0
-			IL_0103: box [System.Runtime]System.Double
-			IL_0108: ldstr "tick"
-			IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0112: dup
-			IL_0113: ldstr "signal"
-			IL_0118: ldloc.1
-			IL_0119: ldstr "signal"
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0123: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_012d: stloc.s 5
-			IL_012f: ldloc.s 5
-			IL_0131: stloc.2
-			IL_0132: ldloc.2
-			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0138: stloc.s 5
-			IL_013a: ldloc.s 5
-			IL_013c: ldstr "next"
-			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0146: stloc.s 5
-			IL_0148: ldloc.0
-			IL_0149: ldc.i4.1
-			IL_014a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_014f: ldloc.0
-			IL_0150: ldloc.s 5
-			IL_0152: ldarg.0
-			IL_0153: ldc.i4.1
-			IL_0154: ldloc.0
-			IL_0155: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_015a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_015f: ldloc.0
-			IL_0160: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0165: dup
-			IL_0166: ldc.i4.0
-			IL_0167: ldloc.1
-			IL_0168: stelem.ref
-			IL_0169: dup
-			IL_016a: ldc.i4.1
-			IL_016b: ldloc.2
-			IL_016c: stelem.ref
-			IL_016d: dup
-			IL_016e: ldc.i4.2
-			IL_016f: ldloc.3
-			IL_0170: stelem.ref
-			IL_0171: dup
-			IL_0172: ldc.i4.3
-			IL_0173: ldloc.s 4
-			IL_0175: stelem.ref
-			IL_0176: dup
-			IL_0177: ldc.i4.4
-			IL_0178: ldloc.s 5
-			IL_017a: stelem.ref
-			IL_017b: dup
-			IL_017c: ldc.i4.5
-			IL_017d: ldloc.s 6
-			IL_017f: stelem.ref
-			IL_0180: pop
-			IL_0181: ldloc.0
-			IL_0182: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0187: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_018c: ret
+			IL_00a5: ldc.i4.1
+			IL_00a6: newarr [System.Runtime]System.Object
+			IL_00ab: dup
+			IL_00ac: ldc.i4.0
+			IL_00ad: ldarg.0
+			IL_00ae: ldc.i4.1
+			IL_00af: ldelem.ref
+			IL_00b0: stelem.ref
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00b6: stloc.s 5
+			IL_00b8: ldloc.s 5
+			IL_00ba: stloc.1
+			IL_00bb: ldarg.0
+			IL_00bc: ldc.i4.1
+			IL_00bd: ldelem.ref
+			IL_00be: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
+			IL_00c3: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00cd: stloc.s 5
+			IL_00cf: ldloc.s 5
+			IL_00d1: ldstr "setInterval"
+			IL_00d6: ldc.r8 0.0
+			IL_00df: box [System.Runtime]System.Double
+			IL_00e4: ldstr "tick"
+			IL_00e9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00ee: dup
+			IL_00ef: ldstr "signal"
+			IL_00f4: ldloc.1
+			IL_00f5: ldstr "signal"
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0109: stloc.s 5
+			IL_010b: ldloc.s 5
+			IL_010d: stloc.2
+			IL_010e: ldloc.2
+			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0114: stloc.s 5
+			IL_0116: ldloc.s 5
+			IL_0118: ldstr "next"
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0122: stloc.s 5
+			IL_0124: ldloc.0
+			IL_0125: ldc.i4.1
+			IL_0126: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_012b: ldloc.0
+			IL_012c: ldloc.s 5
+			IL_012e: ldarg.0
+			IL_012f: ldc.i4.1
+			IL_0130: ldloc.0
+			IL_0131: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0136: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_013b: ldloc.0
+			IL_013c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0141: dup
+			IL_0142: ldc.i4.0
+			IL_0143: ldloc.1
+			IL_0144: stelem.ref
+			IL_0145: dup
+			IL_0146: ldc.i4.1
+			IL_0147: ldloc.2
+			IL_0148: stelem.ref
+			IL_0149: dup
+			IL_014a: ldc.i4.2
+			IL_014b: ldloc.3
+			IL_014c: stelem.ref
+			IL_014d: dup
+			IL_014e: ldc.i4.3
+			IL_014f: ldloc.s 4
+			IL_0151: stelem.ref
+			IL_0152: dup
+			IL_0153: ldc.i4.4
+			IL_0154: ldloc.s 5
+			IL_0156: stelem.ref
+			IL_0157: dup
+			IL_0158: ldc.i4.5
+			IL_0159: ldloc.s 6
+			IL_015b: stelem.ref
+			IL_015c: pop
+			IL_015d: ldloc.0
+			IL_015e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0163: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0168: ret
 
-			IL_018d: ldloc.0
-			IL_018e: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited1
-			IL_0193: stloc.s 5
-			IL_0195: ldloc.s 5
-			IL_0197: stloc.3
-			IL_0198: ldstr "console"
-			IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01a2: stloc.s 5
-			IL_01a4: ldloc.s 5
-			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ab: stloc.s 5
-			IL_01ad: ldloc.s 5
-			IL_01af: ldstr "log"
-			IL_01b4: ldloc.3
-			IL_01b5: ldstr "value"
-			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01c4: pop
-			IL_01c5: ldloc.2
-			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01cb: stloc.s 5
-			IL_01cd: ldloc.s 5
-			IL_01cf: ldstr "next"
-			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01d9: stloc.s 5
-			IL_01db: ldloc.0
-			IL_01dc: ldc.i4.2
-			IL_01dd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01e2: ldloc.0
-			IL_01e3: ldloc.s 5
-			IL_01e5: ldarg.0
-			IL_01e6: ldc.i4.2
-			IL_01e7: ldloc.0
-			IL_01e8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01f2: ldloc.0
-			IL_01f3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01f8: dup
-			IL_01f9: ldc.i4.0
-			IL_01fa: ldloc.1
-			IL_01fb: stelem.ref
-			IL_01fc: dup
-			IL_01fd: ldc.i4.1
-			IL_01fe: ldloc.2
-			IL_01ff: stelem.ref
-			IL_0200: dup
-			IL_0201: ldc.i4.2
-			IL_0202: ldloc.3
-			IL_0203: stelem.ref
-			IL_0204: dup
-			IL_0205: ldc.i4.3
-			IL_0206: ldloc.s 4
-			IL_0208: stelem.ref
-			IL_0209: dup
-			IL_020a: ldc.i4.4
-			IL_020b: ldloc.s 5
-			IL_020d: stelem.ref
-			IL_020e: dup
-			IL_020f: ldc.i4.5
-			IL_0210: ldloc.s 6
-			IL_0212: stelem.ref
-			IL_0213: pop
-			IL_0214: ldloc.0
-			IL_0215: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_021a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_021f: ret
+			IL_0169: ldloc.0
+			IL_016a: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited1
+			IL_016f: stloc.s 5
+			IL_0171: ldloc.s 5
+			IL_0173: stloc.3
+			IL_0174: ldstr "console"
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_017e: stloc.s 5
+			IL_0180: ldloc.s 5
+			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0187: stloc.s 5
+			IL_0189: ldloc.s 5
+			IL_018b: ldstr "log"
+			IL_0190: ldloc.3
+			IL_0191: ldstr "value"
+			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01a0: pop
+			IL_01a1: ldloc.2
+			IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a7: stloc.s 5
+			IL_01a9: ldloc.s 5
+			IL_01ab: ldstr "next"
+			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01b5: stloc.s 5
+			IL_01b7: ldloc.0
+			IL_01b8: ldc.i4.2
+			IL_01b9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01be: ldloc.0
+			IL_01bf: ldloc.s 5
+			IL_01c1: ldarg.0
+			IL_01c2: ldc.i4.2
+			IL_01c3: ldloc.0
+			IL_01c4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01ce: ldloc.0
+			IL_01cf: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01d4: dup
+			IL_01d5: ldc.i4.0
+			IL_01d6: ldloc.1
+			IL_01d7: stelem.ref
+			IL_01d8: dup
+			IL_01d9: ldc.i4.1
+			IL_01da: ldloc.2
+			IL_01db: stelem.ref
+			IL_01dc: dup
+			IL_01dd: ldc.i4.2
+			IL_01de: ldloc.3
+			IL_01df: stelem.ref
+			IL_01e0: dup
+			IL_01e1: ldc.i4.3
+			IL_01e2: ldloc.s 4
+			IL_01e4: stelem.ref
+			IL_01e5: dup
+			IL_01e6: ldc.i4.4
+			IL_01e7: ldloc.s 5
+			IL_01e9: stelem.ref
+			IL_01ea: dup
+			IL_01eb: ldc.i4.5
+			IL_01ec: ldloc.s 6
+			IL_01ee: stelem.ref
+			IL_01ef: pop
+			IL_01f0: ldloc.0
+			IL_01f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01f6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01fb: ret
 
-			IL_0220: ldloc.0
-			IL_0221: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited2
-			IL_0226: stloc.s 5
-			IL_0228: ldloc.s 5
-			IL_022a: stloc.s 4
-			IL_022c: ldstr "console"
-			IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0236: stloc.s 5
-			IL_0238: ldloc.s 5
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_023f: stloc.s 5
-			IL_0241: ldloc.s 5
-			IL_0243: ldstr "log"
-			IL_0248: ldloc.s 4
-			IL_024a: ldstr "value"
-			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0259: pop
-			IL_025a: ldloc.1
-			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0260: stloc.s 5
-			IL_0262: ldstr "boom-reason"
-			IL_0267: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_026c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0271: stloc.s 6
-			IL_0273: ldloc.s 5
-			IL_0275: ldstr "abort"
-			IL_027a: ldloc.s 6
-			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0281: pop
-			IL_0282: ldloc.2
-			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0288: stloc.s 6
-			IL_028a: ldloc.s 6
-			IL_028c: ldstr "next"
-			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0296: stloc.s 6
-			IL_0298: ldloc.s 6
-			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_029f: stloc.s 6
-			IL_02a1: ldnull
-			IL_02a2: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
-			IL_02a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_02ad: ldc.i4.0
-			IL_02ae: conv.r8
-			IL_02af: ldstr ""
-			IL_02b4: ldc.i4.0
-			IL_02b5: ldc.i4.1
-			IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_02bb: stloc.s 5
-			IL_02bd: ldloc.s 6
-			IL_02bf: ldstr "then"
-			IL_02c4: ldloc.s 5
-			IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02cb: stloc.s 5
-			IL_02cd: ldloc.s 5
-			IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02d4: stloc.s 5
-			IL_02d6: ldnull
-			IL_02d7: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
-			IL_02dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_02e2: ldc.i4.1
-			IL_02e3: conv.r8
-			IL_02e4: ldstr ""
-			IL_02e9: ldc.i4.0
-			IL_02ea: ldc.i4.1
-			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_02f0: stloc.s 6
-			IL_02f2: ldloc.s 5
-			IL_02f4: ldstr "catch"
+			IL_01fc: ldloc.0
+			IL_01fd: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited2
+			IL_0202: stloc.s 5
+			IL_0204: ldloc.s 5
+			IL_0206: stloc.s 4
+			IL_0208: ldstr "console"
+			IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0212: stloc.s 5
+			IL_0214: ldloc.s 5
+			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021b: stloc.s 5
+			IL_021d: ldloc.s 5
+			IL_021f: ldstr "log"
+			IL_0224: ldloc.s 4
+			IL_0226: ldstr "value"
+			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0235: pop
+			IL_0236: ldloc.1
+			IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_023c: stloc.s 5
+			IL_023e: ldstr "boom-reason"
+			IL_0243: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0248: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_024d: stloc.s 6
+			IL_024f: ldloc.s 5
+			IL_0251: ldstr "abort"
+			IL_0256: ldloc.s 6
+			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_025d: pop
+			IL_025e: ldloc.2
+			IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0264: stloc.s 6
+			IL_0266: ldloc.s 6
+			IL_0268: ldstr "next"
+			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0272: stloc.s 6
+			IL_0274: ldloc.s 6
+			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_027b: stloc.s 6
+			IL_027d: ldnull
+			IL_027e: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
+			IL_0284: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0289: ldc.i4.0
+			IL_028a: conv.r8
+			IL_028b: ldstr ""
+			IL_0290: ldc.i4.0
+			IL_0291: ldc.i4.1
+			IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0297: stloc.s 5
+			IL_0299: ldloc.s 6
+			IL_029b: ldstr "then"
+			IL_02a0: ldloc.s 5
+			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02a7: stloc.s 5
+			IL_02a9: ldloc.s 5
+			IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02b0: stloc.s 5
+			IL_02b2: ldnull
+			IL_02b3: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
+			IL_02b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_02be: ldc.i4.1
+			IL_02bf: conv.r8
+			IL_02c0: ldstr ""
+			IL_02c5: ldc.i4.0
+			IL_02c6: ldc.i4.1
+			IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_02cc: stloc.s 6
+			IL_02ce: ldloc.s 5
+			IL_02d0: ldstr "catch"
+			IL_02d5: ldloc.s 6
+			IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02dc: stloc.s 6
+			IL_02de: ldloc.0
+			IL_02df: ldc.i4.m1
+			IL_02e0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02e5: ldloc.0
+			IL_02e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_02f0: ldarg.0
+			IL_02f1: ldc.i4.1
+			IL_02f2: newarr [System.Runtime]System.Object
+			IL_02f7: dup
+			IL_02f8: ldc.i4.0
 			IL_02f9: ldloc.s 6
-			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0300: stloc.s 6
+			IL_02fb: stelem.ref
+			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0301: pop
 			IL_0302: ldloc.0
-			IL_0303: ldc.i4.m1
-			IL_0304: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0309: ldloc.0
-			IL_030a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_030f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0314: ldarg.0
-			IL_0315: ldc.i4.1
-			IL_0316: newarr [System.Runtime]System.Object
-			IL_031b: dup
-			IL_031c: ldc.i4.0
-			IL_031d: ldloc.s 6
-			IL_031f: stelem.ref
-			IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0325: pop
-			IL_0326: ldloc.0
-			IL_0327: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_032c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0331: ret
+			IL_0303: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0308: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_030d: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1096,7 +1060,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x279f
+			// Method begins at RVA 0x2743
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1193,7 +1157,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2802
+		// Method begins at RVA 0x27a6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Backpressure_And_Return.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Backpressure_And_Return.verified.txt
@@ -49,7 +49,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x268f
+				// Method begins at RVA 0x2659
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -75,7 +75,7 @@
 			)
 			// Method begins at RVA 0x20a8
 			// Header size: 12
-			// Code size: 1490 (0x5d2)
+			// Code size: 1436 (0x59c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope,
@@ -161,575 +161,557 @@
 
 			IL_0086: ldloc.0
 			IL_0087: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_008c: switch (IL_00b1, IL_015b, IL_024c, IL_02df, IL_0346, IL_03b1, IL_04d3, IL_056d)
+			IL_008c: switch (IL_00b1, IL_0149, IL_0228, IL_02a9, IL_0310, IL_037b, IL_049d, IL_0537)
 
 			IL_00b1: ldarg.0
 			IL_00b2: ldc.i4.1
 			IL_00b3: ldelem.ref
 			IL_00b4: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
 			IL_00b9: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
-			IL_00be: stloc.s 7
-			IL_00c0: ldstr "timersPromises"
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c3: stloc.s 7
 			IL_00c5: ldloc.s 7
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00cc: stloc.s 7
-			IL_00ce: ldloc.s 7
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d5: stloc.s 7
-			IL_00d7: ldloc.s 7
-			IL_00d9: ldstr "setInterval"
-			IL_00de: ldc.r8 0.0
-			IL_00e7: box [System.Runtime]System.Double
-			IL_00ec: ldstr "tick"
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f6: stloc.s 7
-			IL_00f8: ldloc.s 7
-			IL_00fa: stloc.1
-			IL_00fb: ldloc.1
-			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0101: stloc.s 7
-			IL_0103: ldloc.s 7
-			IL_0105: ldstr "next"
-			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_010f: stloc.s 7
-			IL_0111: ldloc.0
-			IL_0112: ldc.i4.1
-			IL_0113: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0118: ldloc.0
-			IL_0119: ldloc.s 7
-			IL_011b: ldarg.0
-			IL_011c: ldc.i4.1
-			IL_011d: ldloc.0
-			IL_011e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0123: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0128: ldloc.0
-			IL_0129: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_012e: dup
-			IL_012f: ldc.i4.0
-			IL_0130: ldloc.1
+			IL_00c7: ldstr "setInterval"
+			IL_00cc: ldc.r8 0.0
+			IL_00d5: box [System.Runtime]System.Double
+			IL_00da: ldstr "tick"
+			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00e4: stloc.s 7
+			IL_00e6: ldloc.s 7
+			IL_00e8: stloc.1
+			IL_00e9: ldloc.1
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ef: stloc.s 7
+			IL_00f1: ldloc.s 7
+			IL_00f3: ldstr "next"
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00fd: stloc.s 7
+			IL_00ff: ldloc.0
+			IL_0100: ldc.i4.1
+			IL_0101: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0106: ldloc.0
+			IL_0107: ldloc.s 7
+			IL_0109: ldarg.0
+			IL_010a: ldc.i4.1
+			IL_010b: ldloc.0
+			IL_010c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0111: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0116: ldloc.0
+			IL_0117: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_011c: dup
+			IL_011d: ldc.i4.0
+			IL_011e: ldloc.1
+			IL_011f: stelem.ref
+			IL_0120: dup
+			IL_0121: ldc.i4.1
+			IL_0122: ldloc.2
+			IL_0123: stelem.ref
+			IL_0124: dup
+			IL_0125: ldc.i4.2
+			IL_0126: ldloc.3
+			IL_0127: stelem.ref
+			IL_0128: dup
+			IL_0129: ldc.i4.3
+			IL_012a: ldloc.s 4
+			IL_012c: stelem.ref
+			IL_012d: dup
+			IL_012e: ldc.i4.4
+			IL_012f: ldloc.s 5
 			IL_0131: stelem.ref
 			IL_0132: dup
-			IL_0133: ldc.i4.1
-			IL_0134: ldloc.2
-			IL_0135: stelem.ref
-			IL_0136: dup
-			IL_0137: ldc.i4.2
-			IL_0138: ldloc.3
-			IL_0139: stelem.ref
-			IL_013a: dup
-			IL_013b: ldc.i4.3
-			IL_013c: ldloc.s 4
-			IL_013e: stelem.ref
-			IL_013f: dup
-			IL_0140: ldc.i4.4
-			IL_0141: ldloc.s 5
-			IL_0143: stelem.ref
-			IL_0144: dup
-			IL_0145: ldc.i4.5
-			IL_0146: ldloc.s 6
-			IL_0148: stelem.ref
-			IL_0149: dup
-			IL_014a: ldc.i4.6
-			IL_014b: ldloc.s 7
-			IL_014d: stelem.ref
-			IL_014e: pop
-			IL_014f: ldloc.0
-			IL_0150: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0155: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_015a: ret
+			IL_0133: ldc.i4.5
+			IL_0134: ldloc.s 6
+			IL_0136: stelem.ref
+			IL_0137: dup
+			IL_0138: ldc.i4.6
+			IL_0139: ldloc.s 7
+			IL_013b: stelem.ref
+			IL_013c: pop
+			IL_013d: ldloc.0
+			IL_013e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0143: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0148: ret
 
-			IL_015b: ldloc.0
-			IL_015c: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited1
-			IL_0161: stloc.s 7
-			IL_0163: ldloc.s 7
-			IL_0165: stloc.2
-			IL_0166: ldstr "console"
-			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0170: stloc.s 7
-			IL_0172: ldloc.s 7
-			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0179: stloc.s 7
-			IL_017b: ldloc.s 7
-			IL_017d: ldstr "log"
-			IL_0182: ldloc.2
-			IL_0183: ldstr "value"
-			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0192: pop
-			IL_0193: ldstr "console"
-			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_019d: stloc.s 7
-			IL_019f: ldloc.s 7
-			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a6: stloc.s 7
-			IL_01a8: ldloc.s 7
-			IL_01aa: ldstr "log"
-			IL_01af: ldloc.2
-			IL_01b0: ldstr "done"
-			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01bf: pop
-			IL_01c0: ldarg.0
-			IL_01c1: ldc.i4.1
-			IL_01c2: ldelem.ref
-			IL_01c3: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
-			IL_01c8: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
-			IL_01cd: stloc.s 7
-			IL_01cf: ldstr "timersPromises"
-			IL_01d4: ldloc.s 7
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_01db: stloc.s 7
-			IL_01dd: ldloc.s 7
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e4: stloc.s 7
+			IL_0149: ldloc.0
+			IL_014a: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited1
+			IL_014f: stloc.s 7
+			IL_0151: ldloc.s 7
+			IL_0153: stloc.2
+			IL_0154: ldstr "console"
+			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_015e: stloc.s 7
+			IL_0160: ldloc.s 7
+			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
+			IL_016b: ldstr "log"
+			IL_0170: ldloc.2
+			IL_0171: ldstr "value"
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0180: pop
+			IL_0181: ldstr "console"
+			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_018b: stloc.s 7
+			IL_018d: ldloc.s 7
+			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0194: stloc.s 7
+			IL_0196: ldloc.s 7
+			IL_0198: ldstr "log"
+			IL_019d: ldloc.2
+			IL_019e: ldstr "done"
+			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01ad: pop
+			IL_01ae: ldarg.0
+			IL_01af: ldc.i4.1
+			IL_01b0: ldelem.ref
+			IL_01b1: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
+			IL_01b6: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
+			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c0: stloc.s 7
+			IL_01c2: ldloc.s 7
+			IL_01c4: ldstr "setTimeout"
+			IL_01c9: ldc.r8 0.0
+			IL_01d2: box [System.Runtime]System.Double
+			IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01dc: stloc.s 7
+			IL_01de: ldloc.0
+			IL_01df: ldc.i4.2
+			IL_01e0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01e5: ldloc.0
 			IL_01e6: ldloc.s 7
-			IL_01e8: ldstr "setTimeout"
-			IL_01ed: ldc.r8 0.0
-			IL_01f6: box [System.Runtime]System.Double
-			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0200: stloc.s 7
-			IL_0202: ldloc.0
-			IL_0203: ldc.i4.2
-			IL_0204: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0209: ldloc.0
-			IL_020a: ldloc.s 7
-			IL_020c: ldarg.0
-			IL_020d: ldc.i4.2
-			IL_020e: ldloc.0
-			IL_020f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0214: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0219: ldloc.0
-			IL_021a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_021f: dup
-			IL_0220: ldc.i4.0
-			IL_0221: ldloc.1
-			IL_0222: stelem.ref
-			IL_0223: dup
-			IL_0224: ldc.i4.1
-			IL_0225: ldloc.2
-			IL_0226: stelem.ref
-			IL_0227: dup
-			IL_0228: ldc.i4.2
-			IL_0229: ldloc.3
-			IL_022a: stelem.ref
-			IL_022b: dup
-			IL_022c: ldc.i4.3
-			IL_022d: ldloc.s 4
-			IL_022f: stelem.ref
-			IL_0230: dup
-			IL_0231: ldc.i4.4
-			IL_0232: ldloc.s 5
-			IL_0234: stelem.ref
-			IL_0235: dup
-			IL_0236: ldc.i4.5
-			IL_0237: ldloc.s 6
-			IL_0239: stelem.ref
-			IL_023a: dup
-			IL_023b: ldc.i4.6
-			IL_023c: ldloc.s 7
-			IL_023e: stelem.ref
-			IL_023f: pop
-			IL_0240: ldloc.0
-			IL_0241: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0246: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_024b: ret
+			IL_01e8: ldarg.0
+			IL_01e9: ldc.i4.2
+			IL_01ea: ldloc.0
+			IL_01eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01f5: ldloc.0
+			IL_01f6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01fb: dup
+			IL_01fc: ldc.i4.0
+			IL_01fd: ldloc.1
+			IL_01fe: stelem.ref
+			IL_01ff: dup
+			IL_0200: ldc.i4.1
+			IL_0201: ldloc.2
+			IL_0202: stelem.ref
+			IL_0203: dup
+			IL_0204: ldc.i4.2
+			IL_0205: ldloc.3
+			IL_0206: stelem.ref
+			IL_0207: dup
+			IL_0208: ldc.i4.3
+			IL_0209: ldloc.s 4
+			IL_020b: stelem.ref
+			IL_020c: dup
+			IL_020d: ldc.i4.4
+			IL_020e: ldloc.s 5
+			IL_0210: stelem.ref
+			IL_0211: dup
+			IL_0212: ldc.i4.5
+			IL_0213: ldloc.s 6
+			IL_0215: stelem.ref
+			IL_0216: dup
+			IL_0217: ldc.i4.6
+			IL_0218: ldloc.s 7
+			IL_021a: stelem.ref
+			IL_021b: pop
+			IL_021c: ldloc.0
+			IL_021d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0222: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0227: ret
 
-			IL_024c: ldloc.0
-			IL_024d: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited2
-			IL_0252: pop
-			IL_0253: ldarg.0
-			IL_0254: ldc.i4.1
-			IL_0255: ldelem.ref
-			IL_0256: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
-			IL_025b: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
-			IL_0260: stloc.s 7
-			IL_0262: ldstr "timersPromises"
+			IL_0228: ldloc.0
+			IL_0229: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited2
+			IL_022e: pop
+			IL_022f: ldarg.0
+			IL_0230: ldc.i4.1
+			IL_0231: ldelem.ref
+			IL_0232: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
+			IL_0237: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
+			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0241: stloc.s 7
+			IL_0243: ldloc.s 7
+			IL_0245: ldstr "setTimeout"
+			IL_024a: ldc.r8 0.0
+			IL_0253: box [System.Runtime]System.Double
+			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_025d: stloc.s 7
+			IL_025f: ldloc.0
+			IL_0260: ldc.i4.3
+			IL_0261: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0266: ldloc.0
 			IL_0267: ldloc.s 7
-			IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_026e: stloc.s 7
-			IL_0270: ldloc.s 7
-			IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0277: stloc.s 7
-			IL_0279: ldloc.s 7
-			IL_027b: ldstr "setTimeout"
-			IL_0280: ldc.r8 0.0
-			IL_0289: box [System.Runtime]System.Double
-			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0293: stloc.s 7
-			IL_0295: ldloc.0
-			IL_0296: ldc.i4.3
-			IL_0297: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_029c: ldloc.0
-			IL_029d: ldloc.s 7
-			IL_029f: ldarg.0
-			IL_02a0: ldc.i4.3
-			IL_02a1: ldloc.0
-			IL_02a2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02a7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02ac: ldloc.0
-			IL_02ad: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02b2: dup
-			IL_02b3: ldc.i4.0
-			IL_02b4: ldloc.1
-			IL_02b5: stelem.ref
-			IL_02b6: dup
-			IL_02b7: ldc.i4.1
-			IL_02b8: ldloc.2
-			IL_02b9: stelem.ref
-			IL_02ba: dup
-			IL_02bb: ldc.i4.2
-			IL_02bc: ldloc.3
-			IL_02bd: stelem.ref
-			IL_02be: dup
-			IL_02bf: ldc.i4.3
-			IL_02c0: ldloc.s 4
-			IL_02c2: stelem.ref
-			IL_02c3: dup
-			IL_02c4: ldc.i4.4
-			IL_02c5: ldloc.s 5
-			IL_02c7: stelem.ref
-			IL_02c8: dup
-			IL_02c9: ldc.i4.5
-			IL_02ca: ldloc.s 6
-			IL_02cc: stelem.ref
-			IL_02cd: dup
-			IL_02ce: ldc.i4.6
-			IL_02cf: ldloc.s 7
-			IL_02d1: stelem.ref
-			IL_02d2: pop
-			IL_02d3: ldloc.0
-			IL_02d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02d9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02de: ret
+			IL_0269: ldarg.0
+			IL_026a: ldc.i4.3
+			IL_026b: ldloc.0
+			IL_026c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0271: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0276: ldloc.0
+			IL_0277: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_027c: dup
+			IL_027d: ldc.i4.0
+			IL_027e: ldloc.1
+			IL_027f: stelem.ref
+			IL_0280: dup
+			IL_0281: ldc.i4.1
+			IL_0282: ldloc.2
+			IL_0283: stelem.ref
+			IL_0284: dup
+			IL_0285: ldc.i4.2
+			IL_0286: ldloc.3
+			IL_0287: stelem.ref
+			IL_0288: dup
+			IL_0289: ldc.i4.3
+			IL_028a: ldloc.s 4
+			IL_028c: stelem.ref
+			IL_028d: dup
+			IL_028e: ldc.i4.4
+			IL_028f: ldloc.s 5
+			IL_0291: stelem.ref
+			IL_0292: dup
+			IL_0293: ldc.i4.5
+			IL_0294: ldloc.s 6
+			IL_0296: stelem.ref
+			IL_0297: dup
+			IL_0298: ldc.i4.6
+			IL_0299: ldloc.s 7
+			IL_029b: stelem.ref
+			IL_029c: pop
+			IL_029d: ldloc.0
+			IL_029e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02a3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02a8: ret
 
-			IL_02df: ldloc.0
-			IL_02e0: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited3
-			IL_02e5: pop
-			IL_02e6: ldloc.1
-			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ec: stloc.s 7
-			IL_02ee: ldloc.s 7
-			IL_02f0: ldstr "next"
-			IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_02fa: stloc.s 7
-			IL_02fc: ldloc.0
-			IL_02fd: ldc.i4.4
-			IL_02fe: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0303: ldloc.0
-			IL_0304: ldloc.s 7
-			IL_0306: ldarg.0
-			IL_0307: ldc.i4.4
-			IL_0308: ldloc.0
-			IL_0309: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_030e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0313: ldloc.0
-			IL_0314: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0319: dup
-			IL_031a: ldc.i4.0
+			IL_02a9: ldloc.0
+			IL_02aa: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited3
+			IL_02af: pop
+			IL_02b0: ldloc.1
+			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02b6: stloc.s 7
+			IL_02b8: ldloc.s 7
+			IL_02ba: ldstr "next"
+			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_02c4: stloc.s 7
+			IL_02c6: ldloc.0
+			IL_02c7: ldc.i4.4
+			IL_02c8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02cd: ldloc.0
+			IL_02ce: ldloc.s 7
+			IL_02d0: ldarg.0
+			IL_02d1: ldc.i4.4
+			IL_02d2: ldloc.0
+			IL_02d3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02dd: ldloc.0
+			IL_02de: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02e3: dup
+			IL_02e4: ldc.i4.0
+			IL_02e5: ldloc.1
+			IL_02e6: stelem.ref
+			IL_02e7: dup
+			IL_02e8: ldc.i4.1
+			IL_02e9: ldloc.2
+			IL_02ea: stelem.ref
+			IL_02eb: dup
+			IL_02ec: ldc.i4.2
+			IL_02ed: ldloc.3
+			IL_02ee: stelem.ref
+			IL_02ef: dup
+			IL_02f0: ldc.i4.3
+			IL_02f1: ldloc.s 4
+			IL_02f3: stelem.ref
+			IL_02f4: dup
+			IL_02f5: ldc.i4.4
+			IL_02f6: ldloc.s 5
+			IL_02f8: stelem.ref
+			IL_02f9: dup
+			IL_02fa: ldc.i4.5
+			IL_02fb: ldloc.s 6
+			IL_02fd: stelem.ref
+			IL_02fe: dup
+			IL_02ff: ldc.i4.6
+			IL_0300: ldloc.s 7
+			IL_0302: stelem.ref
+			IL_0303: pop
+			IL_0304: ldloc.0
+			IL_0305: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_030a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_030f: ret
+
+			IL_0310: ldloc.0
+			IL_0311: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited4
+			IL_0316: stloc.s 7
+			IL_0318: ldloc.s 7
+			IL_031a: stloc.3
 			IL_031b: ldloc.1
-			IL_031c: stelem.ref
-			IL_031d: dup
-			IL_031e: ldc.i4.1
-			IL_031f: ldloc.2
-			IL_0320: stelem.ref
-			IL_0321: dup
-			IL_0322: ldc.i4.2
-			IL_0323: ldloc.3
-			IL_0324: stelem.ref
-			IL_0325: dup
-			IL_0326: ldc.i4.3
-			IL_0327: ldloc.s 4
-			IL_0329: stelem.ref
-			IL_032a: dup
-			IL_032b: ldc.i4.4
-			IL_032c: ldloc.s 5
-			IL_032e: stelem.ref
-			IL_032f: dup
-			IL_0330: ldc.i4.5
-			IL_0331: ldloc.s 6
-			IL_0333: stelem.ref
-			IL_0334: dup
-			IL_0335: ldc.i4.6
-			IL_0336: ldloc.s 7
-			IL_0338: stelem.ref
-			IL_0339: pop
-			IL_033a: ldloc.0
-			IL_033b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0340: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0345: ret
+			IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0321: stloc.s 7
+			IL_0323: ldloc.s 7
+			IL_0325: ldstr "next"
+			IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_032f: stloc.s 7
+			IL_0331: ldloc.0
+			IL_0332: ldc.i4.5
+			IL_0333: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0338: ldloc.0
+			IL_0339: ldloc.s 7
+			IL_033b: ldarg.0
+			IL_033c: ldc.i4.5
+			IL_033d: ldloc.0
+			IL_033e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0343: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0348: ldloc.0
+			IL_0349: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_034e: dup
+			IL_034f: ldc.i4.0
+			IL_0350: ldloc.1
+			IL_0351: stelem.ref
+			IL_0352: dup
+			IL_0353: ldc.i4.1
+			IL_0354: ldloc.2
+			IL_0355: stelem.ref
+			IL_0356: dup
+			IL_0357: ldc.i4.2
+			IL_0358: ldloc.3
+			IL_0359: stelem.ref
+			IL_035a: dup
+			IL_035b: ldc.i4.3
+			IL_035c: ldloc.s 4
+			IL_035e: stelem.ref
+			IL_035f: dup
+			IL_0360: ldc.i4.4
+			IL_0361: ldloc.s 5
+			IL_0363: stelem.ref
+			IL_0364: dup
+			IL_0365: ldc.i4.5
+			IL_0366: ldloc.s 6
+			IL_0368: stelem.ref
+			IL_0369: dup
+			IL_036a: ldc.i4.6
+			IL_036b: ldloc.s 7
+			IL_036d: stelem.ref
+			IL_036e: pop
+			IL_036f: ldloc.0
+			IL_0370: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0375: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_037a: ret
 
-			IL_0346: ldloc.0
-			IL_0347: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited4
-			IL_034c: stloc.s 7
-			IL_034e: ldloc.s 7
-			IL_0350: stloc.3
-			IL_0351: ldloc.1
-			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0357: stloc.s 7
-			IL_0359: ldloc.s 7
-			IL_035b: ldstr "next"
-			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0365: stloc.s 7
-			IL_0367: ldloc.0
-			IL_0368: ldc.i4.5
-			IL_0369: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_036e: ldloc.0
-			IL_036f: ldloc.s 7
-			IL_0371: ldarg.0
-			IL_0372: ldc.i4.5
-			IL_0373: ldloc.0
-			IL_0374: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0379: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_037e: ldloc.0
-			IL_037f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0384: dup
-			IL_0385: ldc.i4.0
-			IL_0386: ldloc.1
-			IL_0387: stelem.ref
-			IL_0388: dup
-			IL_0389: ldc.i4.1
-			IL_038a: ldloc.2
-			IL_038b: stelem.ref
-			IL_038c: dup
-			IL_038d: ldc.i4.2
-			IL_038e: ldloc.3
-			IL_038f: stelem.ref
-			IL_0390: dup
-			IL_0391: ldc.i4.3
-			IL_0392: ldloc.s 4
-			IL_0394: stelem.ref
-			IL_0395: dup
-			IL_0396: ldc.i4.4
-			IL_0397: ldloc.s 5
-			IL_0399: stelem.ref
-			IL_039a: dup
-			IL_039b: ldc.i4.5
-			IL_039c: ldloc.s 6
-			IL_039e: stelem.ref
-			IL_039f: dup
-			IL_03a0: ldc.i4.6
-			IL_03a1: ldloc.s 7
-			IL_03a3: stelem.ref
-			IL_03a4: pop
-			IL_03a5: ldloc.0
-			IL_03a6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03ab: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03b0: ret
-
-			IL_03b1: ldloc.0
-			IL_03b2: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited5
-			IL_03b7: stloc.s 7
-			IL_03b9: ldloc.s 7
-			IL_03bb: stloc.s 4
-			IL_03bd: ldstr "console"
-			IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_037b: ldloc.0
+			IL_037c: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited5
+			IL_0381: stloc.s 7
+			IL_0383: ldloc.s 7
+			IL_0385: stloc.s 4
+			IL_0387: ldstr "console"
+			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0391: stloc.s 7
+			IL_0393: ldloc.s 7
+			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_039a: stloc.s 7
+			IL_039c: ldloc.s 7
+			IL_039e: ldstr "log"
+			IL_03a3: ldloc.3
+			IL_03a4: ldstr "value"
+			IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03b3: pop
+			IL_03b4: ldstr "console"
+			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03be: stloc.s 7
+			IL_03c0: ldloc.s 7
+			IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_03c7: stloc.s 7
 			IL_03c9: ldloc.s 7
-			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03d0: stloc.s 7
-			IL_03d2: ldloc.s 7
-			IL_03d4: ldstr "log"
-			IL_03d9: ldloc.3
-			IL_03da: ldstr "value"
-			IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03e9: pop
-			IL_03ea: ldstr "console"
-			IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03cb: ldstr "log"
+			IL_03d0: ldloc.3
+			IL_03d1: ldstr "done"
+			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03e0: pop
+			IL_03e1: ldstr "console"
+			IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03eb: stloc.s 7
+			IL_03ed: ldloc.s 7
+			IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_03f4: stloc.s 7
 			IL_03f6: ldloc.s 7
-			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03fd: stloc.s 7
-			IL_03ff: ldloc.s 7
-			IL_0401: ldstr "log"
-			IL_0406: ldloc.3
-			IL_0407: ldstr "done"
-			IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0416: pop
-			IL_0417: ldstr "console"
-			IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0421: stloc.s 7
-			IL_0423: ldloc.s 7
-			IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_042a: stloc.s 7
-			IL_042c: ldloc.s 7
-			IL_042e: ldstr "log"
-			IL_0433: ldloc.s 4
-			IL_0435: ldstr "value"
-			IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0444: pop
-			IL_0445: ldstr "console"
-			IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_044f: stloc.s 7
-			IL_0451: ldloc.s 7
-			IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0458: stloc.s 7
-			IL_045a: ldloc.s 7
-			IL_045c: ldstr "log"
-			IL_0461: ldloc.s 4
-			IL_0463: ldstr "done"
-			IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0472: pop
-			IL_0473: ldloc.1
-			IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0479: stloc.s 7
-			IL_047b: ldloc.s 7
-			IL_047d: ldstr "return"
-			IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0487: stloc.s 7
-			IL_0489: ldloc.0
-			IL_048a: ldc.i4.6
-			IL_048b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0490: ldloc.0
-			IL_0491: ldloc.s 7
-			IL_0493: ldarg.0
-			IL_0494: ldc.i4.6
-			IL_0495: ldloc.0
-			IL_0496: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_04a0: ldloc.0
-			IL_04a1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_04a6: dup
-			IL_04a7: ldc.i4.0
-			IL_04a8: ldloc.1
-			IL_04a9: stelem.ref
-			IL_04aa: dup
-			IL_04ab: ldc.i4.1
-			IL_04ac: ldloc.2
-			IL_04ad: stelem.ref
-			IL_04ae: dup
-			IL_04af: ldc.i4.2
-			IL_04b0: ldloc.3
-			IL_04b1: stelem.ref
-			IL_04b2: dup
-			IL_04b3: ldc.i4.3
-			IL_04b4: ldloc.s 4
-			IL_04b6: stelem.ref
-			IL_04b7: dup
-			IL_04b8: ldc.i4.4
-			IL_04b9: ldloc.s 5
-			IL_04bb: stelem.ref
-			IL_04bc: dup
-			IL_04bd: ldc.i4.5
-			IL_04be: ldloc.s 6
-			IL_04c0: stelem.ref
-			IL_04c1: dup
-			IL_04c2: ldc.i4.6
-			IL_04c3: ldloc.s 7
-			IL_04c5: stelem.ref
-			IL_04c6: pop
-			IL_04c7: ldloc.0
-			IL_04c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04cd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04d2: ret
+			IL_03f8: ldstr "log"
+			IL_03fd: ldloc.s 4
+			IL_03ff: ldstr "value"
+			IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_040e: pop
+			IL_040f: ldstr "console"
+			IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0419: stloc.s 7
+			IL_041b: ldloc.s 7
+			IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0422: stloc.s 7
+			IL_0424: ldloc.s 7
+			IL_0426: ldstr "log"
+			IL_042b: ldloc.s 4
+			IL_042d: ldstr "done"
+			IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_043c: pop
+			IL_043d: ldloc.1
+			IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0443: stloc.s 7
+			IL_0445: ldloc.s 7
+			IL_0447: ldstr "return"
+			IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0451: stloc.s 7
+			IL_0453: ldloc.0
+			IL_0454: ldc.i4.6
+			IL_0455: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_045a: ldloc.0
+			IL_045b: ldloc.s 7
+			IL_045d: ldarg.0
+			IL_045e: ldc.i4.6
+			IL_045f: ldloc.0
+			IL_0460: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0465: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_046a: ldloc.0
+			IL_046b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0470: dup
+			IL_0471: ldc.i4.0
+			IL_0472: ldloc.1
+			IL_0473: stelem.ref
+			IL_0474: dup
+			IL_0475: ldc.i4.1
+			IL_0476: ldloc.2
+			IL_0477: stelem.ref
+			IL_0478: dup
+			IL_0479: ldc.i4.2
+			IL_047a: ldloc.3
+			IL_047b: stelem.ref
+			IL_047c: dup
+			IL_047d: ldc.i4.3
+			IL_047e: ldloc.s 4
+			IL_0480: stelem.ref
+			IL_0481: dup
+			IL_0482: ldc.i4.4
+			IL_0483: ldloc.s 5
+			IL_0485: stelem.ref
+			IL_0486: dup
+			IL_0487: ldc.i4.5
+			IL_0488: ldloc.s 6
+			IL_048a: stelem.ref
+			IL_048b: dup
+			IL_048c: ldc.i4.6
+			IL_048d: ldloc.s 7
+			IL_048f: stelem.ref
+			IL_0490: pop
+			IL_0491: ldloc.0
+			IL_0492: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0497: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_049c: ret
 
-			IL_04d3: ldloc.0
-			IL_04d4: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited6
-			IL_04d9: stloc.s 7
-			IL_04db: ldloc.s 7
-			IL_04dd: stloc.s 5
-			IL_04df: ldstr "console"
-			IL_04e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04e9: stloc.s 7
-			IL_04eb: ldloc.s 7
-			IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ldstr "log"
-			IL_04fb: ldloc.s 5
-			IL_04fd: ldstr "done"
-			IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_050c: pop
-			IL_050d: ldloc.1
-			IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0513: stloc.s 7
-			IL_0515: ldloc.s 7
-			IL_0517: ldstr "next"
-			IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0521: stloc.s 7
-			IL_0523: ldloc.0
-			IL_0524: ldc.i4.7
-			IL_0525: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_052a: ldloc.0
-			IL_052b: ldloc.s 7
-			IL_052d: ldarg.0
-			IL_052e: ldc.i4.7
-			IL_052f: ldloc.0
-			IL_0530: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0535: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_053a: ldloc.0
-			IL_053b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0540: dup
-			IL_0541: ldc.i4.0
-			IL_0542: ldloc.1
-			IL_0543: stelem.ref
-			IL_0544: dup
-			IL_0545: ldc.i4.1
-			IL_0546: ldloc.2
-			IL_0547: stelem.ref
-			IL_0548: dup
-			IL_0549: ldc.i4.2
-			IL_054a: ldloc.3
-			IL_054b: stelem.ref
-			IL_054c: dup
-			IL_054d: ldc.i4.3
-			IL_054e: ldloc.s 4
-			IL_0550: stelem.ref
-			IL_0551: dup
-			IL_0552: ldc.i4.4
-			IL_0553: ldloc.s 5
-			IL_0555: stelem.ref
-			IL_0556: dup
-			IL_0557: ldc.i4.5
-			IL_0558: ldloc.s 6
-			IL_055a: stelem.ref
-			IL_055b: dup
-			IL_055c: ldc.i4.6
-			IL_055d: ldloc.s 7
-			IL_055f: stelem.ref
-			IL_0560: pop
-			IL_0561: ldloc.0
-			IL_0562: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0567: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_056c: ret
+			IL_049d: ldloc.0
+			IL_049e: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited6
+			IL_04a3: stloc.s 7
+			IL_04a5: ldloc.s 7
+			IL_04a7: stloc.s 5
+			IL_04a9: ldstr "console"
+			IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04b3: stloc.s 7
+			IL_04b5: ldloc.s 7
+			IL_04b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04bc: stloc.s 7
+			IL_04be: ldloc.s 7
+			IL_04c0: ldstr "log"
+			IL_04c5: ldloc.s 5
+			IL_04c7: ldstr "done"
+			IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_04d6: pop
+			IL_04d7: ldloc.1
+			IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04dd: stloc.s 7
+			IL_04df: ldloc.s 7
+			IL_04e1: ldstr "next"
+			IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_04eb: stloc.s 7
+			IL_04ed: ldloc.0
+			IL_04ee: ldc.i4.7
+			IL_04ef: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04f4: ldloc.0
+			IL_04f5: ldloc.s 7
+			IL_04f7: ldarg.0
+			IL_04f8: ldc.i4.7
+			IL_04f9: ldloc.0
+			IL_04fa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0504: ldloc.0
+			IL_0505: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_050a: dup
+			IL_050b: ldc.i4.0
+			IL_050c: ldloc.1
+			IL_050d: stelem.ref
+			IL_050e: dup
+			IL_050f: ldc.i4.1
+			IL_0510: ldloc.2
+			IL_0511: stelem.ref
+			IL_0512: dup
+			IL_0513: ldc.i4.2
+			IL_0514: ldloc.3
+			IL_0515: stelem.ref
+			IL_0516: dup
+			IL_0517: ldc.i4.3
+			IL_0518: ldloc.s 4
+			IL_051a: stelem.ref
+			IL_051b: dup
+			IL_051c: ldc.i4.4
+			IL_051d: ldloc.s 5
+			IL_051f: stelem.ref
+			IL_0520: dup
+			IL_0521: ldc.i4.5
+			IL_0522: ldloc.s 6
+			IL_0524: stelem.ref
+			IL_0525: dup
+			IL_0526: ldc.i4.6
+			IL_0527: ldloc.s 7
+			IL_0529: stelem.ref
+			IL_052a: pop
+			IL_052b: ldloc.0
+			IL_052c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0531: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0536: ret
 
-			IL_056d: ldloc.0
-			IL_056e: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited7
-			IL_0573: stloc.s 7
-			IL_0575: ldloc.s 7
-			IL_0577: stloc.s 6
-			IL_0579: ldstr "console"
-			IL_057e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0583: stloc.s 7
-			IL_0585: ldloc.s 7
-			IL_0587: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_058c: stloc.s 7
-			IL_058e: ldloc.s 7
-			IL_0590: ldstr "log"
-			IL_0595: ldloc.s 6
-			IL_0597: ldstr "done"
-			IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05a6: pop
-			IL_05a7: ldloc.0
-			IL_05a8: ldc.i4.m1
-			IL_05a9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05ae: ldloc.0
-			IL_05af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_05b9: ldarg.0
-			IL_05ba: ldc.i4.1
-			IL_05bb: newarr [System.Runtime]System.Object
-			IL_05c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05c5: pop
-			IL_05c6: ldloc.0
-			IL_05c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05cc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05d1: ret
+			IL_0537: ldloc.0
+			IL_0538: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited7
+			IL_053d: stloc.s 7
+			IL_053f: ldloc.s 7
+			IL_0541: stloc.s 6
+			IL_0543: ldstr "console"
+			IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_054d: stloc.s 7
+			IL_054f: ldloc.s 7
+			IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0556: stloc.s 7
+			IL_0558: ldloc.s 7
+			IL_055a: ldstr "log"
+			IL_055f: ldloc.s 6
+			IL_0561: ldstr "done"
+			IL_0566: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0570: pop
+			IL_0571: ldloc.0
+			IL_0572: ldc.i4.m1
+			IL_0573: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0578: ldloc.0
+			IL_0579: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_057e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0583: ldarg.0
+			IL_0584: ldc.i4.1
+			IL_0585: newarr [System.Runtime]System.Object
+			IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_058f: pop
+			IL_0590: ldloc.0
+			IL_0591: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0596: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_059b: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -751,7 +733,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2686
+			// Method begins at RVA 0x2650
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -827,7 +809,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2698
+		// Method begins at RVA 0x2662
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2513
+				// Method begins at RVA 0x2501
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x252e
+						// Method begins at RVA 0x251c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -74,7 +74,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2525
+					// Method begins at RVA 0x2513
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x251c
+				// Method begins at RVA 0x250a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			)
 			// Method begins at RVA 0x20a8
 			// Header size: 12
-			// Code size: 1110 (0x456)
+			// Code size: 1092 (0x444)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope,
@@ -239,7 +239,7 @@
 
 			IL_00d5: ldloc.0
 			IL_00d6: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00db: switch (IL_00f4, IL_029d, IL_0363, IL_020f, IL_0357)
+			IL_00db: switch (IL_00f4, IL_028b, IL_0351, IL_01fd, IL_0345)
 
 			IL_00f4: ldc.r8 0.0
 			IL_00fd: stloc.1
@@ -248,363 +248,357 @@
 			IL_0100: ldelem.ref
 			IL_0101: castclass Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope
 			IL_0106: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope::timersPromises
-			IL_010b: stloc.s 10
-			IL_010d: ldstr "timersPromises"
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0110: stloc.s 10
 			IL_0112: ldloc.s 10
-			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0119: stloc.s 10
-			IL_011b: ldloc.s 10
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0122: stloc.s 10
-			IL_0124: ldloc.s 10
-			IL_0126: ldstr "setInterval"
-			IL_012b: ldc.r8 0.0
-			IL_0134: box [System.Runtime]System.Double
-			IL_0139: ldstr "tick"
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0143: stloc.s 10
-			IL_0145: ldloc.s 10
-			IL_0147: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-			IL_014c: stloc.2
+			IL_0114: ldstr "setInterval"
+			IL_0119: ldc.r8 0.0
+			IL_0122: box [System.Runtime]System.Double
+			IL_0127: ldstr "tick"
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0131: stloc.s 10
+			IL_0133: ldloc.s 10
+			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+			IL_013a: stloc.2
+			IL_013b: ldc.i4.0
+			IL_013c: stloc.3
+			IL_013d: ldc.i4.0
+			IL_013e: stloc.s 4
+			IL_0140: ldloc.0
+			IL_0141: ldc.i4.0
+			IL_0142: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0147: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_014c: ldloc.0
 			IL_014d: ldc.i4.0
-			IL_014e: stloc.3
-			IL_014f: ldc.i4.0
-			IL_0150: stloc.s 4
-			IL_0152: ldloc.0
-			IL_0153: ldc.i4.0
-			IL_0154: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0159: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_015e: ldloc.0
-			IL_015f: ldc.i4.0
-			IL_0160: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0165: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_016a: ldloc.0
-			IL_016b: ldc.i4.0
-			IL_016c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0171: ldloc.0
-			IL_0172: ldc.i4.0
-			IL_0173: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_014e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0153: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0158: ldloc.0
+			IL_0159: ldc.i4.0
+			IL_015a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_015f: ldloc.0
+			IL_0160: ldc.i4.0
+			IL_0161: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-			IL_0178: ldloc.2
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-			IL_017e: stloc.s 10
-			IL_0180: ldloc.0
-			IL_0181: ldc.i4.3
-			IL_0182: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0187: ldloc.0
-			IL_0188: ldloc.s 10
-			IL_018a: ldarg.0
-			IL_018b: ldc.i4.1
-			IL_018c: ldloc.0
-			IL_018d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0192: ldc.i4.1
-			IL_0193: ldstr "_pendingException"
-			IL_0198: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_019d: ldloc.0
-			IL_019e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01a3: dup
-			IL_01a4: ldc.i4.0
-			IL_01a5: ldloc.1
-			IL_01a6: box [System.Runtime]System.Double
-			IL_01ab: stelem.ref
-			IL_01ac: dup
-			IL_01ad: ldc.i4.1
-			IL_01ae: ldloc.2
-			IL_01af: stelem.ref
-			IL_01b0: dup
-			IL_01b1: ldc.i4.2
-			IL_01b2: ldloc.3
-			IL_01b3: box [System.Runtime]System.Boolean
-			IL_01b8: stelem.ref
-			IL_01b9: dup
-			IL_01ba: ldc.i4.3
-			IL_01bb: ldloc.s 4
-			IL_01bd: box [System.Runtime]System.Boolean
-			IL_01c2: stelem.ref
-			IL_01c3: dup
-			IL_01c4: ldc.i4.4
-			IL_01c5: ldloc.s 5
-			IL_01c7: stelem.ref
-			IL_01c8: dup
-			IL_01c9: ldc.i4.5
-			IL_01ca: ldloc.s 6
-			IL_01cc: stelem.ref
-			IL_01cd: dup
-			IL_01ce: ldc.i4.6
-			IL_01cf: ldloc.s 7
-			IL_01d1: stelem.ref
-			IL_01d2: dup
-			IL_01d3: ldc.i4.7
-			IL_01d4: ldloc.s 8
-			IL_01d6: box [System.Runtime]System.Boolean
-			IL_01db: stelem.ref
-			IL_01dc: dup
-			IL_01dd: ldc.i4.8
-			IL_01de: ldloc.s 9
-			IL_01e0: box [System.Runtime]System.Boolean
-			IL_01e5: stelem.ref
-			IL_01e6: dup
-			IL_01e7: ldc.i4.s 9
-			IL_01e9: ldloc.s 10
-			IL_01eb: stelem.ref
-			IL_01ec: dup
-			IL_01ed: ldc.i4.s 10
-			IL_01ef: ldloc.s 11
-			IL_01f1: box [System.Runtime]System.Boolean
-			IL_01f6: stelem.ref
-			IL_01f7: dup
-			IL_01f8: ldc.i4.s 11
-			IL_01fa: ldloc.s 12
-			IL_01fc: box [System.Runtime]System.Double
-			IL_0201: stelem.ref
-			IL_0202: pop
-			IL_0203: ldloc.0
-			IL_0204: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0209: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_020e: ret
+			IL_0166: ldloc.2
+			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+			IL_016c: stloc.s 10
+			IL_016e: ldloc.0
+			IL_016f: ldc.i4.3
+			IL_0170: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0175: ldloc.0
+			IL_0176: ldloc.s 10
+			IL_0178: ldarg.0
+			IL_0179: ldc.i4.1
+			IL_017a: ldloc.0
+			IL_017b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0180: ldc.i4.1
+			IL_0181: ldstr "_pendingException"
+			IL_0186: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_018b: ldloc.0
+			IL_018c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0191: dup
+			IL_0192: ldc.i4.0
+			IL_0193: ldloc.1
+			IL_0194: box [System.Runtime]System.Double
+			IL_0199: stelem.ref
+			IL_019a: dup
+			IL_019b: ldc.i4.1
+			IL_019c: ldloc.2
+			IL_019d: stelem.ref
+			IL_019e: dup
+			IL_019f: ldc.i4.2
+			IL_01a0: ldloc.3
+			IL_01a1: box [System.Runtime]System.Boolean
+			IL_01a6: stelem.ref
+			IL_01a7: dup
+			IL_01a8: ldc.i4.3
+			IL_01a9: ldloc.s 4
+			IL_01ab: box [System.Runtime]System.Boolean
+			IL_01b0: stelem.ref
+			IL_01b1: dup
+			IL_01b2: ldc.i4.4
+			IL_01b3: ldloc.s 5
+			IL_01b5: stelem.ref
+			IL_01b6: dup
+			IL_01b7: ldc.i4.5
+			IL_01b8: ldloc.s 6
+			IL_01ba: stelem.ref
+			IL_01bb: dup
+			IL_01bc: ldc.i4.6
+			IL_01bd: ldloc.s 7
+			IL_01bf: stelem.ref
+			IL_01c0: dup
+			IL_01c1: ldc.i4.7
+			IL_01c2: ldloc.s 8
+			IL_01c4: box [System.Runtime]System.Boolean
+			IL_01c9: stelem.ref
+			IL_01ca: dup
+			IL_01cb: ldc.i4.8
+			IL_01cc: ldloc.s 9
+			IL_01ce: box [System.Runtime]System.Boolean
+			IL_01d3: stelem.ref
+			IL_01d4: dup
+			IL_01d5: ldc.i4.s 9
+			IL_01d7: ldloc.s 10
+			IL_01d9: stelem.ref
+			IL_01da: dup
+			IL_01db: ldc.i4.s 10
+			IL_01dd: ldloc.s 11
+			IL_01df: box [System.Runtime]System.Boolean
+			IL_01e4: stelem.ref
+			IL_01e5: dup
+			IL_01e6: ldc.i4.s 11
+			IL_01e8: ldloc.s 12
+			IL_01ea: box [System.Runtime]System.Double
+			IL_01ef: stelem.ref
+			IL_01f0: pop
+			IL_01f1: ldloc.0
+			IL_01f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01f7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01fc: ret
 
-			IL_020f: ldloc.0
-			IL_0210: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope::_awaited1
-			IL_0215: stloc.s 10
-			IL_0217: ldloc.s 10
-			IL_0219: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_021e: stloc.s 11
-			IL_0220: ldloc.s 11
-			IL_0222: brtrue IL_0296
+			IL_01fd: ldloc.0
+			IL_01fe: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope::_awaited1
+			IL_0203: stloc.s 10
+			IL_0205: ldloc.s 10
+			IL_0207: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_020c: stloc.s 11
+			IL_020e: ldloc.s 11
+			IL_0210: brtrue IL_0284
 
-			IL_0227: ldloc.s 10
-			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_022e: stloc.s 10
-			IL_0230: ldloc.s 10
-			IL_0232: stloc.s 5
-			IL_0234: newobj instance void Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope_ForOf_L8C13/Block_L8C67::.ctor()
-			IL_0239: stloc.s 6
-			IL_023b: ldstr "console"
-			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0245: stloc.s 10
-			IL_0247: ldloc.s 10
-			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_024e: stloc.s 10
-			IL_0250: ldloc.s 10
-			IL_0252: ldstr "log"
-			IL_0257: ldloc.s 5
-			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_025e: pop
-			IL_025f: ldloc.1
-			IL_0260: ldc.r8 1
-			IL_0269: add
-			IL_026a: stloc.1
-			IL_026b: ldloc.1
-			IL_026c: stloc.s 12
-			IL_026e: ldloc.s 12
-			IL_0270: ldc.r8 3
-			IL_0279: ceq
-			IL_027b: brfalse IL_028c
+			IL_0215: ldloc.s 10
+			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_021c: stloc.s 10
+			IL_021e: ldloc.s 10
+			IL_0220: stloc.s 5
+			IL_0222: newobj instance void Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope_ForOf_L8C13/Block_L8C67::.ctor()
+			IL_0227: stloc.s 6
+			IL_0229: ldstr "console"
+			IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0233: stloc.s 10
+			IL_0235: ldloc.s 10
+			IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_023c: stloc.s 10
+			IL_023e: ldloc.s 10
+			IL_0240: ldstr "log"
+			IL_0245: ldloc.s 5
+			IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_024c: pop
+			IL_024d: ldloc.1
+			IL_024e: ldc.r8 1
+			IL_0257: add
+			IL_0258: stloc.1
+			IL_0259: ldloc.1
+			IL_025a: stloc.s 12
+			IL_025c: ldloc.s 12
+			IL_025e: ldc.r8 3
+			IL_0267: ceq
+			IL_0269: brfalse IL_027a
 
-			IL_0280: newobj instance void Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope_ForOf_L8C13/Block_L8C67/Block_L12C21::.ctor()
-			IL_0285: stloc.s 7
-			IL_0287: br IL_0291
+			IL_026e: newobj instance void Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope_ForOf_L8C13/Block_L8C67/Block_L12C21::.ctor()
+			IL_0273: stloc.s 7
+			IL_0275: br IL_027f
 
-			IL_028c: br IL_0178
+			IL_027a: br IL_0166
 
-			IL_0291: br IL_02b0
+			IL_027f: br IL_029e
 
-			IL_0296: ldc.i4.1
-			IL_0297: stloc.3
-			IL_0298: br IL_02b0
+			IL_0284: ldc.i4.1
+			IL_0285: stloc.3
+			IL_0286: br IL_029e
 
-			IL_029d: ldloc.0
-			IL_029e: ldc.i4.1
-			IL_029f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02a4: ldloc.0
-			IL_02a5: ldc.i4.0
-			IL_02a6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02ab: br IL_02b0
+			IL_028b: ldloc.0
+			IL_028c: ldc.i4.1
+			IL_028d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0292: ldloc.0
+			IL_0293: ldc.i4.0
+			IL_0294: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0299: br IL_029e
 
-			IL_02b0: ldloc.3
-			IL_02b1: brtrue IL_035e
+			IL_029e: ldloc.3
+			IL_029f: brtrue IL_034c
 
-			IL_02b6: ldloc.s 4
-			IL_02b8: brtrue IL_035e
+			IL_02a4: ldloc.s 4
+			IL_02a6: brtrue IL_034c
 
-			IL_02bd: ldc.i4.1
-			IL_02be: stloc.s 4
-			IL_02c0: ldloc.2
-			IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-			IL_02c6: stloc.s 10
-			IL_02c8: ldloc.0
-			IL_02c9: ldc.i4.4
-			IL_02ca: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02cf: ldloc.0
-			IL_02d0: ldloc.s 10
-			IL_02d2: ldarg.0
-			IL_02d3: ldc.i4.2
-			IL_02d4: ldloc.0
-			IL_02d5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02da: ldc.i4.2
-			IL_02db: ldstr "_pendingException"
-			IL_02e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_02e5: ldloc.0
-			IL_02e6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02eb: dup
-			IL_02ec: ldc.i4.0
-			IL_02ed: ldloc.1
-			IL_02ee: box [System.Runtime]System.Double
-			IL_02f3: stelem.ref
-			IL_02f4: dup
-			IL_02f5: ldc.i4.1
-			IL_02f6: ldloc.2
-			IL_02f7: stelem.ref
-			IL_02f8: dup
-			IL_02f9: ldc.i4.2
-			IL_02fa: ldloc.3
-			IL_02fb: box [System.Runtime]System.Boolean
-			IL_0300: stelem.ref
-			IL_0301: dup
-			IL_0302: ldc.i4.3
-			IL_0303: ldloc.s 4
-			IL_0305: box [System.Runtime]System.Boolean
-			IL_030a: stelem.ref
-			IL_030b: dup
-			IL_030c: ldc.i4.4
-			IL_030d: ldloc.s 5
-			IL_030f: stelem.ref
-			IL_0310: dup
-			IL_0311: ldc.i4.5
-			IL_0312: ldloc.s 6
-			IL_0314: stelem.ref
-			IL_0315: dup
-			IL_0316: ldc.i4.6
-			IL_0317: ldloc.s 7
-			IL_0319: stelem.ref
-			IL_031a: dup
-			IL_031b: ldc.i4.7
-			IL_031c: ldloc.s 8
-			IL_031e: box [System.Runtime]System.Boolean
-			IL_0323: stelem.ref
-			IL_0324: dup
-			IL_0325: ldc.i4.8
-			IL_0326: ldloc.s 9
-			IL_0328: box [System.Runtime]System.Boolean
-			IL_032d: stelem.ref
-			IL_032e: dup
-			IL_032f: ldc.i4.s 9
-			IL_0331: ldloc.s 10
-			IL_0333: stelem.ref
-			IL_0334: dup
-			IL_0335: ldc.i4.s 10
-			IL_0337: ldloc.s 11
-			IL_0339: box [System.Runtime]System.Boolean
-			IL_033e: stelem.ref
-			IL_033f: dup
-			IL_0340: ldc.i4.s 11
-			IL_0342: ldloc.s 12
-			IL_0344: box [System.Runtime]System.Double
-			IL_0349: stelem.ref
-			IL_034a: pop
-			IL_034b: ldloc.0
-			IL_034c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0351: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0356: ret
+			IL_02ab: ldc.i4.1
+			IL_02ac: stloc.s 4
+			IL_02ae: ldloc.2
+			IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+			IL_02b4: stloc.s 10
+			IL_02b6: ldloc.0
+			IL_02b7: ldc.i4.4
+			IL_02b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02bd: ldloc.0
+			IL_02be: ldloc.s 10
+			IL_02c0: ldarg.0
+			IL_02c1: ldc.i4.2
+			IL_02c2: ldloc.0
+			IL_02c3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02c8: ldc.i4.2
+			IL_02c9: ldstr "_pendingException"
+			IL_02ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_02d3: ldloc.0
+			IL_02d4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02d9: dup
+			IL_02da: ldc.i4.0
+			IL_02db: ldloc.1
+			IL_02dc: box [System.Runtime]System.Double
+			IL_02e1: stelem.ref
+			IL_02e2: dup
+			IL_02e3: ldc.i4.1
+			IL_02e4: ldloc.2
+			IL_02e5: stelem.ref
+			IL_02e6: dup
+			IL_02e7: ldc.i4.2
+			IL_02e8: ldloc.3
+			IL_02e9: box [System.Runtime]System.Boolean
+			IL_02ee: stelem.ref
+			IL_02ef: dup
+			IL_02f0: ldc.i4.3
+			IL_02f1: ldloc.s 4
+			IL_02f3: box [System.Runtime]System.Boolean
+			IL_02f8: stelem.ref
+			IL_02f9: dup
+			IL_02fa: ldc.i4.4
+			IL_02fb: ldloc.s 5
+			IL_02fd: stelem.ref
+			IL_02fe: dup
+			IL_02ff: ldc.i4.5
+			IL_0300: ldloc.s 6
+			IL_0302: stelem.ref
+			IL_0303: dup
+			IL_0304: ldc.i4.6
+			IL_0305: ldloc.s 7
+			IL_0307: stelem.ref
+			IL_0308: dup
+			IL_0309: ldc.i4.7
+			IL_030a: ldloc.s 8
+			IL_030c: box [System.Runtime]System.Boolean
+			IL_0311: stelem.ref
+			IL_0312: dup
+			IL_0313: ldc.i4.8
+			IL_0314: ldloc.s 9
+			IL_0316: box [System.Runtime]System.Boolean
+			IL_031b: stelem.ref
+			IL_031c: dup
+			IL_031d: ldc.i4.s 9
+			IL_031f: ldloc.s 10
+			IL_0321: stelem.ref
+			IL_0322: dup
+			IL_0323: ldc.i4.s 10
+			IL_0325: ldloc.s 11
+			IL_0327: box [System.Runtime]System.Boolean
+			IL_032c: stelem.ref
+			IL_032d: dup
+			IL_032e: ldc.i4.s 11
+			IL_0330: ldloc.s 12
+			IL_0332: box [System.Runtime]System.Double
+			IL_0337: stelem.ref
+			IL_0338: pop
+			IL_0339: ldloc.0
+			IL_033a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_033f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0344: ret
 
-			IL_0357: ldloc.0
-			IL_0358: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope::_awaited2
-			IL_035d: pop
+			IL_0345: ldloc.0
+			IL_0346: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope::_awaited2
+			IL_034b: pop
 
-			IL_035e: br IL_0376
+			IL_034c: br IL_0364
 
-			IL_0363: ldloc.0
-			IL_0364: ldc.i4.1
-			IL_0365: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_036a: ldloc.0
-			IL_036b: ldc.i4.0
-			IL_036c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0371: br IL_0376
+			IL_0351: ldloc.0
+			IL_0352: ldc.i4.1
+			IL_0353: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0358: ldloc.0
+			IL_0359: ldc.i4.0
+			IL_035a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_035f: br IL_0364
 
-			IL_0376: ldloc.0
-			IL_0377: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_037c: stloc.s 8
-			IL_037e: ldloc.s 8
-			IL_0380: brfalse IL_03bd
+			IL_0364: ldloc.0
+			IL_0365: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_036a: stloc.s 8
+			IL_036c: ldloc.s 8
+			IL_036e: brfalse IL_03ab
 
-			IL_0385: ldloc.0
-			IL_0386: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_038b: stloc.s 10
-			IL_038d: ldloc.0
-			IL_038e: ldc.i4.m1
-			IL_038f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0394: ldloc.0
-			IL_0395: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_039a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_039f: ldarg.0
-			IL_03a0: ldc.i4.1
-			IL_03a1: newarr [System.Runtime]System.Object
-			IL_03a6: dup
-			IL_03a7: ldc.i4.0
-			IL_03a8: ldloc.s 10
-			IL_03aa: stelem.ref
-			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03b0: pop
-			IL_03b1: ldloc.0
-			IL_03b2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03b7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03bc: ret
+			IL_0373: ldloc.0
+			IL_0374: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0379: stloc.s 10
+			IL_037b: ldloc.0
+			IL_037c: ldc.i4.m1
+			IL_037d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0382: ldloc.0
+			IL_0383: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0388: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_038d: ldarg.0
+			IL_038e: ldc.i4.1
+			IL_038f: newarr [System.Runtime]System.Object
+			IL_0394: dup
+			IL_0395: ldc.i4.0
+			IL_0396: ldloc.s 10
+			IL_0398: stelem.ref
+			IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_039e: pop
+			IL_039f: ldloc.0
+			IL_03a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03a5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03aa: ret
 
-			IL_03bd: ldloc.0
-			IL_03be: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_03c3: stloc.s 9
-			IL_03c5: ldloc.s 9
-			IL_03c7: brfalse IL_0404
+			IL_03ab: ldloc.0
+			IL_03ac: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_03b1: stloc.s 9
+			IL_03b3: ldloc.s 9
+			IL_03b5: brfalse IL_03f2
 
-			IL_03cc: ldloc.0
-			IL_03cd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_03d2: stloc.s 10
-			IL_03d4: ldloc.0
-			IL_03d5: ldc.i4.m1
-			IL_03d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03db: ldloc.0
-			IL_03dc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_03e6: ldarg.0
-			IL_03e7: ldc.i4.1
-			IL_03e8: newarr [System.Runtime]System.Object
-			IL_03ed: dup
-			IL_03ee: ldc.i4.0
-			IL_03ef: ldloc.s 10
-			IL_03f1: stelem.ref
-			IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03f7: pop
-			IL_03f8: ldloc.0
-			IL_03f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03fe: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0403: ret
+			IL_03ba: ldloc.0
+			IL_03bb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_03c0: stloc.s 10
+			IL_03c2: ldloc.0
+			IL_03c3: ldc.i4.m1
+			IL_03c4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03c9: ldloc.0
+			IL_03ca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_03d4: ldarg.0
+			IL_03d5: ldc.i4.1
+			IL_03d6: newarr [System.Runtime]System.Object
+			IL_03db: dup
+			IL_03dc: ldc.i4.0
+			IL_03dd: ldloc.s 10
+			IL_03df: stelem.ref
+			IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03e5: pop
+			IL_03e6: ldloc.0
+			IL_03e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03ec: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03f1: ret
 
-			IL_0404: ldstr "console"
-			IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_040e: stloc.s 10
-			IL_0410: ldloc.s 10
-			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0417: stloc.s 10
-			IL_0419: ldloc.s 10
-			IL_041b: ldstr "log"
-			IL_0420: ldstr "break-done"
-			IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_042a: pop
-			IL_042b: ldloc.0
-			IL_042c: ldc.i4.m1
-			IL_042d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0432: ldloc.0
-			IL_0433: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0438: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_043d: ldarg.0
-			IL_043e: ldc.i4.1
-			IL_043f: newarr [System.Runtime]System.Object
-			IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0449: pop
-			IL_044a: ldloc.0
-			IL_044b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0450: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0455: ret
+			IL_03f2: ldstr "console"
+			IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03fc: stloc.s 10
+			IL_03fe: ldloc.s 10
+			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0405: stloc.s 10
+			IL_0407: ldloc.s 10
+			IL_0409: ldstr "log"
+			IL_040e: ldstr "break-done"
+			IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0418: pop
+			IL_0419: ldloc.0
+			IL_041a: ldc.i4.m1
+			IL_041b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0420: ldloc.0
+			IL_0421: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0426: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_042b: ldarg.0
+			IL_042c: ldc.i4.1
+			IL_042d: newarr [System.Runtime]System.Object
+			IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0437: pop
+			IL_0438: ldloc.0
+			IL_0439: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_043e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0443: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -626,7 +620,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x250a
+			// Method begins at RVA 0x24f8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -702,7 +696,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2537
+		// Method begins at RVA 0x2525
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_InfinityDelay_ClampsToTick.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_InfinityDelay_ClampsToTick.verified.txt
@@ -33,7 +33,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x231c
+				// Method begins at RVA 0x230a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -59,7 +59,7 @@
 			)
 			// Method begins at RVA 0x20a8
 			// Header size: 12
-			// Code size: 607 (0x25f)
+			// Code size: 589 (0x24d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope,
@@ -135,190 +135,184 @@
 
 			IL_007c: ldloc.0
 			IL_007d: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0082: switch (IL_0093, IL_0141, IL_01fc)
+			IL_0082: switch (IL_0093, IL_012f, IL_01ea)
 
 			IL_0093: ldarg.0
 			IL_0094: ldc.i4.1
 			IL_0095: ldelem.ref
 			IL_0096: castclass Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope
 			IL_009b: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope::timersPromises
-			IL_00a0: stloc.s 4
-			IL_00a2: ldstr "timersPromises"
-			IL_00a7: ldloc.s 4
-			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00ae: stloc.s 4
-			IL_00b0: ldloc.s 4
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b7: stloc.s 4
-			IL_00b9: ldstr "Number"
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00c3: stloc.s 5
-			IL_00c5: ldloc.s 5
-			IL_00c7: ldstr "POSITIVE_INFINITY"
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d1: stloc.s 5
-			IL_00d3: ldloc.s 4
-			IL_00d5: ldstr "setInterval"
-			IL_00da: ldloc.s 5
-			IL_00dc: ldstr "tick"
-			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00e6: stloc.s 5
-			IL_00e8: ldloc.s 5
-			IL_00ea: stloc.1
-			IL_00eb: ldloc.1
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f1: stloc.s 5
-			IL_00f3: ldloc.s 5
-			IL_00f5: ldstr "next"
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00ff: stloc.s 5
-			IL_0101: ldloc.0
-			IL_0102: ldc.i4.1
-			IL_0103: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0108: ldloc.0
-			IL_0109: ldloc.s 5
-			IL_010b: ldarg.0
-			IL_010c: ldc.i4.1
-			IL_010d: ldloc.0
-			IL_010e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0113: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0118: ldloc.0
-			IL_0119: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_011e: dup
-			IL_011f: ldc.i4.0
-			IL_0120: ldloc.1
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a5: stloc.s 4
+			IL_00a7: ldstr "Number"
+			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00b1: stloc.s 5
+			IL_00b3: ldloc.s 5
+			IL_00b5: ldstr "POSITIVE_INFINITY"
+			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00bf: stloc.s 5
+			IL_00c1: ldloc.s 4
+			IL_00c3: ldstr "setInterval"
+			IL_00c8: ldloc.s 5
+			IL_00ca: ldstr "tick"
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00d4: stloc.s 5
+			IL_00d6: ldloc.s 5
+			IL_00d8: stloc.1
+			IL_00d9: ldloc.1
+			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00df: stloc.s 5
+			IL_00e1: ldloc.s 5
+			IL_00e3: ldstr "next"
+			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00ed: stloc.s 5
+			IL_00ef: ldloc.0
+			IL_00f0: ldc.i4.1
+			IL_00f1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00f6: ldloc.0
+			IL_00f7: ldloc.s 5
+			IL_00f9: ldarg.0
+			IL_00fa: ldc.i4.1
+			IL_00fb: ldloc.0
+			IL_00fc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0101: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0106: ldloc.0
+			IL_0107: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_010c: dup
+			IL_010d: ldc.i4.0
+			IL_010e: ldloc.1
+			IL_010f: stelem.ref
+			IL_0110: dup
+			IL_0111: ldc.i4.1
+			IL_0112: ldloc.2
+			IL_0113: stelem.ref
+			IL_0114: dup
+			IL_0115: ldc.i4.2
+			IL_0116: ldloc.3
+			IL_0117: stelem.ref
+			IL_0118: dup
+			IL_0119: ldc.i4.3
+			IL_011a: ldloc.s 4
+			IL_011c: stelem.ref
+			IL_011d: dup
+			IL_011e: ldc.i4.4
+			IL_011f: ldloc.s 5
 			IL_0121: stelem.ref
-			IL_0122: dup
-			IL_0123: ldc.i4.1
-			IL_0124: ldloc.2
-			IL_0125: stelem.ref
-			IL_0126: dup
-			IL_0127: ldc.i4.2
-			IL_0128: ldloc.3
-			IL_0129: stelem.ref
-			IL_012a: dup
-			IL_012b: ldc.i4.3
-			IL_012c: ldloc.s 4
-			IL_012e: stelem.ref
-			IL_012f: dup
-			IL_0130: ldc.i4.4
-			IL_0131: ldloc.s 5
-			IL_0133: stelem.ref
-			IL_0134: pop
-			IL_0135: ldloc.0
-			IL_0136: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_013b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0140: ret
+			IL_0122: pop
+			IL_0123: ldloc.0
+			IL_0124: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0129: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_012e: ret
 
-			IL_0141: ldloc.0
-			IL_0142: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope::_awaited1
-			IL_0147: stloc.s 5
-			IL_0149: ldloc.s 5
-			IL_014b: stloc.2
-			IL_014c: ldstr "console"
-			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0156: stloc.s 5
-			IL_0158: ldloc.s 5
-			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_015f: stloc.s 5
-			IL_0161: ldloc.s 5
-			IL_0163: ldstr "log"
-			IL_0168: ldloc.2
-			IL_0169: ldstr "value"
-			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0178: pop
-			IL_0179: ldstr "console"
-			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0183: stloc.s 5
-			IL_0185: ldloc.s 5
-			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 5
-			IL_018e: ldloc.s 5
-			IL_0190: ldstr "log"
-			IL_0195: ldloc.2
-			IL_0196: ldstr "done"
-			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01a5: pop
-			IL_01a6: ldloc.1
-			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ac: stloc.s 5
-			IL_01ae: ldloc.s 5
-			IL_01b0: ldstr "return"
-			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01ba: stloc.s 5
-			IL_01bc: ldloc.0
-			IL_01bd: ldc.i4.2
-			IL_01be: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01c3: ldloc.0
-			IL_01c4: ldloc.s 5
-			IL_01c6: ldarg.0
-			IL_01c7: ldc.i4.2
-			IL_01c8: ldloc.0
-			IL_01c9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01d3: ldloc.0
-			IL_01d4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01d9: dup
-			IL_01da: ldc.i4.0
-			IL_01db: ldloc.1
+			IL_012f: ldloc.0
+			IL_0130: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope::_awaited1
+			IL_0135: stloc.s 5
+			IL_0137: ldloc.s 5
+			IL_0139: stloc.2
+			IL_013a: ldstr "console"
+			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0144: stloc.s 5
+			IL_0146: ldloc.s 5
+			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014d: stloc.s 5
+			IL_014f: ldloc.s 5
+			IL_0151: ldstr "log"
+			IL_0156: ldloc.2
+			IL_0157: ldstr "value"
+			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0166: pop
+			IL_0167: ldstr "console"
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0171: stloc.s 5
+			IL_0173: ldloc.s 5
+			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_017a: stloc.s 5
+			IL_017c: ldloc.s 5
+			IL_017e: ldstr "log"
+			IL_0183: ldloc.2
+			IL_0184: ldstr "done"
+			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0193: pop
+			IL_0194: ldloc.1
+			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_019a: stloc.s 5
+			IL_019c: ldloc.s 5
+			IL_019e: ldstr "return"
+			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01a8: stloc.s 5
+			IL_01aa: ldloc.0
+			IL_01ab: ldc.i4.2
+			IL_01ac: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01b1: ldloc.0
+			IL_01b2: ldloc.s 5
+			IL_01b4: ldarg.0
+			IL_01b5: ldc.i4.2
+			IL_01b6: ldloc.0
+			IL_01b7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01c1: ldloc.0
+			IL_01c2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01c7: dup
+			IL_01c8: ldc.i4.0
+			IL_01c9: ldloc.1
+			IL_01ca: stelem.ref
+			IL_01cb: dup
+			IL_01cc: ldc.i4.1
+			IL_01cd: ldloc.2
+			IL_01ce: stelem.ref
+			IL_01cf: dup
+			IL_01d0: ldc.i4.2
+			IL_01d1: ldloc.3
+			IL_01d2: stelem.ref
+			IL_01d3: dup
+			IL_01d4: ldc.i4.3
+			IL_01d5: ldloc.s 4
+			IL_01d7: stelem.ref
+			IL_01d8: dup
+			IL_01d9: ldc.i4.4
+			IL_01da: ldloc.s 5
 			IL_01dc: stelem.ref
-			IL_01dd: dup
-			IL_01de: ldc.i4.1
-			IL_01df: ldloc.2
-			IL_01e0: stelem.ref
-			IL_01e1: dup
-			IL_01e2: ldc.i4.2
-			IL_01e3: ldloc.3
-			IL_01e4: stelem.ref
-			IL_01e5: dup
-			IL_01e6: ldc.i4.3
-			IL_01e7: ldloc.s 4
-			IL_01e9: stelem.ref
-			IL_01ea: dup
-			IL_01eb: ldc.i4.4
-			IL_01ec: ldloc.s 5
-			IL_01ee: stelem.ref
-			IL_01ef: pop
-			IL_01f0: ldloc.0
-			IL_01f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01f6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01fb: ret
+			IL_01dd: pop
+			IL_01de: ldloc.0
+			IL_01df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01e4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01e9: ret
 
-			IL_01fc: ldloc.0
-			IL_01fd: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope::_awaited2
-			IL_0202: stloc.s 5
-			IL_0204: ldloc.s 5
-			IL_0206: stloc.3
-			IL_0207: ldstr "console"
-			IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0211: stloc.s 5
-			IL_0213: ldloc.s 5
-			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_021a: stloc.s 5
-			IL_021c: ldloc.s 5
-			IL_021e: ldstr "log"
-			IL_0223: ldloc.3
-			IL_0224: ldstr "done"
-			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0233: pop
-			IL_0234: ldloc.0
-			IL_0235: ldc.i4.m1
-			IL_0236: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_023b: ldloc.0
-			IL_023c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0241: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0246: ldarg.0
-			IL_0247: ldc.i4.1
-			IL_0248: newarr [System.Runtime]System.Object
-			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0252: pop
-			IL_0253: ldloc.0
-			IL_0254: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0259: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_025e: ret
+			IL_01ea: ldloc.0
+			IL_01eb: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope::_awaited2
+			IL_01f0: stloc.s 5
+			IL_01f2: ldloc.s 5
+			IL_01f4: stloc.3
+			IL_01f5: ldstr "console"
+			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ff: stloc.s 5
+			IL_0201: ldloc.s 5
+			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0208: stloc.s 5
+			IL_020a: ldloc.s 5
+			IL_020c: ldstr "log"
+			IL_0211: ldloc.3
+			IL_0212: ldstr "done"
+			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0221: pop
+			IL_0222: ldloc.0
+			IL_0223: ldc.i4.m1
+			IL_0224: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0229: ldloc.0
+			IL_022a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_022f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0234: ldarg.0
+			IL_0235: ldc.i4.1
+			IL_0236: newarr [System.Runtime]System.Object
+			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0240: pop
+			IL_0241: ldloc.0
+			IL_0242: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0247: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_024c: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -340,7 +334,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2313
+			// Method begins at RVA 0x2301
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -416,7 +410,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2325
+		// Method begins at RVA 0x2313
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_SearchParams_Mutate.verified.txt
+++ b/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_SearchParams_Mutate.verified.txt
@@ -27,7 +27,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2693
+				// Method begins at RVA 0x2685
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,7 +102,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26a5
+					// Method begins at RVA 0x2697
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x269c
+				// Method begins at RVA 0x268e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -205,7 +205,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26b7
+					// Method begins at RVA 0x26a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -227,7 +227,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26ae
+				// Method begins at RVA 0x26a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -257,7 +257,7 @@
 			)
 			// Method begins at RVA 0x25fc
 			// Header size: 12
-			// Code size: 130 (0x82)
+			// Code size: 116 (0x74)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18/Scope/Block_L35C21,
@@ -291,29 +291,23 @@
 			IL_003e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0043: stloc.3
 			IL_0044: ldloc.3
-			IL_0045: brfalse IL_0080
+			IL_0045: brfalse IL_0072
 
 			IL_004a: newobj instance void Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18/Scope/Block_L35C21::.ctor()
 			IL_004f: stloc.0
 			IL_0050: ldarg.0
 			IL_0051: ldfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
-			IL_0056: stloc.1
-			IL_0057: ldstr "mutating"
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005b: stloc.1
 			IL_005c: ldloc.1
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0062: stloc.1
-			IL_0063: ldloc.1
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0069: stloc.1
-			IL_006a: ldloc.1
-			IL_006b: ldstr "append"
-			IL_0070: ldstr "b"
-			IL_0075: ldstr "2"
-			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_007f: pop
+			IL_005d: ldstr "append"
+			IL_0062: ldstr "b"
+			IL_0067: ldstr "2"
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0071: pop
 
-			IL_0080: ldnull
-			IL_0081: ret
+			IL_0072: ldnull
+			IL_0073: ret
 		} // end of method ArrowFunction_L33C18::__js_call__
 
 	} // end of class ArrowFunction_L33C18
@@ -332,7 +326,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x268a
+			// Method begins at RVA 0x267c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -778,7 +772,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26c0
+		// Method begins at RVA 0x26b2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2888
+					// Method begins at RVA 0x282e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2891
+					// Method begins at RVA 0x2837
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x287f
+				// Method begins at RVA 0x2825
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -231,7 +231,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x289a
+				// Method begins at RVA 0x2840
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -259,7 +259,7 @@
 			)
 			// Method begins at RVA 0x26ac
 			// Header size: 12
-			// Code size: 70 (0x46)
+			// Code size: 56 (0x38)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -267,26 +267,20 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: stloc.0
-			IL_0007: ldstr "zlib"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "gzipSync"
-			IL_0020: ldstr "abc"
-			IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_002a: dup
-			IL_002b: ldstr "chunkSize"
-			IL_0030: ldc.r8 1024
-			IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0043: stloc.0
-			IL_0044: ldloc.0
-			IL_0045: ret
+			IL_000d: ldstr "gzipSync"
+			IL_0012: ldstr "abc"
+			IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001c: dup
+			IL_001d: ldstr "chunkSize"
+			IL_0022: ldc.r8 1024
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0035: stloc.0
+			IL_0036: ldloc.0
+			IL_0037: ret
 		} // end of method ArrowFunction_L25C37::__js_call__
 
 	} // end of class ArrowFunction_L25C37
@@ -302,7 +296,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28a3
+				// Method begins at RVA 0x2849
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -328,9 +322,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2700
+			// Method begins at RVA 0x26f0
 			// Header size: 12
-			// Code size: 109 (0x6d)
+			// Code size: 81 (0x51)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -339,41 +333,29 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: stloc.0
-			IL_0007: ldstr "zlib"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldarg.0
-			IL_001b: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0020: stloc.1
-			IL_0021: ldstr "zlib"
-			IL_0026: ldloc.1
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_002c: stloc.1
-			IL_002d: ldloc.1
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0033: stloc.1
-			IL_0034: ldloc.1
-			IL_0035: ldstr "gzipSync"
-			IL_003a: ldstr "abc"
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0044: stloc.1
-			IL_0045: ldloc.0
-			IL_0046: ldstr "gunzipSync"
-			IL_004b: ldloc.1
-			IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0051: dup
-			IL_0052: ldstr "flush"
-			IL_0057: ldc.r8 2
-			IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_006a: stloc.1
-			IL_006b: ldloc.1
-			IL_006c: ret
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ldstr "gzipSync"
+			IL_001e: ldstr "abc"
+			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0028: stloc.1
+			IL_0029: ldloc.0
+			IL_002a: ldstr "gunzipSync"
+			IL_002f: ldloc.1
+			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0035: dup
+			IL_0036: ldstr "flush"
+			IL_003b: ldc.r8 2
+			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_004e: stloc.1
+			IL_004f: ldloc.1
+			IL_0050: ret
 		} // end of method ArrowFunction_L26C39::__js_call__
 
 	} // end of class ArrowFunction_L26C39
@@ -389,7 +371,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28ac
+				// Method begins at RVA 0x2852
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -415,9 +397,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x277c
+			// Method begins at RVA 0x2750
 			// Header size: 12
-			// Code size: 70 (0x46)
+			// Code size: 56 (0x38)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -425,26 +407,20 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: stloc.0
-			IL_0007: ldstr "zlib"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "gzipSync"
-			IL_0020: ldstr "abc"
-			IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_002a: dup
-			IL_002b: ldstr "level"
-			IL_0030: ldc.r8 10
-			IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0043: stloc.0
-			IL_0044: ldloc.0
-			IL_0045: ret
+			IL_000d: ldstr "gzipSync"
+			IL_0012: ldstr "abc"
+			IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001c: dup
+			IL_001d: ldstr "level"
+			IL_0022: ldc.r8 10
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0035: stloc.0
+			IL_0036: ldloc.0
+			IL_0037: ret
 		} // end of method ArrowFunction_L27C28::__js_call__
 
 	} // end of class ArrowFunction_L27C28
@@ -460,7 +436,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28b5
+				// Method begins at RVA 0x285b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -486,9 +462,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x27d0
+			// Method begins at RVA 0x2794
 			// Header size: 12
-			// Code size: 70 (0x46)
+			// Code size: 56 (0x38)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -496,26 +472,20 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: stloc.0
-			IL_0007: ldstr "zlib"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "gzipSync"
-			IL_0020: ldstr "abc"
-			IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_002a: dup
-			IL_002b: ldstr "level"
-			IL_0030: ldc.r8 (00 00 00 00 00 00 F8 FF)
-			IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0043: stloc.0
-			IL_0044: ldloc.0
-			IL_0045: ret
+			IL_000d: ldstr "gzipSync"
+			IL_0012: ldstr "abc"
+			IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001c: dup
+			IL_001d: ldstr "level"
+			IL_0022: ldc.r8 (00 00 00 00 00 00 F8 FF)
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0035: stloc.0
+			IL_0036: ldloc.0
+			IL_0037: ret
 		} // end of method ArrowFunction_L28C28::__js_call__
 
 	} // end of class ArrowFunction_L28C28
@@ -531,7 +501,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28be
+				// Method begins at RVA 0x2864
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -557,9 +527,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2824
+			// Method begins at RVA 0x27d8
 			// Header size: 12
-			// Code size: 70 (0x46)
+			// Code size: 56 (0x38)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -567,26 +537,20 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: stloc.0
-			IL_0007: ldstr "zlib"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "gzipSync"
-			IL_0020: ldstr "abc"
-			IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_002a: dup
-			IL_002b: ldstr "level"
-			IL_0030: ldc.r8 (00 00 00 00 00 00 F0 7F)
-			IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0043: stloc.0
-			IL_0044: ldloc.0
-			IL_0045: ret
+			IL_000d: ldstr "gzipSync"
+			IL_0012: ldstr "abc"
+			IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001c: dup
+			IL_001d: ldstr "level"
+			IL_0022: ldc.r8 (00 00 00 00 00 00 F0 7F)
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0035: stloc.0
+			IL_0036: ldloc.0
+			IL_0037: ret
 		} // end of method ArrowFunction_L29C33::__js_call__
 
 	} // end of class ArrowFunction_L29C33
@@ -607,7 +571,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28c7
+				// Method begins at RVA 0x286d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -627,7 +591,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28d0
+				// Method begins at RVA 0x2876
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -649,7 +613,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2876
+			// Method begins at RVA 0x281c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1127,7 +1091,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x28d9
+		// Method begins at RVA 0x287f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_Stream_RoundTrip.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_Stream_RoundTrip.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25e7
+				// Method begins at RVA 0x2536
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,30 +46,23 @@
 			)
 			// Method begins at RVA 0x23d8
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] float64,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0006: stloc.0
-			IL_0007: ldstr "events"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "gzip:finish"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
+			IL_0006: ldstr "gzip:finish"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L14C19::__js_call__
 
 	} // end of class ArrowFunction_L14C19
@@ -85,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25f0
+				// Method begins at RVA 0x253f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,32 +104,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2414
+			// Method begins at RVA 0x2400
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] float64,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0006: stloc.0
-			IL_0007: ldstr "events"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "gzip:end"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
+			IL_0006: ldstr "gzip:end"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L15C16::__js_call__
 
 	} // end of class ArrowFunction_L15C16
@@ -152,7 +138,67 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25f9
+				// Method begins at RVA 0x2548
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Require_Zlib_Stream_RoundTrip/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 09 00 00 02
+			)
+			// Method begins at RVA 0x2428
+			// Header size: 12
+			// Code size: 26 (0x1a)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
+			IL_0006: ldstr "gunzip:finish"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
+		} // end of method ArrowFunction_L16C21::__js_call__
+
+	} // end of class ArrowFunction_L16C21
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L17C18
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2551
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,97 +226,23 @@
 			)
 			// Method begins at RVA 0x2450
 			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] float64,
 				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0006: stloc.0
-			IL_0007: ldstr "events"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "gunzip:finish"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
-		} // end of method ArrowFunction_L16C21::__js_call__
-
-	} // end of class ArrowFunction_L16C21
-
-	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L17C18
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x2602
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Require_Zlib_Stream_RoundTrip/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 09 00 00 02
-			)
-			// Method begins at RVA 0x248c
-			// Header size: 12
-			// Code size: 45 (0x2d)
-			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
-
-			IL_0000: ldarg.0
-			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0006: stloc.0
-			IL_0007: ldstr "events"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "gunzip:end"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: ret
+			IL_0006: ldstr "gunzip:end"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L17C18::__js_call__
 
 	} // end of class ArrowFunction_L17C18
@@ -286,7 +258,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x260b
+				// Method begins at RVA 0x255a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -313,32 +285,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x24c8
-			// Header size: 12
-			// Code size: 41 (0x29)
+			// Method begins at RVA 0x2476
+			// Header size: 1
+			// Code size: 15 (0xf)
 			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::chunks
-			IL_0006: stloc.0
-			IL_0007: ldstr "chunks"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldarg.2
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0026: pop
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_0006: ldarg.2
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldnull
+			IL_000e: ret
 		} // end of method FunctionExpression_L19C18::__js_call__
 
 	} // end of class FunctionExpression_L19C18
@@ -354,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2614
+				// Method begins at RVA 0x2563
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -380,91 +338,70 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2500
+			// Method begins at RVA 0x2488
 			// Header size: 12
-			// Code size: 210 (0xd2)
+			// Code size: 153 (0x99)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object,
+				[0] object,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
+				[3] string
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0006: stloc.0
-			IL_0007: ldstr "events"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldstr "writable:finish"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002a: pop
-			IL_002b: ldstr "console"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0035: stloc.1
-			IL_0036: ldloc.1
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003c: stloc.1
-			IL_003d: ldarg.0
-			IL_003e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::chunks
-			IL_0043: stloc.0
-			IL_0044: ldstr "chunks"
-			IL_0049: ldloc.0
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_004f: stloc.2
-			IL_0050: ldloc.2
-			IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
-			IL_0056: stloc.3
-			IL_0057: ldloc.3
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005d: stloc.2
-			IL_005e: ldloc.2
-			IL_005f: ldstr "toString"
-			IL_0064: ldstr "utf8"
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_006e: stloc.2
-			IL_006f: ldloc.1
-			IL_0070: ldstr "log"
-			IL_0075: ldstr "output:"
-			IL_007a: ldloc.2
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0080: pop
-			IL_0081: ldstr "console"
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_008b: stloc.2
-			IL_008c: ldloc.2
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0092: stloc.2
-			IL_0093: ldarg.0
-			IL_0094: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0099: stloc.0
-			IL_009a: ldstr "events"
-			IL_009f: ldloc.0
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00a5: stloc.1
-			IL_00a6: ldloc.1
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ac: stloc.1
-			IL_00ad: ldloc.1
-			IL_00ae: ldstr "join"
-			IL_00b3: ldstr ","
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00bd: stloc.1
-			IL_00be: ldloc.2
-			IL_00bf: ldstr "log"
-			IL_00c4: ldstr "events:"
-			IL_00c9: ldloc.1
-			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00cf: pop
-			IL_00d0: ldnull
-			IL_00d1: ret
+			IL_0006: ldstr "writable:finish"
+			IL_000b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0010: pop
+			IL_0011: ldstr "console"
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_001b: stloc.0
+			IL_001c: ldloc.0
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0022: stloc.0
+			IL_0023: ldarg.0
+			IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::chunks
+			IL_0029: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
+			IL_002e: stloc.1
+			IL_002f: ldloc.1
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0035: stloc.2
+			IL_0036: ldloc.2
+			IL_0037: ldstr "toString"
+			IL_003c: ldstr "utf8"
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0046: stloc.2
+			IL_0047: ldloc.0
+			IL_0048: ldstr "log"
+			IL_004d: ldstr "output:"
+			IL_0052: ldloc.2
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0058: pop
+			IL_0059: ldstr "console"
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0063: stloc.2
+			IL_0064: ldloc.2
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006a: stloc.2
+			IL_006b: ldarg.0
+			IL_006c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
+			IL_0071: ldc.i4.1
+			IL_0072: newarr [System.Runtime]System.Object
+			IL_0077: dup
+			IL_0078: ldc.i4.0
+			IL_0079: ldstr ","
+			IL_007e: stelem.ref
+			IL_007f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0084: stloc.3
+			IL_0085: ldloc.2
+			IL_0086: ldstr "log"
+			IL_008b: ldstr "events:"
+			IL_0090: ldloc.3
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0096: pop
+			IL_0097: ldnull
+			IL_0098: ret
 		} // end of method FunctionExpression_L23C22::__js_call__
 
 	} // end of class FunctionExpression_L23C22
@@ -485,7 +422,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25de
+			// Method begins at RVA 0x252d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -852,7 +789,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x261d
+		// Method begins at RVA 0x256c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectDefineProperty_Accessor.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectDefineProperty_Accessor.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x220d
+				// Method begins at RVA 0x2201
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 			)
 			// Method begins at RVA 0x2180
 			// Header size: 12
-			// Code size: 56 (0x38)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -65,13 +65,7 @@
 			IL_0022: pop
 			IL_0023: ldarg.0
 			IL_0024: ldfld object Modules.ObjectDefineProperty_Accessor/Scope::backing
-			IL_0029: stloc.0
-			IL_002a: ldstr "backing"
-			IL_002f: ldloc.0
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0035: stloc.0
-			IL_0036: ldloc.0
-			IL_0037: ret
+			IL_0029: ret
 		} // end of method FunctionExpression_L7C7::__js_call__
 
 	} // end of class FunctionExpression_L7C7
@@ -87,7 +81,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2216
+				// Method begins at RVA 0x220a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +108,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21b8
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -161,7 +155,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2204
+			// Method begins at RVA 0x21f8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -308,7 +302,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x221f
+		// Method begins at RVA 0x2213
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ComputedKey_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ComputedKey_EvaluationOrder.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2299
+				// Method begins at RVA 0x226f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,29 +46,22 @@
 			)
 			// Method begins at RVA 0x21c8
 			// Header size: 12
-			// Code size: 44 (0x2c)
+			// Code size: 30 (0x1e)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
-			IL_0006: stloc.0
-			IL_0007: ldstr "log"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "f"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001e: stloc.1
-			IL_001f: ldarg.0
-			IL_0020: ldloc.1
-			IL_0021: stfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
-			IL_0026: ldstr "k"
-			IL_002b: ret
+			IL_0006: ldstr "f"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0010: stloc.0
+			IL_0011: ldarg.0
+			IL_0012: ldloc.0
+			IL_0013: stfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
+			IL_0018: ldstr "k"
+			IL_001d: ret
 		} // end of method f::__js_call__
 
 	} // end of class f
@@ -84,7 +77,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a2
+				// Method begins at RVA 0x2278
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -110,32 +103,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2200
+			// Method begins at RVA 0x21f4
 			// Header size: 12
-			// Code size: 53 (0x35)
+			// Code size: 39 (0x27)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
-			IL_0006: stloc.0
-			IL_0007: ldstr "log"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "g"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001e: stloc.1
-			IL_001f: ldarg.0
-			IL_0020: ldloc.1
-			IL_0021: stfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
-			IL_0026: ldc.r8 1
-			IL_002f: box [System.Runtime]System.Double
-			IL_0034: ret
+			IL_0006: ldstr "g"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0010: stloc.0
+			IL_0011: ldarg.0
+			IL_0012: ldloc.0
+			IL_0013: stfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
+			IL_0018: ldc.r8 1
+			IL_0021: box [System.Runtime]System.Double
+			IL_0026: ret
 		} // end of method g::__js_call__
 
 	} // end of class g
@@ -151,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ab
+				// Method begins at RVA 0x2281
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -177,35 +163,28 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2244
+			// Method begins at RVA 0x2228
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 50 (0x32)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
-			IL_0006: stloc.0
-			IL_0007: ldstr "log"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "h"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001e: stloc.1
-			IL_001f: ldarg.0
-			IL_0020: ldloc.1
-			IL_0021: stfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
-			IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_002b: dup
-			IL_002c: ldstr "a"
-			IL_0031: ldc.r8 2
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_003f: ret
+			IL_0006: ldstr "h"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0010: stloc.0
+			IL_0011: ldarg.0
+			IL_0012: ldloc.0
+			IL_0013: stfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
+			IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001d: dup
+			IL_001e: ldstr "a"
+			IL_0023: ldc.r8 2
+			IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0031: ret
 		} // end of method h::__js_call__
 
 	} // end of class h
@@ -228,7 +207,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2290
+			// Method begins at RVA 0x2266
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -407,7 +386,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22b4
+		// Method begins at RVA 0x228a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_AccessorTransitions_And_Invariants.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_AccessorTransitions_And_Invariants.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x294e
+				// Method begins at RVA 0x2930
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2957
+				// Method begins at RVA 0x2939
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -92,7 +92,7 @@
 			)
 			// Method begins at RVA 0x28c0
 			// Header size: 12
-			// Code size: 53 (0x35)
+			// Code size: 39 (0x27)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -101,25 +101,19 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope::log
-			IL_0006: stloc.0
-			IL_0007: ldstr "log"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldstr "s1:"
-			IL_001f: ldarg.2
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0025: stloc.1
-			IL_0026: ldloc.0
-			IL_0027: ldstr "push"
-			IL_002c: ldloc.1
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0032: pop
-			IL_0033: ldnull
-			IL_0034: ret
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
+			IL_000c: ldstr "s1:"
+			IL_0011: ldarg.2
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0017: stloc.1
+			IL_0018: ldloc.0
+			IL_0019: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_001e: ldloc.1
+			IL_001f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0024: pop
+			IL_0025: ldnull
+			IL_0026: ret
 		} // end of method setter1::__js_call__
 
 	} // end of class setter1
@@ -135,7 +129,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2960
+				// Method begins at RVA 0x2942
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -162,9 +156,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2904
+			// Method begins at RVA 0x28f4
 			// Header size: 12
-			// Code size: 53 (0x35)
+			// Code size: 39 (0x27)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -173,25 +167,19 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope::log
-			IL_0006: stloc.0
-			IL_0007: ldstr "log"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldstr "s2:"
-			IL_001f: ldarg.2
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0025: stloc.1
-			IL_0026: ldloc.0
-			IL_0027: ldstr "push"
-			IL_002c: ldloc.1
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0032: pop
-			IL_0033: ldnull
-			IL_0034: ret
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
+			IL_000c: ldstr "s2:"
+			IL_0011: ldarg.2
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0017: stloc.1
+			IL_0018: ldloc.0
+			IL_0019: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_001e: ldloc.1
+			IL_001f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0024: pop
+			IL_0025: ldnull
+			IL_0026: ret
 		} // end of method setter2::__js_call__
 
 	} // end of class setter2
@@ -214,7 +202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2969
+				// Method begins at RVA 0x294b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -234,7 +222,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2972
+				// Method begins at RVA 0x2954
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -254,7 +242,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x297b
+				// Method begins at RVA 0x295d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +262,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2984
+				// Method begins at RVA 0x2966
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -294,7 +282,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x298d
+				// Method begins at RVA 0x296f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -314,7 +302,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2996
+				// Method begins at RVA 0x2978
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -334,7 +322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x299f
+				// Method begins at RVA 0x2981
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -354,7 +342,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29a8
+				// Method begins at RVA 0x298a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -378,7 +366,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2945
+			// Method begins at RVA 0x2927
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1140,7 +1128,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29b1
+		// Method begins at RVA 0x2993
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21da
+				// Method begins at RVA 0x21be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e3
+				// Method begins at RVA 0x21c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,23 +102,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2180
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x217e
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/Scope::thenable
-			IL_0006: stloc.0
-			IL_0007: ldstr "thenable"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method ArrowFunction_L9C29::__js_call__
 
 	} // end of class ArrowFunction_L9C29
@@ -140,7 +131,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ec
+				// Method begins at RVA 0x21d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -164,7 +155,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a4
+			// Method begins at RVA 0x2188
 			// Header size: 12
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -206,7 +197,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d1
+			// Method begins at RVA 0x21b5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -343,7 +334,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f5
+		// Method begins at RVA 0x21d9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Rejected.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Rejected.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d2
+				// Method begins at RVA 0x21b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21db
+				// Method begins at RVA 0x21bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,23 +102,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2178
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x2176
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/Scope::thenable
-			IL_0006: stloc.0
-			IL_0007: ldstr "thenable"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method ArrowFunction_L9C32::__js_call__
 
 	} // end of class ArrowFunction_L9C32
@@ -140,7 +131,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e4
+				// Method begins at RVA 0x21c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -164,7 +155,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x219c
+			// Method begins at RVA 0x2180
 			// Header size: 12
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -206,7 +197,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c9
+			// Method begins at RVA 0x21ad
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -342,7 +333,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ed
+		// Method begins at RVA 0x21d1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Nested.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Nested.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d2
+				// Method begins at RVA 0x21c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21db
+				// Method begins at RVA 0x21cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -106,11 +106,10 @@
 			)
 			// Method begins at RVA 0x2164
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 27 (0x1b)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] object[]
 			)
 
 			IL_0000: ldc.i4.1
@@ -120,20 +119,14 @@
 			IL_0008: ldarg.0
 			IL_0009: stelem.ref
 			IL_000a: stloc.0
-			IL_000b: ldarg.0
-			IL_000c: ldfld object Modules.Promise_Thenable_Nested/Scope::innerThenable
-			IL_0011: stloc.1
-			IL_0012: ldstr "innerThenable"
-			IL_0017: ldloc.1
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_001d: stloc.1
-			IL_001e: ldarg.2
-			IL_001f: ldloc.0
-			IL_0020: ldloc.1
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0026: pop
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_000b: ldarg.2
+			IL_000c: ldloc.0
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Promise_Thenable_Nested/Scope::innerThenable
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0018: pop
+			IL_0019: ldnull
+			IL_001a: ret
 		} // end of method outerThen::__js_call__
 
 	} // end of class outerThen
@@ -156,7 +149,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e4
+				// Method begins at RVA 0x21d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +173,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x219c
+			// Method begins at RVA 0x218c
 			// Header size: 12
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -225,7 +218,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c9
+			// Method begins at RVA 0x21b9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -356,7 +349,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ed
+		// Method begins at RVA 0x21dd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Delayed.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Delayed.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21eb
+					// Method begins at RVA 0x21df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,7 +48,7 @@
 				)
 				// Method begins at RVA 0x2188
 				// Header size: 12
-				// Code size: 69 (0x45)
+				// Code size: 57 (0x39)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -61,33 +61,29 @@
 				IL_0003: castclass Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope
 				IL_0008: ldfld object Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope::resolve
 				IL_000d: stloc.0
-				IL_000e: ldstr "resolve"
-				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldc.i4.2
-				IL_001b: newarr [System.Runtime]System.Object
-				IL_0020: dup
-				IL_0021: ldc.i4.0
-				IL_0022: ldarg.0
-				IL_0023: ldc.i4.0
-				IL_0024: ldelem.ref
-				IL_0025: stelem.ref
-				IL_0026: dup
-				IL_0027: ldc.i4.1
-				IL_0028: ldarg.0
-				IL_0029: ldc.i4.1
-				IL_002a: ldelem.ref
-				IL_002b: stelem.ref
-				IL_002c: stloc.1
-				IL_002d: ldloc.0
-				IL_002e: ldloc.1
-				IL_002f: ldc.r8 42
-				IL_0038: box [System.Runtime]System.Double
-				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0042: pop
-				IL_0043: ldnull
-				IL_0044: ret
+				IL_000e: ldc.i4.2
+				IL_000f: newarr [System.Runtime]System.Object
+				IL_0014: dup
+				IL_0015: ldc.i4.0
+				IL_0016: ldarg.0
+				IL_0017: ldc.i4.0
+				IL_0018: ldelem.ref
+				IL_0019: stelem.ref
+				IL_001a: dup
+				IL_001b: ldc.i4.1
+				IL_001c: ldarg.0
+				IL_001d: ldc.i4.1
+				IL_001e: ldelem.ref
+				IL_001f: stelem.ref
+				IL_0020: stloc.1
+				IL_0021: ldloc.0
+				IL_0022: ldloc.1
+				IL_0023: ldc.r8 42
+				IL_002c: box [System.Runtime]System.Double
+				IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0036: pop
+				IL_0037: ldnull
+				IL_0038: ret
 			} // end of method later::__js_call__
 
 		} // end of class later
@@ -108,7 +104,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e2
+				// Method begins at RVA 0x21d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -203,7 +199,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f4
+				// Method begins at RVA 0x21e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -266,7 +262,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d9
+			// Method begins at RVA 0x21cd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -375,7 +371,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21fd
+		// Method begins at RVA 0x21f1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Returned_FromHandler.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Returned_FromHandler.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21da
+				// Method begins at RVA 0x21be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e3
+				// Method begins at RVA 0x21c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,23 +102,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2180
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Method begins at RVA 0x217e
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Promise_Thenable_Returned_FromHandler/Scope::thenable
-			IL_0006: stloc.0
-			IL_0007: ldstr "thenable"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method ArrowFunction_L9C26::__js_call__
 
 	} // end of class ArrowFunction_L9C26
@@ -141,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ec
+				// Method begins at RVA 0x21d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +156,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a4
+			// Method begins at RVA 0x2188
 			// Header size: 12
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -207,7 +198,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d1
+			// Method begins at RVA 0x21b5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -344,7 +335,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f5
+		// Method begins at RVA 0x21d9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_ApplyAndConstructTraps_WithFallback.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_ApplyAndConstructTraps_WithFallback.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b9
+				// Method begins at RVA 0x247b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -72,7 +72,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24c2
+				// Method begins at RVA 0x2484
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,7 +103,7 @@
 			)
 			// Method begins at RVA 0x2398
 			// Header size: 12
-			// Code size: 158 (0x9e)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -115,58 +115,42 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::applySeen
 			IL_0006: stloc.0
-			IL_0007: ldstr "applySeen"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldloc.1
-			IL_001b: ldstr "push"
-			IL_0020: ldarg.s args
-			IL_0022: ldc.r8 0.0
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0035: pop
-			IL_0036: ldarg.0
-			IL_0037: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::applySeen
-			IL_003c: stloc.0
-			IL_003d: ldstr "applySeen"
-			IL_0042: ldloc.0
-			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0048: stloc.1
-			IL_0049: ldloc.1
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004f: stloc.1
-			IL_0050: ldloc.1
-			IL_0051: ldstr "push"
-			IL_0056: ldarg.s args
-			IL_0058: ldc.r8 1
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_006b: pop
-			IL_006c: ldarg.2
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0072: stloc.1
-			IL_0073: ldloc.1
-			IL_0074: ldstr "apply"
-			IL_0079: ldarg.3
-			IL_007a: ldarg.s args
-			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0081: stloc.1
-			IL_0082: ldloc.1
-			IL_0083: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0088: stloc.2
-			IL_0089: ldloc.2
-			IL_008a: ldc.r8 2
-			IL_0093: mul
-			IL_0094: stloc.2
-			IL_0095: ldloc.2
-			IL_0096: box [System.Runtime]System.Double
-			IL_009b: stloc.3
-			IL_009c: ldloc.3
-			IL_009d: ret
+			IL_0007: ldloc.0
+			IL_0008: ldarg.s args
+			IL_000a: ldc.r8 0.0
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0018: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_001d: pop
+			IL_001e: ldarg.0
+			IL_001f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::applySeen
+			IL_0024: stloc.0
+			IL_0025: ldloc.0
+			IL_0026: ldarg.s args
+			IL_0028: ldc.r8 1
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0036: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_003b: pop
+			IL_003c: ldarg.2
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0042: stloc.1
+			IL_0043: ldloc.1
+			IL_0044: ldstr "apply"
+			IL_0049: ldarg.3
+			IL_004a: ldarg.s args
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0051: stloc.1
+			IL_0052: ldloc.1
+			IL_0053: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0058: stloc.2
+			IL_0059: ldloc.2
+			IL_005a: ldc.r8 2
+			IL_0063: mul
+			IL_0064: stloc.2
+			IL_0065: ldloc.2
+			IL_0066: box [System.Runtime]System.Double
+			IL_006b: stloc.3
+			IL_006c: ldloc.3
+			IL_006d: ret
 		} // end of method FunctionExpression_applyProxy::__js_call__
 
 	} // end of class FunctionExpression_applyProxy
@@ -182,7 +166,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24cb
+				// Method begins at RVA 0x248d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -206,7 +190,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2442
+			// Method begins at RVA 0x2412
 			// Header size: 1
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -234,7 +218,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d4
+				// Method begins at RVA 0x2496
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -263,44 +247,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2458
+			// Method begins at RVA 0x2428
 			// Header size: 12
-			// Code size: 76 (0x4c)
+			// Code size: 62 (0x3e)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[1] bool,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.3
 			IL_0001: ldc.r8 0.0
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_000f: stloc.0
-			IL_0010: ldarg.0
-			IL_0011: ldfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::constructProxy
-			IL_0016: stloc.1
-			IL_0017: ldstr "constructProxy"
-			IL_001c: ldloc.1
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0022: stloc.1
-			IL_0023: ldarg.s newTarget
-			IL_0025: ldloc.1
-			IL_0026: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_002b: stloc.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "value"
-			IL_0037: ldloc.0
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003d: dup
-			IL_003e: ldstr "sameNewTarget"
-			IL_0043: ldloc.2
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: stloc.3
-			IL_004a: ldloc.3
-			IL_004b: ret
+			IL_0010: ldarg.s newTarget
+			IL_0012: ldarg.0
+			IL_0013: ldfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope::constructProxy
+			IL_0018: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_001d: stloc.1
+			IL_001e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0023: dup
+			IL_0024: ldstr "value"
+			IL_0029: ldloc.0
+			IL_002a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_002f: dup
+			IL_0030: ldstr "sameNewTarget"
+			IL_0035: ldloc.1
+			IL_0036: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003b: stloc.2
+			IL_003c: ldloc.2
+			IL_003d: ret
 		} // end of method FunctionExpression_L25C13::__js_call__
 
 	} // end of class FunctionExpression_L25C13
@@ -326,7 +303,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24b0
+			// Method begins at RVA 0x2472
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -644,7 +621,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24dd
+		// Method begins at RVA 0x249f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_DeletePropertyTrap_And_Fallback.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_DeletePropertyTrap_And_Fallback.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x233f
+					// Method begins at RVA 0x2323
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2336
+				// Method begins at RVA 0x231a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -70,53 +70,41 @@
 			)
 			// Method begins at RVA 0x22c8
 			// Header size: 12
-			// Code size: 89 (0x59)
+			// Code size: 61 (0x3d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/Scope/Block_L9C28,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object,
-				[3] bool,
-				[4] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope::seen
-			IL_0006: stloc.1
-			IL_0007: ldstr "seen"
-			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.2
-			IL_0013: ldloc.2
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.2
-			IL_001a: ldloc.2
-			IL_001b: ldstr "push"
-			IL_0020: ldarg.3
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0026: pop
-			IL_0027: ldarg.3
-			IL_0028: ldstr "blocked"
-			IL_002d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0032: stloc.3
-			IL_0033: ldloc.3
-			IL_0034: brfalse IL_0046
+			IL_0006: ldarg.3
+			IL_0007: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_000c: pop
+			IL_000d: ldarg.3
+			IL_000e: ldstr "blocked"
+			IL_0013: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0018: stloc.1
+			IL_0019: ldloc.1
+			IL_001a: brfalse IL_002c
 
-			IL_0039: newobj instance void Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/Scope/Block_L9C28::.ctor()
-			IL_003e: stloc.0
-			IL_003f: ldc.i4.0
-			IL_0040: box [System.Runtime]System.Boolean
-			IL_0045: ret
+			IL_001f: newobj instance void Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/Scope/Block_L9C28::.ctor()
+			IL_0024: stloc.0
+			IL_0025: ldc.i4.0
+			IL_0026: box [System.Runtime]System.Boolean
+			IL_002b: ret
 
-			IL_0046: ldarg.2
-			IL_0047: ldarg.3
-			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
-			IL_004d: stloc.3
-			IL_004e: ldloc.3
-			IL_004f: box [System.Runtime]System.Boolean
-			IL_0054: stloc.s 4
-			IL_0056: ldloc.s 4
-			IL_0058: ret
+			IL_002c: ldarg.2
+			IL_002d: ldarg.3
+			IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
+			IL_0033: stloc.1
+			IL_0034: ldloc.1
+			IL_0035: box [System.Runtime]System.Boolean
+			IL_003a: stloc.2
+			IL_003b: ldloc.2
+			IL_003c: ret
 		} // end of method FunctionExpression_trappedProxy::__js_call__
 
 	} // end of class FunctionExpression_trappedProxy
@@ -135,7 +123,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x232d
+			// Method begins at RVA 0x2311
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -380,7 +368,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2348
+		// Method begins at RVA 0x232c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_OwnKeys_And_PrototypeTraps_WithFallback.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_OwnKeys_And_PrototypeTraps_WithFallback.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23fe
+				// Method begins at RVA 0x23e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2407
+				// Method begins at RVA 0x23eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -100,22 +100,13 @@
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
 			// Method begins at RVA 0x23a4
-			// Header size: 12
-			// Code size: 21 (0x15)
+			// Header size: 1
+			// Code size: 7 (0x7)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope::trappedPrototype
-			IL_0006: stloc.0
-			IL_0007: ldstr "trappedPrototype"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ret
+			IL_0006: ret
 		} // end of method FunctionExpression_prototypeProxy::__js_call__
 
 	} // end of class FunctionExpression_prototypeProxy
@@ -131,7 +122,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2410
+				// Method begins at RVA 0x23f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -156,7 +147,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23c8
+			// Method begins at RVA 0x23ac
 			// Header size: 12
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -196,7 +187,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23f5
+			// Method begins at RVA 0x23d9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -504,7 +495,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2419
+		// Method begins at RVA 0x23fd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2879
+					// Method begins at RVA 0x27cf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2882
+					// Method begins at RVA 0x27d8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2870
+				// Method begins at RVA 0x27c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -212,7 +212,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x288b
+				// Method begins at RVA 0x27e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -261,7 +261,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2894
+				// Method begins at RVA 0x27ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -316,7 +316,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x289d
+				// Method begins at RVA 0x27f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -342,31 +342,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x25d0
-			// Header size: 12
-			// Code size: 45 (0x2d)
+			// Method begins at RVA 0x25cf
+			// Header size: 1
+			// Code size: 27 (0x1b)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: stloc.0
-			IL_0007: ldstr "revocable"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "proxy"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: ldstr "a"
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_002a: stloc.0
-			IL_002b: ldloc.0
-			IL_002c: ret
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: ldstr "a"
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001a: ret
 		} // end of method FunctionExpression_L28C16::__js_call__
 
 	} // end of class FunctionExpression_L28C16
@@ -382,7 +369,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28a6
+				// Method begins at RVA 0x27fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -408,33 +395,22 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x260c
-			// Header size: 12
-			// Code size: 59 (0x3b)
+			// Method begins at RVA 0x25eb
+			// Header size: 1
+			// Code size: 43 (0x2b)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: stloc.0
-			IL_0007: ldstr "revocable"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "proxy"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: ldstr "c"
-			IL_0025: ldc.r8 3
-			IL_002e: ldc.i4.1
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0034: pop
-			IL_0035: ldstr "set"
-			IL_003a: ret
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: ldstr "c"
+			IL_0015: ldc.r8 3
+			IL_001e: ldc.i4.1
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0024: pop
+			IL_0025: ldstr "set"
+			IL_002a: ret
 		} // end of method FunctionExpression_L29C16::__js_call__
 
 	} // end of class FunctionExpression_L29C16
@@ -450,7 +426,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28af
+				// Method begins at RVA 0x2805
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -476,36 +452,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2654
+			// Method begins at RVA 0x2618
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] bool,
-				[2] object
+				[0] bool,
+				[1] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: stloc.0
-			IL_0007: ldstr "revocable"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "proxy"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.0
-			IL_001f: ldstr "a"
-			IL_0024: ldloc.0
-			IL_0025: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: box [System.Runtime]System.Boolean
-			IL_0031: stloc.2
-			IL_0032: ldloc.2
-			IL_0033: ret
+			IL_0000: ldstr "a"
+			IL_0005: ldarg.0
+			IL_0006: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
+			IL_000b: ldstr "proxy"
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0015: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+			IL_001a: stloc.0
+			IL_001b: ldloc.0
+			IL_001c: box [System.Runtime]System.Boolean
+			IL_0021: stloc.1
+			IL_0022: ldloc.1
+			IL_0023: ret
 		} // end of method FunctionExpression_L30C16::__js_call__
 
 	} // end of class FunctionExpression_L30C16
@@ -521,7 +488,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28b8
+				// Method begins at RVA 0x280e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -547,36 +514,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2694
+			// Method begins at RVA 0x2648
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] bool,
-				[2] object
+				[0] bool,
+				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: stloc.0
-			IL_0007: ldstr "revocable"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "proxy"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: ldstr "a"
-			IL_0025: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: box [System.Runtime]System.Boolean
-			IL_0031: stloc.2
-			IL_0032: ldloc.2
-			IL_0033: ret
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: ldstr "a"
+			IL_0015: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+			IL_001a: stloc.0
+			IL_001b: ldloc.0
+			IL_001c: box [System.Runtime]System.Boolean
+			IL_0021: stloc.1
+			IL_0022: ldloc.1
+			IL_0023: ret
 		} // end of method FunctionExpression_L31C19::__js_call__
 
 	} // end of class FunctionExpression_L31C19
@@ -592,7 +550,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28c1
+				// Method begins at RVA 0x2817
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -618,9 +576,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x26d4
+			// Method begins at RVA 0x2678
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 48 (0x30)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -628,28 +586,20 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: stloc.0
-			IL_0007: ldstr "revocable"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "proxy"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_0025: stloc.0
-			IL_0026: ldloc.0
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002c: stloc.0
-			IL_002d: ldloc.0
-			IL_002e: ldstr "join"
-			IL_0033: ldstr ","
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003d: stloc.0
-			IL_003e: ldloc.0
-			IL_003f: ret
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldstr "join"
+			IL_0023: ldstr ","
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_002d: stloc.0
+			IL_002e: ldloc.0
+			IL_002f: ret
 		} // end of method FunctionExpression_L32C17::__js_call__
 
 	} // end of class FunctionExpression_L32C17
@@ -665,7 +615,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28ca
+				// Method begins at RVA 0x2820
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -691,9 +641,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2720
+			// Method begins at RVA 0x26b4
 			// Header size: 12
-			// Code size: 40 (0x28)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -701,20 +651,12 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: stloc.0
-			IL_0007: ldstr "revocable"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "proxy"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-			IL_0025: stloc.0
-			IL_0026: ldloc.0
-			IL_0027: ret
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: ret
 		} // end of method FunctionExpression_L33C27::__js_call__
 
 	} // end of class FunctionExpression_L33C27
@@ -730,7 +672,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28d3
+				// Method begins at RVA 0x2829
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -756,9 +698,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2754
+			// Method begins at RVA 0x26d8
 			// Header size: 12
-			// Code size: 46 (0x2e)
+			// Code size: 32 (0x20)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -766,22 +708,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: stloc.0
-			IL_0007: ldstr "revocable"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "proxy"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: ldc.i4.0
-			IL_0021: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-			IL_002b: stloc.0
-			IL_002c: ldloc.0
-			IL_002d: ret
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: ldc.i4.0
+			IL_0013: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+			IL_001d: stloc.0
+			IL_001e: ldloc.0
+			IL_001f: ret
 		} // end of method FunctionExpression_L34C27::__js_call__
 
 	} // end of class FunctionExpression_L34C27
@@ -797,7 +733,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28dc
+				// Method begins at RVA 0x2832
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -821,7 +757,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2790
+			// Method begins at RVA 0x2704
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -850,7 +786,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28e5
+				// Method begins at RVA 0x283b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -876,9 +812,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x27b0
+			// Method begins at RVA 0x2724
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 40 (0x28)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -886,22 +822,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
-			IL_0006: stloc.0
-			IL_0007: ldstr "callable"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ldstr "proxy"
-			IL_0020: ldc.r8 1
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0033: stloc.0
-			IL_0034: ldloc.0
-			IL_0035: ret
+			IL_000d: ldstr "proxy"
+			IL_0012: ldc.r8 1
+			IL_001b: box [System.Runtime]System.Double
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0025: stloc.0
+			IL_0026: ldloc.0
+			IL_0027: ret
 		} // end of method FunctionExpression_L40C17::__js_call__
 
 	} // end of class FunctionExpression_L40C17
@@ -923,7 +853,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28ee
+				// Method begins at RVA 0x2844
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -947,7 +877,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27f4
+			// Method begins at RVA 0x2758
 			// Header size: 12
 			// Code size: 28 (0x1c)
 			.maxstack 8
@@ -983,7 +913,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28f7
+				// Method begins at RVA 0x284d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1009,9 +939,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x281c
+			// Method begins at RVA 0x2780
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 49 (0x31)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1019,27 +949,21 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
-			IL_0006: stloc.0
-			IL_0007: ldstr "constructible"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldstr "proxy"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: ldc.i4.1
-			IL_0021: newarr [System.Runtime]System.Object
-			IL_0026: dup
-			IL_0027: ldc.i4.0
-			IL_0028: ldc.r8 1
-			IL_0031: box [System.Runtime]System.Double
-			IL_0036: stelem.ref
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_003c: stloc.0
-			IL_003d: ldloc.0
-			IL_003e: ret
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: ldc.i4.1
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldc.r8 1
+			IL_0023: box [System.Runtime]System.Double
+			IL_0028: stelem.ref
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_002e: stloc.0
+			IL_002f: ldloc.0
+			IL_0030: ret
 		} // end of method FunctionExpression_L46C22::__js_call__
 
 	} // end of class FunctionExpression_L46C22
@@ -1066,7 +990,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2867
+			// Method begins at RVA 0x27bd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1512,7 +1436,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2900
+		// Method begins at RVA 0x2856
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_SetTrap_InterceptsWrites.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_SetTrap_InterceptsWrites.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ac
+				// Method begins at RVA 0x2194
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -50,40 +50,31 @@
 			)
 			// Method begins at RVA 0x2154
 			// Header size: 12
-			// Code size: 67 (0x43)
+			// Code size: 43 (0x2b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object,
-				[2] object
+				[1] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_SetTrap_InterceptsWrites/Scope::seen
 			IL_0006: stloc.0
-			IL_0007: ldstr "seen"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
+			IL_0007: ldarg.3
+			IL_0008: ldstr "="
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0012: stloc.1
 			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.1
-			IL_001a: ldarg.3
-			IL_001b: ldstr "="
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0025: stloc.2
-			IL_0026: ldloc.2
-			IL_0027: ldarg.s 'value'
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_002e: stloc.2
-			IL_002f: ldloc.1
-			IL_0030: ldstr "push"
-			IL_0035: ldloc.2
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003b: pop
-			IL_003c: ldc.i4.1
-			IL_003d: box [System.Runtime]System.Boolean
-			IL_0042: ret
+			IL_0014: ldarg.s 'value'
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_001b: stloc.1
+			IL_001c: ldloc.0
+			IL_001d: ldloc.1
+			IL_001e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0023: pop
+			IL_0024: ldc.i4.1
+			IL_0025: box [System.Runtime]System.Boolean
+			IL_002a: ret
 		} // end of method FunctionExpression_handler::__js_call__
 
 	} // end of class FunctionExpression_handler
@@ -102,7 +93,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a3
+			// Method begins at RVA 0x218b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -229,7 +220,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b5
+		// Method begins at RVA 0x219d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a92
+					// Method begins at RVA 0x2a3c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a9b
+					// Method begins at RVA 0x2a45
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a89
+				// Method begins at RVA 0x2a33
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -212,7 +212,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa4
+				// Method begins at RVA 0x2a4e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -265,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aad
+				// Method begins at RVA 0x2a57
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -321,7 +321,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab6
+				// Method begins at RVA 0x2a60
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -374,7 +374,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2abf
+				// Method begins at RVA 0x2a69
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -430,7 +430,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac8
+				// Method begins at RVA 0x2a72
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -475,7 +475,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad1
+				// Method begins at RVA 0x2a7b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -503,7 +503,7 @@
 			)
 			// Method begins at RVA 0x2848
 			// Header size: 12
-			// Code size: 38 (0x26)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -511,22 +511,16 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Validation_EdgeCases/Scope::applyProxy
-			IL_0006: stloc.0
-			IL_0007: ldstr "applyProxy"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0023: stloc.0
-			IL_0024: ldloc.0
-			IL_0025: ret
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: ret
 		} // end of method FunctionExpression_L34C25::__js_call__
 
 	} // end of class FunctionExpression_L34C25
@@ -542,7 +536,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ada
+				// Method begins at RVA 0x2a84
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -568,7 +562,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x287a
+			// Method begins at RVA 0x286c
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -594,7 +588,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae3
+				// Method begins at RVA 0x2a8d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -620,9 +614,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2890
+			// Method begins at RVA 0x2880
 			// Header size: 12
-			// Code size: 34 (0x22)
+			// Code size: 20 (0x14)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -630,18 +624,12 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Validation_EdgeCases/Scope::constructProxy
-			IL_0006: stloc.0
-			IL_0007: ldstr "constructProxy"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.0
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_001f: stloc.0
-			IL_0020: ldloc.0
-			IL_0021: ret
+			IL_0006: ldc.i4.0
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0011: stloc.0
+			IL_0012: ldloc.0
+			IL_0013: ret
 		} // end of method FunctionExpression_L44C34::__js_call__
 
 	} // end of class FunctionExpression_L44C34
@@ -664,7 +652,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aec
+				// Method begins at RVA 0x2a96
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -687,7 +675,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28c0
+			// Method begins at RVA 0x28a0
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -717,7 +705,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2af5
+				// Method begins at RVA 0x2a9f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -740,7 +728,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28d6
+			// Method begins at RVA 0x28b6
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -762,7 +750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2afe
+				// Method begins at RVA 0x2aa8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -788,9 +776,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x28e4
+			// Method begins at RVA 0x28c4
 			// Header size: 12
-			// Code size: 34 (0x22)
+			// Code size: 20 (0x14)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -798,18 +786,12 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Validation_EdgeCases/Scope::badConstructResultProxy
-			IL_0006: stloc.0
-			IL_0007: ldstr "badConstructResultProxy"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.i4.0
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_001f: stloc.0
-			IL_0020: ldloc.0
-			IL_0021: ret
+			IL_0006: ldc.i4.0
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0011: stloc.0
+			IL_0012: ldloc.0
+			IL_0013: ret
 		} // end of method FunctionExpression_L54C34::__js_call__
 
 	} // end of class FunctionExpression_L54C34
@@ -825,7 +807,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b07
+				// Method begins at RVA 0x2ab1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -848,7 +830,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2912
+			// Method begins at RVA 0x28e4
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -871,7 +853,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b10
+				// Method begins at RVA 0x2aba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -894,7 +876,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x291a
+			// Method begins at RVA 0x28ec
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -916,7 +898,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b19
+				// Method begins at RVA 0x2ac3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -942,9 +924,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2928
+			// Method begins at RVA 0x28f8
 			// Header size: 12
-			// Code size: 28 (0x1c)
+			// Code size: 14 (0xe)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -952,16 +934,10 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Validation_EdgeCases/Scope::badGetPrototypeProxy
-			IL_0006: stloc.0
-			IL_0007: ldstr "badGetPrototypeProxy"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: ret
+			IL_000d: ret
 		} // end of method FunctionExpression_L72C32::__js_call__
 
 	} // end of class FunctionExpression_L72C32
@@ -977,7 +953,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b22
+				// Method begins at RVA 0x2acc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1003,7 +979,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2950
+			// Method begins at RVA 0x2912
 			// Header size: 1
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -1037,7 +1013,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b2b
+				// Method begins at RVA 0x2ad5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1063,7 +1039,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x298c
+			// Method begins at RVA 0x2950
 			// Header size: 12
 			// Code size: 67 (0x43)
 			.maxstack 8
@@ -1106,7 +1082,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b34
+				// Method begins at RVA 0x2ade
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1129,7 +1105,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29db
+			// Method begins at RVA 0x299f
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -1151,7 +1127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b3d
+				// Method begins at RVA 0x2ae7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1177,9 +1153,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x29e4
+			// Method begins at RVA 0x29a8
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 38 (0x26)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1187,24 +1163,18 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysProxy
-			IL_0006: stloc.0
-			IL_0007: ldstr "badOwnKeysProxy"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0012: stloc.0
 			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0020: stloc.0
-			IL_0021: ldloc.0
-			IL_0022: ldstr "join"
-			IL_0027: ldstr ","
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0031: stloc.0
-			IL_0032: ldloc.0
-			IL_0033: ret
+			IL_0014: ldstr "join"
+			IL_0019: ldstr ","
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0023: stloc.0
+			IL_0024: ldloc.0
+			IL_0025: ret
 		} // end of method FunctionExpression_L98C25::__js_call__
 
 	} // end of class FunctionExpression_L98C25
@@ -1220,7 +1190,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b46
+				// Method begins at RVA 0x2af0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1243,7 +1213,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a24
+			// Method begins at RVA 0x29da
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -1270,7 +1240,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b4f
+				// Method begins at RVA 0x2af9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1296,9 +1266,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2a40
+			// Method begins at RVA 0x29f8
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 38 (0x26)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1306,24 +1276,18 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysEntryProxy
-			IL_0006: stloc.0
-			IL_0007: ldstr "badOwnKeysEntryProxy"
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0012: stloc.0
 			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_0019: stloc.0
-			IL_001a: ldloc.0
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0020: stloc.0
-			IL_0021: ldloc.0
-			IL_0022: ldstr "join"
-			IL_0027: ldstr ","
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0031: stloc.0
-			IL_0032: ldloc.0
-			IL_0033: ret
+			IL_0014: ldstr "join"
+			IL_0019: ldstr ","
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0023: stloc.0
+			IL_0024: ldloc.0
+			IL_0025: ret
 		} // end of method FunctionExpression_L108C21::__js_call__
 
 	} // end of class FunctionExpression_L108C21
@@ -1362,7 +1326,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a80
+			// Method begins at RVA 0x2a2a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1989,7 +1953,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b58
+		// Method begins at RVA 0x2b02
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x29dd
+						// Method begins at RVA 0x2929
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29d4
+					// Method begins at RVA 0x2920
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -70,16 +70,14 @@
 				)
 				// Method begins at RVA 0x2644
 				// Header size: 12
-				// Code size: 260 (0x104)
+				// Code size: 200 (0xc8)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/Scope/Block_L10C43,
 					[1] object,
-					[2] object,
-					[3] float64,
-					[4] float64,
-					[5] object,
-					[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+					[2] float64,
+					[3] object,
+					[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
 				IL_0000: ldarg.0
@@ -88,101 +86,75 @@
 				IL_0003: castclass Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope
 				IL_0008: ldfld object Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope::index
 				IL_000d: stloc.1
-				IL_000e: ldstr "index"
-				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldarg.0
-				IL_001b: ldc.i4.1
-				IL_001c: ldelem.ref
-				IL_001d: castclass Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope
-				IL_0022: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope::values
-				IL_0027: stloc.2
-				IL_0028: ldstr "values"
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: castclass Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope
+				IL_0016: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope::values
+				IL_001b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0020: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+				IL_0025: conv.r8
+				IL_0026: stloc.2
+				IL_0027: ldloc.1
+				IL_0028: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_002d: ldloc.2
-				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0033: stloc.2
-				IL_0034: ldloc.2
-				IL_0035: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.1
-				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.s 4
-				IL_0045: ldloc.3
-				IL_0046: clt
-				IL_0048: brfalse IL_00e6
+				IL_002e: clt
+				IL_0030: brfalse IL_00aa
 
-				IL_004d: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/Scope/Block_L10C43::.ctor()
-				IL_0052: stloc.0
-				IL_0053: ldarg.0
-				IL_0054: ldc.i4.1
-				IL_0055: ldelem.ref
-				IL_0056: castclass Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope
-				IL_005b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope::values
-				IL_0060: stloc.1
-				IL_0061: ldstr "values"
-				IL_0066: ldloc.1
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006c: stloc.1
-				IL_006d: ldarg.0
-				IL_006e: ldc.i4.1
-				IL_006f: ldelem.ref
-				IL_0070: castclass Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope
-				IL_0075: ldfld object Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope::index
-				IL_007a: stloc.2
-				IL_007b: ldstr "index"
-				IL_0080: ldloc.2
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0086: stloc.2
-				IL_0087: ldloc.2
-				IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_008d: stloc.3
-				IL_008e: ldloc.3
-				IL_008f: box [System.Runtime]System.Double
-				IL_0094: stloc.s 5
-				IL_0096: ldloc.s 5
-				IL_0098: stloc.2
-				IL_0099: ldloc.3
-				IL_009a: ldc.r8 1
-				IL_00a3: add
-				IL_00a4: stloc.3
-				IL_00a5: ldloc.3
-				IL_00a6: box [System.Runtime]System.Double
-				IL_00ab: stloc.s 5
-				IL_00ad: ldarg.0
-				IL_00ae: ldc.i4.1
-				IL_00af: ldelem.ref
-				IL_00b0: castclass Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope
-				IL_00b5: ldloc.s 5
-				IL_00b7: stfld object Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope::index
-				IL_00bc: ldloc.1
-				IL_00bd: ldloc.2
-				IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00c3: stloc.2
-				IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00c9: dup
-				IL_00ca: ldstr "value"
-				IL_00cf: ldloc.2
-				IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_00d5: dup
-				IL_00d6: ldstr "done"
-				IL_00db: ldc.i4.0
-				IL_00dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_00e1: stloc.s 6
-				IL_00e3: ldloc.s 6
-				IL_00e5: ret
+				IL_0035: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/Scope/Block_L10C43::.ctor()
+				IL_003a: stloc.0
+				IL_003b: ldarg.0
+				IL_003c: ldc.i4.1
+				IL_003d: ldelem.ref
+				IL_003e: castclass Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope
+				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope::values
+				IL_0048: stloc.1
+				IL_0049: ldarg.0
+				IL_004a: ldc.i4.1
+				IL_004b: ldelem.ref
+				IL_004c: castclass Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope
+				IL_0051: ldfld object Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope::index
+				IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005b: stloc.2
+				IL_005c: ldloc.2
+				IL_005d: box [System.Runtime]System.Double
+				IL_0062: stloc.3
+				IL_0063: ldarg.0
+				IL_0064: ldc.i4.1
+				IL_0065: ldelem.ref
+				IL_0066: castclass Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope
+				IL_006b: ldloc.2
+				IL_006c: ldc.r8 1
+				IL_0075: add
+				IL_0076: box [System.Runtime]System.Double
+				IL_007b: stfld object Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope::index
+				IL_0080: ldloc.1
+				IL_0081: ldloc.3
+				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0087: stloc.3
+				IL_0088: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_008d: dup
+				IL_008e: ldstr "value"
+				IL_0093: ldloc.3
+				IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0099: dup
+				IL_009a: ldstr "done"
+				IL_009f: ldc.i4.0
+				IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_00a5: stloc.s 4
+				IL_00a7: ldloc.s 4
+				IL_00a9: ret
 
-				IL_00e6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00eb: dup
-				IL_00ec: ldstr "value"
-				IL_00f1: ldnull
-				IL_00f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_00f7: dup
-				IL_00f8: ldstr "done"
-				IL_00fd: ldc.i4.1
-				IL_00fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0103: ret
+				IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_00af: dup
+				IL_00b0: ldstr "value"
+				IL_00b5: ldnull
+				IL_00b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_00bb: dup
+				IL_00bc: ldstr "done"
+				IL_00c1: ldc.i4.1
+				IL_00c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_00c7: ret
 			} // end of method FunctionExpression_iterable::__js_call__
 
 		} // end of class FunctionExpression_iterable
@@ -203,7 +175,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29cb
+				// Method begins at RVA 0x2917
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -318,7 +290,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x29f8
+						// Method begins at RVA 0x2944
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -336,7 +308,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29ef
+					// Method begins at RVA 0x293b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -360,18 +332,16 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2754
+				// Method begins at RVA 0x2718
 				// Header size: 12
-				// Code size: 260 (0x104)
+				// Code size: 200 (0xc8)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/Scope/Block_L34C43,
 					[1] object,
-					[2] object,
-					[3] float64,
-					[4] float64,
-					[5] object,
-					[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+					[2] float64,
+					[3] object,
+					[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
 				IL_0000: ldarg.0
@@ -380,101 +350,75 @@
 				IL_0003: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
 				IL_0008: ldfld object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope::index
 				IL_000d: stloc.1
-				IL_000e: ldstr "index"
-				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldarg.0
-				IL_001b: ldc.i4.1
-				IL_001c: ldelem.ref
-				IL_001d: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
-				IL_0022: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope::values
-				IL_0027: stloc.2
-				IL_0028: ldstr "values"
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
+				IL_0016: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope::values
+				IL_001b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0020: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+				IL_0025: conv.r8
+				IL_0026: stloc.2
+				IL_0027: ldloc.1
+				IL_0028: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_002d: ldloc.2
-				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0033: stloc.2
-				IL_0034: ldloc.2
-				IL_0035: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.1
-				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.s 4
-				IL_0045: ldloc.3
-				IL_0046: clt
-				IL_0048: brfalse IL_00e6
+				IL_002e: clt
+				IL_0030: brfalse IL_00aa
 
-				IL_004d: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/Scope/Block_L34C43::.ctor()
-				IL_0052: stloc.0
-				IL_0053: ldarg.0
-				IL_0054: ldc.i4.1
-				IL_0055: ldelem.ref
-				IL_0056: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
-				IL_005b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope::values
-				IL_0060: stloc.1
-				IL_0061: ldstr "values"
-				IL_0066: ldloc.1
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006c: stloc.1
-				IL_006d: ldarg.0
-				IL_006e: ldc.i4.1
-				IL_006f: ldelem.ref
-				IL_0070: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
-				IL_0075: ldfld object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope::index
-				IL_007a: stloc.2
-				IL_007b: ldstr "index"
-				IL_0080: ldloc.2
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0086: stloc.2
-				IL_0087: ldloc.2
-				IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_008d: stloc.3
-				IL_008e: ldloc.3
-				IL_008f: box [System.Runtime]System.Double
-				IL_0094: stloc.s 5
-				IL_0096: ldloc.s 5
-				IL_0098: stloc.2
-				IL_0099: ldloc.3
-				IL_009a: ldc.r8 1
-				IL_00a3: add
-				IL_00a4: stloc.3
-				IL_00a5: ldloc.3
-				IL_00a6: box [System.Runtime]System.Double
-				IL_00ab: stloc.s 5
-				IL_00ad: ldarg.0
-				IL_00ae: ldc.i4.1
-				IL_00af: ldelem.ref
-				IL_00b0: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
-				IL_00b5: ldloc.s 5
-				IL_00b7: stfld object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope::index
-				IL_00bc: ldloc.1
-				IL_00bd: ldloc.2
-				IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00c3: stloc.2
-				IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00c9: dup
-				IL_00ca: ldstr "value"
-				IL_00cf: ldloc.2
-				IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_00d5: dup
-				IL_00d6: ldstr "done"
-				IL_00db: ldc.i4.0
-				IL_00dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_00e1: stloc.s 6
-				IL_00e3: ldloc.s 6
-				IL_00e5: ret
+				IL_0035: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/Scope/Block_L34C43::.ctor()
+				IL_003a: stloc.0
+				IL_003b: ldarg.0
+				IL_003c: ldc.i4.1
+				IL_003d: ldelem.ref
+				IL_003e: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
+				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope::values
+				IL_0048: stloc.1
+				IL_0049: ldarg.0
+				IL_004a: ldc.i4.1
+				IL_004b: ldelem.ref
+				IL_004c: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
+				IL_0051: ldfld object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope::index
+				IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005b: stloc.2
+				IL_005c: ldloc.2
+				IL_005d: box [System.Runtime]System.Double
+				IL_0062: stloc.3
+				IL_0063: ldarg.0
+				IL_0064: ldc.i4.1
+				IL_0065: ldelem.ref
+				IL_0066: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
+				IL_006b: ldloc.2
+				IL_006c: ldc.r8 1
+				IL_0075: add
+				IL_0076: box [System.Runtime]System.Double
+				IL_007b: stfld object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope::index
+				IL_0080: ldloc.1
+				IL_0081: ldloc.3
+				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0087: stloc.3
+				IL_0088: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_008d: dup
+				IL_008e: ldstr "value"
+				IL_0093: ldloc.3
+				IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0099: dup
+				IL_009a: ldstr "done"
+				IL_009f: ldc.i4.0
+				IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_00a5: stloc.s 4
+				IL_00a7: ldloc.s 4
+				IL_00a9: ret
 
-				IL_00e6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00eb: dup
-				IL_00ec: ldstr "value"
-				IL_00f1: ldnull
-				IL_00f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_00f7: dup
-				IL_00f8: ldstr "done"
-				IL_00fd: ldc.i4.1
-				IL_00fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0103: ret
+				IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_00af: dup
+				IL_00b0: ldstr "value"
+				IL_00b5: ldnull
+				IL_00b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_00bb: dup
+				IL_00bc: ldstr "done"
+				IL_00c1: ldc.i4.1
+				IL_00c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_00c7: ret
 			} // end of method FunctionExpression_closableIterable::__js_call__
 
 		} // end of class FunctionExpression_closableIterable
@@ -490,7 +434,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a01
+					// Method begins at RVA 0x294d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -514,7 +458,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2864
+				// Method begins at RVA 0x27ec
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -552,7 +496,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29e6
+				// Method begins at RVA 0x2932
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -686,7 +630,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a1c
+						// Method begins at RVA 0x2968
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -704,7 +648,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a13
+					// Method begins at RVA 0x295f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -728,18 +672,16 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x288c
+				// Method begins at RVA 0x2814
 				// Header size: 12
-				// Code size: 260 (0x104)
+				// Code size: 200 (0xc8)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/FunctionExpression_unionIterable/Scope/Block_L60C43,
 					[1] object,
-					[2] object,
-					[3] float64,
-					[4] float64,
-					[5] object,
-					[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+					[2] float64,
+					[3] object,
+					[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
 				IL_0000: ldarg.0
@@ -748,101 +690,75 @@
 				IL_0003: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope
 				IL_0008: ldfld object Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope::index
 				IL_000d: stloc.1
-				IL_000e: ldstr "index"
-				IL_0013: ldloc.1
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.1
-				IL_001a: ldarg.0
-				IL_001b: ldc.i4.1
-				IL_001c: ldelem.ref
-				IL_001d: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope
-				IL_0022: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope::values
-				IL_0027: stloc.2
-				IL_0028: ldstr "values"
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope
+				IL_0016: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope::values
+				IL_001b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0020: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+				IL_0025: conv.r8
+				IL_0026: stloc.2
+				IL_0027: ldloc.1
+				IL_0028: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_002d: ldloc.2
-				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0033: stloc.2
-				IL_0034: ldloc.2
-				IL_0035: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.1
-				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.s 4
-				IL_0045: ldloc.3
-				IL_0046: clt
-				IL_0048: brfalse IL_00e6
+				IL_002e: clt
+				IL_0030: brfalse IL_00aa
 
-				IL_004d: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/FunctionExpression_unionIterable/Scope/Block_L60C43::.ctor()
-				IL_0052: stloc.0
-				IL_0053: ldarg.0
-				IL_0054: ldc.i4.1
-				IL_0055: ldelem.ref
-				IL_0056: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope
-				IL_005b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope::values
-				IL_0060: stloc.1
-				IL_0061: ldstr "values"
-				IL_0066: ldloc.1
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_006c: stloc.1
-				IL_006d: ldarg.0
-				IL_006e: ldc.i4.1
-				IL_006f: ldelem.ref
-				IL_0070: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope
-				IL_0075: ldfld object Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope::index
-				IL_007a: stloc.2
-				IL_007b: ldstr "index"
-				IL_0080: ldloc.2
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0086: stloc.2
-				IL_0087: ldloc.2
-				IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_008d: stloc.3
-				IL_008e: ldloc.3
-				IL_008f: box [System.Runtime]System.Double
-				IL_0094: stloc.s 5
-				IL_0096: ldloc.s 5
-				IL_0098: stloc.2
-				IL_0099: ldloc.3
-				IL_009a: ldc.r8 1
-				IL_00a3: add
-				IL_00a4: stloc.3
-				IL_00a5: ldloc.3
-				IL_00a6: box [System.Runtime]System.Double
-				IL_00ab: stloc.s 5
-				IL_00ad: ldarg.0
-				IL_00ae: ldc.i4.1
-				IL_00af: ldelem.ref
-				IL_00b0: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope
-				IL_00b5: ldloc.s 5
-				IL_00b7: stfld object Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope::index
-				IL_00bc: ldloc.1
-				IL_00bd: ldloc.2
-				IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00c3: stloc.2
-				IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00c9: dup
-				IL_00ca: ldstr "value"
-				IL_00cf: ldloc.2
-				IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_00d5: dup
-				IL_00d6: ldstr "done"
-				IL_00db: ldc.i4.0
-				IL_00dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_00e1: stloc.s 6
-				IL_00e3: ldloc.s 6
-				IL_00e5: ret
+				IL_0035: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/FunctionExpression_unionIterable/Scope/Block_L60C43::.ctor()
+				IL_003a: stloc.0
+				IL_003b: ldarg.0
+				IL_003c: ldc.i4.1
+				IL_003d: ldelem.ref
+				IL_003e: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope
+				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope::values
+				IL_0048: stloc.1
+				IL_0049: ldarg.0
+				IL_004a: ldc.i4.1
+				IL_004b: ldelem.ref
+				IL_004c: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope
+				IL_0051: ldfld object Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope::index
+				IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005b: stloc.2
+				IL_005c: ldloc.2
+				IL_005d: box [System.Runtime]System.Double
+				IL_0062: stloc.3
+				IL_0063: ldarg.0
+				IL_0064: ldc.i4.1
+				IL_0065: ldelem.ref
+				IL_0066: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope
+				IL_006b: ldloc.2
+				IL_006c: ldc.r8 1
+				IL_0075: add
+				IL_0076: box [System.Runtime]System.Double
+				IL_007b: stfld object Modules.Set_Constructor_Iterable/FunctionExpression_unionIterable/Scope::index
+				IL_0080: ldloc.1
+				IL_0081: ldloc.3
+				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0087: stloc.3
+				IL_0088: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_008d: dup
+				IL_008e: ldstr "value"
+				IL_0093: ldloc.3
+				IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0099: dup
+				IL_009a: ldstr "done"
+				IL_009f: ldc.i4.0
+				IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_00a5: stloc.s 4
+				IL_00a7: ldloc.s 4
+				IL_00a9: ret
 
-				IL_00e6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_00eb: dup
-				IL_00ec: ldstr "value"
-				IL_00f1: ldnull
-				IL_00f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_00f7: dup
-				IL_00f8: ldstr "done"
-				IL_00fd: ldc.i4.1
-				IL_00fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0103: ret
+				IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_00af: dup
+				IL_00b0: ldstr "value"
+				IL_00b5: ldnull
+				IL_00b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_00bb: dup
+				IL_00bc: ldstr "done"
+				IL_00c1: ldc.i4.1
+				IL_00c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_00c7: ret
 			} // end of method FunctionExpression_unionIterable::__js_call__
 
 		} // end of class FunctionExpression_unionIterable
@@ -858,7 +774,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a25
+					// Method begins at RVA 0x2971
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -882,7 +798,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x299c
+				// Method begins at RVA 0x28e8
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -920,7 +836,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a0a
+				// Method begins at RVA 0x2956
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1056,7 +972,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29c2
+			// Method begins at RVA 0x290e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1389,7 +1305,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a2e
+		// Method begins at RVA 0x297a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_ForEach_Basic.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_ForEach_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2265
+				// Method begins at RVA 0x2247
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,73 +49,60 @@
 			)
 			// Method begins at RVA 0x21b8
 			// Header size: 12
-			// Code size: 152 (0x98)
+			// Code size: 122 (0x7a)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
-				[2] object,
-				[3] bool,
-				[4] object
+				[2] bool,
+				[3] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Set_ForEach_Basic/Scope::seen
-			IL_0006: stloc.0
-			IL_0007: ldstr "seen"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: stloc.0
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_001f: ldstr "label"
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0029: ldstr ":"
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0033: stloc.1
-			IL_0034: ldloc.1
-			IL_0035: ldarg.2
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_003b: stloc.1
-			IL_003c: ldloc.1
-			IL_003d: ldstr ":"
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0047: stloc.1
-			IL_0048: ldloc.1
-			IL_0049: ldarg.3
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_004f: stloc.1
-			IL_0050: ldloc.1
-			IL_0051: ldstr ":"
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_005b: stloc.1
-			IL_005c: ldarg.0
-			IL_005d: ldfld object Modules.Set_ForEach_Basic/Scope::set
-			IL_0062: stloc.2
-			IL_0063: ldstr "set"
-			IL_0068: ldloc.2
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_006e: stloc.2
-			IL_006f: ldarg.s receiver
-			IL_0071: ldloc.2
-			IL_0072: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0077: stloc.3
-			IL_0078: ldloc.3
-			IL_0079: box [System.Runtime]System.Boolean
-			IL_007e: stloc.s 4
-			IL_0080: ldloc.1
-			IL_0081: ldloc.s 4
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0088: stloc.1
-			IL_0089: ldloc.0
-			IL_008a: ldstr "push"
-			IL_008f: ldloc.1
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0095: pop
-			IL_0096: ldnull
-			IL_0097: ret
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0011: ldstr "label"
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001b: ldstr ":"
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0025: stloc.1
+			IL_0026: ldloc.1
+			IL_0027: ldarg.2
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_002d: stloc.1
+			IL_002e: ldloc.1
+			IL_002f: ldstr ":"
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0039: stloc.1
+			IL_003a: ldloc.1
+			IL_003b: ldarg.3
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0041: stloc.1
+			IL_0042: ldloc.1
+			IL_0043: ldstr ":"
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004d: stloc.1
+			IL_004e: ldarg.s receiver
+			IL_0050: ldarg.0
+			IL_0051: ldfld object Modules.Set_ForEach_Basic/Scope::set
+			IL_0056: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_005b: stloc.2
+			IL_005c: ldloc.2
+			IL_005d: box [System.Runtime]System.Boolean
+			IL_0062: stloc.3
+			IL_0063: ldloc.1
+			IL_0064: ldloc.3
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_006a: stloc.1
+			IL_006b: ldloc.0
+			IL_006c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0071: ldloc.1
+			IL_0072: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0077: pop
+			IL_0078: ldnull
+			IL_0079: ret
 		} // end of method FunctionExpression_L7C12::__js_call__
 
 	} // end of class FunctionExpression_L7C12
@@ -135,7 +122,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x225c
+			// Method begins at RVA 0x223e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -284,7 +271,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x226e
+		// Method begins at RVA 0x2250
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharAt_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharAt_Basic.verified.txt
@@ -96,9 +96,10 @@
 			[8] object,
 			[9] object,
 			[10] object,
-			[11] bool,
-			[12] object,
-			[13] object
+			[11] string,
+			[12] bool,
+			[13] object,
+			[14] object
 		)
 
 		IL_0000: newobj instance void Modules.String_CharAt_Basic/Scope::.ctor()
@@ -115,32 +116,32 @@
 		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0027: stloc.s 10
 		IL_0029: ldloc.s 10
-		IL_002b: ldstr "charAt"
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0035: stloc.s 10
+		IL_002b: castclass [System.Runtime]System.String
+		IL_0030: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string)
+		IL_0035: stloc.s 11
 		IL_0037: ldloc.s 9
 		IL_0039: ldstr "log"
-		IL_003e: ldloc.s 10
+		IL_003e: ldloc.s 11
 		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0045: pop
 		IL_0046: ldstr "console"
 		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0050: stloc.s 10
-		IL_0052: ldloc.s 10
+		IL_0050: stloc.s 9
+		IL_0052: ldloc.s 9
 		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0059: stloc.s 10
+		IL_0059: stloc.s 9
 		IL_005b: ldloc.1
 		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0061: stloc.s 9
-		IL_0063: ldloc.s 9
-		IL_0065: ldstr "charAt"
+		IL_0061: stloc.s 10
+		IL_0063: ldloc.s 10
+		IL_0065: castclass [System.Runtime]System.String
 		IL_006a: ldc.r8 1
 		IL_0073: box [System.Runtime]System.Double
-		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_007d: stloc.s 9
-		IL_007f: ldloc.s 10
+		IL_0078: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_007d: stloc.s 11
+		IL_007f: ldloc.s 9
 		IL_0081: ldstr "log"
-		IL_0086: ldloc.s 9
+		IL_0086: ldloc.s 11
 		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_008d: pop
 		IL_008e: ldstr "console"
@@ -153,69 +154,69 @@
 		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00a9: stloc.s 10
 		IL_00ab: ldloc.s 10
-		IL_00ad: ldstr "charAt"
+		IL_00ad: castclass [System.Runtime]System.String
 		IL_00b2: ldc.r8 4
 		IL_00bb: box [System.Runtime]System.Double
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c5: stloc.s 10
+		IL_00c0: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_00c5: stloc.s 11
 		IL_00c7: ldloc.s 9
 		IL_00c9: ldstr "log"
-		IL_00ce: ldloc.s 10
+		IL_00ce: ldloc.s 11
 		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00d5: pop
 		IL_00d6: ldstr "console"
 		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e0: stloc.s 10
-		IL_00e2: ldloc.s 10
+		IL_00e0: stloc.s 9
+		IL_00e2: ldloc.s 9
 		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e9: stloc.s 10
+		IL_00e9: stloc.s 9
 		IL_00eb: ldloc.1
 		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f1: stloc.s 9
-		IL_00f3: ldloc.s 9
-		IL_00f5: ldstr "charAt"
+		IL_00f1: stloc.s 10
+		IL_00f3: ldloc.s 10
+		IL_00f5: castclass [System.Runtime]System.String
 		IL_00fa: ldc.r8 5
 		IL_0103: box [System.Runtime]System.Double
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_010d: stloc.s 9
-		IL_010f: ldloc.s 9
+		IL_0108: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_010d: stloc.s 11
+		IL_010f: ldloc.s 11
 		IL_0111: ldstr ""
 		IL_0116: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_011b: stloc.s 11
-		IL_011d: ldloc.s 11
+		IL_011b: stloc.s 12
+		IL_011d: ldloc.s 12
 		IL_011f: box [System.Runtime]System.Boolean
-		IL_0124: stloc.s 12
-		IL_0126: ldloc.s 10
+		IL_0124: stloc.s 13
+		IL_0126: ldloc.s 9
 		IL_0128: ldstr "log"
-		IL_012d: ldloc.s 12
+		IL_012d: ldloc.s 13
 		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0134: pop
 		IL_0135: ldstr "console"
 		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013f: stloc.s 10
-		IL_0141: ldloc.s 10
+		IL_013f: stloc.s 9
+		IL_0141: ldloc.s 9
 		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0148: stloc.s 10
+		IL_0148: stloc.s 9
 		IL_014a: ldloc.1
 		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0150: stloc.s 9
-		IL_0152: ldloc.s 9
-		IL_0154: ldstr "charAt"
+		IL_0150: stloc.s 10
+		IL_0152: ldloc.s 10
+		IL_0154: castclass [System.Runtime]System.String
 		IL_0159: ldc.r8 1
 		IL_0162: neg
 		IL_0163: box [System.Runtime]System.Double
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_016d: stloc.s 9
-		IL_016f: ldloc.s 9
+		IL_0168: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_016d: stloc.s 11
+		IL_016f: ldloc.s 11
 		IL_0171: ldstr ""
 		IL_0176: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_017b: stloc.s 11
-		IL_017d: ldloc.s 11
+		IL_017b: stloc.s 12
+		IL_017d: ldloc.s 12
 		IL_017f: box [System.Runtime]System.Boolean
-		IL_0184: stloc.s 12
-		IL_0186: ldloc.s 10
+		IL_0184: stloc.s 13
+		IL_0186: ldloc.s 9
 		IL_0188: ldstr "log"
-		IL_018d: ldloc.s 12
+		IL_018d: ldloc.s 13
 		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0194: pop
 		.try
@@ -224,25 +225,25 @@
 			IL_019a: stloc.2
 			IL_019b: ldstr "console"
 			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01a5: stloc.s 10
-			IL_01a7: ldloc.s 10
+			IL_01a5: stloc.s 9
+			IL_01a7: ldloc.s 9
 			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ae: stloc.s 10
+			IL_01ae: stloc.s 9
 			IL_01b0: ldloc.1
 			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b6: stloc.s 9
+			IL_01b6: stloc.s 10
 			IL_01b8: ldc.r8 1
 			IL_01c1: box [System.Runtime]System.Double
 			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_01cb: stloc.s 13
-			IL_01cd: ldloc.s 9
-			IL_01cf: ldstr "charAt"
-			IL_01d4: ldloc.s 13
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01db: stloc.s 9
-			IL_01dd: ldloc.s 10
+			IL_01cb: stloc.s 14
+			IL_01cd: ldloc.s 10
+			IL_01cf: castclass [System.Runtime]System.String
+			IL_01d4: ldloc.s 14
+			IL_01d6: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+			IL_01db: stloc.s 11
+			IL_01dd: ldloc.s 9
 			IL_01df: ldstr "log"
-			IL_01e4: ldloc.s 9
+			IL_01e4: ldloc.s 11
 			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_01eb: pop
 			IL_01ec: leave IL_02c3

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharCodeAt_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharCodeAt_Basic.verified.txt
@@ -45,7 +45,8 @@
 		.locals init (
 			[0] class Modules.String_CharCodeAt_Basic/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] float64
 		)
 
 		IL_0000: newobj instance void Modules.String_CharCodeAt_Basic/Scope::.ctor()
@@ -60,34 +61,34 @@
 		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0022: stloc.2
 		IL_0023: ldloc.2
-		IL_0024: ldstr "charCodeAt"
+		IL_0024: castclass [System.Runtime]System.String
 		IL_0029: ldc.r8 0.0
-		IL_0032: box [System.Runtime]System.Double
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_003c: stloc.2
-		IL_003d: ldloc.1
-		IL_003e: ldstr "log"
-		IL_0043: ldloc.2
+		IL_0032: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
+		IL_0037: stloc.3
+		IL_0038: ldloc.1
+		IL_0039: ldstr "log"
+		IL_003e: ldloc.3
+		IL_003f: box [System.Runtime]System.Double
 		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0049: pop
 		IL_004a: ldstr "console"
 		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0054: stloc.2
-		IL_0055: ldloc.2
+		IL_0054: stloc.1
+		IL_0055: ldloc.1
 		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005b: stloc.2
+		IL_005b: stloc.1
 		IL_005c: ldstr "ABC"
 		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0066: stloc.1
-		IL_0067: ldloc.1
-		IL_0068: ldstr "charCodeAt"
+		IL_0066: stloc.2
+		IL_0067: ldloc.2
+		IL_0068: castclass [System.Runtime]System.String
 		IL_006d: ldc.r8 2
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0080: stloc.1
-		IL_0081: ldloc.2
-		IL_0082: ldstr "log"
-		IL_0087: ldloc.1
+		IL_0076: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
+		IL_007b: stloc.3
+		IL_007c: ldloc.1
+		IL_007d: ldstr "log"
+		IL_0082: ldloc.3
+		IL_0083: box [System.Runtime]System.Double
 		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_008d: pop
 		IL_008e: ret

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_FromCharCode_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_FromCharCode_Basic.verified.txt
@@ -47,7 +47,8 @@
 			[1] string,
 			[2] string,
 			[3] object,
-			[4] object
+			[4] object,
+			[5] float64
 		)
 
 		IL_0000: newobj instance void Modules.String_FromCharCode_Basic/Scope::.ctor()
@@ -162,39 +163,39 @@
 		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0162: stloc.s 4
 		IL_0164: ldloc.s 4
-		IL_0166: ldstr "charCodeAt"
+		IL_0166: castclass [System.Runtime]System.String
 		IL_016b: ldc.r8 0.0
-		IL_0174: box [System.Runtime]System.Double
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_017e: stloc.s 4
-		IL_0180: ldloc.3
-		IL_0181: ldstr "log"
-		IL_0186: ldloc.s 4
+		IL_0174: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
+		IL_0179: stloc.s 5
+		IL_017b: ldloc.3
+		IL_017c: ldstr "log"
+		IL_0181: ldloc.s 5
+		IL_0183: box [System.Runtime]System.Double
 		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_018d: pop
 		IL_018e: ldstr "console"
 		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0198: stloc.s 4
-		IL_019a: ldloc.s 4
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a1: stloc.s 4
-		IL_01a3: ldc.r8 1
-		IL_01ac: neg
-		IL_01ad: box [System.Runtime]System.Double
-		IL_01b2: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
-		IL_01b7: stloc.2
-		IL_01b8: ldloc.2
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01be: stloc.3
-		IL_01bf: ldloc.3
-		IL_01c0: ldstr "charCodeAt"
-		IL_01c5: ldc.r8 0.0
-		IL_01ce: box [System.Runtime]System.Double
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01d8: stloc.3
-		IL_01d9: ldloc.s 4
-		IL_01db: ldstr "log"
-		IL_01e0: ldloc.3
+		IL_0198: stloc.3
+		IL_0199: ldloc.3
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019f: stloc.3
+		IL_01a0: ldc.r8 1
+		IL_01a9: neg
+		IL_01aa: box [System.Runtime]System.Double
+		IL_01af: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
+		IL_01b4: stloc.2
+		IL_01b5: ldloc.2
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01bb: stloc.s 4
+		IL_01bd: ldloc.s 4
+		IL_01bf: castclass [System.Runtime]System.String
+		IL_01c4: ldc.r8 0.0
+		IL_01cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, float64)
+		IL_01d2: stloc.s 5
+		IL_01d4: ldloc.3
+		IL_01d5: ldstr "log"
+		IL_01da: ldloc.s 5
+		IL_01dc: box [System.Runtime]System.Double
 		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01e6: pop
 		IL_01e7: ret

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_LastIndexOf_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_LastIndexOf_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2268
+			// Method begins at RVA 0x22a0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,13 +40,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 524 (0x20c)
+		// Code size: 580 (0x244)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_LastIndexOf_Basic/Scope,
 			[1] string,
 			[2] object,
-			[3] object
+			[3] object,
+			[4] float64
 		)
 
 		IL_0000: newobj instance void Modules.String_LastIndexOf_Basic/Scope::.ctor()
@@ -63,160 +64,168 @@
 		IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0024: stloc.3
 		IL_0025: ldloc.3
-		IL_0026: ldstr "lastIndexOf"
+		IL_0026: castclass [System.Runtime]System.String
 		IL_002b: ldstr "a"
-		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0035: stloc.3
-		IL_0036: ldloc.2
-		IL_0037: ldstr "log"
-		IL_003c: ldloc.3
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0042: pop
-		IL_0043: ldstr "console"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_004d: stloc.3
-		IL_004e: ldloc.3
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0054: stloc.3
-		IL_0055: ldloc.1
+		IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+		IL_0035: stloc.s 4
+		IL_0037: ldloc.2
+		IL_0038: ldstr "log"
+		IL_003d: ldloc.s 4
+		IL_003f: box [System.Runtime]System.Double
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0049: pop
+		IL_004a: ldstr "console"
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0054: stloc.2
+		IL_0055: ldloc.2
 		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_005b: stloc.2
-		IL_005c: ldloc.2
-		IL_005d: ldstr "lastIndexOf"
-		IL_0062: ldstr "a"
-		IL_0067: ldc.r8 2
-		IL_0070: box [System.Runtime]System.Double
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_007a: stloc.2
-		IL_007b: ldloc.3
-		IL_007c: ldstr "log"
-		IL_0081: ldloc.2
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0087: pop
-		IL_0088: ldstr "console"
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0092: stloc.2
-		IL_0093: ldloc.2
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0099: stloc.2
-		IL_009a: ldloc.1
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a0: stloc.3
-		IL_00a1: ldloc.3
-		IL_00a2: ldstr "lastIndexOf"
-		IL_00a7: ldstr "a"
-		IL_00ac: ldc.r8 1
-		IL_00b5: neg
-		IL_00b6: box [System.Runtime]System.Double
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00c0: stloc.3
-		IL_00c1: ldloc.2
-		IL_00c2: ldstr "log"
-		IL_00c7: ldloc.3
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00cd: pop
-		IL_00ce: ldstr "console"
-		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d8: stloc.3
-		IL_00d9: ldloc.3
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00df: stloc.3
-		IL_00e0: ldloc.1
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e6: stloc.2
-		IL_00e7: ldloc.2
-		IL_00e8: ldstr "lastIndexOf"
-		IL_00ed: ldstr "a"
-		IL_00f2: ldc.r8 99
-		IL_00fb: box [System.Runtime]System.Double
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0105: stloc.2
-		IL_0106: ldloc.3
-		IL_0107: ldstr "log"
-		IL_010c: ldloc.2
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0112: pop
-		IL_0113: ldstr "console"
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011d: stloc.2
-		IL_011e: ldloc.2
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0124: stloc.2
-		IL_0125: ldloc.1
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012b: stloc.3
-		IL_012c: ldloc.3
-		IL_012d: ldstr "lastIndexOf"
-		IL_0132: ldstr ""
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_013c: stloc.3
-		IL_013d: ldloc.2
-		IL_013e: ldstr "log"
-		IL_0143: ldloc.3
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0149: pop
-		IL_014a: ldstr "console"
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0154: stloc.3
-		IL_0155: ldloc.3
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015b: stloc.3
-		IL_015c: ldloc.1
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0162: stloc.2
-		IL_0163: ldloc.2
-		IL_0164: ldstr "lastIndexOf"
-		IL_0169: ldstr ""
-		IL_016e: ldc.r8 2
-		IL_0177: box [System.Runtime]System.Double
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0181: stloc.2
-		IL_0182: ldloc.3
-		IL_0183: ldstr "log"
-		IL_0188: ldloc.2
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_018e: pop
-		IL_018f: ldstr "console"
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0199: stloc.2
-		IL_019a: ldloc.2
-		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a0: stloc.2
-		IL_01a1: ldloc.1
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a7: stloc.3
-		IL_01a8: ldloc.3
-		IL_01a9: ldstr "lastIndexOf"
-		IL_01ae: ldstr "ab"
-		IL_01b3: ldc.r8 1
-		IL_01bc: box [System.Runtime]System.Double
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01c6: stloc.3
-		IL_01c7: ldloc.2
-		IL_01c8: ldstr "log"
-		IL_01cd: ldloc.3
-		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01d3: pop
-		IL_01d4: ldstr "console"
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01de: stloc.3
-		IL_01df: ldloc.3
-		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e5: stloc.3
-		IL_01e6: ldloc.1
-		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ec: stloc.2
-		IL_01ed: ldloc.2
-		IL_01ee: ldstr "lastIndexOf"
-		IL_01f3: ldstr "z"
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01fd: stloc.2
-		IL_01fe: ldloc.3
-		IL_01ff: ldstr "log"
-		IL_0204: ldloc.2
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_020a: pop
-		IL_020b: ret
+		IL_005c: ldloc.1
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0062: stloc.3
+		IL_0063: ldloc.3
+		IL_0064: castclass [System.Runtime]System.String
+		IL_0069: ldstr "a"
+		IL_006e: ldc.r8 2
+		IL_0077: box [System.Runtime]System.Double
+		IL_007c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_0081: stloc.s 4
+		IL_0083: ldloc.2
+		IL_0084: ldstr "log"
+		IL_0089: ldloc.s 4
+		IL_008b: box [System.Runtime]System.Double
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0095: pop
+		IL_0096: ldstr "console"
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a0: stloc.2
+		IL_00a1: ldloc.2
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a7: stloc.2
+		IL_00a8: ldloc.1
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ae: stloc.3
+		IL_00af: ldloc.3
+		IL_00b0: castclass [System.Runtime]System.String
+		IL_00b5: ldstr "a"
+		IL_00ba: ldc.r8 1
+		IL_00c3: neg
+		IL_00c4: box [System.Runtime]System.Double
+		IL_00c9: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_00ce: stloc.s 4
+		IL_00d0: ldloc.2
+		IL_00d1: ldstr "log"
+		IL_00d6: ldloc.s 4
+		IL_00d8: box [System.Runtime]System.Double
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e2: pop
+		IL_00e3: ldstr "console"
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ed: stloc.2
+		IL_00ee: ldloc.2
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f4: stloc.2
+		IL_00f5: ldloc.1
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fb: stloc.3
+		IL_00fc: ldloc.3
+		IL_00fd: castclass [System.Runtime]System.String
+		IL_0102: ldstr "a"
+		IL_0107: ldc.r8 99
+		IL_0110: box [System.Runtime]System.Double
+		IL_0115: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_011a: stloc.s 4
+		IL_011c: ldloc.2
+		IL_011d: ldstr "log"
+		IL_0122: ldloc.s 4
+		IL_0124: box [System.Runtime]System.Double
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_012e: pop
+		IL_012f: ldstr "console"
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0139: stloc.2
+		IL_013a: ldloc.2
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0140: stloc.2
+		IL_0141: ldloc.1
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0147: stloc.3
+		IL_0148: ldloc.3
+		IL_0149: castclass [System.Runtime]System.String
+		IL_014e: ldstr ""
+		IL_0153: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+		IL_0158: stloc.s 4
+		IL_015a: ldloc.2
+		IL_015b: ldstr "log"
+		IL_0160: ldloc.s 4
+		IL_0162: box [System.Runtime]System.Double
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_016c: pop
+		IL_016d: ldstr "console"
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0177: stloc.2
+		IL_0178: ldloc.2
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017e: stloc.2
+		IL_017f: ldloc.1
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0185: stloc.3
+		IL_0186: ldloc.3
+		IL_0187: castclass [System.Runtime]System.String
+		IL_018c: ldstr ""
+		IL_0191: ldc.r8 2
+		IL_019a: box [System.Runtime]System.Double
+		IL_019f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_01a4: stloc.s 4
+		IL_01a6: ldloc.2
+		IL_01a7: ldstr "log"
+		IL_01ac: ldloc.s 4
+		IL_01ae: box [System.Runtime]System.Double
+		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01b8: pop
+		IL_01b9: ldstr "console"
+		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c3: stloc.2
+		IL_01c4: ldloc.2
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ca: stloc.2
+		IL_01cb: ldloc.1
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d1: stloc.3
+		IL_01d2: ldloc.3
+		IL_01d3: castclass [System.Runtime]System.String
+		IL_01d8: ldstr "ab"
+		IL_01dd: ldc.r8 1
+		IL_01e6: box [System.Runtime]System.Double
+		IL_01eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_01f0: stloc.s 4
+		IL_01f2: ldloc.2
+		IL_01f3: ldstr "log"
+		IL_01f8: ldloc.s 4
+		IL_01fa: box [System.Runtime]System.Double
+		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0204: pop
+		IL_0205: ldstr "console"
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_020f: stloc.2
+		IL_0210: ldloc.2
+		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0216: stloc.2
+		IL_0217: ldloc.1
+		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021d: stloc.3
+		IL_021e: ldloc.3
+		IL_021f: castclass [System.Runtime]System.String
+		IL_0224: ldstr "z"
+		IL_0229: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+		IL_022e: stloc.s 4
+		IL_0230: ldloc.2
+		IL_0231: ldstr "log"
+		IL_0236: ldloc.s 4
+		IL_0238: box [System.Runtime]System.Double
+		IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0242: pop
+		IL_0243: ret
 	} // end of method String_LastIndexOf_Basic::__js_module_init__
 
 } // end of class Modules.String_LastIndexOf_Basic
@@ -228,7 +237,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2271
+		// Method begins at RVA 0x22a9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
@@ -375,7 +375,8 @@
 			[1] object,
 			[2] object,
 			[3] object[],
-			[4] object
+			[4] object,
+			[5] string
 		)
 
 		IL_0000: newobj instance void Modules.String_MemberCall_FastPath_CommonMethods/Scope::.ctor()
@@ -409,30 +410,30 @@
 		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0052: stloc.s 4
 		IL_0054: ldloc.s 4
-		IL_0056: ldstr "trim"
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0060: stloc.s 4
+		IL_0056: castclass [System.Runtime]System.String
+		IL_005b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+		IL_0060: stloc.s 5
 		IL_0062: ldloc.2
 		IL_0063: ldstr "log"
-		IL_0068: ldloc.s 4
+		IL_0068: ldloc.s 5
 		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_006f: pop
 		IL_0070: ldstr "console"
 		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_007a: stloc.s 4
-		IL_007c: ldloc.s 4
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0083: stloc.s 4
-		IL_0085: ldstr "  x  "
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008f: stloc.2
-		IL_0090: ldloc.2
-		IL_0091: ldstr "trimStart"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_009b: stloc.2
-		IL_009c: ldloc.s 4
-		IL_009e: ldstr "log"
-		IL_00a3: ldloc.2
+		IL_007a: stloc.2
+		IL_007b: ldloc.2
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0081: stloc.2
+		IL_0082: ldstr "  x  "
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008c: stloc.s 4
+		IL_008e: ldloc.s 4
+		IL_0090: castclass [System.Runtime]System.String
+		IL_0095: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimStart(string)
+		IL_009a: stloc.s 5
+		IL_009c: ldloc.2
+		IL_009d: ldstr "log"
+		IL_00a2: ldloc.s 5
 		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00a9: pop
 		IL_00aa: ldstr "console"
@@ -445,30 +446,30 @@
 		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_00c6: stloc.s 4
 		IL_00c8: ldloc.s 4
-		IL_00ca: ldstr "trimEnd"
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00d4: stloc.s 4
+		IL_00ca: castclass [System.Runtime]System.String
+		IL_00cf: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimEnd(string)
+		IL_00d4: stloc.s 5
 		IL_00d6: ldloc.2
 		IL_00d7: ldstr "log"
-		IL_00dc: ldloc.s 4
+		IL_00dc: ldloc.s 5
 		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00e3: pop
 		IL_00e4: ldstr "console"
 		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ee: stloc.s 4
-		IL_00f0: ldloc.s 4
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f7: stloc.s 4
-		IL_00f9: ldstr "  x  "
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0103: stloc.2
-		IL_0104: ldloc.2
-		IL_0105: ldstr "trimLeft"
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_010f: stloc.2
-		IL_0110: ldloc.s 4
-		IL_0112: ldstr "log"
-		IL_0117: ldloc.2
+		IL_00ee: stloc.2
+		IL_00ef: ldloc.2
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f5: stloc.2
+		IL_00f6: ldstr "  x  "
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0100: stloc.s 4
+		IL_0102: ldloc.s 4
+		IL_0104: castclass [System.Runtime]System.String
+		IL_0109: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimLeft(string)
+		IL_010e: stloc.s 5
+		IL_0110: ldloc.2
+		IL_0111: ldstr "log"
+		IL_0116: ldloc.s 5
 		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_011d: pop
 		IL_011e: ldstr "console"
@@ -481,30 +482,30 @@
 		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_013a: stloc.s 4
 		IL_013c: ldloc.s 4
-		IL_013e: ldstr "trimRight"
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0148: stloc.s 4
+		IL_013e: castclass [System.Runtime]System.String
+		IL_0143: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimRight(string)
+		IL_0148: stloc.s 5
 		IL_014a: ldloc.2
 		IL_014b: ldstr "log"
-		IL_0150: ldloc.s 4
+		IL_0150: ldloc.s 5
 		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0157: pop
 		IL_0158: ldstr "console"
 		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0162: stloc.s 4
-		IL_0164: ldloc.s 4
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016b: stloc.s 4
-		IL_016d: ldstr "A"
-		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0177: stloc.2
-		IL_0178: ldloc.2
-		IL_0179: ldstr "toLowerCase"
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0183: stloc.2
-		IL_0184: ldloc.s 4
-		IL_0186: ldstr "log"
-		IL_018b: ldloc.2
+		IL_0162: stloc.2
+		IL_0163: ldloc.2
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0169: stloc.2
+		IL_016a: ldstr "A"
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0174: stloc.s 4
+		IL_0176: ldloc.s 4
+		IL_0178: castclass [System.Runtime]System.String
+		IL_017d: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
+		IL_0182: stloc.s 5
+		IL_0184: ldloc.2
+		IL_0185: ldstr "log"
+		IL_018a: ldloc.s 5
 		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0191: pop
 		IL_0192: ldstr "console"
@@ -517,12 +518,12 @@
 		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_01ae: stloc.s 4
 		IL_01b0: ldloc.s 4
-		IL_01b2: ldstr "toUpperCase"
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_01bc: stloc.s 4
+		IL_01b2: castclass [System.Runtime]System.String
+		IL_01b7: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+		IL_01bc: stloc.s 5
 		IL_01be: ldloc.2
 		IL_01bf: ldstr "log"
-		IL_01c4: ldloc.s 4
+		IL_01c4: ldloc.s 5
 		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01cb: pop
 		IL_01cc: ret

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26b6
+				// Method begins at RVA 0x2678
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,13 +47,12 @@
 			)
 			// Method begins at RVA 0x246c
 			// Header size: 12
-			// Code size: 118 (0x76)
+			// Code size: 104 (0x68)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -62,42 +61,36 @@
 			IL_000b: ldloc.0
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
-			IL_0012: ldarg.0
-			IL_0013: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-			IL_0018: stloc.1
-			IL_0019: ldstr "custom"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_002a: ldloc.1
-			IL_002b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0030: stloc.2
-			IL_0031: ldloc.2
-			IL_0032: box [System.Runtime]System.Boolean
-			IL_0037: stloc.3
-			IL_0038: ldloc.0
-			IL_0039: ldstr "log"
-			IL_003e: ldloc.3
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0044: pop
-			IL_0045: ldstr "console"
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_004f: stloc.0
-			IL_0050: ldloc.0
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.0
-			IL_0057: ldloc.0
-			IL_0058: ldstr "log"
-			IL_005d: ldarg.2
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0063: pop
-			IL_0064: ldc.i4.1
-			IL_0065: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_006a: dup
-			IL_006b: ldstr "MATCH"
-			IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0075: ret
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0017: ldarg.0
+			IL_0018: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0022: stloc.1
+			IL_0023: ldloc.1
+			IL_0024: box [System.Runtime]System.Boolean
+			IL_0029: stloc.2
+			IL_002a: ldloc.0
+			IL_002b: ldstr "log"
+			IL_0030: ldloc.2
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0036: pop
+			IL_0037: ldstr "console"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0041: stloc.0
+			IL_0042: ldloc.0
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0048: stloc.0
+			IL_0049: ldloc.0
+			IL_004a: ldstr "log"
+			IL_004f: ldarg.2
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0055: pop
+			IL_0056: ldc.i4.1
+			IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_005c: dup
+			IL_005d: ldstr "MATCH"
+			IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0067: ret
 		} // end of method FunctionExpression_L5C23::__js_call__
 
 	} // end of class FunctionExpression_L5C23
@@ -113,7 +106,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26bf
+				// Method begins at RVA 0x2681
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -141,15 +134,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x24f0
+			// Method begins at RVA 0x24e0
 			// Header size: 12
-			// Code size: 146 (0x92)
+			// Code size: 132 (0x84)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -158,50 +150,44 @@
 			IL_000b: ldloc.0
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
-			IL_0012: ldarg.0
-			IL_0013: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-			IL_0018: stloc.1
-			IL_0019: ldstr "custom"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_002a: ldloc.1
-			IL_002b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0030: stloc.2
-			IL_0031: ldloc.2
-			IL_0032: box [System.Runtime]System.Boolean
-			IL_0037: stloc.3
-			IL_0038: ldloc.0
-			IL_0039: ldstr "log"
-			IL_003e: ldloc.3
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0044: pop
-			IL_0045: ldstr "console"
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_004f: stloc.0
-			IL_0050: ldloc.0
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.0
-			IL_0057: ldloc.0
-			IL_0058: ldstr "log"
-			IL_005d: ldarg.2
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0063: pop
-			IL_0064: ldstr "console"
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_006e: stloc.0
-			IL_006f: ldloc.0
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0075: stloc.0
-			IL_0076: ldloc.0
-			IL_0077: ldstr "log"
-			IL_007c: ldarg.3
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0082: pop
-			IL_0083: ldc.r8 17
-			IL_008c: box [System.Runtime]System.Double
-			IL_0091: ret
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0017: ldarg.0
+			IL_0018: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0022: stloc.1
+			IL_0023: ldloc.1
+			IL_0024: box [System.Runtime]System.Boolean
+			IL_0029: stloc.2
+			IL_002a: ldloc.0
+			IL_002b: ldstr "log"
+			IL_0030: ldloc.2
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0036: pop
+			IL_0037: ldstr "console"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0041: stloc.0
+			IL_0042: ldloc.0
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0048: stloc.0
+			IL_0049: ldloc.0
+			IL_004a: ldstr "log"
+			IL_004f: ldarg.2
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0055: pop
+			IL_0056: ldstr "console"
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0060: stloc.0
+			IL_0061: ldloc.0
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0067: stloc.0
+			IL_0068: ldloc.0
+			IL_0069: ldstr "log"
+			IL_006e: ldarg.3
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0074: pop
+			IL_0075: ldc.r8 17
+			IL_007e: box [System.Runtime]System.Double
+			IL_0083: ret
 		} // end of method FunctionExpression_L11C25::__js_call__
 
 	} // end of class FunctionExpression_L11C25
@@ -217,7 +203,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26c8
+				// Method begins at RVA 0x268a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -244,15 +230,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2590
+			// Method begins at RVA 0x2570
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 92 (0x5c)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -261,38 +246,32 @@
 			IL_000b: ldloc.0
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
-			IL_0012: ldarg.0
-			IL_0013: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-			IL_0018: stloc.1
-			IL_0019: ldstr "custom"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_002a: ldloc.1
-			IL_002b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0030: stloc.2
-			IL_0031: ldloc.2
-			IL_0032: box [System.Runtime]System.Boolean
-			IL_0037: stloc.3
-			IL_0038: ldloc.0
-			IL_0039: ldstr "log"
-			IL_003e: ldloc.3
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0044: pop
-			IL_0045: ldstr "console"
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_004f: stloc.0
-			IL_0050: ldloc.0
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.0
-			IL_0057: ldloc.0
-			IL_0058: ldstr "log"
-			IL_005d: ldarg.2
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0063: pop
-			IL_0064: ldstr "SEARCH"
-			IL_0069: ret
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0017: ldarg.0
+			IL_0018: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0022: stloc.1
+			IL_0023: ldloc.1
+			IL_0024: box [System.Runtime]System.Boolean
+			IL_0029: stloc.2
+			IL_002a: ldloc.0
+			IL_002b: ldstr "log"
+			IL_0030: ldloc.2
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0036: pop
+			IL_0037: ldstr "console"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0041: stloc.0
+			IL_0042: ldloc.0
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0048: stloc.0
+			IL_0049: ldloc.0
+			IL_004a: ldstr "log"
+			IL_004f: ldarg.2
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0055: pop
+			IL_0056: ldstr "SEARCH"
+			IL_005b: ret
 		} // end of method FunctionExpression_L18C24::__js_call__
 
 	} // end of class FunctionExpression_L18C24
@@ -308,7 +287,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26d1
+				// Method begins at RVA 0x2693
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -336,15 +315,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2608
+			// Method begins at RVA 0x25d8
 			// Header size: 12
-			// Code size: 153 (0x99)
+			// Code size: 139 (0x8b)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -353,53 +331,47 @@
 			IL_000b: ldloc.0
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
-			IL_0012: ldarg.0
-			IL_0013: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-			IL_0018: stloc.1
-			IL_0019: ldstr "custom"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_002a: ldloc.1
-			IL_002b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0030: stloc.2
-			IL_0031: ldloc.2
-			IL_0032: box [System.Runtime]System.Boolean
-			IL_0037: stloc.3
-			IL_0038: ldloc.0
-			IL_0039: ldstr "log"
-			IL_003e: ldloc.3
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0044: pop
-			IL_0045: ldstr "console"
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_004f: stloc.0
-			IL_0050: ldloc.0
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.0
-			IL_0057: ldloc.0
-			IL_0058: ldstr "log"
-			IL_005d: ldarg.2
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0063: pop
-			IL_0064: ldstr "console"
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_006e: stloc.0
-			IL_006f: ldloc.0
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0075: stloc.0
-			IL_0076: ldloc.0
-			IL_0077: ldstr "log"
-			IL_007c: ldarg.3
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0082: pop
-			IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0088: dup
-			IL_0089: ldstr "marker"
-			IL_008e: ldstr "split-result"
-			IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0098: ret
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0017: ldarg.0
+			IL_0018: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0022: stloc.1
+			IL_0023: ldloc.1
+			IL_0024: box [System.Runtime]System.Boolean
+			IL_0029: stloc.2
+			IL_002a: ldloc.0
+			IL_002b: ldstr "log"
+			IL_0030: ldloc.2
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0036: pop
+			IL_0037: ldstr "console"
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0041: stloc.0
+			IL_0042: ldloc.0
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0048: stloc.0
+			IL_0049: ldloc.0
+			IL_004a: ldstr "log"
+			IL_004f: ldarg.2
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0055: pop
+			IL_0056: ldstr "console"
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0060: stloc.0
+			IL_0061: ldloc.0
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0067: stloc.0
+			IL_0068: ldloc.0
+			IL_0069: ldstr "log"
+			IL_006e: ldarg.3
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0074: pop
+			IL_0075: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_007a: dup
+			IL_007b: ldstr "marker"
+			IL_0080: ldstr "split-result"
+			IL_0085: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_008a: ret
 		} // end of method FunctionExpression_L24C23::__js_call__
 
 	} // end of class FunctionExpression_L24C23
@@ -419,7 +391,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26da
+				// Method begins at RVA 0x269c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -439,7 +411,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26e3
+				// Method begins at RVA 0x26a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -460,7 +432,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26ad
+			// Method begins at RVA 0x266f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -864,7 +836,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26ec
+		// Method begins at RVA 0x26ae
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpOverride.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpOverride.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25f8
+				// Method begins at RVA 0x25be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,13 +47,12 @@
 			)
 			// Method begins at RVA 0x2320
 			// Header size: 12
-			// Code size: 153 (0x99)
+			// Code size: 139 (0x8b)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -73,42 +72,36 @@
 			IL_002e: ldloc.0
 			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0034: stloc.0
-			IL_0035: ldarg.0
-			IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-			IL_003b: stloc.1
-			IL_003c: ldstr "re"
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0047: stloc.1
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_004d: ldloc.1
-			IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0053: stloc.2
-			IL_0054: ldloc.2
-			IL_0055: box [System.Runtime]System.Boolean
-			IL_005a: stloc.3
-			IL_005b: ldloc.0
-			IL_005c: ldstr "log"
-			IL_0061: ldloc.3
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: pop
-			IL_0068: ldstr "console"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0072: stloc.0
-			IL_0073: ldloc.0
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0079: stloc.0
-			IL_007a: ldloc.0
-			IL_007b: ldstr "log"
-			IL_0080: ldarg.2
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0086: pop
-			IL_0087: ldc.i4.1
-			IL_0088: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_008d: dup
-			IL_008e: ldstr "OVERRIDE-MATCH"
-			IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0098: ret
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_003a: ldarg.0
+			IL_003b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+			IL_0040: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0045: stloc.1
+			IL_0046: ldloc.1
+			IL_0047: box [System.Runtime]System.Boolean
+			IL_004c: stloc.2
+			IL_004d: ldloc.0
+			IL_004e: ldstr "log"
+			IL_0053: ldloc.2
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0059: pop
+			IL_005a: ldstr "console"
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0064: stloc.0
+			IL_0065: ldloc.0
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006b: stloc.0
+			IL_006c: ldloc.0
+			IL_006d: ldstr "log"
+			IL_0072: ldarg.2
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0078: pop
+			IL_0079: ldc.i4.1
+			IL_007a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_007f: dup
+			IL_0080: ldstr "OVERRIDE-MATCH"
+			IL_0085: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_008a: ret
 		} // end of method FunctionExpression_L5C19::__js_call__
 
 	} // end of class FunctionExpression_L5C19
@@ -124,7 +117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2601
+				// Method begins at RVA 0x25c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -152,15 +145,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x23c8
+			// Method begins at RVA 0x23b8
 			// Header size: 12
-			// Code size: 172 (0xac)
+			// Code size: 158 (0x9e)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -180,49 +172,43 @@
 			IL_002e: ldloc.0
 			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0034: stloc.0
-			IL_0035: ldarg.0
-			IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-			IL_003b: stloc.1
-			IL_003c: ldstr "re"
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0047: stloc.1
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_004d: ldloc.1
-			IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0053: stloc.2
-			IL_0054: ldloc.2
-			IL_0055: box [System.Runtime]System.Boolean
-			IL_005a: stloc.3
-			IL_005b: ldloc.0
-			IL_005c: ldstr "log"
-			IL_0061: ldloc.3
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: pop
-			IL_0068: ldstr "console"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0072: stloc.0
-			IL_0073: ldloc.0
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0079: stloc.0
-			IL_007a: ldloc.0
-			IL_007b: ldstr "log"
-			IL_0080: ldarg.2
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0086: pop
-			IL_0087: ldstr "console"
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0091: stloc.0
-			IL_0092: ldloc.0
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0098: stloc.0
-			IL_0099: ldloc.0
-			IL_009a: ldstr "log"
-			IL_009f: ldarg.3
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00a5: pop
-			IL_00a6: ldstr "OVERRIDE-REPLACE"
-			IL_00ab: ret
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_003a: ldarg.0
+			IL_003b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+			IL_0040: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0045: stloc.1
+			IL_0046: ldloc.1
+			IL_0047: box [System.Runtime]System.Boolean
+			IL_004c: stloc.2
+			IL_004d: ldloc.0
+			IL_004e: ldstr "log"
+			IL_0053: ldloc.2
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0059: pop
+			IL_005a: ldstr "console"
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0064: stloc.0
+			IL_0065: ldloc.0
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006b: stloc.0
+			IL_006c: ldloc.0
+			IL_006d: ldstr "log"
+			IL_0072: ldarg.2
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0078: pop
+			IL_0079: ldstr "console"
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0083: stloc.0
+			IL_0084: ldloc.0
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008a: stloc.0
+			IL_008b: ldloc.0
+			IL_008c: ldstr "log"
+			IL_0091: ldarg.3
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0097: pop
+			IL_0098: ldstr "OVERRIDE-REPLACE"
+			IL_009d: ret
 		} // end of method FunctionExpression_L12C21::__js_call__
 
 	} // end of class FunctionExpression_L12C21
@@ -238,7 +224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x260a
+				// Method begins at RVA 0x25d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -265,15 +251,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2480
+			// Method begins at RVA 0x2464
 			// Header size: 12
-			// Code size: 150 (0x96)
+			// Code size: 136 (0x88)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -293,39 +278,33 @@
 			IL_002e: ldloc.0
 			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0034: stloc.0
-			IL_0035: ldarg.0
-			IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-			IL_003b: stloc.1
-			IL_003c: ldstr "re"
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0047: stloc.1
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_004d: ldloc.1
-			IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0053: stloc.2
-			IL_0054: ldloc.2
-			IL_0055: box [System.Runtime]System.Boolean
-			IL_005a: stloc.3
-			IL_005b: ldloc.0
-			IL_005c: ldstr "log"
-			IL_0061: ldloc.3
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: pop
-			IL_0068: ldstr "console"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0072: stloc.0
-			IL_0073: ldloc.0
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0079: stloc.0
-			IL_007a: ldloc.0
-			IL_007b: ldstr "log"
-			IL_0080: ldarg.2
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0086: pop
-			IL_0087: ldc.r8 42
-			IL_0090: box [System.Runtime]System.Double
-			IL_0095: ret
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_003a: ldarg.0
+			IL_003b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+			IL_0040: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0045: stloc.1
+			IL_0046: ldloc.1
+			IL_0047: box [System.Runtime]System.Boolean
+			IL_004c: stloc.2
+			IL_004d: ldloc.0
+			IL_004e: ldstr "log"
+			IL_0053: ldloc.2
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0059: pop
+			IL_005a: ldstr "console"
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0064: stloc.0
+			IL_0065: ldloc.0
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006b: stloc.0
+			IL_006c: ldloc.0
+			IL_006d: ldstr "log"
+			IL_0072: ldarg.2
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0078: pop
+			IL_0079: ldc.r8 42
+			IL_0082: box [System.Runtime]System.Double
+			IL_0087: ret
 		} // end of method FunctionExpression_L20C20::__js_call__
 
 	} // end of class FunctionExpression_L20C20
@@ -341,7 +320,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2613
+				// Method begins at RVA 0x25d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -369,15 +348,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2524
+			// Method begins at RVA 0x24f8
 			// Header size: 12
-			// Code size: 191 (0xbf)
+			// Code size: 177 (0xb1)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -397,56 +375,50 @@
 			IL_002e: ldloc.0
 			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0034: stloc.0
-			IL_0035: ldarg.0
-			IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-			IL_003b: stloc.1
-			IL_003c: ldstr "re"
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0047: stloc.1
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_004d: ldloc.1
-			IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0053: stloc.2
-			IL_0054: ldloc.2
-			IL_0055: box [System.Runtime]System.Boolean
-			IL_005a: stloc.3
-			IL_005b: ldloc.0
-			IL_005c: ldstr "log"
-			IL_0061: ldloc.3
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: pop
-			IL_0068: ldstr "console"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0072: stloc.0
-			IL_0073: ldloc.0
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0079: stloc.0
-			IL_007a: ldloc.0
-			IL_007b: ldstr "log"
-			IL_0080: ldarg.2
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0086: pop
-			IL_0087: ldstr "console"
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0091: stloc.0
-			IL_0092: ldloc.0
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0098: stloc.0
-			IL_0099: ldloc.0
-			IL_009a: ldstr "log"
-			IL_009f: ldarg.3
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00a5: pop
-			IL_00a6: ldc.i4.2
-			IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00ac: dup
-			IL_00ad: ldstr "OVERRIDE-SPLIT"
-			IL_00b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00b7: dup
-			IL_00b8: ldarg.3
-			IL_00b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00be: ret
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_003a: ldarg.0
+			IL_003b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+			IL_0040: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0045: stloc.1
+			IL_0046: ldloc.1
+			IL_0047: box [System.Runtime]System.Boolean
+			IL_004c: stloc.2
+			IL_004d: ldloc.0
+			IL_004e: ldstr "log"
+			IL_0053: ldloc.2
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0059: pop
+			IL_005a: ldstr "console"
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0064: stloc.0
+			IL_0065: ldloc.0
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006b: stloc.0
+			IL_006c: ldloc.0
+			IL_006d: ldstr "log"
+			IL_0072: ldarg.2
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0078: pop
+			IL_0079: ldstr "console"
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0083: stloc.0
+			IL_0084: ldloc.0
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008a: stloc.0
+			IL_008b: ldloc.0
+			IL_008c: ldstr "log"
+			IL_0091: ldarg.3
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0097: pop
+			IL_0098: ldc.i4.2
+			IL_0099: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_009e: dup
+			IL_009f: ldstr "OVERRIDE-SPLIT"
+			IL_00a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00a9: dup
+			IL_00aa: ldarg.3
+			IL_00ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00b0: ret
 		} // end of method FunctionExpression_L27C19::__js_call__
 
 	} // end of class FunctionExpression_L27C19
@@ -465,7 +437,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25ef
+			// Method begins at RVA 0x25b5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -751,7 +723,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x261c
+		// Method begins at RVA 0x25e2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpPrototypeOverride.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpPrototypeOverride.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26c0
+				// Method begins at RVA 0x2686
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,13 +47,12 @@
 			)
 			// Method begins at RVA 0x23e8
 			// Header size: 12
-			// Code size: 153 (0x99)
+			// Code size: 139 (0x8b)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -73,42 +72,36 @@
 			IL_002e: ldloc.0
 			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0034: stloc.0
-			IL_0035: ldarg.0
-			IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-			IL_003b: stloc.1
-			IL_003c: ldstr "re"
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0047: stloc.1
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_004d: ldloc.1
-			IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0053: stloc.2
-			IL_0054: ldloc.2
-			IL_0055: box [System.Runtime]System.Boolean
-			IL_005a: stloc.3
-			IL_005b: ldloc.0
-			IL_005c: ldstr "log"
-			IL_0061: ldloc.3
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: pop
-			IL_0068: ldstr "console"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0072: stloc.0
-			IL_0073: ldloc.0
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0079: stloc.0
-			IL_007a: ldloc.0
-			IL_007b: ldstr "log"
-			IL_0080: ldarg.2
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0086: pop
-			IL_0087: ldc.i4.1
-			IL_0088: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_008d: dup
-			IL_008e: ldstr "PROTO-MATCH"
-			IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0098: ret
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_003a: ldarg.0
+			IL_003b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
+			IL_0040: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0045: stloc.1
+			IL_0046: ldloc.1
+			IL_0047: box [System.Runtime]System.Boolean
+			IL_004c: stloc.2
+			IL_004d: ldloc.0
+			IL_004e: ldstr "log"
+			IL_0053: ldloc.2
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0059: pop
+			IL_005a: ldstr "console"
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0064: stloc.0
+			IL_0065: ldloc.0
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006b: stloc.0
+			IL_006c: ldloc.0
+			IL_006d: ldstr "log"
+			IL_0072: ldarg.2
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0078: pop
+			IL_0079: ldc.i4.1
+			IL_007a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_007f: dup
+			IL_0080: ldstr "PROTO-MATCH"
+			IL_0085: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_008a: ret
 		} // end of method FunctionExpression_L10C22::__js_call__
 
 	} // end of class FunctionExpression_L10C22
@@ -124,7 +117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26c9
+				// Method begins at RVA 0x268f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -152,15 +145,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2490
+			// Method begins at RVA 0x2480
 			// Header size: 12
-			// Code size: 172 (0xac)
+			// Code size: 158 (0x9e)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -180,49 +172,43 @@
 			IL_002e: ldloc.0
 			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0034: stloc.0
-			IL_0035: ldarg.0
-			IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-			IL_003b: stloc.1
-			IL_003c: ldstr "re"
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0047: stloc.1
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_004d: ldloc.1
-			IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0053: stloc.2
-			IL_0054: ldloc.2
-			IL_0055: box [System.Runtime]System.Boolean
-			IL_005a: stloc.3
-			IL_005b: ldloc.0
-			IL_005c: ldstr "log"
-			IL_0061: ldloc.3
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: pop
-			IL_0068: ldstr "console"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0072: stloc.0
-			IL_0073: ldloc.0
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0079: stloc.0
-			IL_007a: ldloc.0
-			IL_007b: ldstr "log"
-			IL_0080: ldarg.2
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0086: pop
-			IL_0087: ldstr "console"
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0091: stloc.0
-			IL_0092: ldloc.0
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0098: stloc.0
-			IL_0099: ldloc.0
-			IL_009a: ldstr "log"
-			IL_009f: ldarg.3
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00a5: pop
-			IL_00a6: ldstr "PROTO-REPLACE"
-			IL_00ab: ret
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_003a: ldarg.0
+			IL_003b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
+			IL_0040: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0045: stloc.1
+			IL_0046: ldloc.1
+			IL_0047: box [System.Runtime]System.Boolean
+			IL_004c: stloc.2
+			IL_004d: ldloc.0
+			IL_004e: ldstr "log"
+			IL_0053: ldloc.2
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0059: pop
+			IL_005a: ldstr "console"
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0064: stloc.0
+			IL_0065: ldloc.0
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006b: stloc.0
+			IL_006c: ldloc.0
+			IL_006d: ldstr "log"
+			IL_0072: ldarg.2
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0078: pop
+			IL_0079: ldstr "console"
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0083: stloc.0
+			IL_0084: ldloc.0
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008a: stloc.0
+			IL_008b: ldloc.0
+			IL_008c: ldstr "log"
+			IL_0091: ldarg.3
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0097: pop
+			IL_0098: ldstr "PROTO-REPLACE"
+			IL_009d: ret
 		} // end of method FunctionExpression_L17C24::__js_call__
 
 	} // end of class FunctionExpression_L17C24
@@ -238,7 +224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26d2
+				// Method begins at RVA 0x2698
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -265,15 +251,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2548
+			// Method begins at RVA 0x252c
 			// Header size: 12
-			// Code size: 150 (0x96)
+			// Code size: 136 (0x88)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -293,39 +278,33 @@
 			IL_002e: ldloc.0
 			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0034: stloc.0
-			IL_0035: ldarg.0
-			IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-			IL_003b: stloc.1
-			IL_003c: ldstr "re"
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0047: stloc.1
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_004d: ldloc.1
-			IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0053: stloc.2
-			IL_0054: ldloc.2
-			IL_0055: box [System.Runtime]System.Boolean
-			IL_005a: stloc.3
-			IL_005b: ldloc.0
-			IL_005c: ldstr "log"
-			IL_0061: ldloc.3
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: pop
-			IL_0068: ldstr "console"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0072: stloc.0
-			IL_0073: ldloc.0
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0079: stloc.0
-			IL_007a: ldloc.0
-			IL_007b: ldstr "log"
-			IL_0080: ldarg.2
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0086: pop
-			IL_0087: ldc.r8 24
-			IL_0090: box [System.Runtime]System.Double
-			IL_0095: ret
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_003a: ldarg.0
+			IL_003b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
+			IL_0040: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0045: stloc.1
+			IL_0046: ldloc.1
+			IL_0047: box [System.Runtime]System.Boolean
+			IL_004c: stloc.2
+			IL_004d: ldloc.0
+			IL_004e: ldstr "log"
+			IL_0053: ldloc.2
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0059: pop
+			IL_005a: ldstr "console"
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0064: stloc.0
+			IL_0065: ldloc.0
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006b: stloc.0
+			IL_006c: ldloc.0
+			IL_006d: ldstr "log"
+			IL_0072: ldarg.2
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0078: pop
+			IL_0079: ldc.r8 24
+			IL_0082: box [System.Runtime]System.Double
+			IL_0087: ret
 		} // end of method FunctionExpression_L25C23::__js_call__
 
 	} // end of class FunctionExpression_L25C23
@@ -341,7 +320,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26db
+				// Method begins at RVA 0x26a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -369,15 +348,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x25ec
+			// Method begins at RVA 0x25c0
 			// Header size: 12
-			// Code size: 191 (0xbf)
+			// Code size: 177 (0xb1)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] bool,
-				[3] object
+				[1] bool,
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -397,56 +375,50 @@
 			IL_002e: ldloc.0
 			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0034: stloc.0
-			IL_0035: ldarg.0
-			IL_0036: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-			IL_003b: stloc.1
-			IL_003c: ldstr "re"
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0047: stloc.1
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_004d: ldloc.1
-			IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0053: stloc.2
-			IL_0054: ldloc.2
-			IL_0055: box [System.Runtime]System.Boolean
-			IL_005a: stloc.3
-			IL_005b: ldloc.0
-			IL_005c: ldstr "log"
-			IL_0061: ldloc.3
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: pop
-			IL_0068: ldstr "console"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0072: stloc.0
-			IL_0073: ldloc.0
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0079: stloc.0
-			IL_007a: ldloc.0
-			IL_007b: ldstr "log"
-			IL_0080: ldarg.2
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0086: pop
-			IL_0087: ldstr "console"
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0091: stloc.0
-			IL_0092: ldloc.0
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0098: stloc.0
-			IL_0099: ldloc.0
-			IL_009a: ldstr "log"
-			IL_009f: ldarg.3
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00a5: pop
-			IL_00a6: ldc.i4.2
-			IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00ac: dup
-			IL_00ad: ldstr "PROTO-SPLIT"
-			IL_00b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00b7: dup
-			IL_00b8: ldarg.3
-			IL_00b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00be: ret
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_003a: ldarg.0
+			IL_003b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
+			IL_0040: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0045: stloc.1
+			IL_0046: ldloc.1
+			IL_0047: box [System.Runtime]System.Boolean
+			IL_004c: stloc.2
+			IL_004d: ldloc.0
+			IL_004e: ldstr "log"
+			IL_0053: ldloc.2
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0059: pop
+			IL_005a: ldstr "console"
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0064: stloc.0
+			IL_0065: ldloc.0
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006b: stloc.0
+			IL_006c: ldloc.0
+			IL_006d: ldstr "log"
+			IL_0072: ldarg.2
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0078: pop
+			IL_0079: ldstr "console"
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0083: stloc.0
+			IL_0084: ldloc.0
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008a: stloc.0
+			IL_008b: ldloc.0
+			IL_008c: ldstr "log"
+			IL_0091: ldarg.3
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0097: pop
+			IL_0098: ldc.i4.2
+			IL_0099: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_009e: dup
+			IL_009f: ldstr "PROTO-SPLIT"
+			IL_00a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00a9: dup
+			IL_00aa: ldarg.3
+			IL_00ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00b0: ret
 		} // end of method FunctionExpression_L32C22::__js_call__
 
 	} // end of class FunctionExpression_L32C22
@@ -465,7 +437,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26b7
+			// Method begins at RVA 0x267d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -823,7 +795,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26e4
+		// Method begins at RVA 0x26aa
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x209e
+			// Method begins at RVA 0x20a3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,12 +40,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 66 (0x42)
+		// Code size: 71 (0x47)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_StartsWith_Basic/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] bool
 		)
 
 		IL_0000: newobj instance void Modules.String_StartsWith_Basic/Scope::.ctor()
@@ -60,16 +61,17 @@
 		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0022: stloc.2
 		IL_0023: ldloc.2
-		IL_0024: ldstr "startsWith"
+		IL_0024: castclass [System.Runtime]System.String
 		IL_0029: ldstr "ab"
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0033: stloc.2
+		IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_0033: stloc.3
 		IL_0034: ldloc.1
 		IL_0035: ldstr "log"
-		IL_003a: ldloc.2
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0040: pop
-		IL_0041: ret
+		IL_003a: ldloc.3
+		IL_003b: box [System.Runtime]System.Boolean
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0045: pop
+		IL_0046: ret
 	} // end of method String_StartsWith_Basic::__js_module_init__
 
 } // end of class Modules.String_StartsWith_Basic
@@ -81,7 +83,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20a7
+		// Method begins at RVA 0x20ac
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2176
+					// Method begins at RVA 0x2168
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -49,7 +49,7 @@
 				)
 				// Method begins at RVA 0x2128
 				// Header size: 12
-				// Code size: 48 (0x30)
+				// Code size: 34 (0x22)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -60,21 +60,15 @@
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.String_StartsWith_NestedParam/outer/Scope
 				IL_0008: ldfld object Modules.String_StartsWith_NestedParam/outer/Scope::s
-				IL_000d: stloc.0
-				IL_000e: ldstr "s"
+				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0012: stloc.0
 				IL_0013: ldloc.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0019: stloc.0
-				IL_001a: ldloc.0
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.0
-				IL_0021: ldloc.0
-				IL_0022: ldstr "startsWith"
-				IL_0027: ldarg.2
-				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_002d: stloc.0
-				IL_002e: ldloc.0
-				IL_002f: ret
+				IL_0014: ldstr "startsWith"
+				IL_0019: ldarg.2
+				IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_001f: stloc.0
+				IL_0020: ldloc.0
+				IL_0021: ret
 			} // end of method inner::__js_call__
 
 		} // end of class inner
@@ -94,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x216d
+				// Method begins at RVA 0x215f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -193,7 +187,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2164
+			// Method begins at RVA 0x2156
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -281,7 +275,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x217f
+		// Method begins at RVA 0x2171
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2263
+				// Method begins at RVA 0x2241
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x226c
+				// Method begins at RVA 0x224a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,13 +111,11 @@
 			)
 			// Method begins at RVA 0x21d8
 			// Header size: 12
-			// Code size: 118 (0x76)
+			// Code size: 84 (0x54)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[1] float64
 			)
 
 			IL_0000: ldstr "console"
@@ -126,46 +124,28 @@
 			IL_000b: ldloc.0
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
-			IL_0012: ldarg.0
-			IL_0013: ldfld object Modules.String_TaggedTemplate_EvaluationOrder/Scope::counter
-			IL_0018: stloc.1
-			IL_0019: ldstr "counter"
-			IL_001e: ldloc.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0024: stloc.1
-			IL_0025: ldloc.0
-			IL_0026: ldstr "log"
-			IL_002b: ldstr "getValue called:"
-			IL_0030: ldloc.1
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0036: pop
-			IL_0037: ldarg.0
-			IL_0038: ldfld object Modules.String_TaggedTemplate_EvaluationOrder/Scope::counter
-			IL_003d: stloc.1
-			IL_003e: ldstr "counter"
-			IL_0043: ldloc.1
-			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0049: stloc.1
-			IL_004a: ldloc.1
-			IL_004b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0050: stloc.2
-			IL_0051: ldloc.2
-			IL_0052: box [System.Runtime]System.Double
-			IL_0057: stloc.3
-			IL_0058: ldloc.3
-			IL_0059: stloc.1
-			IL_005a: ldloc.2
-			IL_005b: ldc.r8 1
-			IL_0064: add
-			IL_0065: stloc.2
-			IL_0066: ldloc.2
-			IL_0067: box [System.Runtime]System.Double
-			IL_006c: stloc.3
-			IL_006d: ldarg.0
-			IL_006e: ldloc.3
-			IL_006f: stfld object Modules.String_TaggedTemplate_EvaluationOrder/Scope::counter
-			IL_0074: ldloc.1
-			IL_0075: ret
+			IL_0012: ldloc.0
+			IL_0013: ldstr "log"
+			IL_0018: ldstr "getValue called:"
+			IL_001d: ldarg.0
+			IL_001e: ldfld object Modules.String_TaggedTemplate_EvaluationOrder/Scope::counter
+			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0028: pop
+			IL_0029: ldarg.0
+			IL_002a: ldfld object Modules.String_TaggedTemplate_EvaluationOrder/Scope::counter
+			IL_002f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0034: stloc.1
+			IL_0035: ldloc.1
+			IL_0036: box [System.Runtime]System.Double
+			IL_003b: stloc.0
+			IL_003c: ldarg.0
+			IL_003d: ldloc.1
+			IL_003e: ldc.r8 1
+			IL_0047: add
+			IL_0048: box [System.Runtime]System.Double
+			IL_004d: stfld object Modules.String_TaggedTemplate_EvaluationOrder/Scope::counter
+			IL_0052: ldloc.0
+			IL_0053: ret
 		} // end of method getValue::__js_call__
 
 	} // end of class getValue
@@ -188,7 +168,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x225a
+			// Method begins at RVA 0x2238
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -361,7 +341,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2275
+		// Method begins at RVA 0x2253
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ToLowerCase_ToUpperCase_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ToLowerCase_ToUpperCase_Basic.verified.txt
@@ -45,7 +45,8 @@
 		.locals init (
 			[0] class Modules.String_ToLowerCase_ToUpperCase_Basic/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] string
 		)
 
 		IL_0000: newobj instance void Modules.String_ToLowerCase_ToUpperCase_Basic/Scope::.ctor()
@@ -60,30 +61,30 @@
 		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0022: stloc.2
 		IL_0023: ldloc.2
-		IL_0024: ldstr "toLowerCase"
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_002e: stloc.2
+		IL_0024: castclass [System.Runtime]System.String
+		IL_0029: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
+		IL_002e: stloc.3
 		IL_002f: ldloc.1
 		IL_0030: ldstr "log"
-		IL_0035: ldloc.2
+		IL_0035: ldloc.3
 		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_003b: pop
 		IL_003c: ldstr "console"
 		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0046: stloc.2
-		IL_0047: ldloc.2
+		IL_0046: stloc.1
+		IL_0047: ldloc.1
 		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004d: stloc.2
+		IL_004d: stloc.1
 		IL_004e: ldstr "AbC"
 		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0058: stloc.1
-		IL_0059: ldloc.1
-		IL_005a: ldstr "toUpperCase"
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0064: stloc.1
-		IL_0065: ldloc.2
+		IL_0058: stloc.2
+		IL_0059: ldloc.2
+		IL_005a: castclass [System.Runtime]System.String
+		IL_005f: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+		IL_0064: stloc.3
+		IL_0065: ldloc.1
 		IL_0066: ldstr "log"
-		IL_006b: ldloc.1
+		IL_006b: ldloc.3
 		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0071: pop
 		IL_0072: ret

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Callback_Methods.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Callback_Methods.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a3
+				// Method begins at RVA 0x2497
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -72,7 +72,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ac
+				// Method begins at RVA 0x24a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -122,7 +122,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b5
+				// Method begins at RVA 0x24a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -172,7 +172,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24be
+				// Method begins at RVA 0x24b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -222,7 +222,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24c7
+				// Method begins at RVA 0x24bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -272,7 +272,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d0
+				// Method begins at RVA 0x24c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -322,7 +322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d9
+				// Method begins at RVA 0x24cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -351,29 +351,22 @@
 			)
 			// Method begins at RVA 0x2454
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 22 (0x16)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Float64Array_Callback_Methods/Scope::total
-			IL_0006: stloc.0
-			IL_0007: ldstr "total"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldarg.2
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_001a: stloc.1
-			IL_001b: ldarg.0
-			IL_001c: ldloc.1
-			IL_001d: stfld object Modules.Float64Array_Callback_Methods/Scope::total
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_0006: ldarg.2
+			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_000c: stloc.0
+			IL_000d: ldarg.0
+			IL_000e: ldloc.0
+			IL_000f: stfld object Modules.Float64Array_Callback_Methods/Scope::total
+			IL_0014: ldnull
+			IL_0015: ret
 		} // end of method FunctionExpression_L30C15::__js_call__
 
 	} // end of class FunctionExpression_L30C15
@@ -389,7 +382,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24e2
+				// Method begins at RVA 0x24d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -414,7 +407,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2484
+			// Method begins at RVA 0x2478
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -446,7 +439,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x249a
+			// Method begins at RVA 0x248e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -778,7 +771,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24eb
+		// Method begins at RVA 0x24df
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b76
+				// Method begins at RVA 0x2b5a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b7f
+				// Method begins at RVA 0x2b63
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b91
+					// Method begins at RVA 0x2b75
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b88
+				// Method begins at RVA 0x2b6c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2bac
+						// Method begins at RVA 0x2b90
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -132,7 +132,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2bbe
+							// Method begins at RVA 0x2ba2
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -150,7 +150,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2bb5
+						// Method begins at RVA 0x2b99
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -168,7 +168,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ba3
+					// Method begins at RVA 0x2b87
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -196,7 +196,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2bd9
+							// Method begins at RVA 0x2bbd
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -214,7 +214,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2bd0
+						// Method begins at RVA 0x2bb4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -232,7 +232,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bc7
+					// Method begins at RVA 0x2bab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b9a
+				// Method begins at RVA 0x2b7e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +274,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2beb
+					// Method begins at RVA 0x2bcf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -292,7 +292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2be2
+				// Method begins at RVA 0x2bc6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -312,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bf4
+				// Method begins at RVA 0x2bd8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -336,7 +336,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c06
+					// Method begins at RVA 0x2bea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -354,7 +354,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bfd
+				// Method begins at RVA 0x2be1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -431,7 +431,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a6c
+			// Method begins at RVA 0x2a50
 			// Header size: 12
 			// Code size: 201 (0xc9)
 			.maxstack 8
@@ -553,7 +553,7 @@
 			)
 			// Method begins at RVA 0x27f8
 			// Header size: 12
-			// Code size: 489 (0x1e9)
+			// Code size: 461 (0x1cd)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28,
@@ -570,221 +570,212 @@
 				[11] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75/Block_L34C7,
 				[12] float64,
 				[13] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_For_L43C7/Block_L43C67,
-				[14] object,
-				[15] float64
+				[14] float64
 			)
 
-			IL_0000: ldstr "WORD_SIZE"
-			IL_0005: ldarg.0
-			IL_0006: ldfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::_scopes
-			IL_000b: ldc.i4.0
-			IL_000c: ldelem.ref
-			IL_000d: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope
-			IL_0012: ldfld float64 Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::WORD_SIZE
-			IL_0017: box [System.Runtime]System.Double
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0021: stloc.s 14
-			IL_0023: ldloc.s 14
-			IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002a: stloc.s 15
-			IL_002c: ldloc.s 15
-			IL_002e: ldc.r8 2
-			IL_0037: div
-			IL_0038: stloc.s 15
-			IL_003a: ldarg.2
-			IL_003b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0040: ldloc.s 15
-			IL_0042: cgt
-			IL_0044: brfalse IL_01a9
+			IL_0000: ldarg.0
+			IL_0001: ldfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::_scopes
+			IL_0006: ldc.i4.0
+			IL_0007: ldelem.ref
+			IL_0008: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope
+			IL_000d: ldfld float64 Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::WORD_SIZE
+			IL_0012: ldc.r8 2
+			IL_001b: div
+			IL_001c: stloc.s 14
+			IL_001e: ldarg.2
+			IL_001f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0024: ldloc.s 14
+			IL_0026: cgt
+			IL_0028: brfalse IL_018d
 
-			IL_0049: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28::.ctor()
-			IL_004e: stloc.0
-			IL_004f: ldarg.1
-			IL_0050: ldc.r8 32
-			IL_0059: ldarg.2
-			IL_005a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_005f: mul
-			IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, float64)
-			IL_0065: stloc.s 15
-			IL_0067: ldloc.s 15
-			IL_0069: stloc.1
-			IL_006a: ldloc.1
-			IL_006b: stloc.s 15
-			IL_006d: ldloc.s 15
-			IL_006f: ldarg.3
-			IL_0070: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0075: cgt
-			IL_0077: brfalse IL_00bd
+			IL_002d: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28::.ctor()
+			IL_0032: stloc.0
+			IL_0033: ldarg.1
+			IL_0034: ldc.r8 32
+			IL_003d: ldarg.2
+			IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0043: mul
+			IL_0044: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, float64)
+			IL_0049: stloc.s 14
+			IL_004b: ldloc.s 14
+			IL_004d: stloc.1
+			IL_004e: ldloc.1
+			IL_004f: stloc.s 14
+			IL_0051: ldloc.s 14
+			IL_0053: ldarg.3
+			IL_0054: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0059: cgt
+			IL_005b: brfalse IL_00a1
 
-			IL_007c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28/Block_L22C39::.ctor()
-			IL_0081: stloc.2
-			IL_0082: ldarg.1
-			IL_0083: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0088: stloc.3
-			// loop start (head: IL_0089)
-				IL_0089: ldloc.3
-				IL_008a: stloc.s 15
-				IL_008c: ldloc.s 15
-				IL_008e: ldarg.3
-				IL_008f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0094: clt
-				IL_0096: brfalse IL_00bb
+			IL_0060: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28/Block_L22C39::.ctor()
+			IL_0065: stloc.2
+			IL_0066: ldarg.1
+			IL_0067: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_006c: stloc.3
+			// loop start (head: IL_006d)
+				IL_006d: ldloc.3
+				IL_006e: stloc.s 14
+				IL_0070: ldloc.s 14
+				IL_0072: ldarg.3
+				IL_0073: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0078: clt
+				IL_007a: brfalse IL_009f
 
-				IL_009b: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28/Scope_For_L23C9/Block_L23C69::.ctor()
-				IL_00a0: stloc.s 4
-				IL_00a2: ldarg.0
-				IL_00a3: ldloc.3
-				IL_00a4: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-				IL_00a9: pop
-				IL_00aa: ldloc.3
-				IL_00ab: ldarg.2
-				IL_00ac: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_00b1: stloc.s 15
-				IL_00b3: ldloc.s 15
-				IL_00b5: stloc.3
-				IL_00b6: br IL_0089
+				IL_007f: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28/Scope_For_L23C9/Block_L23C69::.ctor()
+				IL_0084: stloc.s 4
+				IL_0086: ldarg.0
+				IL_0087: ldloc.3
+				IL_0088: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+				IL_008d: pop
+				IL_008e: ldloc.3
+				IL_008f: ldarg.2
+				IL_0090: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_0095: stloc.s 14
+				IL_0097: ldloc.s 14
+				IL_0099: stloc.3
+				IL_009a: br IL_006d
 			// end loop
 
-			IL_00bb: ldnull
-			IL_00bc: ret
+			IL_009f: ldnull
+			IL_00a0: ret
 
-			IL_00bd: ldarg.3
-			IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00c3: conv.i4
-			IL_00c4: conv.u4
-			IL_00c5: ldc.r8 5
-			IL_00ce: conv.i4
-			IL_00cf: shr.un
-			IL_00d0: conv.r.un
-			IL_00d1: stloc.s 15
-			IL_00d3: ldloc.s 15
-			IL_00d5: stloc.s 5
-			IL_00d7: ldarg.1
-			IL_00d8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00dd: stloc.s 6
-			// loop start (head: IL_00df)
-				IL_00df: ldloc.s 6
-				IL_00e1: stloc.s 15
-				IL_00e3: ldloc.s 15
-				IL_00e5: ldloc.1
-				IL_00e6: clt
-				IL_00e8: brfalse IL_01a7
+			IL_00a1: ldarg.3
+			IL_00a2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00a7: conv.i4
+			IL_00a8: conv.u4
+			IL_00a9: ldc.r8 5
+			IL_00b2: conv.i4
+			IL_00b3: shr.un
+			IL_00b4: conv.r.un
+			IL_00b5: stloc.s 14
+			IL_00b7: ldloc.s 14
+			IL_00b9: stloc.s 5
+			IL_00bb: ldarg.1
+			IL_00bc: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00c1: stloc.s 6
+			// loop start (head: IL_00c3)
+				IL_00c3: ldloc.s 6
+				IL_00c5: stloc.s 14
+				IL_00c7: ldloc.s 14
+				IL_00c9: ldloc.1
+				IL_00ca: clt
+				IL_00cc: brfalse IL_018b
 
-				IL_00ed: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75::.ctor()
-				IL_00f2: stloc.s 7
-				IL_00f4: ldloc.s 6
-				IL_00f6: stloc.s 15
-				IL_00f8: ldloc.s 15
-				IL_00fa: conv.i4
-				IL_00fb: conv.u4
-				IL_00fc: ldc.r8 5
-				IL_0105: conv.i4
-				IL_0106: shr.un
-				IL_0107: conv.r.un
-				IL_0108: stloc.s 15
-				IL_010a: ldloc.s 15
-				IL_010c: stloc.s 8
-				IL_010e: ldloc.s 6
-				IL_0110: stloc.s 15
-				IL_0112: ldloc.s 15
+				IL_00d1: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75::.ctor()
+				IL_00d6: stloc.s 7
+				IL_00d8: ldloc.s 6
+				IL_00da: stloc.s 14
+				IL_00dc: ldloc.s 14
+				IL_00de: conv.i4
+				IL_00df: conv.u4
+				IL_00e0: ldc.r8 5
+				IL_00e9: conv.i4
+				IL_00ea: shr.un
+				IL_00eb: conv.r.un
+				IL_00ec: stloc.s 14
+				IL_00ee: ldloc.s 14
+				IL_00f0: stloc.s 8
+				IL_00f2: ldloc.s 6
+				IL_00f4: stloc.s 14
+				IL_00f6: ldloc.s 14
+				IL_00f8: conv.i4
+				IL_00f9: ldc.r8 31
+				IL_0102: conv.i4
+				IL_0103: and
+				IL_0104: conv.r8
+				IL_0105: stloc.s 14
+				IL_0107: ldloc.s 14
+				IL_0109: stloc.s 9
+				IL_010b: ldc.r8 1
 				IL_0114: conv.i4
-				IL_0115: ldc.r8 31
-				IL_011e: conv.i4
-				IL_011f: and
-				IL_0120: conv.r8
-				IL_0121: stloc.s 15
-				IL_0123: ldloc.s 15
-				IL_0125: stloc.s 9
-				IL_0127: ldc.r8 1
-				IL_0130: conv.i4
-				IL_0131: ldloc.s 9
-				IL_0133: conv.i4
-				IL_0134: shl
-				IL_0135: conv.r8
-				IL_0136: stloc.s 15
-				IL_0138: ldloc.s 15
-				IL_013a: stloc.s 10
-				// loop start (head: IL_013c)
-					IL_013c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75/Block_L34C7::.ctor()
-					IL_0141: stloc.s 11
-					IL_0143: ldarg.0
-					IL_0144: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
-					IL_0149: ldloc.s 8
-					IL_014b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_0150: stloc.s 15
-					IL_0152: ldloc.s 15
-					IL_0154: stloc.s 15
-					IL_0156: ldloc.s 15
-					IL_0158: conv.i4
-					IL_0159: ldloc.s 10
-					IL_015b: conv.i4
-					IL_015c: or
-					IL_015d: conv.r8
-					IL_015e: stloc.s 15
-					IL_0160: ldarg.0
-					IL_0161: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
-					IL_0166: ldloc.s 8
-					IL_0168: ldloc.s 15
-					IL_016a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_016f: ldloc.s 8
-					IL_0171: ldarg.2
-					IL_0172: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-					IL_0177: stloc.s 15
-					IL_0179: ldloc.s 15
-					IL_017b: stloc.s 8
-					IL_017d: ldloc.s 8
-					IL_017f: stloc.s 15
-					IL_0181: ldloc.s 15
-					IL_0183: ldloc.s 5
-					IL_0185: cgt
-					IL_0187: ldc.i4.0
-					IL_0188: ceq
-					IL_018a: brfalse IL_0194
+				IL_0115: ldloc.s 9
+				IL_0117: conv.i4
+				IL_0118: shl
+				IL_0119: conv.r8
+				IL_011a: stloc.s 14
+				IL_011c: ldloc.s 14
+				IL_011e: stloc.s 10
+				// loop start (head: IL_0120)
+					IL_0120: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75/Block_L34C7::.ctor()
+					IL_0125: stloc.s 11
+					IL_0127: ldarg.0
+					IL_0128: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
+					IL_012d: ldloc.s 8
+					IL_012f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_0134: stloc.s 14
+					IL_0136: ldloc.s 14
+					IL_0138: stloc.s 14
+					IL_013a: ldloc.s 14
+					IL_013c: conv.i4
+					IL_013d: ldloc.s 10
+					IL_013f: conv.i4
+					IL_0140: or
+					IL_0141: conv.r8
+					IL_0142: stloc.s 14
+					IL_0144: ldarg.0
+					IL_0145: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
+					IL_014a: ldloc.s 8
+					IL_014c: ldloc.s 14
+					IL_014e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_0153: ldloc.s 8
+					IL_0155: ldarg.2
+					IL_0156: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+					IL_015b: stloc.s 14
+					IL_015d: ldloc.s 14
+					IL_015f: stloc.s 8
+					IL_0161: ldloc.s 8
+					IL_0163: stloc.s 14
+					IL_0165: ldloc.s 14
+					IL_0167: ldloc.s 5
+					IL_0169: cgt
+					IL_016b: ldc.i4.0
+					IL_016c: ceq
+					IL_016e: brfalse IL_0178
 
-					IL_018f: br IL_013c
+					IL_0173: br IL_0120
 				// end loop
 
-				IL_0194: ldloc.s 6
-				IL_0196: ldarg.2
-				IL_0197: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_019c: stloc.s 15
-				IL_019e: ldloc.s 15
-				IL_01a0: stloc.s 6
-				IL_01a2: br IL_00df
+				IL_0178: ldloc.s 6
+				IL_017a: ldarg.2
+				IL_017b: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_0180: stloc.s 14
+				IL_0182: ldloc.s 14
+				IL_0184: stloc.s 6
+				IL_0186: br IL_00c3
 			// end loop
 
-			IL_01a7: ldnull
-			IL_01a8: ret
+			IL_018b: ldnull
+			IL_018c: ret
 
-			IL_01a9: ldarg.1
-			IL_01aa: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01af: stloc.s 12
-			// loop start (head: IL_01b1)
-				IL_01b1: ldloc.s 12
-				IL_01b3: stloc.s 15
-				IL_01b5: ldloc.s 15
-				IL_01b7: ldarg.3
-				IL_01b8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01bd: clt
-				IL_01bf: brfalse IL_01e7
+			IL_018d: ldarg.1
+			IL_018e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0193: stloc.s 12
+			// loop start (head: IL_0195)
+				IL_0195: ldloc.s 12
+				IL_0197: stloc.s 14
+				IL_0199: ldloc.s 14
+				IL_019b: ldarg.3
+				IL_019c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01a1: clt
+				IL_01a3: brfalse IL_01cb
 
-				IL_01c4: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_For_L43C7/Block_L43C67::.ctor()
-				IL_01c9: stloc.s 13
-				IL_01cb: ldarg.0
-				IL_01cc: ldloc.s 12
-				IL_01ce: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-				IL_01d3: pop
-				IL_01d4: ldloc.s 12
-				IL_01d6: ldarg.2
-				IL_01d7: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_01dc: stloc.s 15
-				IL_01de: ldloc.s 15
-				IL_01e0: stloc.s 12
-				IL_01e2: br IL_01b1
+				IL_01a8: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_For_L43C7/Block_L43C67::.ctor()
+				IL_01ad: stloc.s 13
+				IL_01af: ldarg.0
+				IL_01b0: ldloc.s 12
+				IL_01b2: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+				IL_01b7: pop
+				IL_01b8: ldloc.s 12
+				IL_01ba: ldarg.2
+				IL_01bb: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_01c0: stloc.s 14
+				IL_01c2: ldloc.s 14
+				IL_01c4: stloc.s 12
+				IL_01c6: br IL_0195
 			// end loop
 
-			IL_01e7: ldnull
-			IL_01e8: ret
+			IL_01cb: ldnull
+			IL_01cc: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -797,7 +788,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29f0
+			// Method begins at RVA 0x29d4
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -889,7 +880,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c2a
+				// Method begins at RVA 0x2c0e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -914,7 +905,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b41
+			// Method begins at RVA 0x2b25
 			// Header size: 1
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -954,7 +945,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c21
+					// Method begins at RVA 0x2c05
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -972,7 +963,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c18
+				// Method begins at RVA 0x2bfc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -990,7 +981,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2c0f
+			// Method begins at RVA 0x2bf3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1675,7 +1666,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2c33
+		// Method begins at RVA 0x2c17
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bfc
+				// Method begins at RVA 0x2be0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c05
+				// Method begins at RVA 0x2be9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c0e
+				// Method begins at RVA 0x2bf2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c20
+					// Method begins at RVA 0x2c04
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2c32
+						// Method begins at RVA 0x2c16
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2c3b
+						// Method begins at RVA 0x2c1f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -144,7 +144,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c29
+					// Method begins at RVA 0x2c0d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c17
+				// Method begins at RVA 0x2bfb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c44
+				// Method begins at RVA 0x2c28
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -334,7 +334,7 @@
 			)
 			// Method begins at RVA 0x2738
 			// Header size: 12
-			// Code size: 1107 (0x453)
+			// Code size: 1079 (0x437)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -416,393 +416,385 @@
 			IL_0097: ldloc.0
 			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 			IL_009d: pop
-			IL_009e: ldstr "WORD_SIZE"
-			IL_00a3: ldarg.0
-			IL_00a4: ldfld object[] Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::_scopes
-			IL_00a9: ldc.i4.0
-			IL_00aa: ldelem.ref
-			IL_00ab: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope
-			IL_00b0: ldfld float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::WORD_SIZE
-			IL_00b5: box [System.Runtime]System.Double
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_00bf: stloc.s 11
-			IL_00c1: ldloc.s 11
-			IL_00c3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00c8: stloc.s 12
-			IL_00ca: ldloc.s 12
-			IL_00cc: ldc.r8 2
-			IL_00d5: div
-			IL_00d6: stloc.s 12
-			IL_00d8: ldarg.2
-			IL_00d9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00de: ldloc.s 12
-			IL_00e0: cgt
-			IL_00e2: brfalse IL_0116
+			IL_009e: ldarg.0
+			IL_009f: ldfld object[] Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::_scopes
+			IL_00a4: ldc.i4.0
+			IL_00a5: ldelem.ref
+			IL_00a6: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope
+			IL_00ab: ldfld float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::WORD_SIZE
+			IL_00b0: ldc.r8 2
+			IL_00b9: div
+			IL_00ba: stloc.s 12
+			IL_00bc: ldarg.2
+			IL_00bd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00c2: ldloc.s 12
+			IL_00c4: cgt
+			IL_00c6: brfalse IL_00fa
 
-			IL_00e7: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L19C28::.ctor()
-			IL_00ec: stloc.1
-			IL_00ed: ldstr "not used in this test"
-			IL_00f2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00fc: stloc.s 11
-			IL_00fe: ldloc.s 11
-			IL_0100: stloc.2
-			IL_0101: ldloc.2
-			IL_0102: isinst [System.Runtime]System.Exception
-			IL_0107: dup
-			IL_0108: brtrue IL_0115
+			IL_00cb: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L19C28::.ctor()
+			IL_00d0: stloc.1
+			IL_00d1: ldstr "not used in this test"
+			IL_00d6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00e0: stloc.s 11
+			IL_00e2: ldloc.s 11
+			IL_00e4: stloc.2
+			IL_00e5: ldloc.2
+			IL_00e6: isinst [System.Runtime]System.Exception
+			IL_00eb: dup
+			IL_00ec: brtrue IL_00f9
 
-			IL_010d: pop
-			IL_010e: ldloc.2
-			IL_010f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0114: throw
+			IL_00f1: pop
+			IL_00f2: ldloc.2
+			IL_00f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00f8: throw
 
-			IL_0115: throw
+			IL_00f9: throw
 
-			IL_0116: ldarg.1
-			IL_0117: stloc.3
-			IL_0118: ldloc.3
-			IL_0119: stloc.s 11
-			IL_011b: ldloc.s 11
-			IL_011d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0122: stloc.s 12
-			IL_0124: ldloc.s 12
-			IL_0126: conv.i4
-			IL_0127: conv.u4
-			IL_0128: ldc.r8 5
-			IL_0131: conv.i4
-			IL_0132: shr.un
-			IL_0133: conv.r.un
-			IL_0134: stloc.s 12
-			IL_0136: ldloc.s 12
-			IL_0138: stloc.s 4
-			IL_013a: ldarg.0
-			IL_013b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_0140: ldloc.s 4
-			IL_0142: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0147: stloc.s 12
-			IL_0149: ldloc.s 12
-			IL_014b: stloc.s 5
-			IL_014d: ldstr "console"
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0157: stloc.s 11
-			IL_0159: ldloc.s 11
-			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0160: stloc.s 11
-			IL_0162: ldloc.s 4
-			IL_0164: box [System.Runtime]System.Double
-			IL_0169: stloc.s 13
-			IL_016b: ldloc.s 5
-			IL_016d: box [System.Runtime]System.Double
-			IL_0172: stloc.s 14
-			IL_0174: ldc.i4.4
-			IL_0175: newarr [System.Runtime]System.Object
-			IL_017a: dup
-			IL_017b: ldc.i4.0
-			IL_017c: ldstr "init"
-			IL_0181: stelem.ref
-			IL_0182: dup
-			IL_0183: ldc.i4.1
-			IL_0184: ldloc.3
-			IL_0185: stelem.ref
-			IL_0186: dup
-			IL_0187: ldc.i4.2
-			IL_0188: ldloc.s 13
-			IL_018a: stelem.ref
-			IL_018b: dup
-			IL_018c: ldc.i4.3
-			IL_018d: ldloc.s 14
-			IL_018f: stelem.ref
-			IL_0190: stloc.s 15
-			IL_0192: ldloc.s 11
-			IL_0194: ldstr "log"
-			IL_0199: ldloc.s 15
-			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_01a0: pop
-			// loop start (head: IL_01a1)
-				IL_01a1: ldloc.3
-				IL_01a2: stloc.s 11
-				IL_01a4: ldloc.s 11
-				IL_01a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01ab: stloc.s 12
-				IL_01ad: ldloc.s 12
-				IL_01af: ldarg.3
-				IL_01b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01b5: clt
-				IL_01b7: brfalse IL_034e
+			IL_00fa: ldarg.1
+			IL_00fb: stloc.3
+			IL_00fc: ldloc.3
+			IL_00fd: stloc.s 11
+			IL_00ff: ldloc.s 11
+			IL_0101: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0106: stloc.s 12
+			IL_0108: ldloc.s 12
+			IL_010a: conv.i4
+			IL_010b: conv.u4
+			IL_010c: ldc.r8 5
+			IL_0115: conv.i4
+			IL_0116: shr.un
+			IL_0117: conv.r.un
+			IL_0118: stloc.s 12
+			IL_011a: ldloc.s 12
+			IL_011c: stloc.s 4
+			IL_011e: ldarg.0
+			IL_011f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_0124: ldloc.s 4
+			IL_0126: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_012b: stloc.s 12
+			IL_012d: ldloc.s 12
+			IL_012f: stloc.s 5
+			IL_0131: ldstr "console"
+			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_013b: stloc.s 11
+			IL_013d: ldloc.s 11
+			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0144: stloc.s 11
+			IL_0146: ldloc.s 4
+			IL_0148: box [System.Runtime]System.Double
+			IL_014d: stloc.s 13
+			IL_014f: ldloc.s 5
+			IL_0151: box [System.Runtime]System.Double
+			IL_0156: stloc.s 14
+			IL_0158: ldc.i4.4
+			IL_0159: newarr [System.Runtime]System.Object
+			IL_015e: dup
+			IL_015f: ldc.i4.0
+			IL_0160: ldstr "init"
+			IL_0165: stelem.ref
+			IL_0166: dup
+			IL_0167: ldc.i4.1
+			IL_0168: ldloc.3
+			IL_0169: stelem.ref
+			IL_016a: dup
+			IL_016b: ldc.i4.2
+			IL_016c: ldloc.s 13
+			IL_016e: stelem.ref
+			IL_016f: dup
+			IL_0170: ldc.i4.3
+			IL_0171: ldloc.s 14
+			IL_0173: stelem.ref
+			IL_0174: stloc.s 15
+			IL_0176: ldloc.s 11
+			IL_0178: ldstr "log"
+			IL_017d: ldloc.s 15
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0184: pop
+			// loop start (head: IL_0185)
+				IL_0185: ldloc.3
+				IL_0186: stloc.s 11
+				IL_0188: ldloc.s 11
+				IL_018a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_018f: stloc.s 12
+				IL_0191: ldloc.s 12
+				IL_0193: ldarg.3
+				IL_0194: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0199: clt
+				IL_019b: brfalse IL_0332
 
-				IL_01bc: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29::.ctor()
-				IL_01c1: stloc.s 6
-				IL_01c3: ldloc.3
-				IL_01c4: stloc.s 11
-				IL_01c6: ldloc.s 11
-				IL_01c8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01cd: stloc.s 12
-				IL_01cf: ldloc.s 12
+				IL_01a0: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29::.ctor()
+				IL_01a5: stloc.s 6
+				IL_01a7: ldloc.3
+				IL_01a8: stloc.s 11
+				IL_01aa: ldloc.s 11
+				IL_01ac: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01b1: stloc.s 12
+				IL_01b3: ldloc.s 12
+				IL_01b5: conv.i4
+				IL_01b6: ldc.r8 31
+				IL_01bf: conv.i4
+				IL_01c0: and
+				IL_01c1: conv.r8
+				IL_01c2: stloc.s 12
+				IL_01c4: ldloc.s 12
+				IL_01c6: stloc.s 7
+				IL_01c8: ldc.r8 1
 				IL_01d1: conv.i4
-				IL_01d2: ldc.r8 31
+				IL_01d2: ldloc.s 7
+				IL_01d4: conv.i4
+				IL_01d5: shl
+				IL_01d6: conv.r8
+				IL_01d7: stloc.s 12
+				IL_01d9: ldloc.s 5
 				IL_01db: conv.i4
-				IL_01dc: and
-				IL_01dd: conv.r8
-				IL_01de: stloc.s 12
-				IL_01e0: ldloc.s 12
-				IL_01e2: stloc.s 7
-				IL_01e4: ldc.r8 1
-				IL_01ed: conv.i4
-				IL_01ee: ldloc.s 7
-				IL_01f0: conv.i4
-				IL_01f1: shl
-				IL_01f2: conv.r8
-				IL_01f3: stloc.s 12
-				IL_01f5: ldloc.s 5
-				IL_01f7: conv.i4
-				IL_01f8: ldloc.s 12
-				IL_01fa: conv.i4
-				IL_01fb: or
-				IL_01fc: conv.r8
-				IL_01fd: stloc.s 12
-				IL_01ff: ldloc.s 12
-				IL_0201: stloc.s 5
-				IL_0203: ldloc.3
-				IL_0204: stloc.s 11
-				IL_0206: ldloc.s 11
-				IL_0208: ldarg.1
-				IL_0209: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_020e: stloc.s 16
-				IL_0210: ldloc.s 16
-				IL_0212: brfalse IL_0272
+				IL_01dc: ldloc.s 12
+				IL_01de: conv.i4
+				IL_01df: or
+				IL_01e0: conv.r8
+				IL_01e1: stloc.s 12
+				IL_01e3: ldloc.s 12
+				IL_01e5: stloc.s 5
+				IL_01e7: ldloc.3
+				IL_01e8: stloc.s 11
+				IL_01ea: ldloc.s 11
+				IL_01ec: ldarg.1
+				IL_01ed: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01f2: stloc.s 16
+				IL_01f4: ldloc.s 16
+				IL_01f6: brfalse IL_0256
 
-				IL_0217: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29/Block_L31C30::.ctor()
-				IL_021c: stloc.s 8
-				IL_021e: ldstr "console"
-				IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0228: stloc.s 11
-				IL_022a: ldloc.s 11
-				IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0231: stloc.s 11
-				IL_0233: ldloc.s 7
-				IL_0235: box [System.Runtime]System.Double
-				IL_023a: stloc.s 14
-				IL_023c: ldloc.s 5
-				IL_023e: box [System.Runtime]System.Double
-				IL_0243: stloc.s 13
-				IL_0245: ldc.i4.4
-				IL_0246: newarr [System.Runtime]System.Object
-				IL_024b: dup
-				IL_024c: ldc.i4.0
-				IL_024d: ldstr "iter0"
-				IL_0252: stelem.ref
-				IL_0253: dup
-				IL_0254: ldc.i4.1
-				IL_0255: ldloc.3
-				IL_0256: stelem.ref
-				IL_0257: dup
-				IL_0258: ldc.i4.2
-				IL_0259: ldloc.s 14
-				IL_025b: stelem.ref
-				IL_025c: dup
-				IL_025d: ldc.i4.3
-				IL_025e: ldloc.s 13
-				IL_0260: stelem.ref
-				IL_0261: stloc.s 15
-				IL_0263: ldloc.s 11
-				IL_0265: ldstr "log"
-				IL_026a: ldloc.s 15
-				IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0271: pop
+				IL_01fb: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29/Block_L31C30::.ctor()
+				IL_0200: stloc.s 8
+				IL_0202: ldstr "console"
+				IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_020c: stloc.s 11
+				IL_020e: ldloc.s 11
+				IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0215: stloc.s 11
+				IL_0217: ldloc.s 7
+				IL_0219: box [System.Runtime]System.Double
+				IL_021e: stloc.s 14
+				IL_0220: ldloc.s 5
+				IL_0222: box [System.Runtime]System.Double
+				IL_0227: stloc.s 13
+				IL_0229: ldc.i4.4
+				IL_022a: newarr [System.Runtime]System.Object
+				IL_022f: dup
+				IL_0230: ldc.i4.0
+				IL_0231: ldstr "iter0"
+				IL_0236: stelem.ref
+				IL_0237: dup
+				IL_0238: ldc.i4.1
+				IL_0239: ldloc.3
+				IL_023a: stelem.ref
+				IL_023b: dup
+				IL_023c: ldc.i4.2
+				IL_023d: ldloc.s 14
+				IL_023f: stelem.ref
+				IL_0240: dup
+				IL_0241: ldc.i4.3
+				IL_0242: ldloc.s 13
+				IL_0244: stelem.ref
+				IL_0245: stloc.s 15
+				IL_0247: ldloc.s 11
+				IL_0249: ldstr "log"
+				IL_024e: ldloc.s 15
+				IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0255: pop
 
-				IL_0272: ldloc.3
-				IL_0273: ldarg.2
-				IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0279: stloc.s 17
-				IL_027b: ldloc.s 17
-				IL_027d: stloc.3
-				IL_027e: ldloc.3
-				IL_027f: stloc.s 17
-				IL_0281: ldloc.s 17
-				IL_0283: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0288: stloc.s 12
-				IL_028a: ldloc.s 12
-				IL_028c: conv.i4
-				IL_028d: conv.u4
-				IL_028e: ldc.r8 5
-				IL_0297: conv.i4
-				IL_0298: shr.un
-				IL_0299: conv.r.un
-				IL_029a: stloc.s 12
-				IL_029c: ldloc.s 12
-				IL_029e: stloc.s 9
-				IL_02a0: ldloc.s 9
-				IL_02a2: stloc.s 12
-				IL_02a4: ldloc.s 12
-				IL_02a6: ldloc.s 4
-				IL_02a8: ceq
-				IL_02aa: ldc.i4.0
-				IL_02ab: ceq
-				IL_02ad: brfalse IL_0349
+				IL_0256: ldloc.3
+				IL_0257: ldarg.2
+				IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_025d: stloc.s 17
+				IL_025f: ldloc.s 17
+				IL_0261: stloc.3
+				IL_0262: ldloc.3
+				IL_0263: stloc.s 17
+				IL_0265: ldloc.s 17
+				IL_0267: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_026c: stloc.s 12
+				IL_026e: ldloc.s 12
+				IL_0270: conv.i4
+				IL_0271: conv.u4
+				IL_0272: ldc.r8 5
+				IL_027b: conv.i4
+				IL_027c: shr.un
+				IL_027d: conv.r.un
+				IL_027e: stloc.s 12
+				IL_0280: ldloc.s 12
+				IL_0282: stloc.s 9
+				IL_0284: ldloc.s 9
+				IL_0286: stloc.s 12
+				IL_0288: ldloc.s 12
+				IL_028a: ldloc.s 4
+				IL_028c: ceq
+				IL_028e: ldc.i4.0
+				IL_028f: ceq
+				IL_0291: brfalse IL_032d
 
-				IL_02b2: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29/Block_L37C36::.ctor()
-				IL_02b7: stloc.s 10
-				IL_02b9: ldstr "console"
-				IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02c3: stloc.s 11
-				IL_02c5: ldloc.s 11
-				IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02cc: stloc.s 11
-				IL_02ce: ldloc.s 4
-				IL_02d0: box [System.Runtime]System.Double
-				IL_02d5: stloc.s 13
-				IL_02d7: ldloc.s 5
-				IL_02d9: box [System.Runtime]System.Double
-				IL_02de: stloc.s 14
-				IL_02e0: ldloc.s 9
-				IL_02e2: box [System.Runtime]System.Double
-				IL_02e7: stloc.s 18
-				IL_02e9: ldc.i4.5
-				IL_02ea: newarr [System.Runtime]System.Object
-				IL_02ef: dup
-				IL_02f0: ldc.i4.0
-				IL_02f1: ldstr "commit"
-				IL_02f6: stelem.ref
-				IL_02f7: dup
-				IL_02f8: ldc.i4.1
-				IL_02f9: ldloc.s 13
-				IL_02fb: stelem.ref
-				IL_02fc: dup
-				IL_02fd: ldc.i4.2
-				IL_02fe: ldloc.s 14
-				IL_0300: stelem.ref
-				IL_0301: dup
-				IL_0302: ldc.i4.3
-				IL_0303: ldstr "->"
-				IL_0308: stelem.ref
-				IL_0309: dup
-				IL_030a: ldc.i4.4
-				IL_030b: ldloc.s 18
-				IL_030d: stelem.ref
-				IL_030e: stloc.s 15
-				IL_0310: ldloc.s 11
-				IL_0312: ldstr "log"
-				IL_0317: ldloc.s 15
-				IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_031e: pop
-				IL_031f: ldarg.0
-				IL_0320: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-				IL_0325: ldloc.s 4
-				IL_0327: ldloc.s 5
-				IL_0329: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_032e: ldloc.s 9
-				IL_0330: stloc.s 12
-				IL_0332: ldloc.s 12
-				IL_0334: stloc.s 4
-				IL_0336: ldarg.0
-				IL_0337: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-				IL_033c: ldloc.s 4
-				IL_033e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_0343: stloc.s 12
-				IL_0345: ldloc.s 12
-				IL_0347: stloc.s 5
+				IL_0296: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29/Block_L37C36::.ctor()
+				IL_029b: stloc.s 10
+				IL_029d: ldstr "console"
+				IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_02a7: stloc.s 11
+				IL_02a9: ldloc.s 11
+				IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02b0: stloc.s 11
+				IL_02b2: ldloc.s 4
+				IL_02b4: box [System.Runtime]System.Double
+				IL_02b9: stloc.s 13
+				IL_02bb: ldloc.s 5
+				IL_02bd: box [System.Runtime]System.Double
+				IL_02c2: stloc.s 14
+				IL_02c4: ldloc.s 9
+				IL_02c6: box [System.Runtime]System.Double
+				IL_02cb: stloc.s 18
+				IL_02cd: ldc.i4.5
+				IL_02ce: newarr [System.Runtime]System.Object
+				IL_02d3: dup
+				IL_02d4: ldc.i4.0
+				IL_02d5: ldstr "commit"
+				IL_02da: stelem.ref
+				IL_02db: dup
+				IL_02dc: ldc.i4.1
+				IL_02dd: ldloc.s 13
+				IL_02df: stelem.ref
+				IL_02e0: dup
+				IL_02e1: ldc.i4.2
+				IL_02e2: ldloc.s 14
+				IL_02e4: stelem.ref
+				IL_02e5: dup
+				IL_02e6: ldc.i4.3
+				IL_02e7: ldstr "->"
+				IL_02ec: stelem.ref
+				IL_02ed: dup
+				IL_02ee: ldc.i4.4
+				IL_02ef: ldloc.s 18
+				IL_02f1: stelem.ref
+				IL_02f2: stloc.s 15
+				IL_02f4: ldloc.s 11
+				IL_02f6: ldstr "log"
+				IL_02fb: ldloc.s 15
+				IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0302: pop
+				IL_0303: ldarg.0
+				IL_0304: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+				IL_0309: ldloc.s 4
+				IL_030b: ldloc.s 5
+				IL_030d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_0312: ldloc.s 9
+				IL_0314: stloc.s 12
+				IL_0316: ldloc.s 12
+				IL_0318: stloc.s 4
+				IL_031a: ldarg.0
+				IL_031b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+				IL_0320: ldloc.s 4
+				IL_0322: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_0327: stloc.s 12
+				IL_0329: ldloc.s 12
+				IL_032b: stloc.s 5
 
-				IL_0349: br IL_01a1
+				IL_032d: br IL_0185
 			// end loop
 
-			IL_034e: ldstr "console"
-			IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0358: stloc.s 11
-			IL_035a: ldloc.s 11
-			IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0361: stloc.s 11
-			IL_0363: ldloc.s 4
-			IL_0365: box [System.Runtime]System.Double
-			IL_036a: stloc.s 18
-			IL_036c: ldloc.s 5
-			IL_036e: box [System.Runtime]System.Double
-			IL_0373: stloc.s 14
-			IL_0375: ldc.i4.4
-			IL_0376: newarr [System.Runtime]System.Object
-			IL_037b: dup
-			IL_037c: ldc.i4.0
-			IL_037d: ldstr "end"
-			IL_0382: stelem.ref
-			IL_0383: dup
-			IL_0384: ldc.i4.1
-			IL_0385: ldloc.3
-			IL_0386: stelem.ref
-			IL_0387: dup
-			IL_0388: ldc.i4.2
-			IL_0389: ldloc.s 18
-			IL_038b: stelem.ref
-			IL_038c: dup
-			IL_038d: ldc.i4.3
-			IL_038e: ldloc.s 14
-			IL_0390: stelem.ref
-			IL_0391: stloc.s 15
-			IL_0393: ldloc.s 11
-			IL_0395: ldstr "log"
-			IL_039a: ldloc.s 15
-			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_03a1: pop
-			IL_03a2: ldarg.0
-			IL_03a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_03a8: ldloc.s 4
-			IL_03aa: ldloc.s 5
-			IL_03ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_03b1: ldstr "console"
-			IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03bb: stloc.s 11
-			IL_03bd: ldloc.s 11
-			IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03c4: stloc.s 11
-			IL_03c6: ldarg.0
-			IL_03c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_03cc: ldc.r8 0.0
-			IL_03d5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_03da: stloc.s 12
-			IL_03dc: ldloc.s 12
-			IL_03de: box [System.Runtime]System.Double
-			IL_03e3: stloc.s 14
-			IL_03e5: ldarg.0
-			IL_03e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_03eb: ldc.r8 1
-			IL_03f4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_03f9: stloc.s 12
-			IL_03fb: ldloc.s 12
-			IL_03fd: box [System.Runtime]System.Double
-			IL_0402: stloc.s 18
-			IL_0404: ldarg.0
-			IL_0405: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_040a: ldc.r8 2
-			IL_0413: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0418: stloc.s 12
-			IL_041a: ldloc.s 12
-			IL_041c: box [System.Runtime]System.Double
-			IL_0421: stloc.s 13
-			IL_0423: ldc.i4.4
-			IL_0424: newarr [System.Runtime]System.Object
-			IL_0429: dup
-			IL_042a: ldc.i4.0
-			IL_042b: ldstr "after"
-			IL_0430: stelem.ref
-			IL_0431: dup
-			IL_0432: ldc.i4.1
-			IL_0433: ldloc.s 14
-			IL_0435: stelem.ref
-			IL_0436: dup
-			IL_0437: ldc.i4.2
-			IL_0438: ldloc.s 18
-			IL_043a: stelem.ref
-			IL_043b: dup
-			IL_043c: ldc.i4.3
-			IL_043d: ldloc.s 13
-			IL_043f: stelem.ref
-			IL_0440: stloc.s 15
-			IL_0442: ldloc.s 11
-			IL_0444: ldstr "log"
-			IL_0449: ldloc.s 15
-			IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0450: pop
-			IL_0451: ldnull
-			IL_0452: ret
+			IL_0332: ldstr "console"
+			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_033c: stloc.s 11
+			IL_033e: ldloc.s 11
+			IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0345: stloc.s 11
+			IL_0347: ldloc.s 4
+			IL_0349: box [System.Runtime]System.Double
+			IL_034e: stloc.s 18
+			IL_0350: ldloc.s 5
+			IL_0352: box [System.Runtime]System.Double
+			IL_0357: stloc.s 14
+			IL_0359: ldc.i4.4
+			IL_035a: newarr [System.Runtime]System.Object
+			IL_035f: dup
+			IL_0360: ldc.i4.0
+			IL_0361: ldstr "end"
+			IL_0366: stelem.ref
+			IL_0367: dup
+			IL_0368: ldc.i4.1
+			IL_0369: ldloc.3
+			IL_036a: stelem.ref
+			IL_036b: dup
+			IL_036c: ldc.i4.2
+			IL_036d: ldloc.s 18
+			IL_036f: stelem.ref
+			IL_0370: dup
+			IL_0371: ldc.i4.3
+			IL_0372: ldloc.s 14
+			IL_0374: stelem.ref
+			IL_0375: stloc.s 15
+			IL_0377: ldloc.s 11
+			IL_0379: ldstr "log"
+			IL_037e: ldloc.s 15
+			IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0385: pop
+			IL_0386: ldarg.0
+			IL_0387: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_038c: ldloc.s 4
+			IL_038e: ldloc.s 5
+			IL_0390: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_0395: ldstr "console"
+			IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_039f: stloc.s 11
+			IL_03a1: ldloc.s 11
+			IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03a8: stloc.s 11
+			IL_03aa: ldarg.0
+			IL_03ab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_03b0: ldc.r8 0.0
+			IL_03b9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_03be: stloc.s 12
+			IL_03c0: ldloc.s 12
+			IL_03c2: box [System.Runtime]System.Double
+			IL_03c7: stloc.s 14
+			IL_03c9: ldarg.0
+			IL_03ca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_03cf: ldc.r8 1
+			IL_03d8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_03dd: stloc.s 12
+			IL_03df: ldloc.s 12
+			IL_03e1: box [System.Runtime]System.Double
+			IL_03e6: stloc.s 18
+			IL_03e8: ldarg.0
+			IL_03e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_03ee: ldc.r8 2
+			IL_03f7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_03fc: stloc.s 12
+			IL_03fe: ldloc.s 12
+			IL_0400: box [System.Runtime]System.Double
+			IL_0405: stloc.s 13
+			IL_0407: ldc.i4.4
+			IL_0408: newarr [System.Runtime]System.Object
+			IL_040d: dup
+			IL_040e: ldc.i4.0
+			IL_040f: ldstr "after"
+			IL_0414: stelem.ref
+			IL_0415: dup
+			IL_0416: ldc.i4.1
+			IL_0417: ldloc.s 14
+			IL_0419: stelem.ref
+			IL_041a: dup
+			IL_041b: ldc.i4.2
+			IL_041c: ldloc.s 18
+			IL_041e: stelem.ref
+			IL_041f: dup
+			IL_0420: ldc.i4.3
+			IL_0421: ldloc.s 13
+			IL_0423: stelem.ref
+			IL_0424: stloc.s 15
+			IL_0426: ldloc.s 11
+			IL_0428: ldstr "log"
+			IL_042d: ldloc.s 15
+			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0434: pop
+			IL_0435: ldnull
+			IL_0436: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -813,7 +805,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b98
+			// Method begins at RVA 0x2b7c
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -885,7 +877,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2bf3
+			// Method begins at RVA 0x2bd7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1441,7 +1433,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2c4d
+		// Method begins at RVA 0x2c31
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25ad
+				// Method begins at RVA 0x250b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25b6
+				// Method begins at RVA 0x2514
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,117 +126,85 @@
 			)
 			// Method begins at RVA 0x22f0
 			// Header size: 12
-			// Code size: 222 (0xde)
+			// Code size: 149 (0x95)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] object,
 				[2] float64,
-				[3] object,
-				[4] float64,
-				[5] object,
-				[6] object[],
+				[3] float64,
+				[4] object,
+				[5] object[],
+				[6] object,
 				[7] object,
 				[8] object[]
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
-			IL_0006: stloc.3
-			IL_0007: ldstr "capturedGlobalDouble"
-			IL_000c: ldloc.3
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.3
-			IL_0013: ldloc.3
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.s 4
-			IL_001b: ldloc.s 4
-			IL_001d: stloc.0
-			IL_001e: ldarg.0
-			IL_001f: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
-			IL_0024: stloc.3
-			IL_0025: ldstr "capturedGlobalDouble"
-			IL_002a: ldloc.3
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0030: stloc.3
-			IL_0031: ldloc.3
-			IL_0032: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0037: stloc.s 4
-			IL_0039: ldloc.s 4
-			IL_003b: box [System.Runtime]System.Double
-			IL_0040: stloc.s 5
-			IL_0042: ldloc.s 5
-			IL_0044: stloc.3
-			IL_0045: ldloc.s 4
-			IL_0047: ldc.r8 1
-			IL_0050: sub
-			IL_0051: stloc.s 4
-			IL_0053: ldloc.s 4
-			IL_0055: box [System.Runtime]System.Double
-			IL_005a: stloc.s 5
-			IL_005c: ldarg.0
-			IL_005d: ldloc.s 5
-			IL_005f: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
-			IL_0064: ldloc.3
-			IL_0065: stloc.1
-			IL_0066: ldarg.0
-			IL_0067: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
-			IL_006c: stloc.3
-			IL_006d: ldstr "capturedGlobalDouble"
-			IL_0072: ldloc.3
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0078: stloc.3
-			IL_0079: ldloc.3
-			IL_007a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_007f: stloc.s 4
-			IL_0081: ldloc.s 4
-			IL_0083: stloc.2
-			IL_0084: ldarg.0
-			IL_0085: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
-			IL_008a: stloc.3
-			IL_008b: ldstr "logCase"
-			IL_0090: ldloc.3
-			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0096: stloc.3
-			IL_0097: ldc.i4.1
-			IL_0098: newarr [System.Runtime]System.Object
-			IL_009d: dup
-			IL_009e: ldc.i4.0
-			IL_009f: ldarg.0
-			IL_00a0: stelem.ref
-			IL_00a1: stloc.s 6
-			IL_00a3: ldloc.0
-			IL_00a4: box [System.Runtime]System.Double
-			IL_00a9: stloc.s 5
-			IL_00ab: ldloc.2
-			IL_00ac: box [System.Runtime]System.Double
-			IL_00b1: stloc.s 7
-			IL_00b3: ldc.i4.4
-			IL_00b4: newarr [System.Runtime]System.Object
-			IL_00b9: dup
-			IL_00ba: ldc.i4.0
-			IL_00bb: ldstr "captured-double"
-			IL_00c0: stelem.ref
-			IL_00c1: dup
-			IL_00c2: ldc.i4.1
-			IL_00c3: ldloc.s 5
-			IL_00c5: stelem.ref
-			IL_00c6: dup
-			IL_00c7: ldc.i4.2
-			IL_00c8: ldloc.1
-			IL_00c9: stelem.ref
-			IL_00ca: dup
-			IL_00cb: ldc.i4.3
-			IL_00cc: ldloc.s 7
-			IL_00ce: stelem.ref
-			IL_00cf: stloc.s 8
-			IL_00d1: ldloc.3
-			IL_00d2: ldloc.s 6
-			IL_00d4: ldloc.s 8
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_00db: pop
-			IL_00dc: ldnull
-			IL_00dd: ret
+			IL_0006: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000b: stloc.0
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
+			IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0017: stloc.3
+			IL_0018: ldloc.3
+			IL_0019: box [System.Runtime]System.Double
+			IL_001e: stloc.s 4
+			IL_0020: ldarg.0
+			IL_0021: ldloc.3
+			IL_0022: ldc.r8 1
+			IL_002b: sub
+			IL_002c: box [System.Runtime]System.Double
+			IL_0031: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
+			IL_0036: ldloc.s 4
+			IL_0038: stloc.1
+			IL_0039: ldarg.0
+			IL_003a: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
+			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0044: stloc.2
+			IL_0045: ldarg.0
+			IL_0046: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
+			IL_004b: stloc.s 4
+			IL_004d: ldc.i4.1
+			IL_004e: newarr [System.Runtime]System.Object
+			IL_0053: dup
+			IL_0054: ldc.i4.0
+			IL_0055: ldarg.0
+			IL_0056: stelem.ref
+			IL_0057: stloc.s 5
+			IL_0059: ldloc.0
+			IL_005a: box [System.Runtime]System.Double
+			IL_005f: stloc.s 6
+			IL_0061: ldloc.2
+			IL_0062: box [System.Runtime]System.Double
+			IL_0067: stloc.s 7
+			IL_0069: ldc.i4.4
+			IL_006a: newarr [System.Runtime]System.Object
+			IL_006f: dup
+			IL_0070: ldc.i4.0
+			IL_0071: ldstr "captured-double"
+			IL_0076: stelem.ref
+			IL_0077: dup
+			IL_0078: ldc.i4.1
+			IL_0079: ldloc.s 6
+			IL_007b: stelem.ref
+			IL_007c: dup
+			IL_007d: ldc.i4.2
+			IL_007e: ldloc.1
+			IL_007f: stelem.ref
+			IL_0080: dup
+			IL_0081: ldc.i4.3
+			IL_0082: ldloc.s 7
+			IL_0084: stelem.ref
+			IL_0085: stloc.s 8
+			IL_0087: ldloc.s 4
+			IL_0089: ldloc.s 5
+			IL_008b: ldloc.s 8
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0092: pop
+			IL_0093: ldnull
+			IL_0094: ret
 		} // end of method capturedDouble::__js_call__
 
 	} // end of class capturedDouble
@@ -252,7 +220,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25bf
+				// Method begins at RVA 0x251d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -279,9 +247,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23dc
+			// Method begins at RVA 0x2394
 			// Header size: 12
-			// Code size: 116 (0x74)
+			// Code size: 102 (0x66)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -313,43 +281,39 @@
 			IL_0028: ldarg.0
 			IL_0029: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
 			IL_002e: stloc.s 4
-			IL_0030: ldstr "logCase"
-			IL_0035: ldloc.s 4
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.s 4
-			IL_003e: ldc.i4.1
-			IL_003f: newarr [System.Runtime]System.Object
-			IL_0044: dup
-			IL_0045: ldc.i4.0
-			IL_0046: ldarg.0
-			IL_0047: stelem.ref
-			IL_0048: stloc.s 5
-			IL_004a: ldc.i4.4
-			IL_004b: newarr [System.Runtime]System.Object
-			IL_0050: dup
-			IL_0051: ldc.i4.0
-			IL_0052: ldstr "arg-double"
-			IL_0057: stelem.ref
-			IL_0058: dup
-			IL_0059: ldc.i4.1
-			IL_005a: ldloc.0
-			IL_005b: stelem.ref
-			IL_005c: dup
-			IL_005d: ldc.i4.2
-			IL_005e: ldloc.1
-			IL_005f: stelem.ref
-			IL_0060: dup
-			IL_0061: ldc.i4.3
-			IL_0062: ldloc.2
-			IL_0063: stelem.ref
-			IL_0064: stloc.s 6
-			IL_0066: ldloc.s 4
-			IL_0068: ldloc.s 5
-			IL_006a: ldloc.s 6
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0071: pop
-			IL_0072: ldnull
-			IL_0073: ret
+			IL_0030: ldc.i4.1
+			IL_0031: newarr [System.Runtime]System.Object
+			IL_0036: dup
+			IL_0037: ldc.i4.0
+			IL_0038: ldarg.0
+			IL_0039: stelem.ref
+			IL_003a: stloc.s 5
+			IL_003c: ldc.i4.4
+			IL_003d: newarr [System.Runtime]System.Object
+			IL_0042: dup
+			IL_0043: ldc.i4.0
+			IL_0044: ldstr "arg-double"
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.1
+			IL_004c: ldloc.0
+			IL_004d: stelem.ref
+			IL_004e: dup
+			IL_004f: ldc.i4.2
+			IL_0050: ldloc.1
+			IL_0051: stelem.ref
+			IL_0052: dup
+			IL_0053: ldc.i4.3
+			IL_0054: ldloc.2
+			IL_0055: stelem.ref
+			IL_0056: stloc.s 6
+			IL_0058: ldloc.s 4
+			IL_005a: ldloc.s 5
+			IL_005c: ldloc.s 6
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0063: pop
+			IL_0064: ldnull
+			IL_0065: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -365,7 +329,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25c8
+				// Method begins at RVA 0x2526
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -391,106 +355,77 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x245c
+			// Method begins at RVA 0x2408
 			// Header size: 12
-			// Code size: 186 (0xba)
+			// Code size: 121 (0x79)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object,
-				[4] float64,
-				[5] object,
-				[6] object[],
-				[7] object[]
+				[3] float64,
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
-			IL_0006: stloc.3
-			IL_0007: ldstr "capturedGlobalString"
-			IL_000c: ldloc.3
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
+			IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0012: stloc.3
 			IL_0013: ldloc.3
-			IL_0014: stloc.0
-			IL_0015: ldarg.0
-			IL_0016: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
-			IL_001b: stloc.3
-			IL_001c: ldstr "capturedGlobalString"
-			IL_0021: ldloc.3
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0027: stloc.3
-			IL_0028: ldloc.3
-			IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002e: stloc.s 4
-			IL_0030: ldloc.s 4
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: stloc.s 5
-			IL_0039: ldloc.s 5
-			IL_003b: stloc.3
-			IL_003c: ldloc.s 4
-			IL_003e: ldc.r8 1
-			IL_0047: sub
-			IL_0048: stloc.s 4
-			IL_004a: ldloc.s 4
-			IL_004c: box [System.Runtime]System.Double
-			IL_0051: stloc.s 5
-			IL_0053: ldarg.0
-			IL_0054: ldloc.s 5
-			IL_0056: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
-			IL_005b: ldloc.3
-			IL_005c: stloc.1
-			IL_005d: ldarg.0
-			IL_005e: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
-			IL_0063: stloc.3
-			IL_0064: ldstr "capturedGlobalString"
-			IL_0069: ldloc.3
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_006f: stloc.3
-			IL_0070: ldloc.3
-			IL_0071: stloc.2
-			IL_0072: ldarg.0
-			IL_0073: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
-			IL_0078: stloc.3
-			IL_0079: ldstr "logCase"
-			IL_007e: ldloc.3
-			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0084: stloc.3
-			IL_0085: ldc.i4.1
-			IL_0086: newarr [System.Runtime]System.Object
-			IL_008b: dup
-			IL_008c: ldc.i4.0
-			IL_008d: ldarg.0
-			IL_008e: stelem.ref
-			IL_008f: stloc.s 6
-			IL_0091: ldc.i4.4
-			IL_0092: newarr [System.Runtime]System.Object
-			IL_0097: dup
-			IL_0098: ldc.i4.0
-			IL_0099: ldstr "captured-string"
-			IL_009e: stelem.ref
-			IL_009f: dup
-			IL_00a0: ldc.i4.1
-			IL_00a1: ldloc.0
-			IL_00a2: stelem.ref
-			IL_00a3: dup
-			IL_00a4: ldc.i4.2
-			IL_00a5: ldloc.1
-			IL_00a6: stelem.ref
-			IL_00a7: dup
-			IL_00a8: ldc.i4.3
-			IL_00a9: ldloc.2
-			IL_00aa: stelem.ref
-			IL_00ab: stloc.s 7
-			IL_00ad: ldloc.3
-			IL_00ae: ldloc.s 6
-			IL_00b0: ldloc.s 7
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_00b7: pop
-			IL_00b8: ldnull
-			IL_00b9: ret
+			IL_0014: box [System.Runtime]System.Double
+			IL_0019: stloc.s 4
+			IL_001b: ldarg.0
+			IL_001c: ldloc.3
+			IL_001d: ldc.r8 1
+			IL_0026: sub
+			IL_0027: box [System.Runtime]System.Double
+			IL_002c: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
+			IL_0031: ldloc.s 4
+			IL_0033: stloc.1
+			IL_0034: ldarg.0
+			IL_0035: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
+			IL_003a: stloc.2
+			IL_003b: ldarg.0
+			IL_003c: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
+			IL_0041: stloc.s 4
+			IL_0043: ldc.i4.1
+			IL_0044: newarr [System.Runtime]System.Object
+			IL_0049: dup
+			IL_004a: ldc.i4.0
+			IL_004b: ldarg.0
+			IL_004c: stelem.ref
+			IL_004d: stloc.s 5
+			IL_004f: ldc.i4.4
+			IL_0050: newarr [System.Runtime]System.Object
+			IL_0055: dup
+			IL_0056: ldc.i4.0
+			IL_0057: ldstr "captured-string"
+			IL_005c: stelem.ref
+			IL_005d: dup
+			IL_005e: ldc.i4.1
+			IL_005f: ldloc.0
+			IL_0060: stelem.ref
+			IL_0061: dup
+			IL_0062: ldc.i4.2
+			IL_0063: ldloc.1
+			IL_0064: stelem.ref
+			IL_0065: dup
+			IL_0066: ldc.i4.3
+			IL_0067: ldloc.2
+			IL_0068: stelem.ref
+			IL_0069: stloc.s 6
+			IL_006b: ldloc.s 4
+			IL_006d: ldloc.s 5
+			IL_006f: ldloc.s 6
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0076: pop
+			IL_0077: ldnull
+			IL_0078: ret
 		} // end of method capturedString::__js_call__
 
 	} // end of class capturedString
@@ -506,7 +441,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25d1
+				// Method begins at RVA 0x252f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -533,9 +468,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2524
+			// Method begins at RVA 0x2490
 			// Header size: 12
-			// Code size: 116 (0x74)
+			// Code size: 102 (0x66)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -567,43 +502,39 @@
 			IL_0028: ldarg.0
 			IL_0029: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
 			IL_002e: stloc.s 4
-			IL_0030: ldstr "logCase"
-			IL_0035: ldloc.s 4
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.s 4
-			IL_003e: ldc.i4.1
-			IL_003f: newarr [System.Runtime]System.Object
-			IL_0044: dup
-			IL_0045: ldc.i4.0
-			IL_0046: ldarg.0
-			IL_0047: stelem.ref
-			IL_0048: stloc.s 5
-			IL_004a: ldc.i4.4
-			IL_004b: newarr [System.Runtime]System.Object
-			IL_0050: dup
-			IL_0051: ldc.i4.0
-			IL_0052: ldstr "arg-string"
-			IL_0057: stelem.ref
-			IL_0058: dup
-			IL_0059: ldc.i4.1
-			IL_005a: ldloc.0
-			IL_005b: stelem.ref
-			IL_005c: dup
-			IL_005d: ldc.i4.2
-			IL_005e: ldloc.1
-			IL_005f: stelem.ref
-			IL_0060: dup
-			IL_0061: ldc.i4.3
-			IL_0062: ldloc.2
-			IL_0063: stelem.ref
-			IL_0064: stloc.s 6
-			IL_0066: ldloc.s 4
-			IL_0068: ldloc.s 5
-			IL_006a: ldloc.s 6
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0071: pop
-			IL_0072: ldnull
-			IL_0073: ret
+			IL_0030: ldc.i4.1
+			IL_0031: newarr [System.Runtime]System.Object
+			IL_0036: dup
+			IL_0037: ldc.i4.0
+			IL_0038: ldarg.0
+			IL_0039: stelem.ref
+			IL_003a: stloc.s 5
+			IL_003c: ldc.i4.4
+			IL_003d: newarr [System.Runtime]System.Object
+			IL_0042: dup
+			IL_0043: ldc.i4.0
+			IL_0044: ldstr "arg-string"
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.1
+			IL_004c: ldloc.0
+			IL_004d: stelem.ref
+			IL_004e: dup
+			IL_004f: ldc.i4.2
+			IL_0050: ldloc.1
+			IL_0051: stelem.ref
+			IL_0052: dup
+			IL_0053: ldc.i4.3
+			IL_0054: ldloc.2
+			IL_0055: stelem.ref
+			IL_0056: stloc.s 6
+			IL_0058: ldloc.s 4
+			IL_005a: ldloc.s 5
+			IL_005c: ldloc.s 6
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0063: pop
+			IL_0064: ldnull
+			IL_0065: ret
 		} // end of method argString::__js_call__
 
 	} // end of class argString
@@ -641,7 +572,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25a4
+			// Method begins at RVA 0x2502
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -932,7 +863,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25da
+		// Method begins at RVA 0x2538
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2580
+				// Method begins at RVA 0x24de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2589
+				// Method begins at RVA 0x24e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,112 +126,81 @@
 			)
 			// Method begins at RVA 0x22ec
 			// Header size: 12
-			// Code size: 211 (0xd3)
+			// Code size: 138 (0x8a)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] object,
 				[2] float64,
 				[3] object,
-				[4] float64,
-				[5] object,
-				[6] object[],
-				[7] object,
-				[8] object[]
+				[4] object,
+				[5] object[],
+				[6] object,
+				[7] object[]
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
-			IL_0006: stloc.3
-			IL_0007: ldstr "capturedGlobalDouble"
-			IL_000c: ldloc.3
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.3
-			IL_0013: ldloc.3
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.s 4
-			IL_001b: ldloc.s 4
-			IL_001d: stloc.0
-			IL_001e: ldarg.0
-			IL_001f: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
-			IL_0024: stloc.3
-			IL_0025: ldstr "capturedGlobalDouble"
-			IL_002a: ldloc.3
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0030: stloc.3
-			IL_0031: ldloc.3
-			IL_0032: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0037: stloc.s 4
-			IL_0039: ldloc.s 4
-			IL_003b: ldc.r8 1
-			IL_0044: sub
-			IL_0045: stloc.s 4
-			IL_0047: ldloc.s 4
-			IL_0049: box [System.Runtime]System.Double
+			IL_0006: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000b: stloc.0
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
+			IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0017: ldc.r8 1
+			IL_0020: sub
+			IL_0021: box [System.Runtime]System.Double
+			IL_0026: stloc.3
+			IL_0027: ldarg.0
+			IL_0028: ldloc.3
+			IL_0029: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
+			IL_002e: ldloc.3
+			IL_002f: stloc.1
+			IL_0030: ldarg.0
+			IL_0031: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
+			IL_0036: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_003b: stloc.2
+			IL_003c: ldarg.0
+			IL_003d: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
+			IL_0042: stloc.s 4
+			IL_0044: ldc.i4.1
+			IL_0045: newarr [System.Runtime]System.Object
+			IL_004a: dup
+			IL_004b: ldc.i4.0
+			IL_004c: ldarg.0
+			IL_004d: stelem.ref
 			IL_004e: stloc.s 5
-			IL_0050: ldarg.0
-			IL_0051: ldloc.s 5
-			IL_0053: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
-			IL_0058: ldloc.s 5
-			IL_005a: stloc.1
-			IL_005b: ldarg.0
-			IL_005c: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
-			IL_0061: stloc.3
-			IL_0062: ldstr "capturedGlobalDouble"
-			IL_0067: ldloc.3
-			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_006d: stloc.3
-			IL_006e: ldloc.3
-			IL_006f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0074: stloc.s 4
-			IL_0076: ldloc.s 4
-			IL_0078: stloc.2
-			IL_0079: ldarg.0
-			IL_007a: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
-			IL_007f: stloc.3
-			IL_0080: ldstr "logCase"
-			IL_0085: ldloc.3
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_008b: stloc.3
-			IL_008c: ldc.i4.1
-			IL_008d: newarr [System.Runtime]System.Object
-			IL_0092: dup
-			IL_0093: ldc.i4.0
-			IL_0094: ldarg.0
-			IL_0095: stelem.ref
-			IL_0096: stloc.s 6
-			IL_0098: ldloc.0
-			IL_0099: box [System.Runtime]System.Double
-			IL_009e: stloc.s 5
-			IL_00a0: ldloc.2
-			IL_00a1: box [System.Runtime]System.Double
-			IL_00a6: stloc.s 7
-			IL_00a8: ldc.i4.4
-			IL_00a9: newarr [System.Runtime]System.Object
-			IL_00ae: dup
-			IL_00af: ldc.i4.0
-			IL_00b0: ldstr "captured-double"
-			IL_00b5: stelem.ref
-			IL_00b6: dup
-			IL_00b7: ldc.i4.1
-			IL_00b8: ldloc.s 5
-			IL_00ba: stelem.ref
-			IL_00bb: dup
-			IL_00bc: ldc.i4.2
-			IL_00bd: ldloc.1
-			IL_00be: stelem.ref
-			IL_00bf: dup
-			IL_00c0: ldc.i4.3
-			IL_00c1: ldloc.s 7
-			IL_00c3: stelem.ref
-			IL_00c4: stloc.s 8
-			IL_00c6: ldloc.3
-			IL_00c7: ldloc.s 6
-			IL_00c9: ldloc.s 8
-			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_00d0: pop
-			IL_00d1: ldnull
-			IL_00d2: ret
+			IL_0050: ldloc.0
+			IL_0051: box [System.Runtime]System.Double
+			IL_0056: stloc.3
+			IL_0057: ldloc.2
+			IL_0058: box [System.Runtime]System.Double
+			IL_005d: stloc.s 6
+			IL_005f: ldc.i4.4
+			IL_0060: newarr [System.Runtime]System.Object
+			IL_0065: dup
+			IL_0066: ldc.i4.0
+			IL_0067: ldstr "captured-double"
+			IL_006c: stelem.ref
+			IL_006d: dup
+			IL_006e: ldc.i4.1
+			IL_006f: ldloc.3
+			IL_0070: stelem.ref
+			IL_0071: dup
+			IL_0072: ldc.i4.2
+			IL_0073: ldloc.1
+			IL_0074: stelem.ref
+			IL_0075: dup
+			IL_0076: ldc.i4.3
+			IL_0077: ldloc.s 6
+			IL_0079: stelem.ref
+			IL_007a: stloc.s 7
+			IL_007c: ldloc.s 4
+			IL_007e: ldloc.s 5
+			IL_0080: ldloc.s 7
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0087: pop
+			IL_0088: ldnull
+			IL_0089: ret
 		} // end of method capturedDouble::__js_call__
 
 	} // end of class capturedDouble
@@ -247,7 +216,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2592
+				// Method begins at RVA 0x24f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,9 +243,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23cc
+			// Method begins at RVA 0x2384
 			// Header size: 12
-			// Code size: 107 (0x6b)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -305,43 +274,39 @@
 			IL_001f: ldarg.0
 			IL_0020: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
 			IL_0025: stloc.s 4
-			IL_0027: ldstr "logCase"
-			IL_002c: ldloc.s 4
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0033: stloc.s 4
-			IL_0035: ldc.i4.1
-			IL_0036: newarr [System.Runtime]System.Object
-			IL_003b: dup
-			IL_003c: ldc.i4.0
-			IL_003d: ldarg.0
-			IL_003e: stelem.ref
-			IL_003f: stloc.s 5
-			IL_0041: ldc.i4.4
-			IL_0042: newarr [System.Runtime]System.Object
-			IL_0047: dup
-			IL_0048: ldc.i4.0
-			IL_0049: ldstr "arg-double"
-			IL_004e: stelem.ref
-			IL_004f: dup
-			IL_0050: ldc.i4.1
-			IL_0051: ldloc.0
-			IL_0052: stelem.ref
-			IL_0053: dup
-			IL_0054: ldc.i4.2
-			IL_0055: ldloc.1
-			IL_0056: stelem.ref
-			IL_0057: dup
-			IL_0058: ldc.i4.3
-			IL_0059: ldloc.2
-			IL_005a: stelem.ref
-			IL_005b: stloc.s 6
-			IL_005d: ldloc.s 4
-			IL_005f: ldloc.s 5
-			IL_0061: ldloc.s 6
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0068: pop
-			IL_0069: ldnull
-			IL_006a: ret
+			IL_0027: ldc.i4.1
+			IL_0028: newarr [System.Runtime]System.Object
+			IL_002d: dup
+			IL_002e: ldc.i4.0
+			IL_002f: ldarg.0
+			IL_0030: stelem.ref
+			IL_0031: stloc.s 5
+			IL_0033: ldc.i4.4
+			IL_0034: newarr [System.Runtime]System.Object
+			IL_0039: dup
+			IL_003a: ldc.i4.0
+			IL_003b: ldstr "arg-double"
+			IL_0040: stelem.ref
+			IL_0041: dup
+			IL_0042: ldc.i4.1
+			IL_0043: ldloc.0
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.2
+			IL_0047: ldloc.1
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.3
+			IL_004b: ldloc.2
+			IL_004c: stelem.ref
+			IL_004d: stloc.s 6
+			IL_004f: ldloc.s 4
+			IL_0051: ldloc.s 5
+			IL_0053: ldloc.s 6
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_005a: pop
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -357,7 +322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x259b
+				// Method begins at RVA 0x24f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -383,101 +348,74 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2444
+			// Method begins at RVA 0x23f0
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 112 (0x70)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] object,
-				[4] float64,
-				[5] object,
-				[6] object[],
-				[7] object[]
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
-			IL_0006: stloc.3
-			IL_0007: ldstr "capturedGlobalString"
-			IL_000c: ldloc.3
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.3
-			IL_0013: ldloc.3
-			IL_0014: stloc.0
-			IL_0015: ldarg.0
-			IL_0016: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
-			IL_001b: stloc.3
-			IL_001c: ldstr "capturedGlobalString"
-			IL_0021: ldloc.3
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0027: stloc.3
-			IL_0028: ldloc.3
-			IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002e: stloc.s 4
-			IL_0030: ldloc.s 4
-			IL_0032: ldc.r8 1
-			IL_003b: sub
-			IL_003c: stloc.s 4
-			IL_003e: ldloc.s 4
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: stloc.s 5
-			IL_0047: ldarg.0
-			IL_0048: ldloc.s 5
-			IL_004a: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
-			IL_004f: ldloc.s 5
-			IL_0051: stloc.1
-			IL_0052: ldarg.0
-			IL_0053: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
-			IL_0058: stloc.3
-			IL_0059: ldstr "capturedGlobalString"
-			IL_005e: ldloc.3
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0064: stloc.3
-			IL_0065: ldloc.3
-			IL_0066: stloc.2
-			IL_0067: ldarg.0
-			IL_0068: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
-			IL_006d: stloc.3
-			IL_006e: ldstr "logCase"
-			IL_0073: ldloc.3
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0079: stloc.3
-			IL_007a: ldc.i4.1
-			IL_007b: newarr [System.Runtime]System.Object
-			IL_0080: dup
-			IL_0081: ldc.i4.0
-			IL_0082: ldarg.0
-			IL_0083: stelem.ref
-			IL_0084: stloc.s 6
-			IL_0086: ldc.i4.4
-			IL_0087: newarr [System.Runtime]System.Object
-			IL_008c: dup
-			IL_008d: ldc.i4.0
-			IL_008e: ldstr "captured-string"
-			IL_0093: stelem.ref
-			IL_0094: dup
-			IL_0095: ldc.i4.1
-			IL_0096: ldloc.0
-			IL_0097: stelem.ref
-			IL_0098: dup
-			IL_0099: ldc.i4.2
-			IL_009a: ldloc.1
-			IL_009b: stelem.ref
-			IL_009c: dup
-			IL_009d: ldc.i4.3
-			IL_009e: ldloc.2
-			IL_009f: stelem.ref
-			IL_00a0: stloc.s 7
-			IL_00a2: ldloc.3
-			IL_00a3: ldloc.s 6
-			IL_00a5: ldloc.s 7
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_00ac: pop
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
+			IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0012: ldc.r8 1
+			IL_001b: sub
+			IL_001c: box [System.Runtime]System.Double
+			IL_0021: stloc.3
+			IL_0022: ldarg.0
+			IL_0023: ldloc.3
+			IL_0024: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
+			IL_0029: ldloc.3
+			IL_002a: stloc.1
+			IL_002b: ldarg.0
+			IL_002c: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
+			IL_0031: stloc.2
+			IL_0032: ldarg.0
+			IL_0033: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
+			IL_0038: stloc.s 4
+			IL_003a: ldc.i4.1
+			IL_003b: newarr [System.Runtime]System.Object
+			IL_0040: dup
+			IL_0041: ldc.i4.0
+			IL_0042: ldarg.0
+			IL_0043: stelem.ref
+			IL_0044: stloc.s 5
+			IL_0046: ldc.i4.4
+			IL_0047: newarr [System.Runtime]System.Object
+			IL_004c: dup
+			IL_004d: ldc.i4.0
+			IL_004e: ldstr "captured-string"
+			IL_0053: stelem.ref
+			IL_0054: dup
+			IL_0055: ldc.i4.1
+			IL_0056: ldloc.0
+			IL_0057: stelem.ref
+			IL_0058: dup
+			IL_0059: ldc.i4.2
+			IL_005a: ldloc.1
+			IL_005b: stelem.ref
+			IL_005c: dup
+			IL_005d: ldc.i4.3
+			IL_005e: ldloc.2
+			IL_005f: stelem.ref
+			IL_0060: stloc.s 6
+			IL_0062: ldloc.s 4
+			IL_0064: ldloc.s 5
+			IL_0066: ldloc.s 6
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_006d: pop
+			IL_006e: ldnull
+			IL_006f: ret
 		} // end of method capturedString::__js_call__
 
 	} // end of class capturedString
@@ -493,7 +431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25a4
+				// Method begins at RVA 0x2502
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -520,9 +458,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2500
+			// Method begins at RVA 0x246c
 			// Header size: 12
-			// Code size: 107 (0x6b)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -551,43 +489,39 @@
 			IL_001f: ldarg.0
 			IL_0020: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
 			IL_0025: stloc.s 4
-			IL_0027: ldstr "logCase"
-			IL_002c: ldloc.s 4
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0033: stloc.s 4
-			IL_0035: ldc.i4.1
-			IL_0036: newarr [System.Runtime]System.Object
-			IL_003b: dup
-			IL_003c: ldc.i4.0
-			IL_003d: ldarg.0
-			IL_003e: stelem.ref
-			IL_003f: stloc.s 5
-			IL_0041: ldc.i4.4
-			IL_0042: newarr [System.Runtime]System.Object
-			IL_0047: dup
-			IL_0048: ldc.i4.0
-			IL_0049: ldstr "arg-string"
-			IL_004e: stelem.ref
-			IL_004f: dup
-			IL_0050: ldc.i4.1
-			IL_0051: ldloc.0
-			IL_0052: stelem.ref
-			IL_0053: dup
-			IL_0054: ldc.i4.2
-			IL_0055: ldloc.1
-			IL_0056: stelem.ref
-			IL_0057: dup
-			IL_0058: ldc.i4.3
-			IL_0059: ldloc.2
-			IL_005a: stelem.ref
-			IL_005b: stloc.s 6
-			IL_005d: ldloc.s 4
-			IL_005f: ldloc.s 5
-			IL_0061: ldloc.s 6
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0068: pop
-			IL_0069: ldnull
-			IL_006a: ret
+			IL_0027: ldc.i4.1
+			IL_0028: newarr [System.Runtime]System.Object
+			IL_002d: dup
+			IL_002e: ldc.i4.0
+			IL_002f: ldarg.0
+			IL_0030: stelem.ref
+			IL_0031: stloc.s 5
+			IL_0033: ldc.i4.4
+			IL_0034: newarr [System.Runtime]System.Object
+			IL_0039: dup
+			IL_003a: ldc.i4.0
+			IL_003b: ldstr "arg-string"
+			IL_0040: stelem.ref
+			IL_0041: dup
+			IL_0042: ldc.i4.1
+			IL_0043: ldloc.0
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.2
+			IL_0047: ldloc.1
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.3
+			IL_004b: ldloc.2
+			IL_004c: stelem.ref
+			IL_004d: stloc.s 6
+			IL_004f: ldloc.s 4
+			IL_0051: ldloc.s 5
+			IL_0053: ldloc.s 6
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_005a: pop
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method argString::__js_call__
 
 	} // end of class argString
@@ -625,7 +559,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2577
+			// Method begins at RVA 0x24d5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -914,7 +848,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25ad
+		// Method begins at RVA 0x250b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22da
+					// Method begins at RVA 0x228e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,12 +48,12 @@
 				)
 				// Method begins at RVA 0x2124
 				// Header size: 12
-				// Code size: 408 (0x198)
+				// Code size: 332 (0x14c)
 				.maxstack 8
 				.locals init (
 					[0] object,
-					[1] object,
-					[2] float64,
+					[1] float64,
+					[2] object,
 					[3] object
 				)
 
@@ -68,155 +68,111 @@
 				IL_0014: ldelem.ref
 				IL_0015: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
 				IL_001a: ldfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
-				IL_001f: stloc.1
-				IL_0020: ldstr "x"
+				IL_001f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0024: stloc.1
 				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_002b: stloc.1
-				IL_002c: ldloc.1
-				IL_002d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0032: stloc.2
-				IL_0033: ldloc.2
-				IL_0034: box [System.Runtime]System.Double
-				IL_0039: stloc.3
-				IL_003a: ldloc.3
-				IL_003b: stloc.1
-				IL_003c: ldloc.2
-				IL_003d: ldc.r8 1
-				IL_0046: add
-				IL_0047: stloc.2
-				IL_0048: ldloc.2
-				IL_0049: box [System.Runtime]System.Double
-				IL_004e: stloc.3
-				IL_004f: ldarg.0
-				IL_0050: ldc.i4.1
-				IL_0051: ldelem.ref
-				IL_0052: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
-				IL_0057: ldloc.3
-				IL_0058: stfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
-				IL_005d: ldloc.0
-				IL_005e: ldstr "log"
-				IL_0063: ldloc.1
-				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0069: pop
-				IL_006a: ldstr "console"
-				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0074: stloc.1
-				IL_0075: ldloc.1
-				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_007b: stloc.1
-				IL_007c: ldarg.0
-				IL_007d: ldc.i4.1
-				IL_007e: ldelem.ref
-				IL_007f: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
-				IL_0084: ldfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
-				IL_0089: stloc.0
-				IL_008a: ldstr "x"
-				IL_008f: ldloc.0
-				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0095: stloc.0
-				IL_0096: ldloc.0
-				IL_0097: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_009c: stloc.2
-				IL_009d: ldloc.2
-				IL_009e: ldc.r8 1
-				IL_00a7: add
-				IL_00a8: stloc.2
-				IL_00a9: ldloc.2
-				IL_00aa: box [System.Runtime]System.Double
-				IL_00af: stloc.3
-				IL_00b0: ldarg.0
-				IL_00b1: ldc.i4.1
-				IL_00b2: ldelem.ref
-				IL_00b3: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
-				IL_00b8: ldloc.3
-				IL_00b9: stfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
-				IL_00be: ldloc.1
-				IL_00bf: ldstr "log"
-				IL_00c4: ldloc.3
-				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00ca: pop
-				IL_00cb: ldstr "console"
-				IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00d5: stloc.1
-				IL_00d6: ldloc.1
-				IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00dc: stloc.1
-				IL_00dd: ldarg.0
-				IL_00de: ldc.i4.1
-				IL_00df: ldelem.ref
-				IL_00e0: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
-				IL_00e5: ldfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
-				IL_00ea: stloc.0
-				IL_00eb: ldstr "x"
-				IL_00f0: ldloc.0
-				IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_00f6: stloc.0
-				IL_00f7: ldloc.0
-				IL_00f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00fd: stloc.2
-				IL_00fe: ldloc.2
-				IL_00ff: box [System.Runtime]System.Double
-				IL_0104: stloc.3
-				IL_0105: ldloc.3
-				IL_0106: stloc.0
-				IL_0107: ldloc.2
-				IL_0108: ldc.r8 1
-				IL_0111: sub
-				IL_0112: stloc.2
-				IL_0113: ldloc.2
-				IL_0114: box [System.Runtime]System.Double
-				IL_0119: stloc.3
-				IL_011a: ldarg.0
-				IL_011b: ldc.i4.1
-				IL_011c: ldelem.ref
-				IL_011d: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
-				IL_0122: ldloc.3
-				IL_0123: stfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
-				IL_0128: ldloc.1
-				IL_0129: ldstr "log"
-				IL_012e: ldloc.0
-				IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0134: pop
-				IL_0135: ldstr "console"
-				IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_013f: stloc.0
-				IL_0140: ldloc.0
-				IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0146: stloc.0
-				IL_0147: ldarg.0
-				IL_0148: ldc.i4.1
-				IL_0149: ldelem.ref
-				IL_014a: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
-				IL_014f: ldfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
-				IL_0154: stloc.1
-				IL_0155: ldstr "x"
-				IL_015a: ldloc.1
-				IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-				IL_0160: stloc.1
-				IL_0161: ldloc.1
-				IL_0162: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0167: stloc.2
-				IL_0168: ldloc.2
-				IL_0169: ldc.r8 1
-				IL_0172: sub
-				IL_0173: stloc.2
-				IL_0174: ldloc.2
-				IL_0175: box [System.Runtime]System.Double
-				IL_017a: stloc.3
-				IL_017b: ldarg.0
-				IL_017c: ldc.i4.1
-				IL_017d: ldelem.ref
-				IL_017e: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
-				IL_0183: ldloc.3
-				IL_0184: stfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
-				IL_0189: ldloc.0
-				IL_018a: ldstr "log"
-				IL_018f: ldloc.3
-				IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0195: pop
-				IL_0196: ldnull
-				IL_0197: ret
+				IL_0026: box [System.Runtime]System.Double
+				IL_002b: stloc.2
+				IL_002c: ldarg.0
+				IL_002d: ldc.i4.1
+				IL_002e: ldelem.ref
+				IL_002f: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
+				IL_0034: ldloc.1
+				IL_0035: ldc.r8 1
+				IL_003e: add
+				IL_003f: box [System.Runtime]System.Double
+				IL_0044: stfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
+				IL_0049: ldloc.0
+				IL_004a: ldstr "log"
+				IL_004f: ldloc.2
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0055: pop
+				IL_0056: ldstr "console"
+				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0060: stloc.2
+				IL_0061: ldloc.2
+				IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0067: stloc.2
+				IL_0068: ldarg.0
+				IL_0069: ldc.i4.1
+				IL_006a: ldelem.ref
+				IL_006b: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
+				IL_0070: ldfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
+				IL_0075: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_007a: ldc.r8 1
+				IL_0083: add
+				IL_0084: box [System.Runtime]System.Double
+				IL_0089: stloc.3
+				IL_008a: ldarg.0
+				IL_008b: ldc.i4.1
+				IL_008c: ldelem.ref
+				IL_008d: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
+				IL_0092: ldloc.3
+				IL_0093: stfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
+				IL_0098: ldloc.2
+				IL_0099: ldstr "log"
+				IL_009e: ldloc.3
+				IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00a4: pop
+				IL_00a5: ldstr "console"
+				IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00af: stloc.2
+				IL_00b0: ldloc.2
+				IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00b6: stloc.2
+				IL_00b7: ldarg.0
+				IL_00b8: ldc.i4.1
+				IL_00b9: ldelem.ref
+				IL_00ba: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
+				IL_00bf: ldfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
+				IL_00c4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00c9: stloc.1
+				IL_00ca: ldloc.1
+				IL_00cb: box [System.Runtime]System.Double
+				IL_00d0: stloc.0
+				IL_00d1: ldarg.0
+				IL_00d2: ldc.i4.1
+				IL_00d3: ldelem.ref
+				IL_00d4: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
+				IL_00d9: ldloc.1
+				IL_00da: ldc.r8 1
+				IL_00e3: sub
+				IL_00e4: box [System.Runtime]System.Double
+				IL_00e9: stfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
+				IL_00ee: ldloc.2
+				IL_00ef: ldstr "log"
+				IL_00f4: ldloc.0
+				IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00fa: pop
+				IL_00fb: ldstr "console"
+				IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0105: stloc.0
+				IL_0106: ldloc.0
+				IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_010c: stloc.0
+				IL_010d: ldarg.0
+				IL_010e: ldc.i4.1
+				IL_010f: ldelem.ref
+				IL_0110: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
+				IL_0115: ldfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
+				IL_011a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_011f: ldc.r8 1
+				IL_0128: sub
+				IL_0129: box [System.Runtime]System.Double
+				IL_012e: stloc.3
+				IL_012f: ldarg.0
+				IL_0130: ldc.i4.1
+				IL_0131: ldelem.ref
+				IL_0132: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
+				IL_0137: ldloc.3
+				IL_0138: stfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
+				IL_013d: ldloc.0
+				IL_013e: ldstr "log"
+				IL_0143: ldloc.3
+				IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0149: pop
+				IL_014a: ldnull
+				IL_014b: ret
 			} // end of method inner::__js_call__
 
 		} // end of class inner
@@ -236,7 +192,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d1
+				// Method begins at RVA 0x2285
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -340,7 +296,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22c8
+			// Method begins at RVA 0x227c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -412,7 +368,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e3
+		// Method begins at RVA 0x2297
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25ad
+				// Method begins at RVA 0x250b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25b6
+				// Method begins at RVA 0x2514
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,117 +126,85 @@
 			)
 			// Method begins at RVA 0x22f0
 			// Header size: 12
-			// Code size: 222 (0xde)
+			// Code size: 149 (0x95)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] object,
 				[2] float64,
-				[3] object,
-				[4] float64,
-				[5] object,
-				[6] object[],
+				[3] float64,
+				[4] object,
+				[5] object[],
+				[6] object,
 				[7] object,
 				[8] object[]
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
-			IL_0006: stloc.3
-			IL_0007: ldstr "capturedGlobalDouble"
-			IL_000c: ldloc.3
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.3
-			IL_0013: ldloc.3
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.s 4
-			IL_001b: ldloc.s 4
-			IL_001d: stloc.0
-			IL_001e: ldarg.0
-			IL_001f: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
-			IL_0024: stloc.3
-			IL_0025: ldstr "capturedGlobalDouble"
-			IL_002a: ldloc.3
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0030: stloc.3
-			IL_0031: ldloc.3
-			IL_0032: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0037: stloc.s 4
-			IL_0039: ldloc.s 4
-			IL_003b: box [System.Runtime]System.Double
-			IL_0040: stloc.s 5
-			IL_0042: ldloc.s 5
-			IL_0044: stloc.3
-			IL_0045: ldloc.s 4
-			IL_0047: ldc.r8 1
-			IL_0050: add
-			IL_0051: stloc.s 4
-			IL_0053: ldloc.s 4
-			IL_0055: box [System.Runtime]System.Double
-			IL_005a: stloc.s 5
-			IL_005c: ldarg.0
-			IL_005d: ldloc.s 5
-			IL_005f: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
-			IL_0064: ldloc.3
-			IL_0065: stloc.1
-			IL_0066: ldarg.0
-			IL_0067: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
-			IL_006c: stloc.3
-			IL_006d: ldstr "capturedGlobalDouble"
-			IL_0072: ldloc.3
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0078: stloc.3
-			IL_0079: ldloc.3
-			IL_007a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_007f: stloc.s 4
-			IL_0081: ldloc.s 4
-			IL_0083: stloc.2
-			IL_0084: ldarg.0
-			IL_0085: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
-			IL_008a: stloc.3
-			IL_008b: ldstr "logCase"
-			IL_0090: ldloc.3
-			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0096: stloc.3
-			IL_0097: ldc.i4.1
-			IL_0098: newarr [System.Runtime]System.Object
-			IL_009d: dup
-			IL_009e: ldc.i4.0
-			IL_009f: ldarg.0
-			IL_00a0: stelem.ref
-			IL_00a1: stloc.s 6
-			IL_00a3: ldloc.0
-			IL_00a4: box [System.Runtime]System.Double
-			IL_00a9: stloc.s 5
-			IL_00ab: ldloc.2
-			IL_00ac: box [System.Runtime]System.Double
-			IL_00b1: stloc.s 7
-			IL_00b3: ldc.i4.4
-			IL_00b4: newarr [System.Runtime]System.Object
-			IL_00b9: dup
-			IL_00ba: ldc.i4.0
-			IL_00bb: ldstr "captured-double"
-			IL_00c0: stelem.ref
-			IL_00c1: dup
-			IL_00c2: ldc.i4.1
-			IL_00c3: ldloc.s 5
-			IL_00c5: stelem.ref
-			IL_00c6: dup
-			IL_00c7: ldc.i4.2
-			IL_00c8: ldloc.1
-			IL_00c9: stelem.ref
-			IL_00ca: dup
-			IL_00cb: ldc.i4.3
-			IL_00cc: ldloc.s 7
-			IL_00ce: stelem.ref
-			IL_00cf: stloc.s 8
-			IL_00d1: ldloc.3
-			IL_00d2: ldloc.s 6
-			IL_00d4: ldloc.s 8
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_00db: pop
-			IL_00dc: ldnull
-			IL_00dd: ret
+			IL_0006: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000b: stloc.0
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
+			IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0017: stloc.3
+			IL_0018: ldloc.3
+			IL_0019: box [System.Runtime]System.Double
+			IL_001e: stloc.s 4
+			IL_0020: ldarg.0
+			IL_0021: ldloc.3
+			IL_0022: ldc.r8 1
+			IL_002b: add
+			IL_002c: box [System.Runtime]System.Double
+			IL_0031: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
+			IL_0036: ldloc.s 4
+			IL_0038: stloc.1
+			IL_0039: ldarg.0
+			IL_003a: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
+			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0044: stloc.2
+			IL_0045: ldarg.0
+			IL_0046: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
+			IL_004b: stloc.s 4
+			IL_004d: ldc.i4.1
+			IL_004e: newarr [System.Runtime]System.Object
+			IL_0053: dup
+			IL_0054: ldc.i4.0
+			IL_0055: ldarg.0
+			IL_0056: stelem.ref
+			IL_0057: stloc.s 5
+			IL_0059: ldloc.0
+			IL_005a: box [System.Runtime]System.Double
+			IL_005f: stloc.s 6
+			IL_0061: ldloc.2
+			IL_0062: box [System.Runtime]System.Double
+			IL_0067: stloc.s 7
+			IL_0069: ldc.i4.4
+			IL_006a: newarr [System.Runtime]System.Object
+			IL_006f: dup
+			IL_0070: ldc.i4.0
+			IL_0071: ldstr "captured-double"
+			IL_0076: stelem.ref
+			IL_0077: dup
+			IL_0078: ldc.i4.1
+			IL_0079: ldloc.s 6
+			IL_007b: stelem.ref
+			IL_007c: dup
+			IL_007d: ldc.i4.2
+			IL_007e: ldloc.1
+			IL_007f: stelem.ref
+			IL_0080: dup
+			IL_0081: ldc.i4.3
+			IL_0082: ldloc.s 7
+			IL_0084: stelem.ref
+			IL_0085: stloc.s 8
+			IL_0087: ldloc.s 4
+			IL_0089: ldloc.s 5
+			IL_008b: ldloc.s 8
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0092: pop
+			IL_0093: ldnull
+			IL_0094: ret
 		} // end of method capturedDouble::__js_call__
 
 	} // end of class capturedDouble
@@ -252,7 +220,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25bf
+				// Method begins at RVA 0x251d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -279,9 +247,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23dc
+			// Method begins at RVA 0x2394
 			// Header size: 12
-			// Code size: 116 (0x74)
+			// Code size: 102 (0x66)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -313,43 +281,39 @@
 			IL_0028: ldarg.0
 			IL_0029: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
 			IL_002e: stloc.s 4
-			IL_0030: ldstr "logCase"
-			IL_0035: ldloc.s 4
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.s 4
-			IL_003e: ldc.i4.1
-			IL_003f: newarr [System.Runtime]System.Object
-			IL_0044: dup
-			IL_0045: ldc.i4.0
-			IL_0046: ldarg.0
-			IL_0047: stelem.ref
-			IL_0048: stloc.s 5
-			IL_004a: ldc.i4.4
-			IL_004b: newarr [System.Runtime]System.Object
-			IL_0050: dup
-			IL_0051: ldc.i4.0
-			IL_0052: ldstr "arg-double"
-			IL_0057: stelem.ref
-			IL_0058: dup
-			IL_0059: ldc.i4.1
-			IL_005a: ldloc.0
-			IL_005b: stelem.ref
-			IL_005c: dup
-			IL_005d: ldc.i4.2
-			IL_005e: ldloc.1
-			IL_005f: stelem.ref
-			IL_0060: dup
-			IL_0061: ldc.i4.3
-			IL_0062: ldloc.2
-			IL_0063: stelem.ref
-			IL_0064: stloc.s 6
-			IL_0066: ldloc.s 4
-			IL_0068: ldloc.s 5
-			IL_006a: ldloc.s 6
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0071: pop
-			IL_0072: ldnull
-			IL_0073: ret
+			IL_0030: ldc.i4.1
+			IL_0031: newarr [System.Runtime]System.Object
+			IL_0036: dup
+			IL_0037: ldc.i4.0
+			IL_0038: ldarg.0
+			IL_0039: stelem.ref
+			IL_003a: stloc.s 5
+			IL_003c: ldc.i4.4
+			IL_003d: newarr [System.Runtime]System.Object
+			IL_0042: dup
+			IL_0043: ldc.i4.0
+			IL_0044: ldstr "arg-double"
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.1
+			IL_004c: ldloc.0
+			IL_004d: stelem.ref
+			IL_004e: dup
+			IL_004f: ldc.i4.2
+			IL_0050: ldloc.1
+			IL_0051: stelem.ref
+			IL_0052: dup
+			IL_0053: ldc.i4.3
+			IL_0054: ldloc.2
+			IL_0055: stelem.ref
+			IL_0056: stloc.s 6
+			IL_0058: ldloc.s 4
+			IL_005a: ldloc.s 5
+			IL_005c: ldloc.s 6
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0063: pop
+			IL_0064: ldnull
+			IL_0065: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -365,7 +329,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25c8
+				// Method begins at RVA 0x2526
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -391,106 +355,77 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x245c
+			// Method begins at RVA 0x2408
 			// Header size: 12
-			// Code size: 186 (0xba)
+			// Code size: 121 (0x79)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object,
-				[4] float64,
-				[5] object,
-				[6] object[],
-				[7] object[]
+				[3] float64,
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
-			IL_0006: stloc.3
-			IL_0007: ldstr "capturedGlobalString"
-			IL_000c: ldloc.3
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
+			IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0012: stloc.3
 			IL_0013: ldloc.3
-			IL_0014: stloc.0
-			IL_0015: ldarg.0
-			IL_0016: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
-			IL_001b: stloc.3
-			IL_001c: ldstr "capturedGlobalString"
-			IL_0021: ldloc.3
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0027: stloc.3
-			IL_0028: ldloc.3
-			IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002e: stloc.s 4
-			IL_0030: ldloc.s 4
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: stloc.s 5
-			IL_0039: ldloc.s 5
-			IL_003b: stloc.3
-			IL_003c: ldloc.s 4
-			IL_003e: ldc.r8 1
-			IL_0047: add
-			IL_0048: stloc.s 4
-			IL_004a: ldloc.s 4
-			IL_004c: box [System.Runtime]System.Double
-			IL_0051: stloc.s 5
-			IL_0053: ldarg.0
-			IL_0054: ldloc.s 5
-			IL_0056: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
-			IL_005b: ldloc.3
-			IL_005c: stloc.1
-			IL_005d: ldarg.0
-			IL_005e: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
-			IL_0063: stloc.3
-			IL_0064: ldstr "capturedGlobalString"
-			IL_0069: ldloc.3
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_006f: stloc.3
-			IL_0070: ldloc.3
-			IL_0071: stloc.2
-			IL_0072: ldarg.0
-			IL_0073: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
-			IL_0078: stloc.3
-			IL_0079: ldstr "logCase"
-			IL_007e: ldloc.3
-			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0084: stloc.3
-			IL_0085: ldc.i4.1
-			IL_0086: newarr [System.Runtime]System.Object
-			IL_008b: dup
-			IL_008c: ldc.i4.0
-			IL_008d: ldarg.0
-			IL_008e: stelem.ref
-			IL_008f: stloc.s 6
-			IL_0091: ldc.i4.4
-			IL_0092: newarr [System.Runtime]System.Object
-			IL_0097: dup
-			IL_0098: ldc.i4.0
-			IL_0099: ldstr "captured-string"
-			IL_009e: stelem.ref
-			IL_009f: dup
-			IL_00a0: ldc.i4.1
-			IL_00a1: ldloc.0
-			IL_00a2: stelem.ref
-			IL_00a3: dup
-			IL_00a4: ldc.i4.2
-			IL_00a5: ldloc.1
-			IL_00a6: stelem.ref
-			IL_00a7: dup
-			IL_00a8: ldc.i4.3
-			IL_00a9: ldloc.2
-			IL_00aa: stelem.ref
-			IL_00ab: stloc.s 7
-			IL_00ad: ldloc.3
-			IL_00ae: ldloc.s 6
-			IL_00b0: ldloc.s 7
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_00b7: pop
-			IL_00b8: ldnull
-			IL_00b9: ret
+			IL_0014: box [System.Runtime]System.Double
+			IL_0019: stloc.s 4
+			IL_001b: ldarg.0
+			IL_001c: ldloc.3
+			IL_001d: ldc.r8 1
+			IL_0026: add
+			IL_0027: box [System.Runtime]System.Double
+			IL_002c: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
+			IL_0031: ldloc.s 4
+			IL_0033: stloc.1
+			IL_0034: ldarg.0
+			IL_0035: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
+			IL_003a: stloc.2
+			IL_003b: ldarg.0
+			IL_003c: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
+			IL_0041: stloc.s 4
+			IL_0043: ldc.i4.1
+			IL_0044: newarr [System.Runtime]System.Object
+			IL_0049: dup
+			IL_004a: ldc.i4.0
+			IL_004b: ldarg.0
+			IL_004c: stelem.ref
+			IL_004d: stloc.s 5
+			IL_004f: ldc.i4.4
+			IL_0050: newarr [System.Runtime]System.Object
+			IL_0055: dup
+			IL_0056: ldc.i4.0
+			IL_0057: ldstr "captured-string"
+			IL_005c: stelem.ref
+			IL_005d: dup
+			IL_005e: ldc.i4.1
+			IL_005f: ldloc.0
+			IL_0060: stelem.ref
+			IL_0061: dup
+			IL_0062: ldc.i4.2
+			IL_0063: ldloc.1
+			IL_0064: stelem.ref
+			IL_0065: dup
+			IL_0066: ldc.i4.3
+			IL_0067: ldloc.2
+			IL_0068: stelem.ref
+			IL_0069: stloc.s 6
+			IL_006b: ldloc.s 4
+			IL_006d: ldloc.s 5
+			IL_006f: ldloc.s 6
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0076: pop
+			IL_0077: ldnull
+			IL_0078: ret
 		} // end of method capturedString::__js_call__
 
 	} // end of class capturedString
@@ -506,7 +441,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25d1
+				// Method begins at RVA 0x252f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -533,9 +468,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2524
+			// Method begins at RVA 0x2490
 			// Header size: 12
-			// Code size: 116 (0x74)
+			// Code size: 102 (0x66)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -567,43 +502,39 @@
 			IL_0028: ldarg.0
 			IL_0029: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
 			IL_002e: stloc.s 4
-			IL_0030: ldstr "logCase"
-			IL_0035: ldloc.s 4
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_003c: stloc.s 4
-			IL_003e: ldc.i4.1
-			IL_003f: newarr [System.Runtime]System.Object
-			IL_0044: dup
-			IL_0045: ldc.i4.0
-			IL_0046: ldarg.0
-			IL_0047: stelem.ref
-			IL_0048: stloc.s 5
-			IL_004a: ldc.i4.4
-			IL_004b: newarr [System.Runtime]System.Object
-			IL_0050: dup
-			IL_0051: ldc.i4.0
-			IL_0052: ldstr "arg-string"
-			IL_0057: stelem.ref
-			IL_0058: dup
-			IL_0059: ldc.i4.1
-			IL_005a: ldloc.0
-			IL_005b: stelem.ref
-			IL_005c: dup
-			IL_005d: ldc.i4.2
-			IL_005e: ldloc.1
-			IL_005f: stelem.ref
-			IL_0060: dup
-			IL_0061: ldc.i4.3
-			IL_0062: ldloc.2
-			IL_0063: stelem.ref
-			IL_0064: stloc.s 6
-			IL_0066: ldloc.s 4
-			IL_0068: ldloc.s 5
-			IL_006a: ldloc.s 6
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0071: pop
-			IL_0072: ldnull
-			IL_0073: ret
+			IL_0030: ldc.i4.1
+			IL_0031: newarr [System.Runtime]System.Object
+			IL_0036: dup
+			IL_0037: ldc.i4.0
+			IL_0038: ldarg.0
+			IL_0039: stelem.ref
+			IL_003a: stloc.s 5
+			IL_003c: ldc.i4.4
+			IL_003d: newarr [System.Runtime]System.Object
+			IL_0042: dup
+			IL_0043: ldc.i4.0
+			IL_0044: ldstr "arg-string"
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.1
+			IL_004c: ldloc.0
+			IL_004d: stelem.ref
+			IL_004e: dup
+			IL_004f: ldc.i4.2
+			IL_0050: ldloc.1
+			IL_0051: stelem.ref
+			IL_0052: dup
+			IL_0053: ldc.i4.3
+			IL_0054: ldloc.2
+			IL_0055: stelem.ref
+			IL_0056: stloc.s 6
+			IL_0058: ldloc.s 4
+			IL_005a: ldloc.s 5
+			IL_005c: ldloc.s 6
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0063: pop
+			IL_0064: ldnull
+			IL_0065: ret
 		} // end of method argString::__js_call__
 
 	} // end of class argString
@@ -641,7 +572,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25a4
+			// Method begins at RVA 0x2502
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -932,7 +863,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25da
+		// Method begins at RVA 0x2538
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2580
+				// Method begins at RVA 0x24de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2589
+				// Method begins at RVA 0x24e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,112 +126,81 @@
 			)
 			// Method begins at RVA 0x22ec
 			// Header size: 12
-			// Code size: 211 (0xd3)
+			// Code size: 138 (0x8a)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] object,
 				[2] float64,
 				[3] object,
-				[4] float64,
-				[5] object,
-				[6] object[],
-				[7] object,
-				[8] object[]
+				[4] object,
+				[5] object[],
+				[6] object,
+				[7] object[]
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
-			IL_0006: stloc.3
-			IL_0007: ldstr "capturedGlobalDouble"
-			IL_000c: ldloc.3
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.3
-			IL_0013: ldloc.3
-			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0019: stloc.s 4
-			IL_001b: ldloc.s 4
-			IL_001d: stloc.0
-			IL_001e: ldarg.0
-			IL_001f: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
-			IL_0024: stloc.3
-			IL_0025: ldstr "capturedGlobalDouble"
-			IL_002a: ldloc.3
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0030: stloc.3
-			IL_0031: ldloc.3
-			IL_0032: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0037: stloc.s 4
-			IL_0039: ldloc.s 4
-			IL_003b: ldc.r8 1
-			IL_0044: add
-			IL_0045: stloc.s 4
-			IL_0047: ldloc.s 4
-			IL_0049: box [System.Runtime]System.Double
+			IL_0006: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000b: stloc.0
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
+			IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0017: ldc.r8 1
+			IL_0020: add
+			IL_0021: box [System.Runtime]System.Double
+			IL_0026: stloc.3
+			IL_0027: ldarg.0
+			IL_0028: ldloc.3
+			IL_0029: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
+			IL_002e: ldloc.3
+			IL_002f: stloc.1
+			IL_0030: ldarg.0
+			IL_0031: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
+			IL_0036: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_003b: stloc.2
+			IL_003c: ldarg.0
+			IL_003d: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
+			IL_0042: stloc.s 4
+			IL_0044: ldc.i4.1
+			IL_0045: newarr [System.Runtime]System.Object
+			IL_004a: dup
+			IL_004b: ldc.i4.0
+			IL_004c: ldarg.0
+			IL_004d: stelem.ref
 			IL_004e: stloc.s 5
-			IL_0050: ldarg.0
-			IL_0051: ldloc.s 5
-			IL_0053: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
-			IL_0058: ldloc.s 5
-			IL_005a: stloc.1
-			IL_005b: ldarg.0
-			IL_005c: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
-			IL_0061: stloc.3
-			IL_0062: ldstr "capturedGlobalDouble"
-			IL_0067: ldloc.3
-			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_006d: stloc.3
-			IL_006e: ldloc.3
-			IL_006f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0074: stloc.s 4
-			IL_0076: ldloc.s 4
-			IL_0078: stloc.2
-			IL_0079: ldarg.0
-			IL_007a: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
-			IL_007f: stloc.3
-			IL_0080: ldstr "logCase"
-			IL_0085: ldloc.3
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_008b: stloc.3
-			IL_008c: ldc.i4.1
-			IL_008d: newarr [System.Runtime]System.Object
-			IL_0092: dup
-			IL_0093: ldc.i4.0
-			IL_0094: ldarg.0
-			IL_0095: stelem.ref
-			IL_0096: stloc.s 6
-			IL_0098: ldloc.0
-			IL_0099: box [System.Runtime]System.Double
-			IL_009e: stloc.s 5
-			IL_00a0: ldloc.2
-			IL_00a1: box [System.Runtime]System.Double
-			IL_00a6: stloc.s 7
-			IL_00a8: ldc.i4.4
-			IL_00a9: newarr [System.Runtime]System.Object
-			IL_00ae: dup
-			IL_00af: ldc.i4.0
-			IL_00b0: ldstr "captured-double"
-			IL_00b5: stelem.ref
-			IL_00b6: dup
-			IL_00b7: ldc.i4.1
-			IL_00b8: ldloc.s 5
-			IL_00ba: stelem.ref
-			IL_00bb: dup
-			IL_00bc: ldc.i4.2
-			IL_00bd: ldloc.1
-			IL_00be: stelem.ref
-			IL_00bf: dup
-			IL_00c0: ldc.i4.3
-			IL_00c1: ldloc.s 7
-			IL_00c3: stelem.ref
-			IL_00c4: stloc.s 8
-			IL_00c6: ldloc.3
-			IL_00c7: ldloc.s 6
-			IL_00c9: ldloc.s 8
-			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_00d0: pop
-			IL_00d1: ldnull
-			IL_00d2: ret
+			IL_0050: ldloc.0
+			IL_0051: box [System.Runtime]System.Double
+			IL_0056: stloc.3
+			IL_0057: ldloc.2
+			IL_0058: box [System.Runtime]System.Double
+			IL_005d: stloc.s 6
+			IL_005f: ldc.i4.4
+			IL_0060: newarr [System.Runtime]System.Object
+			IL_0065: dup
+			IL_0066: ldc.i4.0
+			IL_0067: ldstr "captured-double"
+			IL_006c: stelem.ref
+			IL_006d: dup
+			IL_006e: ldc.i4.1
+			IL_006f: ldloc.3
+			IL_0070: stelem.ref
+			IL_0071: dup
+			IL_0072: ldc.i4.2
+			IL_0073: ldloc.1
+			IL_0074: stelem.ref
+			IL_0075: dup
+			IL_0076: ldc.i4.3
+			IL_0077: ldloc.s 6
+			IL_0079: stelem.ref
+			IL_007a: stloc.s 7
+			IL_007c: ldloc.s 4
+			IL_007e: ldloc.s 5
+			IL_0080: ldloc.s 7
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0087: pop
+			IL_0088: ldnull
+			IL_0089: ret
 		} // end of method capturedDouble::__js_call__
 
 	} // end of class capturedDouble
@@ -247,7 +216,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2592
+				// Method begins at RVA 0x24f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,9 +243,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23cc
+			// Method begins at RVA 0x2384
 			// Header size: 12
-			// Code size: 107 (0x6b)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -305,43 +274,39 @@
 			IL_001f: ldarg.0
 			IL_0020: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
 			IL_0025: stloc.s 4
-			IL_0027: ldstr "logCase"
-			IL_002c: ldloc.s 4
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0033: stloc.s 4
-			IL_0035: ldc.i4.1
-			IL_0036: newarr [System.Runtime]System.Object
-			IL_003b: dup
-			IL_003c: ldc.i4.0
-			IL_003d: ldarg.0
-			IL_003e: stelem.ref
-			IL_003f: stloc.s 5
-			IL_0041: ldc.i4.4
-			IL_0042: newarr [System.Runtime]System.Object
-			IL_0047: dup
-			IL_0048: ldc.i4.0
-			IL_0049: ldstr "arg-double"
-			IL_004e: stelem.ref
-			IL_004f: dup
-			IL_0050: ldc.i4.1
-			IL_0051: ldloc.0
-			IL_0052: stelem.ref
-			IL_0053: dup
-			IL_0054: ldc.i4.2
-			IL_0055: ldloc.1
-			IL_0056: stelem.ref
-			IL_0057: dup
-			IL_0058: ldc.i4.3
-			IL_0059: ldloc.2
-			IL_005a: stelem.ref
-			IL_005b: stloc.s 6
-			IL_005d: ldloc.s 4
-			IL_005f: ldloc.s 5
-			IL_0061: ldloc.s 6
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0068: pop
-			IL_0069: ldnull
-			IL_006a: ret
+			IL_0027: ldc.i4.1
+			IL_0028: newarr [System.Runtime]System.Object
+			IL_002d: dup
+			IL_002e: ldc.i4.0
+			IL_002f: ldarg.0
+			IL_0030: stelem.ref
+			IL_0031: stloc.s 5
+			IL_0033: ldc.i4.4
+			IL_0034: newarr [System.Runtime]System.Object
+			IL_0039: dup
+			IL_003a: ldc.i4.0
+			IL_003b: ldstr "arg-double"
+			IL_0040: stelem.ref
+			IL_0041: dup
+			IL_0042: ldc.i4.1
+			IL_0043: ldloc.0
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.2
+			IL_0047: ldloc.1
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.3
+			IL_004b: ldloc.2
+			IL_004c: stelem.ref
+			IL_004d: stloc.s 6
+			IL_004f: ldloc.s 4
+			IL_0051: ldloc.s 5
+			IL_0053: ldloc.s 6
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_005a: pop
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -357,7 +322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x259b
+				// Method begins at RVA 0x24f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -383,101 +348,74 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2444
+			// Method begins at RVA 0x23f0
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 112 (0x70)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] object,
-				[4] float64,
-				[5] object,
-				[6] object[],
-				[7] object[]
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
-			IL_0006: stloc.3
-			IL_0007: ldstr "capturedGlobalString"
-			IL_000c: ldloc.3
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.3
-			IL_0013: ldloc.3
-			IL_0014: stloc.0
-			IL_0015: ldarg.0
-			IL_0016: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
-			IL_001b: stloc.3
-			IL_001c: ldstr "capturedGlobalString"
-			IL_0021: ldloc.3
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0027: stloc.3
-			IL_0028: ldloc.3
-			IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002e: stloc.s 4
-			IL_0030: ldloc.s 4
-			IL_0032: ldc.r8 1
-			IL_003b: add
-			IL_003c: stloc.s 4
-			IL_003e: ldloc.s 4
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: stloc.s 5
-			IL_0047: ldarg.0
-			IL_0048: ldloc.s 5
-			IL_004a: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
-			IL_004f: ldloc.s 5
-			IL_0051: stloc.1
-			IL_0052: ldarg.0
-			IL_0053: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
-			IL_0058: stloc.3
-			IL_0059: ldstr "capturedGlobalString"
-			IL_005e: ldloc.3
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0064: stloc.3
-			IL_0065: ldloc.3
-			IL_0066: stloc.2
-			IL_0067: ldarg.0
-			IL_0068: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
-			IL_006d: stloc.3
-			IL_006e: ldstr "logCase"
-			IL_0073: ldloc.3
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0079: stloc.3
-			IL_007a: ldc.i4.1
-			IL_007b: newarr [System.Runtime]System.Object
-			IL_0080: dup
-			IL_0081: ldc.i4.0
-			IL_0082: ldarg.0
-			IL_0083: stelem.ref
-			IL_0084: stloc.s 6
-			IL_0086: ldc.i4.4
-			IL_0087: newarr [System.Runtime]System.Object
-			IL_008c: dup
-			IL_008d: ldc.i4.0
-			IL_008e: ldstr "captured-string"
-			IL_0093: stelem.ref
-			IL_0094: dup
-			IL_0095: ldc.i4.1
-			IL_0096: ldloc.0
-			IL_0097: stelem.ref
-			IL_0098: dup
-			IL_0099: ldc.i4.2
-			IL_009a: ldloc.1
-			IL_009b: stelem.ref
-			IL_009c: dup
-			IL_009d: ldc.i4.3
-			IL_009e: ldloc.2
-			IL_009f: stelem.ref
-			IL_00a0: stloc.s 7
-			IL_00a2: ldloc.3
-			IL_00a3: ldloc.s 6
-			IL_00a5: ldloc.s 7
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_00ac: pop
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
+			IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0012: ldc.r8 1
+			IL_001b: add
+			IL_001c: box [System.Runtime]System.Double
+			IL_0021: stloc.3
+			IL_0022: ldarg.0
+			IL_0023: ldloc.3
+			IL_0024: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
+			IL_0029: ldloc.3
+			IL_002a: stloc.1
+			IL_002b: ldarg.0
+			IL_002c: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
+			IL_0031: stloc.2
+			IL_0032: ldarg.0
+			IL_0033: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
+			IL_0038: stloc.s 4
+			IL_003a: ldc.i4.1
+			IL_003b: newarr [System.Runtime]System.Object
+			IL_0040: dup
+			IL_0041: ldc.i4.0
+			IL_0042: ldarg.0
+			IL_0043: stelem.ref
+			IL_0044: stloc.s 5
+			IL_0046: ldc.i4.4
+			IL_0047: newarr [System.Runtime]System.Object
+			IL_004c: dup
+			IL_004d: ldc.i4.0
+			IL_004e: ldstr "captured-string"
+			IL_0053: stelem.ref
+			IL_0054: dup
+			IL_0055: ldc.i4.1
+			IL_0056: ldloc.0
+			IL_0057: stelem.ref
+			IL_0058: dup
+			IL_0059: ldc.i4.2
+			IL_005a: ldloc.1
+			IL_005b: stelem.ref
+			IL_005c: dup
+			IL_005d: ldc.i4.3
+			IL_005e: ldloc.2
+			IL_005f: stelem.ref
+			IL_0060: stloc.s 6
+			IL_0062: ldloc.s 4
+			IL_0064: ldloc.s 5
+			IL_0066: ldloc.s 6
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_006d: pop
+			IL_006e: ldnull
+			IL_006f: ret
 		} // end of method capturedString::__js_call__
 
 	} // end of class capturedString
@@ -493,7 +431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25a4
+				// Method begins at RVA 0x2502
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -520,9 +458,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2500
+			// Method begins at RVA 0x246c
 			// Header size: 12
-			// Code size: 107 (0x6b)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -551,43 +489,39 @@
 			IL_001f: ldarg.0
 			IL_0020: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
 			IL_0025: stloc.s 4
-			IL_0027: ldstr "logCase"
-			IL_002c: ldloc.s 4
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0033: stloc.s 4
-			IL_0035: ldc.i4.1
-			IL_0036: newarr [System.Runtime]System.Object
-			IL_003b: dup
-			IL_003c: ldc.i4.0
-			IL_003d: ldarg.0
-			IL_003e: stelem.ref
-			IL_003f: stloc.s 5
-			IL_0041: ldc.i4.4
-			IL_0042: newarr [System.Runtime]System.Object
-			IL_0047: dup
-			IL_0048: ldc.i4.0
-			IL_0049: ldstr "arg-string"
-			IL_004e: stelem.ref
-			IL_004f: dup
-			IL_0050: ldc.i4.1
-			IL_0051: ldloc.0
-			IL_0052: stelem.ref
-			IL_0053: dup
-			IL_0054: ldc.i4.2
-			IL_0055: ldloc.1
-			IL_0056: stelem.ref
-			IL_0057: dup
-			IL_0058: ldc.i4.3
-			IL_0059: ldloc.2
-			IL_005a: stelem.ref
-			IL_005b: stloc.s 6
-			IL_005d: ldloc.s 4
-			IL_005f: ldloc.s 5
-			IL_0061: ldloc.s 6
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0068: pop
-			IL_0069: ldnull
-			IL_006a: ret
+			IL_0027: ldc.i4.1
+			IL_0028: newarr [System.Runtime]System.Object
+			IL_002d: dup
+			IL_002e: ldc.i4.0
+			IL_002f: ldarg.0
+			IL_0030: stelem.ref
+			IL_0031: stloc.s 5
+			IL_0033: ldc.i4.4
+			IL_0034: newarr [System.Runtime]System.Object
+			IL_0039: dup
+			IL_003a: ldc.i4.0
+			IL_003b: ldstr "arg-string"
+			IL_0040: stelem.ref
+			IL_0041: dup
+			IL_0042: ldc.i4.1
+			IL_0043: ldloc.0
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.2
+			IL_0047: ldloc.1
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.3
+			IL_004b: ldloc.2
+			IL_004c: stelem.ref
+			IL_004d: stloc.s 6
+			IL_004f: ldloc.s 4
+			IL_0051: ldloc.s 5
+			IL_0053: ldloc.s 6
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_005a: pop
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method argString::__js_call__
 
 	} // end of class argString
@@ -625,7 +559,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2577
+			// Method begins at RVA 0x24d5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -914,7 +848,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25ad
+		// Method begins at RVA 0x250b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2123
+				// Method begins at RVA 0x20ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,39 +44,21 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20d0
-			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Method begins at RVA 0x20cd
+			// Header size: 1
+			// Code size: 24 (0x18)
 			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] bool
-			)
 
-			IL_0000: ldstr "FLAG"
-			IL_0005: ldarg.0
-			IL_0006: ldfld bool Modules.Variable_CapturedConst_BoolStringFieldType/Scope::FLAG
-			IL_000b: box [System.Runtime]System.Boolean
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0015: stloc.0
-			IL_0016: ldloc.0
-			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_001c: stloc.1
-			IL_001d: ldloc.1
-			IL_001e: brfalse IL_0038
+			IL_0000: ldarg.0
+			IL_0001: ldfld bool Modules.Variable_CapturedConst_BoolStringFieldType/Scope::FLAG
+			IL_0006: brfalse IL_0012
 
-			IL_0023: ldarg.0
-			IL_0024: ldfld string Modules.Variable_CapturedConst_BoolStringFieldType/Scope::NAME
-			IL_0029: stloc.0
-			IL_002a: ldstr "NAME"
-			IL_002f: ldloc.0
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0035: stloc.0
-			IL_0036: ldloc.0
-			IL_0037: ret
+			IL_000b: ldarg.0
+			IL_000c: ldfld string Modules.Variable_CapturedConst_BoolStringFieldType/Scope::NAME
+			IL_0011: ret
 
-			IL_0038: ldstr "untyped"
-			IL_003d: ret
+			IL_0012: ldstr "untyped"
+			IL_0017: ret
 		} // end of method run::__js_call__
 
 	} // end of class run
@@ -98,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211a
+			// Method begins at RVA 0x20e6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -188,7 +170,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212c
+		// Method begins at RVA 0x20f8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2109
+				// Method begins at RVA 0x20ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,27 +44,17 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20cc
-			// Header size: 12
-			// Code size: 40 (0x28)
+			// Method begins at RVA 0x20ca
+			// Header size: 1
+			// Code size: 22 (0x16)
 			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object
-			)
 
-			IL_0000: ldstr "NOW_UNITS_PER_SECOND"
-			IL_0005: ldarg.0
-			IL_0006: ldfld float64 Modules.Variable_CapturedConst_NumberFieldType/Scope::NOW_UNITS_PER_SECOND
-			IL_000b: box [System.Runtime]System.Double
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0015: stloc.0
-			IL_0016: ldloc.0
-			IL_0017: ldc.r8 23
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0025: stloc.1
-			IL_0026: ldloc.1
-			IL_0027: ret
+			IL_0000: ldarg.0
+			IL_0001: ldfld float64 Modules.Variable_CapturedConst_NumberFieldType/Scope::NOW_UNITS_PER_SECOND
+			IL_0006: ldc.r8 23
+			IL_000f: add
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: ret
 		} // end of method run::__js_call__
 
 	} // end of class run
@@ -86,7 +76,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2100
+			// Method begins at RVA 0x20e1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -173,7 +163,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2112
+		// Method begins at RVA 0x20f3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_SpreadArgument.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_SpreadArgument.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x217d
+				// Method begins at RVA 0x216b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,41 +46,33 @@
 			)
 			// Method begins at RVA 0x212c
 			// Header size: 12
-			// Code size: 60 (0x3c)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] object,
-				[3] object[],
-				[4] float64,
-				[5] object
+				[1] object[],
+				[2] float64,
+				[3] object
 			)
 
 			IL_0000: ldc.i4.0
 			IL_0001: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_0006: stloc.0
-			IL_0007: ldarg.0
-			IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Variable_CapturedConst_SpreadArgument/Scope::repeatCounts
-			IL_000d: stloc.1
-			IL_000e: ldstr "repeatCounts"
-			IL_0013: ldloc.1
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0019: stloc.2
-			IL_001a: ldloc.0
-			IL_001b: ldloc.2
-			IL_001c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-			IL_0021: ldloc.0
-			IL_0022: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+			IL_0007: ldloc.0
+			IL_0008: ldarg.0
+			IL_0009: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Variable_CapturedConst_SpreadArgument/Scope::repeatCounts
+			IL_000e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+			IL_0013: ldloc.0
+			IL_0014: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+			IL_0019: stloc.1
+			IL_001a: ldloc.1
+			IL_001b: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::max(object[])
+			IL_0020: stloc.2
+			IL_0021: ldloc.2
+			IL_0022: box [System.Runtime]System.Double
 			IL_0027: stloc.3
 			IL_0028: ldloc.3
-			IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::max(object[])
-			IL_002e: stloc.s 4
-			IL_0030: ldloc.s 4
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: stloc.s 5
-			IL_0039: ldloc.s 5
-			IL_003b: ret
+			IL_0029: ret
 		} // end of method ArrowFunction_L2C17::__js_call__
 
 	} // end of class ArrowFunction_L2C17
@@ -100,7 +92,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2174
+			// Method begins at RVA 0x2162
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -214,7 +206,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2186
+		// Method begins at RVA 0x2174
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24da
+					// Method begins at RVA 0x24a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24e3
+					// Method begins at RVA 0x24ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d1
+				// Method begins at RVA 0x2499
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -183,7 +183,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ec
+				// Method begins at RVA 0x24b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -211,7 +211,7 @@
 			)
 			// Method begins at RVA 0x22b8
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -221,28 +221,24 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::x
 			IL_0006: stloc.1
-			IL_0007: ldstr "x"
-			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: brfalse IL_0024
+			IL_0007: ldloc.1
+			IL_0008: brfalse IL_0018
 
-			IL_0019: ldloc.1
-			IL_001a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_001f: brfalse IL_0034
+			IL_000d: ldloc.1
+			IL_000e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0013: brfalse IL_0028
 
-			IL_0024: ldloc.1
-			IL_0025: ldstr "x"
-			IL_002a: ldstr "a"
-			IL_002f: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_0018: ldloc.1
+			IL_0019: ldstr "x"
+			IL_001e: ldstr "a"
+			IL_0023: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_0034: ldloc.1
-			IL_0035: ldstr "a"
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003f: stloc.0
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0028: ldloc.1
+			IL_0029: ldstr "a"
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0033: stloc.0
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method ArrowFunction_L12C10::__js_call__
 
 	} // end of class ArrowFunction_L12C10
@@ -258,7 +254,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f5
+				// Method begins at RVA 0x24bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -284,9 +280,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2308
+			// Method begins at RVA 0x22fc
 			// Header size: 12
-			// Code size: 66 (0x42)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -296,28 +292,24 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::x
 			IL_0006: stloc.1
-			IL_0007: ldstr "x"
-			IL_000c: ldloc.1
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: brfalse IL_0024
+			IL_0007: ldloc.1
+			IL_0008: brfalse IL_0018
 
-			IL_0019: ldloc.1
-			IL_001a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_001f: brfalse IL_0034
+			IL_000d: ldloc.1
+			IL_000e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0013: brfalse IL_0028
 
-			IL_0024: ldloc.1
-			IL_0025: ldstr "x"
-			IL_002a: ldstr "a"
-			IL_002f: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_0018: ldloc.1
+			IL_0019: ldstr "x"
+			IL_001e: ldstr "a"
+			IL_0023: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_0034: ldloc.1
-			IL_0035: ldstr "a"
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003f: stloc.0
-			IL_0040: ldnull
-			IL_0041: ret
+			IL_0028: ldloc.1
+			IL_0029: ldstr "a"
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0033: stloc.0
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method ArrowFunction_L18C10::__js_call__
 
 	} // end of class ArrowFunction_L18C10
@@ -333,7 +325,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24fe
+				// Method begins at RVA 0x24c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -359,9 +351,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2358
+			// Method begins at RVA 0x2340
 			// Header size: 12
-			// Code size: 154 (0x9a)
+			// Code size: 140 (0x8c)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
@@ -374,81 +366,77 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::y
 			IL_0006: stloc.s 4
-			IL_0008: ldstr "y"
-			IL_000d: ldloc.s 4
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 4
-			IL_0016: ldloc.s 4
-			IL_0018: brfalse IL_0029
+			IL_0008: ldloc.s 4
+			IL_000a: brfalse IL_001b
 
-			IL_001d: ldloc.s 4
-			IL_001f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0024: brfalse IL_003a
+			IL_000f: ldloc.s 4
+			IL_0011: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0016: brfalse IL_002c
 
-			IL_0029: ldloc.s 4
-			IL_002b: ldstr "y"
-			IL_0030: ldstr "0"
-			IL_0035: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_001b: ldloc.s 4
+			IL_001d: ldstr "y"
+			IL_0022: ldstr "0"
+			IL_0027: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_003a: ldloc.s 4
-			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_0041: stloc.0
-			IL_0042: ldc.i4.0
-			IL_0043: stloc.1
-			IL_0044: ldc.i4.0
-			IL_0045: stloc.2
+			IL_002c: ldloc.s 4
+			IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_0033: stloc.0
+			IL_0034: ldc.i4.0
+			IL_0035: stloc.1
+			IL_0036: ldc.i4.0
+			IL_0037: stloc.2
 			.try
 			{
-				IL_0046: ldloc.2
-				IL_0047: brtrue IL_006e
+				IL_0038: ldloc.2
+				IL_0039: brtrue IL_0060
 
-				IL_004c: ldloc.0
-				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
-				IL_0052: stloc.s 4
-				IL_0054: ldloc.s 4
-				IL_0056: brfalse IL_006c
+				IL_003e: ldloc.0
+				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
+				IL_0044: stloc.s 4
+				IL_0046: ldloc.s 4
+				IL_0048: brfalse IL_005e
 
-				IL_005b: ldloc.s 4
-				IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
-				IL_0062: stloc.s 4
-				IL_0064: ldloc.s 4
-				IL_0066: stloc.3
-				IL_0067: br IL_0070
+				IL_004d: ldloc.s 4
+				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
+				IL_0054: stloc.s 4
+				IL_0056: ldloc.s 4
+				IL_0058: stloc.3
+				IL_0059: br IL_0062
 
-				IL_006c: ldc.i4.1
-				IL_006d: stloc.2
+				IL_005e: ldc.i4.1
+				IL_005f: stloc.2
 
-				IL_006e: ldnull
-				IL_006f: stloc.3
+				IL_0060: ldnull
+				IL_0061: stloc.3
 
-				IL_0070: ldloc.2
-				IL_0071: brtrue IL_007e
+				IL_0062: ldloc.2
+				IL_0063: brtrue IL_0070
 
-				IL_0076: ldc.i4.1
-				IL_0077: stloc.1
-				IL_0078: ldloc.0
-				IL_0079: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0068: ldc.i4.1
+				IL_0069: stloc.1
+				IL_006a: ldloc.0
+				IL_006b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
 
-				IL_007e: ldc.i4.1
-				IL_007f: stloc.1
-				IL_0080: leave IL_0098
+				IL_0070: ldc.i4.1
+				IL_0071: stloc.1
+				IL_0072: leave IL_008a
 			} // end .try
 			finally
 			{
-				IL_0085: ldloc.1
-				IL_0086: brtrue IL_0097
+				IL_0077: ldloc.1
+				IL_0078: brtrue IL_0089
 
-				IL_008b: ldloc.2
-				IL_008c: brtrue IL_0097
+				IL_007d: ldloc.2
+				IL_007e: brtrue IL_0089
 
-				IL_0091: ldloc.0
-				IL_0092: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_0083: ldloc.0
+				IL_0084: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_0097: endfinally
+				IL_0089: endfinally
 			} // end handler
 
-			IL_0098: ldnull
-			IL_0099: ret
+			IL_008a: ldnull
+			IL_008b: ret
 		} // end of method ArrowFunction_L24C10::__js_call__
 
 	} // end of class ArrowFunction_L24C10
@@ -464,7 +452,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2507
+				// Method begins at RVA 0x24cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -490,9 +478,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2410
+			// Method begins at RVA 0x23e8
 			// Header size: 12
-			// Code size: 154 (0x9a)
+			// Code size: 140 (0x8c)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
@@ -505,81 +493,77 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::y
 			IL_0006: stloc.s 4
-			IL_0008: ldstr "y"
-			IL_000d: ldloc.s 4
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0014: stloc.s 4
-			IL_0016: ldloc.s 4
-			IL_0018: brfalse IL_0029
+			IL_0008: ldloc.s 4
+			IL_000a: brfalse IL_001b
 
-			IL_001d: ldloc.s 4
-			IL_001f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0024: brfalse IL_003a
+			IL_000f: ldloc.s 4
+			IL_0011: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0016: brfalse IL_002c
 
-			IL_0029: ldloc.s 4
-			IL_002b: ldstr "y"
-			IL_0030: ldstr "0"
-			IL_0035: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_001b: ldloc.s 4
+			IL_001d: ldstr "y"
+			IL_0022: ldstr "0"
+			IL_0027: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_003a: ldloc.s 4
-			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_0041: stloc.0
-			IL_0042: ldc.i4.0
-			IL_0043: stloc.1
-			IL_0044: ldc.i4.0
-			IL_0045: stloc.2
+			IL_002c: ldloc.s 4
+			IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_0033: stloc.0
+			IL_0034: ldc.i4.0
+			IL_0035: stloc.1
+			IL_0036: ldc.i4.0
+			IL_0037: stloc.2
 			.try
 			{
-				IL_0046: ldloc.2
-				IL_0047: brtrue IL_006e
+				IL_0038: ldloc.2
+				IL_0039: brtrue IL_0060
 
-				IL_004c: ldloc.0
-				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
-				IL_0052: stloc.s 4
-				IL_0054: ldloc.s 4
-				IL_0056: brfalse IL_006c
+				IL_003e: ldloc.0
+				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
+				IL_0044: stloc.s 4
+				IL_0046: ldloc.s 4
+				IL_0048: brfalse IL_005e
 
-				IL_005b: ldloc.s 4
-				IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
-				IL_0062: stloc.s 4
-				IL_0064: ldloc.s 4
-				IL_0066: stloc.3
-				IL_0067: br IL_0070
+				IL_004d: ldloc.s 4
+				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
+				IL_0054: stloc.s 4
+				IL_0056: ldloc.s 4
+				IL_0058: stloc.3
+				IL_0059: br IL_0062
 
-				IL_006c: ldc.i4.1
-				IL_006d: stloc.2
+				IL_005e: ldc.i4.1
+				IL_005f: stloc.2
 
-				IL_006e: ldnull
-				IL_006f: stloc.3
+				IL_0060: ldnull
+				IL_0061: stloc.3
 
-				IL_0070: ldloc.2
-				IL_0071: brtrue IL_007e
+				IL_0062: ldloc.2
+				IL_0063: brtrue IL_0070
 
-				IL_0076: ldc.i4.1
-				IL_0077: stloc.1
-				IL_0078: ldloc.0
-				IL_0079: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0068: ldc.i4.1
+				IL_0069: stloc.1
+				IL_006a: ldloc.0
+				IL_006b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
 
-				IL_007e: ldc.i4.1
-				IL_007f: stloc.1
-				IL_0080: leave IL_0098
+				IL_0070: ldc.i4.1
+				IL_0071: stloc.1
+				IL_0072: leave IL_008a
 			} // end .try
 			finally
 			{
-				IL_0085: ldloc.1
-				IL_0086: brtrue IL_0097
+				IL_0077: ldloc.1
+				IL_0078: brtrue IL_0089
 
-				IL_008b: ldloc.2
-				IL_008c: brtrue IL_0097
+				IL_007d: ldloc.2
+				IL_007e: brtrue IL_0089
 
-				IL_0091: ldloc.0
-				IL_0092: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_0083: ldloc.0
+				IL_0084: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_0097: endfinally
+				IL_0089: endfinally
 			} // end handler
 
-			IL_0098: ldnull
-			IL_0099: ret
+			IL_008a: ldnull
+			IL_008b: ret
 		} // end of method ArrowFunction_L30C10::__js_call__
 
 	} // end of class ArrowFunction_L30C10
@@ -601,7 +585,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24c8
+			// Method begins at RVA 0x2490
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -812,7 +796,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2510
+		// Method begins at RVA 0x24d8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e0
+				// Method begins at RVA 0x21be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,45 +46,26 @@
 			)
 			// Method begins at RVA 0x2188
 			// Header size: 12
-			// Code size: 67 (0x43)
+			// Code size: 33 (0x21)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] float64,
-				[3] float64,
-				[4] object
+				[1] float64
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::a
+			IL_0001: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::b
 			IL_0006: stloc.0
-			IL_0007: ldstr "a"
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldarg.0
-			IL_0014: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::b
-			IL_0019: stloc.1
-			IL_001a: ldstr "b"
-			IL_001f: ldloc.1
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_0025: stloc.1
-			IL_0026: ldloc.0
-			IL_0027: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002c: stloc.2
-			IL_002d: ldloc.1
-			IL_002e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0033: stloc.3
-			IL_0034: ldloc.2
-			IL_0035: ldloc.3
-			IL_0036: mul
-			IL_0037: stloc.3
-			IL_0038: ldloc.3
-			IL_0039: box [System.Runtime]System.Double
-			IL_003e: stloc.s 4
-			IL_0040: ldloc.s 4
-			IL_0042: ret
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::a
+			IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0012: stloc.1
+			IL_0013: ldloc.1
+			IL_0014: ldloc.0
+			IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_001a: mul
+			IL_001b: box [System.Runtime]System.Double
+			IL_0020: ret
 		} // end of method compute::__js_call__
 
 	} // end of class compute
@@ -106,7 +87,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d7
+			// Method begins at RVA 0x21b5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -250,7 +231,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e9
+		// Method begins at RVA 0x21c7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ea
+				// Method begins at RVA 0x21de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 			)
 			// Method begins at RVA 0x218c
 			// Header size: 12
-			// Code size: 62 (0x3e)
+			// Code size: 50 (0x32)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -64,17 +64,13 @@
 			IL_0018: ldstr "Cannot access 'value' before initialization"
 			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_0022: stloc.1
-			IL_0023: ldstr "value"
-			IL_0028: ldloc.1
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_002e: stloc.1
-			IL_002f: ldloc.0
-			IL_0030: ldstr "log"
-			IL_0035: ldloc.1
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003b: pop
-			IL_003c: ldnull
-			IL_003d: ret
+			IL_0023: ldloc.0
+			IL_0024: ldstr "log"
+			IL_0029: ldloc.1
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_002f: pop
+			IL_0030: ldnull
+			IL_0031: ret
 		} // end of method readValue::__js_call__
 
 	} // end of class readValue
@@ -95,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f3
+				// Method begins at RVA 0x21e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -115,7 +111,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fc
+				// Method begins at RVA 0x21f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -137,7 +133,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d6
+			// Method begins at RVA 0x21ca
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -300,7 +296,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2205
+		// Method begins at RVA 0x21f9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
+++ b/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2396
+				// Method begins at RVA 0x2388
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -130,7 +130,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b1
+				// Method begins at RVA 0x23a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +158,7 @@
 			)
 			// Method begins at RVA 0x2320
 			// Header size: 12
-			// Code size: 97 (0x61)
+			// Code size: 83 (0x53)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -177,33 +177,27 @@
 			IL_0017: stloc.0
 			IL_0018: ldarg.0
 			IL_0019: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
-			IL_001e: stloc.1
-			IL_001f: ldstr "ref"
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0023: stloc.1
 			IL_0024: ldloc.1
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0031: stloc.1
-			IL_0032: ldloc.1
-			IL_0033: ldstr "deref"
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_003d: stloc.1
-			IL_003e: ldloc.1
-			IL_003f: ldc.i4.0
-			IL_0040: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0045: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_004a: stloc.2
-			IL_004b: ldloc.2
-			IL_004c: box [System.Runtime]System.Boolean
-			IL_0051: stloc.3
-			IL_0052: ldloc.0
-			IL_0053: ldstr "log"
-			IL_0058: ldloc.3
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005e: pop
-			IL_005f: ldnull
-			IL_0060: ret
+			IL_0025: ldstr "deref"
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_002f: stloc.1
+			IL_0030: ldloc.1
+			IL_0031: ldc.i4.0
+			IL_0032: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0037: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+			IL_003c: stloc.2
+			IL_003d: ldloc.2
+			IL_003e: box [System.Runtime]System.Boolean
+			IL_0043: stloc.3
+			IL_0044: ldloc.0
+			IL_0045: ldstr "log"
+			IL_004a: ldloc.3
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0050: pop
+			IL_0051: ldnull
+			IL_0052: ret
 		} // end of method ArrowFunction_L23C14::__js_call__
 
 	} // end of class ArrowFunction_L23C14
@@ -225,7 +219,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x239f
+				// Method begins at RVA 0x2391
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -245,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a8
+				// Method begins at RVA 0x239a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -267,7 +261,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x238d
+			// Method begins at RVA 0x237f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -496,7 +490,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23ba
+		// Method begins at RVA 0x23ac
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary
- restores direct `JavaScriptRuntime.Array` member-call lowering for proven array receivers in hot paths
- limits `with` binding fallback emission to callables created inside `with` bodies
- updates generator snapshots for the changed IL shape
- adds Unreleased changelog entries for this perf fix and the missing PR #1360 Date Section 21.4 work

## Validation
- `dotnet test .\tests\Jroc.Test262.Tests\Jroc.Test262.Tests.csproj --no-restore --filter "FullyQualifiedName~language.expressions.arrow_function.ExecutionTests.arrow_capturing_closure_variables_2" --nologo`
- `dotnet test .\tests\Jroc.Tests\Jroc.Tests.csproj --no-restore --filter "FullyQualifiedName~Array" --nologo`
- compiled/disassembled `tests\performance\Benchmarks\Scenarios\dromaeo-object-array.js` and confirmed the hot paths emit direct `JavaScriptRuntime.Array::{push,pop,shift,unshift,slice,splice}` calls with no `Object.CallMember*` / `ResolveWithBindingOrDefault` matches