### PR TITLE
feat(node-fs): add unlinkSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- runtime/tests/docs/nodejs: add `fs.unlinkSync(path)` support so compiled tooling like `scripts/release.js` can delete temporary `pr-body.md` / `release-notes.md` artifacts after `gh pr create` and `gh release create`; cover the release-style cleanup flow with focused Node `fs` execution/generator tests and document the new API in the Node module docs.
 
 ## v0.11.10 - 2026-07-05
 

--- a/docs/nodejs/fs.json
+++ b/docs/nodejs/fs.json
@@ -102,6 +102,23 @@
       ]
     },
     {
+      "name": "unlinkSync(path)",
+      "kind": "function",
+      "status": "supported",
+      "notes": "Removes a file synchronously. Missing files throw ENOENT-style errors, and directory paths reject with EISDIR-style errors.",
+      "docs": "https://nodejs.org/api/fs.html#fsunlinksyncpath",
+      "tests": [
+        {
+          "name": "Jroc.Tests.Node.FS.ExecutionTests.FS_UnlinkSync_ReleaseCleanup",
+          "file": "tests/Jroc.Tests/Node/FS/ExecutionTests.cs"
+        },
+        {
+          "name": "Jroc.Tests.Node.FS.GeneratorTests.FS_UnlinkSync_ReleaseCleanup",
+          "file": "tests/Jroc.Tests/Node/FS/GeneratorTests.cs"
+        }
+      ]
+    },
+    {
       "name": "statSync(path)",
       "kind": "function",
       "status": "supported",

--- a/docs/nodejs/fs.md
+++ b/docs/nodejs/fs.md
@@ -24,6 +24,7 @@
 | readdirSync(path) | function | supported | [docs](https://nodejs.org/api/fs.html#fsreaddirsyncpath-options) |
 | readFileSync(path[, options]) | function | supported | [docs](https://nodejs.org/api/fs.html#fsreadfilesyncpath-options) |
 | rmSync(path[, options]) | function | supported | [docs](https://nodejs.org/api/fs.html#fsrmsyncpath-options) |
+| unlinkSync(path) | function | supported | [docs](https://nodejs.org/api/fs.html#fsunlinksyncpath) |
 | statSync(path) | function | supported | [docs](https://nodejs.org/api/fs.html#fsstatsyncpath-options) |
 | writeFileSync(path, data[, options]) | function | supported | [docs](https://nodejs.org/api/fs.html#fswritefilesyncfile-data-options) |
 | promises | property | supported | [docs](https://nodejs.org/api/fs.html#fspromisesapi) |
@@ -86,6 +87,14 @@ Removes a file or directory (recursive). Supports options.force to ignore errors
 
 **Tests:**
 - `Jroc.Tests.Node.FS.ExecutionTests.FS_RmSync_Removes_File_And_Directory` (`tests/Jroc.Tests/Node/FS/ExecutionTests.cs`)
+
+### unlinkSync(path)
+
+Removes a file synchronously. Missing files throw ENOENT-style errors, and directory paths reject with EISDIR-style errors.
+
+**Tests:**
+- `Jroc.Tests.Node.FS.ExecutionTests.FS_UnlinkSync_ReleaseCleanup` (`tests/Jroc.Tests/Node/FS/ExecutionTests.cs`)
+- `Jroc.Tests.Node.FS.GeneratorTests.FS_UnlinkSync_ReleaseCleanup` (`tests/Jroc.Tests/Node/FS/GeneratorTests.cs`)
 
 ### statSync(path)
 

--- a/src/JavaScriptRuntime/Node/FS.cs
+++ b/src/JavaScriptRuntime/Node/FS.cs
@@ -1000,6 +1000,39 @@ namespace JavaScriptRuntime.Node
                 : FsCommon.CreateZeroStats();
         }
 
+        public object unlinkSync(object file)
+        {
+            var path = file?.ToString() ?? string.Empty;
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new Error("Path must be a non-empty string");
+            }
+
+            try
+            {
+                if (System.IO.Directory.Exists(path))
+                {
+                    throw new IOException($"Cannot unlink directory '{path}'.");
+                }
+
+                if (!System.IO.File.Exists(path))
+                {
+                    throw new FileNotFoundException(path);
+                }
+
+                System.IO.File.Delete(path);
+                return null!; // undefined
+            }
+            catch (Error)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw FsCommon.TranslateUnlinkError(path, ex);
+            }
+        }
+
         public object rmSync(object file, object? options)
         {
             var path = file?.ToString() ?? string.Empty;

--- a/tests/Jroc.Tests/Node/FS/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Node/FS/ExecutionTests.cs
@@ -87,6 +87,17 @@ namespace Jroc.Tests.Node.FS
                 });
 
         [Fact]
+        public Task FS_UnlinkSync_ReleaseCleanup()
+            => ExecutionTest(
+                nameof(FS_UnlinkSync_ReleaseCleanup),
+                configureSettings: s =>
+                {
+                    s.AddScrubber(sb => sb.Replace('\\', '/'));
+                    var temp = System.IO.Path.GetTempPath().Replace('\\', '/');
+                    s.AddScrubber(sb => sb.Replace(temp, "{TempPath}"));
+                });
+
+        [Fact]
         public Task FS_ExistsSync_EmptyPath_ReturnsFalse()
             => ExecutionTest(
                 nameof(FS_ExistsSync_EmptyPath_ReturnsFalse),

--- a/tests/Jroc.Tests/Node/FS/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Node/FS/GeneratorTests.cs
@@ -93,5 +93,9 @@ namespace Jroc.Tests.Node.FS
         [Fact]
         public Task FS_Append_Rename_Unlink_Callback() => GenerateTest(
             nameof(FS_Append_Rename_Unlink_Callback));
+
+        [Fact]
+        public Task FS_UnlinkSync_ReleaseCleanup() => GenerateTest(
+            nameof(FS_UnlinkSync_ReleaseCleanup));
     }
 }

--- a/tests/Jroc.Tests/Node/FS/JavaScript/FS_UnlinkSync_ReleaseCleanup.js
+++ b/tests/Jroc.Tests/Node/FS/JavaScript/FS_UnlinkSync_ReleaseCleanup.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const uniqueSuffix = `${Date.now()}-${Math.floor(Math.random() * 1000000000)}`;
+const root = path.join(os.tmpdir(), `jroc-release-cleanup-${uniqueSuffix}`);
+const prBody = path.join(root, "pr-body.md");
+const releaseNotes = path.join(root, "release-notes.md");
+
+fs.rmSync(root, { recursive: true, force: true });
+fs.mkdirSync(root, { recursive: true });
+
+try {
+    fs.writeFileSync(prBody, "Patch release body", "utf8");
+    fs.writeFileSync(releaseNotes, "# Release notes", "utf8");
+
+    console.log("Before:", fs.existsSync(prBody), fs.existsSync(releaseNotes));
+
+    fs.unlinkSync(prBody);
+    fs.unlinkSync(releaseNotes);
+
+    console.log("After:", fs.existsSync(prBody), fs.existsSync(releaseNotes));
+
+    try {
+        fs.unlinkSync(prBody);
+    } catch (e) {
+        console.log("MissingError:", e.message.includes("ENOENT:"), e.message.includes("pr-body.md"));
+    }
+} finally {
+    fs.rmSync(root, { recursive: true, force: true });
+}

--- a/tests/Jroc.Tests/Node/FS/Snapshots/ExecutionTests.FS_UnlinkSync_ReleaseCleanup.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/ExecutionTests.FS_UnlinkSync_ReleaseCleanup.verified.txt
@@ -1,0 +1,3 @@
+﻿Before: true true
+After: false false
+MissingError: true true

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_UnlinkSync_ReleaseCleanup.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_UnlinkSync_ReleaseCleanup.verified.txt
@@ -1,0 +1,519 @@
+﻿// IL code: FS_UnlinkSync_ReleaseCleanup
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.FS_UnlinkSync_ReleaseCleanup
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Block_L15C4
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L26C8
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2482
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L26C8::.ctor
+
+			} // end of class Block_L26C8
+
+			.class nested public auto ansi beforefieldinit Block_L28C16
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x248b
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L28C16::.ctor
+
+			} // end of class Block_L28C16
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2479
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L15C4::.ctor
+
+		} // end of class Block_L15C4
+
+		.class nested public auto ansi beforefieldinit Block_L31C10
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2494
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L31C10::.ctor
+
+		} // end of class Block_L31C10
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2470
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 989 (0x3dd)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.FS_UnlinkSync_ReleaseCleanup/Scope,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] string,
+			[5] object,
+			[6] object,
+			[7] object,
+			[8] class Modules.FS_UnlinkSync_ReleaseCleanup/Scope/Block_L15C4,
+			[9] class Modules.FS_UnlinkSync_ReleaseCleanup/Scope/Block_L15C4/Block_L26C8,
+			[10] class [System.Runtime]System.Exception,
+			[11] object,
+			[12] object,
+			[13] class Modules.FS_UnlinkSync_ReleaseCleanup/Scope/Block_L15C4/Block_L28C16,
+			[14] class Modules.FS_UnlinkSync_ReleaseCleanup/Scope/Block_L31C10,
+			[15] object,
+			[16] object,
+			[17] string,
+			[18] float64,
+			[19] object,
+			[20] string,
+			[21] object,
+			[22] object
+		)
+
+		IL_0000: newobj instance void Modules.FS_UnlinkSync_ReleaseCleanup/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldarg.1
+		IL_0007: ldstr "fs"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 16
+		IL_0013: ldloc.s 16
+		IL_0015: stloc.1
+		IL_0016: ldarg.1
+		IL_0017: ldstr "path"
+		IL_001c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0021: stloc.s 16
+		IL_0023: ldloc.s 16
+		IL_0025: stloc.2
+		IL_0026: ldarg.1
+		IL_0027: ldstr "os"
+		IL_002c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0031: stloc.s 16
+		IL_0033: ldloc.s 16
+		IL_0035: stloc.3
+		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
+		IL_003b: stloc.s 16
+		IL_003d: ldloc.s 16
+		IL_003f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0044: stloc.s 17
+		IL_0046: ldstr ""
+		IL_004b: ldloc.s 17
+		IL_004d: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0052: stloc.s 17
+		IL_0054: ldloc.s 17
+		IL_0056: ldstr "-"
+		IL_005b: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0060: stloc.s 17
+		IL_0062: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+		IL_0067: stloc.s 18
+		IL_0069: ldloc.s 18
+		IL_006b: ldc.r8 1000000000
+		IL_0074: mul
+		IL_0075: stloc.s 18
+		IL_0077: ldloc.s 18
+		IL_0079: box [System.Runtime]System.Double
+		IL_007e: stloc.s 19
+		IL_0080: ldloc.s 19
+		IL_0082: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+		IL_0087: stloc.s 18
+		IL_0089: ldloc.s 18
+		IL_008b: box [System.Runtime]System.Double
+		IL_0090: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0095: stloc.s 20
+		IL_0097: ldloc.s 17
+		IL_0099: ldloc.s 20
+		IL_009b: call string [System.Runtime]System.String::Concat(string, string)
+		IL_00a0: stloc.s 20
+		IL_00a2: ldloc.s 20
+		IL_00a4: stloc.s 4
+		IL_00a6: ldloc.2
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ac: stloc.s 16
+		IL_00ae: ldloc.3
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b4: stloc.s 21
+		IL_00b6: ldloc.s 21
+		IL_00b8: ldstr "tmpdir"
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00c2: stloc.s 21
+		IL_00c4: ldloc.s 4
+		IL_00c6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_00cb: stloc.s 20
+		IL_00cd: ldstr "jroc-release-cleanup-"
+		IL_00d2: ldloc.s 20
+		IL_00d4: call string [System.Runtime]System.String::Concat(string, string)
+		IL_00d9: stloc.s 20
+		IL_00db: ldloc.s 16
+		IL_00dd: ldstr "join"
+		IL_00e2: ldloc.s 21
+		IL_00e4: ldloc.s 20
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_00eb: stloc.s 21
+		IL_00ed: ldloc.s 21
+		IL_00ef: stloc.s 5
+		IL_00f1: ldloc.2
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f7: stloc.s 21
+		IL_00f9: ldloc.s 21
+		IL_00fb: ldstr "join"
+		IL_0100: ldloc.s 5
+		IL_0102: ldstr "pr-body.md"
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_010c: stloc.s 21
+		IL_010e: ldloc.s 21
+		IL_0110: stloc.s 6
+		IL_0112: ldloc.2
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0118: stloc.s 21
+		IL_011a: ldloc.s 21
+		IL_011c: ldstr "join"
+		IL_0121: ldloc.s 5
+		IL_0123: ldstr "release-notes.md"
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_012d: stloc.s 21
+		IL_012f: ldloc.s 21
+		IL_0131: stloc.s 7
+		IL_0133: ldloc.1
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0139: stloc.s 21
+		IL_013b: ldloc.s 21
+		IL_013d: ldstr "rmSync"
+		IL_0142: ldloc.s 5
+		IL_0144: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0149: dup
+		IL_014a: ldstr "recursive"
+		IL_014f: ldc.i4.1
+		IL_0150: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0155: dup
+		IL_0156: ldstr "force"
+		IL_015b: ldc.i4.1
+		IL_015c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0166: pop
+		IL_0167: ldloc.1
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016d: stloc.s 21
+		IL_016f: ldloc.s 21
+		IL_0171: ldstr "mkdirSync"
+		IL_0176: ldloc.s 5
+		IL_0178: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_017d: dup
+		IL_017e: ldstr "recursive"
+		IL_0183: ldc.i4.1
+		IL_0184: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_018e: pop
+		.try
+		{
+			IL_018f: newobj instance void Modules.FS_UnlinkSync_ReleaseCleanup/Scope/Block_L15C4::.ctor()
+			IL_0194: stloc.s 8
+			IL_0196: ldloc.1
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_019c: stloc.s 21
+			IL_019e: ldloc.s 21
+			IL_01a0: ldstr "writeFileSync"
+			IL_01a5: ldloc.s 6
+			IL_01a7: ldstr "Patch release body"
+			IL_01ac: ldstr "utf8"
+			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01b6: pop
+			IL_01b7: ldloc.1
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01bd: stloc.s 21
+			IL_01bf: ldloc.s 21
+			IL_01c1: ldstr "writeFileSync"
+			IL_01c6: ldloc.s 7
+			IL_01c8: ldstr "# Release notes"
+			IL_01cd: ldstr "utf8"
+			IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01d7: pop
+			IL_01d8: ldstr "console"
+			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01e2: stloc.s 21
+			IL_01e4: ldloc.s 21
+			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01eb: stloc.s 21
+			IL_01ed: ldloc.1
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f3: stloc.s 16
+			IL_01f5: ldloc.s 16
+			IL_01f7: ldstr "existsSync"
+			IL_01fc: ldloc.s 6
+			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0203: stloc.s 16
+			IL_0205: ldloc.1
+			IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_020b: stloc.s 22
+			IL_020d: ldloc.s 22
+			IL_020f: ldstr "existsSync"
+			IL_0214: ldloc.s 7
+			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_021b: stloc.s 22
+			IL_021d: ldloc.s 21
+			IL_021f: ldstr "log"
+			IL_0224: ldstr "Before:"
+			IL_0229: ldloc.s 16
+			IL_022b: ldloc.s 22
+			IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0232: pop
+			IL_0233: ldloc.1
+			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0239: stloc.s 22
+			IL_023b: ldloc.s 22
+			IL_023d: ldstr "unlinkSync"
+			IL_0242: ldloc.s 6
+			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0249: pop
+			IL_024a: ldloc.1
+			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0250: stloc.s 22
+			IL_0252: ldloc.s 22
+			IL_0254: ldstr "unlinkSync"
+			IL_0259: ldloc.s 7
+			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0260: pop
+			IL_0261: ldstr "console"
+			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_026b: stloc.s 22
+			IL_026d: ldloc.s 22
+			IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0274: stloc.s 22
+			IL_0276: ldloc.1
+			IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_027c: stloc.s 16
+			IL_027e: ldloc.s 16
+			IL_0280: ldstr "existsSync"
+			IL_0285: ldloc.s 6
+			IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_028c: stloc.s 16
+			IL_028e: ldloc.1
+			IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0294: stloc.s 21
+			IL_0296: ldloc.s 21
+			IL_0298: ldstr "existsSync"
+			IL_029d: ldloc.s 7
+			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02a4: stloc.s 21
+			IL_02a6: ldloc.s 22
+			IL_02a8: ldstr "log"
+			IL_02ad: ldstr "After:"
+			IL_02b2: ldloc.s 16
+			IL_02b4: ldloc.s 21
+			IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_02bb: pop
+			.try
+			{
+				IL_02bc: newobj instance void Modules.FS_UnlinkSync_ReleaseCleanup/Scope/Block_L15C4/Block_L26C8::.ctor()
+				IL_02c1: stloc.s 9
+				IL_02c3: ldloc.1
+				IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02c9: stloc.s 21
+				IL_02cb: ldloc.s 21
+				IL_02cd: ldstr "unlinkSync"
+				IL_02d2: ldloc.s 6
+				IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02d9: pop
+				IL_02da: leave IL_0398
+			} // end .try
+			catch [System.Runtime]System.Exception
+			{
+				IL_02df: stloc.s 10
+				IL_02e1: ldloc.s 10
+				IL_02e3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_02e8: dup
+				IL_02e9: brtrue IL_02ff
+
+				IL_02ee: pop
+				IL_02ef: ldloc.s 10
+				IL_02f1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_02f6: dup
+				IL_02f7: brtrue IL_030b
+
+				IL_02fc: pop
+				IL_02fd: rethrow
+
+				IL_02ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0304: stloc.s 11
+				IL_0306: br IL_030d
+
+				IL_030b: stloc.s 11
+
+				IL_030d: ldloc.s 11
+				IL_030f: stloc.s 21
+				IL_0311: ldloc.s 21
+				IL_0313: stloc.s 12
+				IL_0315: newobj instance void Modules.FS_UnlinkSync_ReleaseCleanup/Scope/Block_L15C4/Block_L28C16::.ctor()
+				IL_031a: stloc.s 13
+				IL_031c: ldstr "console"
+				IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0326: stloc.s 21
+				IL_0328: ldloc.s 21
+				IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_032f: stloc.s 21
+				IL_0331: ldloc.s 12
+				IL_0333: ldstr "message"
+				IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0342: stloc.s 16
+				IL_0344: ldloc.s 16
+				IL_0346: ldstr "includes"
+				IL_034b: ldstr "ENOENT:"
+				IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0355: stloc.s 16
+				IL_0357: ldloc.s 12
+				IL_0359: ldstr "message"
+				IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0368: stloc.s 22
+				IL_036a: ldloc.s 22
+				IL_036c: ldstr "includes"
+				IL_0371: ldstr "pr-body.md"
+				IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_037b: stloc.s 22
+				IL_037d: ldloc.s 21
+				IL_037f: ldstr "log"
+				IL_0384: ldstr "MissingError:"
+				IL_0389: ldloc.s 16
+				IL_038b: ldloc.s 22
+				IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0392: pop
+				IL_0393: leave IL_0398
+			} // end handler
+
+			IL_0398: leave IL_03d9
+		} // end .try
+		finally
+		{
+			IL_039d: newobj instance void Modules.FS_UnlinkSync_ReleaseCleanup/Scope/Block_L31C10::.ctor()
+			IL_03a2: stloc.s 14
+			IL_03a4: ldloc.1
+			IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03aa: stloc.s 22
+			IL_03ac: ldloc.s 22
+			IL_03ae: ldstr "rmSync"
+			IL_03b3: ldloc.s 5
+			IL_03b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03ba: dup
+			IL_03bb: ldstr "recursive"
+			IL_03c0: ldc.i4.1
+			IL_03c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_03c6: dup
+			IL_03c7: ldstr "force"
+			IL_03cc: ldc.i4.1
+			IL_03cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_03d7: pop
+			IL_03d8: endfinally
+		} // end handler
+
+		IL_03d9: ldnull
+		IL_03da: stloc.s 15
+		IL_03dc: ret
+	} // end of method FS_UnlinkSync_ReleaseCleanup::__js_module_init__
+
+} // end of class Modules.FS_UnlinkSync_ReleaseCleanup
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x249d
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.FS_UnlinkSync_ReleaseCleanup::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+


### PR DESCRIPTION
## Summary
- add `fs.unlinkSync(path)` to the Node fs runtime with Node-like ENOENT/EISDIR error shaping
- add a focused Node fs regression that mirrors `scripts/release.js` cleanup of `pr-body.md` and `release-notes.md`
- document the new fs API in `CHANGELOG.md` and `docs/nodejs/fs.*`

## Testing
- `dotnet test .\tests\Jroc.Tests\Jroc.Tests.csproj --no-restore --filter "FullyQualifiedName~Jroc.Tests.Node.FS" --nologo`