### PR TITLE
perf(compiler): infer partial stable parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf/compiler/tests: support partial stable parameter type inference so unknown or conflicting evidence disables only the affected parameter instead of the whole callable, allowing Dromaeo 3D cube helpers like `Translate(M, Dx, Dy, Dz)` and downstream `MMulti(...)` calls to keep stable array parameter signatures.
 - runtime/tests/docs/nodejs: add `fs.unlinkSync(path)` support so compiled tooling like `scripts/release.js` can delete temporary `pr-body.md` / `release-notes.md` artifacts after `gh pr create` and `gh release create`; cover the release-style cleanup flow with focused Node `fs` execution/generator tests and document the new API in the Node module docs.
 
 ## v0.11.10 - 2026-07-05

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
@@ -69,7 +69,7 @@ public partial class SymbolTableBuilder
                 && parentMap.TryGetValue(candidate.Scope.AstNode, out var parent)
                 && parent is not Acornima.Ast.MethodDefinition)
             {
-                candidate.IsUnsafe = true;
+                candidate.IsCallableUnsafe = true;
             }
         }
 
@@ -116,7 +116,7 @@ public partial class SymbolTableBuilder
                     && candidatesByScope.TryGetValue(referencedScope, out var referencedCandidate)
                     && !IsDirectIdentifierCall(id, parent))
                 {
-                    referencedCandidate.IsUnsafe = true;
+                    referencedCandidate.IsCallableUnsafe = true;
                 }
 
                 if (binding?.DeclarationNode is ClassDeclaration classDecl
@@ -141,7 +141,7 @@ public partial class SymbolTableBuilder
             {
                 foreach (var methodCandidate in methodCandidates)
                 {
-                    methodCandidate.IsUnsafe = true;
+                    methodCandidate.IsCallableUnsafe = true;
                 }
             }
         });
@@ -149,7 +149,7 @@ public partial class SymbolTableBuilder
         var changed = false;
         foreach (var candidate in candidatesByScope.Values)
         {
-            if (candidate.IsUnsafe)
+            if (candidate.IsCallableUnsafe)
             {
                 continue;
             }
@@ -190,35 +190,48 @@ public partial class SymbolTableBuilder
             ParameterNames = parameterNames;
             InferredTypes = new Type?[parameterNames.Count];
             HasEvidence = new bool[parameterNames.Count];
+            IsParameterUnsafe = new bool[parameterNames.Count];
         }
 
         public Scope Scope { get; }
         public IReadOnlyList<string> ParameterNames { get; }
         public Type?[] InferredTypes { get; }
         public bool[] HasEvidence { get; }
-        public bool IsUnsafe { get; set; }
+        public bool[] IsParameterUnsafe { get; }
+        public bool IsCallableUnsafe { get; set; }
 
         public void RecordCall(CallExpression call, Scope callScope, SymbolTableBuilder builder)
         {
             if (call.Arguments.Count < ParameterNames.Count)
             {
-                IsUnsafe = true;
+                IsCallableUnsafe = true;
                 return;
             }
 
             for (var i = 0; i < ParameterNames.Count; i++)
             {
+                if (IsParameterUnsafe[i])
+                {
+                    continue;
+                }
+
+                if (call.Arguments[i] is SpreadElement)
+                {
+                    IsCallableUnsafe = true;
+                    return;
+                }
+
                 if (call.Arguments[i] is not Node arg)
                 {
-                    IsUnsafe = true;
-                    return;
+                    MarkParameterUnsafe(i);
+                    continue;
                 }
 
                 var argType = builder.InferStableParameterArgumentClrType(arg, callScope);
                 if (!IsSupportedStableParameterType(argType))
                 {
-                    IsUnsafe = true;
-                    return;
+                    MarkParameterUnsafe(i);
+                    continue;
                 }
 
                 if (!HasEvidence[i])
@@ -228,10 +241,16 @@ public partial class SymbolTableBuilder
                 }
                 else if (InferredTypes[i] != argType)
                 {
-                    IsUnsafe = true;
-                    return;
+                    MarkParameterUnsafe(i);
                 }
             }
+        }
+
+        private void MarkParameterUnsafe(int index)
+        {
+            IsParameterUnsafe[index] = true;
+            HasEvidence[index] = false;
+            InferredTypes[index] = null;
         }
     }
 
@@ -573,7 +592,7 @@ public partial class SymbolTableBuilder
         {
             if (candidatesByScope.TryGetValue(methodScope, out var candidate))
             {
-                candidate.IsUnsafe = true;
+                candidate.IsCallableUnsafe = true;
             }
         }
     }

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -1052,7 +1052,7 @@
 			object __js_call__ (
 				object newTarget,
 				object 'value',
-				object label
+				string label
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -1268,7 +1268,7 @@
 			object __js_call__ (
 				object newTarget,
 				object 'value',
-				object label
+				string label
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -6600,8 +6600,8 @@
 		IL_011f: ldloc.s 11
 		IL_0121: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
 		IL_0126: ldnull
-		IL_0127: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
-		IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0127: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
+		IL_012d: newobj instance void class [System.Runtime]System.Func`4<object, object, string, object>::.ctor(object, native int)
 		IL_0132: ldc.i4.2
 		IL_0133: conv.r8
 		IL_0134: ldstr "ensureString"
@@ -6613,8 +6613,8 @@
 		IL_0143: ldloc.s 11
 		IL_0145: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
 		IL_014a: ldnull
-		IL_014b: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
-		IL_0151: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_014b: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
+		IL_0151: newobj instance void class [System.Runtime]System.Func`4<object, object, string, object>::.ctor(object, native int)
 		IL_0156: ldc.i4.2
 		IL_0157: conv.r8
 		IL_0158: ldstr "ensureStringArray"

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x69ae
+				// Method begins at RVA 0x698a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x69c0
+					// Method begins at RVA 0x699c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -153,7 +153,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x69c9
+					// Method begins at RVA 0x69a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -173,7 +173,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x69d2
+					// Method begins at RVA 0x69ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x69b7
+				// Method begins at RVA 0x6993
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x69e4
+					// Method begins at RVA 0x69c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -321,7 +321,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x69db
+				// Method begins at RVA 0x69b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -444,7 +444,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x69f6
+					// Method begins at RVA 0x69d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -462,7 +462,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x69ed
+				// Method begins at RVA 0x69c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -606,7 +606,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x69ff
+				// Method begins at RVA 0x69db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -625,7 +625,7 @@
 			object __js_call__ (
 				class Modules.Compile_Scripts_Test262MetadataParser/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object parsed
 			) cil managed 
 		{
@@ -2474,7 +2474,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x69a5
+			// Method begins at RVA 0x6981
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2602,8 +2602,8 @@
 		IL_00d0: ldc.i4.0
 		IL_00d1: ldelem.ref
 		IL_00d2: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_00d7: ldftn object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
-		IL_00dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00d7: ldftn object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, string, object)
+		IL_00dd: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_00e2: ldc.i4.2
 		IL_00e3: conv.r8
 		IL_00e4: ldstr "writeParsedResult"
@@ -2807,7 +2807,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6a11
+				// Method begins at RVA 0x69ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2895,7 +2895,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6a2c
+						// Method begins at RVA 0x6a08
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2913,7 +2913,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a23
+					// Method begins at RVA 0x69ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2931,7 +2931,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6a1a
+				// Method begins at RVA 0x69f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3071,7 +3071,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6a47
+						// Method begins at RVA 0x6a23
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3089,7 +3089,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a3e
+					// Method begins at RVA 0x6a1a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3107,7 +3107,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6a35
+				// Method begins at RVA 0x6a11
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3298,7 +3298,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a59
+					// Method begins at RVA 0x6a35
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3316,7 +3316,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6a50
+				// Method begins at RVA 0x6a2c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3344,7 +3344,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6a74
+						// Method begins at RVA 0x6a50
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3362,7 +3362,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a6b
+					// Method begins at RVA 0x6a47
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3380,7 +3380,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6a62
+				// Method begins at RVA 0x6a3e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3558,7 +3558,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a86
+					// Method begins at RVA 0x6a62
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3576,7 +3576,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6a7d
+				// Method begins at RVA 0x6a59
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3696,7 +3696,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6a8f
+				// Method begins at RVA 0x6a6b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3724,7 +3724,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6aaa
+						// Method begins at RVA 0x6a86
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3744,7 +3744,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6ab3
+						// Method begins at RVA 0x6a8f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3764,7 +3764,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6abc
+						// Method begins at RVA 0x6a98
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3784,7 +3784,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6ac5
+						// Method begins at RVA 0x6aa1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3802,7 +3802,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6aa1
+					// Method begins at RVA 0x6a7d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3820,7 +3820,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6a98
+				// Method begins at RVA 0x6a74
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4017,7 +4017,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6ae0
+						// Method begins at RVA 0x6abc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4037,7 +4037,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6ae9
+						// Method begins at RVA 0x6ac5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4057,7 +4057,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6af2
+						// Method begins at RVA 0x6ace
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4075,7 +4075,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6ad7
+					// Method begins at RVA 0x6ab3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4093,7 +4093,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6ace
+				// Method begins at RVA 0x6aaa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4114,7 +4114,7 @@
 				object newTarget,
 				object lines,
 				object state,
-				object parentIndent,
+				float64 parentIndent,
 				object style
 			) cil managed 
 		{
@@ -4125,7 +4125,7 @@
 			)
 			// Method begins at RVA 0x450c
 			// Header size: 12
-			// Code size: 458 (0x1ca)
+			// Code size: 453 (0x1c5)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -4167,7 +4167,7 @@
 				IL_003c: ldloc.s 9
 				IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0043: clt
-				IL_0045: brfalse IL_0187
+				IL_0045: brfalse IL_0182
 
 				IL_004a: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37::.ctor()
 				IL_004f: stloc.2
@@ -4229,86 +4229,85 @@
 				IL_00ee: stloc.s 10
 				IL_00f0: ldloc.s 10
 				IL_00f2: ldarg.s parentIndent
-				IL_00f4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00f9: cgt
-				IL_00fb: ldc.i4.0
-				IL_00fc: ceq
-				IL_00fe: brfalse IL_010f
+				IL_00f4: cgt
+				IL_00f6: ldc.i4.0
+				IL_00f7: ceq
+				IL_00f9: brfalse IL_010a
 
-				IL_0103: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L126C32::.ctor()
-				IL_0108: stloc.s 6
-				IL_010a: br IL_0187
+				IL_00fe: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L126C32::.ctor()
+				IL_0103: stloc.s 6
+				IL_0105: br IL_0182
 
-				IL_010f: ldloc.1
-				IL_0110: stloc.s 12
-				IL_0112: ldloc.s 12
-				IL_0114: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0119: stloc.s 10
-				IL_011b: ldloc.s 10
-				IL_011d: ldc.r8 0.0
-				IL_0126: clt
-				IL_0128: brfalse IL_0140
+				IL_010a: ldloc.1
+				IL_010b: stloc.s 12
+				IL_010d: ldloc.s 12
+				IL_010f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0114: stloc.s 10
+				IL_0116: ldloc.s 10
+				IL_0118: ldc.r8 0.0
+				IL_0121: clt
+				IL_0123: brfalse IL_013b
 
-				IL_012d: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L130C25::.ctor()
-				IL_0132: stloc.s 7
-				IL_0134: ldloc.s 5
-				IL_0136: box [System.Runtime]System.Double
-				IL_013b: stloc.s 12
-				IL_013d: ldloc.s 12
-				IL_013f: stloc.1
+				IL_0128: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L130C25::.ctor()
+				IL_012d: stloc.s 7
+				IL_012f: ldloc.s 5
+				IL_0131: box [System.Runtime]System.Double
+				IL_0136: stloc.s 12
+				IL_0138: ldloc.s 12
+				IL_013a: stloc.1
 
-				IL_0140: ldloc.3
-				IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0146: stloc.s 9
-				IL_0148: ldloc.s 9
-				IL_014a: ldstr "substring"
-				IL_014f: ldloc.1
-				IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0155: stloc.s 9
-				IL_0157: ldloc.0
-				IL_0158: ldloc.s 9
-				IL_015a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_015f: pop
-				IL_0160: ldarg.3
-				IL_0161: ldstr "index"
-				IL_0166: ldarg.3
-				IL_0167: ldstr "index"
-				IL_016c: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0171: ldc.r8 1
-				IL_017a: add
-				IL_017b: ldc.i4.1
-				IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_0181: pop
-				IL_0182: br IL_0017
+				IL_013b: ldloc.3
+				IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0141: stloc.s 9
+				IL_0143: ldloc.s 9
+				IL_0145: ldstr "substring"
+				IL_014a: ldloc.1
+				IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0150: stloc.s 9
+				IL_0152: ldloc.0
+				IL_0153: ldloc.s 9
+				IL_0155: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_015a: pop
+				IL_015b: ldarg.3
+				IL_015c: ldstr "index"
+				IL_0161: ldarg.3
+				IL_0162: ldstr "index"
+				IL_0167: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_016c: ldc.r8 1
+				IL_0175: add
+				IL_0176: ldc.i4.1
+				IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_017c: pop
+				IL_017d: br IL_0017
 			// end loop
 
-			IL_0187: ldarg.s style
-			IL_0189: ldstr ">"
-			IL_018e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0193: stloc.s 11
-			IL_0195: ldloc.s 11
-			IL_0197: brfalse IL_01b1
+			IL_0182: ldarg.s style
+			IL_0184: ldstr ">"
+			IL_0189: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_018e: stloc.s 11
+			IL_0190: ldloc.s 11
+			IL_0192: brfalse IL_01ac
 
-			IL_019c: ldarg.0
-			IL_019d: castclass Modules.test262_metadataParser/Scope
-			IL_01a2: ldnull
-			IL_01a3: ldloc.0
-			IL_01a4: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01a9: tail.
-			IL_01ab: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-			IL_01b0: ret
+			IL_0197: ldarg.0
+			IL_0198: castclass Modules.test262_metadataParser/Scope
+			IL_019d: ldnull
+			IL_019e: ldloc.0
+			IL_019f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01a4: tail.
+			IL_01a6: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_01ab: ret
 
-			IL_01b1: ldloc.0
-			IL_01b2: ldc.i4.1
-			IL_01b3: newarr [System.Runtime]System.Object
-			IL_01b8: dup
-			IL_01b9: ldc.i4.0
-			IL_01ba: ldstr "\n"
-			IL_01bf: stelem.ref
-			IL_01c0: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01c5: stloc.s 13
-			IL_01c7: ldloc.s 13
-			IL_01c9: ret
+			IL_01ac: ldloc.0
+			IL_01ad: ldc.i4.1
+			IL_01ae: newarr [System.Runtime]System.Object
+			IL_01b3: dup
+			IL_01b4: ldc.i4.0
+			IL_01b5: ldstr "\n"
+			IL_01ba: stelem.ref
+			IL_01bb: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_01c0: stloc.s 13
+			IL_01c2: ldloc.s 13
+			IL_01c4: ret
 		} // end of method parseBlockScalar::__js_call__
 
 	} // end of class parseBlockScalar
@@ -4328,7 +4327,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6b04
+					// Method begins at RVA 0x6ae0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4348,7 +4347,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6b0d
+					// Method begins at RVA 0x6ae9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4368,7 +4367,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6b16
+					// Method begins at RVA 0x6af2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4386,7 +4385,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6afb
+				// Method begins at RVA 0x6ad7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4407,7 +4406,7 @@
 				object newTarget,
 				object lines,
 				object state,
-				object parentIndent
+				float64 parentIndent
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -4415,9 +4414,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x46e4
+			// Method begins at RVA 0x46e0
 			// Header size: 12
-			// Code size: 412 (0x19c)
+			// Code size: 406 (0x196)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4565,44 +4564,43 @@
 			IL_0141: stloc.s 7
 			IL_0143: ldloc.s 7
 			IL_0145: ldarg.s parentIndent
-			IL_0147: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_014c: cgt
-			IL_014e: ldc.i4.0
-			IL_014f: ceq
-			IL_0151: brfalse IL_0171
+			IL_0147: cgt
+			IL_0149: ldc.i4.0
+			IL_014a: ceq
+			IL_014c: brfalse IL_016c
 
-			IL_0156: newobj instance void Modules.test262_metadataParser/parseIndentedValue/Scope/Block_L153C34::.ctor()
-			IL_015b: stloc.s 4
-			IL_015d: ldarg.3
-			IL_015e: ldstr "index"
-			IL_0163: ldloc.0
-			IL_0164: ldc.i4.1
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_016a: pop
-			IL_016b: ldstr ""
-			IL_0170: ret
+			IL_0151: newobj instance void Modules.test262_metadataParser/parseIndentedValue/Scope/Block_L153C34::.ctor()
+			IL_0156: stloc.s 4
+			IL_0158: ldarg.3
+			IL_0159: ldstr "index"
+			IL_015e: ldloc.0
+			IL_015f: ldc.i4.1
+			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0165: pop
+			IL_0166: ldstr ""
+			IL_016b: ret
 
-			IL_0171: ldarg.3
-			IL_0172: ldstr "index"
-			IL_0177: ldloc.0
-			IL_0178: ldc.i4.1
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_017e: pop
-			IL_017f: ldloc.3
-			IL_0180: box [System.Runtime]System.Double
-			IL_0185: stloc.s 13
-			IL_0187: ldarg.0
-			IL_0188: castclass Modules.test262_metadataParser/Scope
-			IL_018d: ldnull
-			IL_018e: ldarg.2
-			IL_018f: ldarg.3
-			IL_0190: ldloc.s 13
-			IL_0192: tail.
-			IL_0194: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0199: ret
+			IL_016c: ldarg.3
+			IL_016d: ldstr "index"
+			IL_0172: ldloc.0
+			IL_0173: ldc.i4.1
+			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0179: pop
+			IL_017a: ldloc.3
+			IL_017b: box [System.Runtime]System.Double
+			IL_0180: stloc.s 13
+			IL_0182: ldarg.0
+			IL_0183: castclass Modules.test262_metadataParser/Scope
+			IL_0188: ldnull
+			IL_0189: ldarg.2
+			IL_018a: ldarg.3
+			IL_018b: ldloc.3
+			IL_018c: tail.
+			IL_018e: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+			IL_0193: ret
 
-			IL_019a: ldnull
-			IL_019b: ret
+			IL_0194: ldnull
+			IL_0195: ret
 		} // end of method parseIndentedValue::__js_call__
 
 	} // end of class parseIndentedValue
@@ -4626,7 +4624,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6b31
+						// Method begins at RVA 0x6b0d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4646,7 +4644,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6b3a
+						// Method begins at RVA 0x6b16
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4666,7 +4664,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6b43
+						// Method begins at RVA 0x6b1f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4686,7 +4684,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6b4c
+						// Method begins at RVA 0x6b28
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4706,7 +4704,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6b55
+						// Method begins at RVA 0x6b31
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4726,7 +4724,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6b5e
+						// Method begins at RVA 0x6b3a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4746,7 +4744,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6b67
+						// Method begins at RVA 0x6b43
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4764,7 +4762,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6b28
+					// Method begins at RVA 0x6b04
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4782,7 +4780,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6b1f
+				// Method begins at RVA 0x6afb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4803,7 +4801,7 @@
 				object newTarget,
 				object lines,
 				object state,
-				object baseIndent
+				float64 baseIndent
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -4811,9 +4809,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x488c
+			// Method begins at RVA 0x4884
 			// Header size: 12
-			// Code size: 1001 (0x3e9)
+			// Code size: 1005 (0x3ed)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -4868,7 +4866,7 @@
 				IL_002b: ldloc.s 19
 				IL_002d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0032: clt
-				IL_0034: brfalse IL_03e7
+				IL_0034: brfalse IL_03eb
 
 				IL_0039: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37::.ctor()
 				IL_003e: stloc.1
@@ -4926,299 +4924,301 @@
 				IL_00d0: stloc.s 20
 				IL_00d2: ldloc.s 20
 				IL_00d4: ldarg.s baseIndent
-				IL_00d6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00db: clt
-				IL_00dd: brfalse IL_00ee
+				IL_00d6: clt
+				IL_00d8: brfalse IL_00e9
 
-				IL_00e2: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L173C29::.ctor()
-				IL_00e7: stloc.s 5
-				IL_00e9: br IL_03e7
+				IL_00dd: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L173C29::.ctor()
+				IL_00e2: stloc.s 5
+				IL_00e4: br IL_03eb
 
-				IL_00ee: ldloc.s 4
-				IL_00f0: stloc.s 20
-				IL_00f2: ldloc.s 20
-				IL_00f4: ldarg.s baseIndent
-				IL_00f6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00fb: cgt
-				IL_00fd: brfalse IL_0172
+				IL_00e9: ldloc.s 4
+				IL_00eb: stloc.s 20
+				IL_00ed: ldloc.s 20
+				IL_00ef: ldarg.s baseIndent
+				IL_00f1: cgt
+				IL_00f3: brfalse IL_0168
 
-				IL_0102: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L177C29::.ctor()
-				IL_0107: stloc.s 6
-				IL_0109: ldarg.3
-				IL_010a: ldstr "index"
-				IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0114: ldc.r8 1
-				IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0122: stloc.s 22
-				IL_0124: ldloc.s 22
-				IL_0126: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_012b: stloc.s 23
-				IL_012d: ldstr "Unexpected indentation at frontmatter line "
-				IL_0132: ldloc.s 23
-				IL_0134: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0139: stloc.s 23
-				IL_013b: ldloc.s 23
-				IL_013d: ldstr "."
-				IL_0142: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0147: stloc.s 23
-				IL_0149: ldloc.s 23
-				IL_014b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0150: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0155: stloc.s 19
-				IL_0157: ldloc.s 19
-				IL_0159: stloc.s 7
-				IL_015b: ldloc.s 7
-				IL_015d: isinst [System.Runtime]System.Exception
-				IL_0162: dup
-				IL_0163: brtrue IL_0171
+				IL_00f8: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L177C29::.ctor()
+				IL_00fd: stloc.s 6
+				IL_00ff: ldarg.3
+				IL_0100: ldstr "index"
+				IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_010a: ldc.r8 1
+				IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0118: stloc.s 22
+				IL_011a: ldloc.s 22
+				IL_011c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0121: stloc.s 23
+				IL_0123: ldstr "Unexpected indentation at frontmatter line "
+				IL_0128: ldloc.s 23
+				IL_012a: call string [System.Runtime]System.String::Concat(string, string)
+				IL_012f: stloc.s 23
+				IL_0131: ldloc.s 23
+				IL_0133: ldstr "."
+				IL_0138: call string [System.Runtime]System.String::Concat(string, string)
+				IL_013d: stloc.s 23
+				IL_013f: ldloc.s 23
+				IL_0141: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0146: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_014b: stloc.s 19
+				IL_014d: ldloc.s 19
+				IL_014f: stloc.s 7
+				IL_0151: ldloc.s 7
+				IL_0153: isinst [System.Runtime]System.Exception
+				IL_0158: dup
+				IL_0159: brtrue IL_0167
 
-				IL_0168: pop
-				IL_0169: ldloc.s 7
-				IL_016b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0170: throw
+				IL_015e: pop
+				IL_015f: ldloc.s 7
+				IL_0161: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0166: throw
 
-				IL_0171: throw
+				IL_0167: throw
 
-				IL_0172: ldloc.2
-				IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0178: stloc.s 19
-				IL_017a: ldloc.s 4
-				IL_017c: box [System.Runtime]System.Double
-				IL_0181: stloc.s 24
-				IL_0183: ldloc.s 19
-				IL_0185: ldstr "substring"
-				IL_018a: ldloc.s 24
-				IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0191: stloc.s 19
-				IL_0193: ldloc.s 19
-				IL_0195: stloc.s 8
-				IL_0197: ldstr "^([A-Za-z0-9_-]+):(.*)$"
-				IL_019c: ldstr ""
-				IL_01a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_01a6: stloc.s 25
-				IL_01a8: ldloc.s 25
-				IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01af: stloc.s 19
-				IL_01b1: ldloc.s 19
-				IL_01b3: ldstr "exec"
-				IL_01b8: ldloc.s 8
-				IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_01bf: stloc.s 19
-				IL_01c1: ldloc.s 19
-				IL_01c3: stloc.s 9
-				IL_01c5: ldloc.s 9
-				IL_01c7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_01cc: ldc.i4.0
-				IL_01cd: ceq
-				IL_01cf: stloc.s 21
-				IL_01d1: ldloc.s 21
-				IL_01d3: brfalse IL_025c
+				IL_0168: ldloc.2
+				IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_016e: stloc.s 19
+				IL_0170: ldloc.s 4
+				IL_0172: box [System.Runtime]System.Double
+				IL_0177: stloc.s 24
+				IL_0179: ldloc.s 19
+				IL_017b: ldstr "substring"
+				IL_0180: ldloc.s 24
+				IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0187: stloc.s 19
+				IL_0189: ldloc.s 19
+				IL_018b: stloc.s 8
+				IL_018d: ldstr "^([A-Za-z0-9_-]+):(.*)$"
+				IL_0192: ldstr ""
+				IL_0197: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_019c: stloc.s 25
+				IL_019e: ldloc.s 25
+				IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01a5: stloc.s 19
+				IL_01a7: ldloc.s 19
+				IL_01a9: ldstr "exec"
+				IL_01ae: ldloc.s 8
+				IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_01b5: stloc.s 19
+				IL_01b7: ldloc.s 19
+				IL_01b9: stloc.s 9
+				IL_01bb: ldloc.s 9
+				IL_01bd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_01c2: ldc.i4.0
+				IL_01c3: ceq
+				IL_01c5: stloc.s 21
+				IL_01c7: ldloc.s 21
+				IL_01c9: brfalse IL_0252
 
-				IL_01d8: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L183C16::.ctor()
-				IL_01dd: stloc.s 10
-				IL_01df: ldarg.3
-				IL_01e0: ldstr "index"
-				IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01ea: ldc.r8 1
-				IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_01f8: stloc.s 22
-				IL_01fa: ldloc.s 22
-				IL_01fc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0201: stloc.s 23
-				IL_0203: ldstr "Invalid frontmatter line "
-				IL_0208: ldloc.s 23
-				IL_020a: call string [System.Runtime]System.String::Concat(string, string)
-				IL_020f: stloc.s 23
-				IL_0211: ldloc.s 23
-				IL_0213: ldstr ": "
-				IL_0218: call string [System.Runtime]System.String::Concat(string, string)
-				IL_021d: stloc.s 23
-				IL_021f: ldloc.s 8
-				IL_0221: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0226: stloc.s 26
-				IL_0228: ldloc.s 23
-				IL_022a: ldloc.s 26
-				IL_022c: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0231: stloc.s 26
-				IL_0233: ldloc.s 26
-				IL_0235: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_023a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_023f: stloc.s 19
-				IL_0241: ldloc.s 19
-				IL_0243: stloc.s 11
-				IL_0245: ldloc.s 11
-				IL_0247: isinst [System.Runtime]System.Exception
-				IL_024c: dup
-				IL_024d: brtrue IL_025b
+				IL_01ce: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L183C16::.ctor()
+				IL_01d3: stloc.s 10
+				IL_01d5: ldarg.3
+				IL_01d6: ldstr "index"
+				IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01e0: ldc.r8 1
+				IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_01ee: stloc.s 22
+				IL_01f0: ldloc.s 22
+				IL_01f2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01f7: stloc.s 23
+				IL_01f9: ldstr "Invalid frontmatter line "
+				IL_01fe: ldloc.s 23
+				IL_0200: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0205: stloc.s 23
+				IL_0207: ldloc.s 23
+				IL_0209: ldstr ": "
+				IL_020e: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0213: stloc.s 23
+				IL_0215: ldloc.s 8
+				IL_0217: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_021c: stloc.s 26
+				IL_021e: ldloc.s 23
+				IL_0220: ldloc.s 26
+				IL_0222: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0227: stloc.s 26
+				IL_0229: ldloc.s 26
+				IL_022b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0230: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0235: stloc.s 19
+				IL_0237: ldloc.s 19
+				IL_0239: stloc.s 11
+				IL_023b: ldloc.s 11
+				IL_023d: isinst [System.Runtime]System.Exception
+				IL_0242: dup
+				IL_0243: brtrue IL_0251
 
-				IL_0252: pop
-				IL_0253: ldloc.s 11
-				IL_0255: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_025a: throw
+				IL_0248: pop
+				IL_0249: ldloc.s 11
+				IL_024b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0250: throw
 
-				IL_025b: throw
+				IL_0251: throw
 
-				IL_025c: ldloc.s 9
-				IL_025e: ldc.r8 1
-				IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_026c: stloc.s 12
-				IL_026e: ldloc.s 9
-				IL_0270: ldc.r8 2
-				IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0283: stloc.s 19
-				IL_0285: ldloc.s 19
-				IL_0287: ldstr "trim"
-				IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0291: stloc.s 19
-				IL_0293: ldloc.s 19
-				IL_0295: stloc.s 13
-				IL_0297: ldarg.3
-				IL_0298: ldstr "index"
-				IL_029d: ldarg.3
-				IL_029e: ldstr "index"
-				IL_02a3: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_02a8: ldc.r8 1
-				IL_02b1: add
-				IL_02b2: ldc.i4.1
-				IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_02b8: pop
-				IL_02b9: ldnull
-				IL_02ba: stloc.s 14
-				IL_02bc: ldloc.s 13
-				IL_02be: stloc.s 19
-				IL_02c0: ldloc.s 19
-				IL_02c2: ldstr "|"
-				IL_02c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02cc: stloc.s 21
-				IL_02ce: ldloc.s 21
-				IL_02d0: box [System.Runtime]System.Boolean
-				IL_02d5: stloc.s 27
-				IL_02d7: ldloc.s 27
-				IL_02d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02de: stloc.s 21
-				IL_02e0: ldloc.s 21
-				IL_02e2: brtrue IL_030b
+				IL_0252: ldloc.s 9
+				IL_0254: ldc.r8 1
+				IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0262: stloc.s 12
+				IL_0264: ldloc.s 9
+				IL_0266: ldc.r8 2
+				IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0279: stloc.s 19
+				IL_027b: ldloc.s 19
+				IL_027d: ldstr "trim"
+				IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0287: stloc.s 19
+				IL_0289: ldloc.s 19
+				IL_028b: stloc.s 13
+				IL_028d: ldarg.3
+				IL_028e: ldstr "index"
+				IL_0293: ldarg.3
+				IL_0294: ldstr "index"
+				IL_0299: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_029e: ldc.r8 1
+				IL_02a7: add
+				IL_02a8: ldc.i4.1
+				IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_02ae: pop
+				IL_02af: ldnull
+				IL_02b0: stloc.s 14
+				IL_02b2: ldloc.s 13
+				IL_02b4: stloc.s 19
+				IL_02b6: ldloc.s 19
+				IL_02b8: ldstr "|"
+				IL_02bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02c2: stloc.s 21
+				IL_02c4: ldloc.s 21
+				IL_02c6: box [System.Runtime]System.Boolean
+				IL_02cb: stloc.s 27
+				IL_02cd: ldloc.s 27
+				IL_02cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02d4: stloc.s 21
+				IL_02d6: ldloc.s 21
+				IL_02d8: brtrue IL_0301
 
-				IL_02e7: ldloc.s 13
-				IL_02e9: stloc.s 19
-				IL_02eb: ldloc.s 19
-				IL_02ed: ldstr ">"
-				IL_02f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02f7: stloc.s 21
-				IL_02f9: ldloc.s 21
-				IL_02fb: box [System.Runtime]System.Boolean
-				IL_0300: stloc.s 28
-				IL_0302: ldloc.s 28
-				IL_0304: stloc.s 29
-				IL_0306: br IL_030f
+				IL_02dd: ldloc.s 13
+				IL_02df: stloc.s 19
+				IL_02e1: ldloc.s 19
+				IL_02e3: ldstr ">"
+				IL_02e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02ed: stloc.s 21
+				IL_02ef: ldloc.s 21
+				IL_02f1: box [System.Runtime]System.Boolean
+				IL_02f6: stloc.s 28
+				IL_02f8: ldloc.s 28
+				IL_02fa: stloc.s 29
+				IL_02fc: br IL_0305
 
-				IL_030b: ldloc.s 27
-				IL_030d: stloc.s 29
+				IL_0301: ldloc.s 27
+				IL_0303: stloc.s 29
 
-				IL_030f: ldloc.s 29
-				IL_0311: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0316: stloc.s 21
-				IL_0318: ldloc.s 21
-				IL_031a: brfalse IL_036a
+				IL_0305: ldloc.s 29
+				IL_0307: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_030c: stloc.s 21
+				IL_030e: ldloc.s 21
+				IL_0310: brfalse IL_0365
 
-				IL_031f: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L192C48::.ctor()
-				IL_0324: stloc.s 15
-				IL_0326: ldarg.0
-				IL_0327: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
-				IL_032c: stloc.s 19
-				IL_032e: ldc.i4.1
-				IL_032f: newarr [System.Runtime]System.Object
-				IL_0334: dup
-				IL_0335: ldc.i4.0
-				IL_0336: ldarg.0
-				IL_0337: stelem.ref
-				IL_0338: stloc.s 30
-				IL_033a: ldc.i4.4
-				IL_033b: newarr [System.Runtime]System.Object
-				IL_0340: dup
-				IL_0341: ldc.i4.0
-				IL_0342: ldarg.2
-				IL_0343: stelem.ref
-				IL_0344: dup
-				IL_0345: ldc.i4.1
-				IL_0346: ldarg.3
+				IL_0315: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L192C48::.ctor()
+				IL_031a: stloc.s 15
+				IL_031c: ldarg.0
+				IL_031d: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
+				IL_0322: stloc.s 19
+				IL_0324: ldc.i4.1
+				IL_0325: newarr [System.Runtime]System.Object
+				IL_032a: dup
+				IL_032b: ldc.i4.0
+				IL_032c: ldarg.0
+				IL_032d: stelem.ref
+				IL_032e: stloc.s 30
+				IL_0330: ldc.i4.4
+				IL_0331: newarr [System.Runtime]System.Object
+				IL_0336: dup
+				IL_0337: ldc.i4.0
+				IL_0338: ldarg.2
+				IL_0339: stelem.ref
+				IL_033a: dup
+				IL_033b: ldc.i4.1
+				IL_033c: ldarg.3
+				IL_033d: stelem.ref
+				IL_033e: dup
+				IL_033f: ldc.i4.2
+				IL_0340: ldarg.s baseIndent
+				IL_0342: box [System.Runtime]System.Double
 				IL_0347: stelem.ref
 				IL_0348: dup
-				IL_0349: ldc.i4.2
-				IL_034a: ldarg.s baseIndent
+				IL_0349: ldc.i4.3
+				IL_034a: ldloc.s 13
 				IL_034c: stelem.ref
-				IL_034d: dup
-				IL_034e: ldc.i4.3
-				IL_034f: ldloc.s 13
-				IL_0351: stelem.ref
-				IL_0352: stloc.s 31
-				IL_0354: ldloc.s 19
-				IL_0356: ldloc.s 30
-				IL_0358: ldloc.s 31
-				IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_035f: stloc.s 19
-				IL_0361: ldloc.s 19
-				IL_0363: stloc.s 14
-				IL_0365: br IL_03d6
+				IL_034d: stloc.s 31
+				IL_034f: ldloc.s 19
+				IL_0351: ldloc.s 30
+				IL_0353: ldloc.s 31
+				IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_035a: stloc.s 19
+				IL_035c: ldloc.s 19
+				IL_035e: stloc.s 14
+				IL_0360: br IL_03da
 
-				IL_036a: ldloc.s 13
-				IL_036c: stloc.s 19
-				IL_036e: ldloc.s 19
-				IL_0370: ldstr ""
-				IL_0375: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_037a: stloc.s 21
-				IL_037c: ldloc.s 21
-				IL_037e: brfalse IL_03b2
+				IL_0365: ldloc.s 13
+				IL_0367: stloc.s 19
+				IL_0369: ldloc.s 19
+				IL_036b: ldstr ""
+				IL_0370: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0375: stloc.s 21
+				IL_0377: ldloc.s 21
+				IL_0379: brfalse IL_03b6
 
-				IL_0383: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L194C33::.ctor()
-				IL_0388: stloc.s 16
-				IL_038a: ldc.i4.1
-				IL_038b: newarr [System.Runtime]System.Object
-				IL_0390: dup
-				IL_0391: ldc.i4.0
-				IL_0392: ldarg.0
-				IL_0393: stelem.ref
-				IL_0394: stloc.s 31
-				IL_0396: ldarg.0
-				IL_0397: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
-				IL_039c: ldloc.s 31
-				IL_039e: ldarg.2
-				IL_039f: ldarg.3
-				IL_03a0: ldarg.s baseIndent
-				IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_03a7: stloc.s 19
-				IL_03a9: ldloc.s 19
-				IL_03ab: stloc.s 14
-				IL_03ad: br IL_03d6
+				IL_037e: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L194C33::.ctor()
+				IL_0383: stloc.s 16
+				IL_0385: ldarg.0
+				IL_0386: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
+				IL_038b: stloc.s 19
+				IL_038d: ldc.i4.1
+				IL_038e: newarr [System.Runtime]System.Object
+				IL_0393: dup
+				IL_0394: ldc.i4.0
+				IL_0395: ldarg.0
+				IL_0396: stelem.ref
+				IL_0397: stloc.s 31
+				IL_0399: ldloc.s 19
+				IL_039b: ldloc.s 31
+				IL_039d: ldarg.2
+				IL_039e: ldarg.3
+				IL_039f: ldarg.s baseIndent
+				IL_03a1: box [System.Runtime]System.Double
+				IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_03ab: stloc.s 19
+				IL_03ad: ldloc.s 19
+				IL_03af: stloc.s 14
+				IL_03b1: br IL_03da
 
-				IL_03b2: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L196C11::.ctor()
-				IL_03b7: stloc.s 17
-				IL_03b9: ldarg.0
-				IL_03ba: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
-				IL_03bf: ldc.i4.1
-				IL_03c0: newarr [System.Runtime]System.Object
-				IL_03c5: dup
-				IL_03c6: ldc.i4.0
-				IL_03c7: ldarg.0
-				IL_03c8: stelem.ref
-				IL_03c9: ldloc.s 13
-				IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_03d0: stloc.s 19
-				IL_03d2: ldloc.s 19
-				IL_03d4: stloc.s 14
+				IL_03b6: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L196C11::.ctor()
+				IL_03bb: stloc.s 17
+				IL_03bd: ldarg.0
+				IL_03be: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
+				IL_03c3: ldc.i4.1
+				IL_03c4: newarr [System.Runtime]System.Object
+				IL_03c9: dup
+				IL_03ca: ldc.i4.0
+				IL_03cb: ldarg.0
+				IL_03cc: stelem.ref
+				IL_03cd: ldloc.s 13
+				IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_03d4: stloc.s 19
+				IL_03d6: ldloc.s 19
+				IL_03d8: stloc.s 14
 
-				IL_03d6: ldloc.0
-				IL_03d7: ldloc.s 12
-				IL_03d9: ldloc.s 14
-				IL_03db: ldc.i4.1
-				IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_03e1: pop
-				IL_03e2: br IL_0006
+				IL_03da: ldloc.0
+				IL_03db: ldloc.s 12
+				IL_03dd: ldloc.s 14
+				IL_03df: ldc.i4.1
+				IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_03e5: pop
+				IL_03e6: br IL_0006
 			// end loop
 
-			IL_03e7: ldloc.0
-			IL_03e8: ret
+			IL_03eb: ldloc.0
+			IL_03ec: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -5234,7 +5234,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6b70
+				// Method begins at RVA 0x6b4c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5261,9 +5261,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4c84
+			// Method begins at RVA 0x4c80
 			// Header size: 12
-			// Code size: 110 (0x6e)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5307,13 +5307,12 @@
 			IL_0054: ldloc.0
 			IL_0055: ldloc.3
 			IL_0056: ldc.r8 0.0
-			IL_005f: box [System.Runtime]System.Double
-			IL_0064: tail.
-			IL_0066: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_006b: ret
+			IL_005f: tail.
+			IL_0061: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+			IL_0066: ret
 
-			IL_006c: ldnull
-			IL_006d: ret
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method parseTest262Frontmatter::__js_call__
 
 	} // end of class parseTest262Frontmatter
@@ -5333,7 +5332,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6b82
+					// Method begins at RVA 0x6b5e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5353,7 +5352,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6b8b
+					// Method begins at RVA 0x6b67
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5373,7 +5372,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6b94
+					// Method begins at RVA 0x6b70
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5391,7 +5390,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6b79
+				// Method begins at RVA 0x6b55
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5418,7 +5417,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4d00
+			// Method begins at RVA 0x4cf8
 			// Header size: 12
 			// Code size: 383 (0x17f)
 			.maxstack 8
@@ -5589,7 +5588,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6b9d
+				// Method begins at RVA 0x6b79
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5613,7 +5612,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4e8c
+			// Method begins at RVA 0x4e84
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -5672,7 +5671,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6baf
+					// Method begins at RVA 0x6b8b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5690,7 +5689,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6ba6
+				// Method begins at RVA 0x6b82
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5714,7 +5713,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4ee0
+			// Method begins at RVA 0x4ed8
 			// Header size: 12
 			// Code size: 131 (0x83)
 			.maxstack 8
@@ -5797,7 +5796,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6bb8
+				// Method begins at RVA 0x6b94
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5822,7 +5821,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4f70
+			// Method begins at RVA 0x4f68
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -5870,7 +5869,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6bc1
+				// Method begins at RVA 0x6b9d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5888,8 +5887,8 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object newTarget,
-				object target,
-				object code,
+				class [JavaScriptRuntime]JavaScriptRuntime.Array target,
+				string code,
 				object source,
 				object reason
 			) cil managed 
@@ -5897,36 +5896,29 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4fb0
-			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Method begins at RVA 0x4fa8
+			// Header size: 1
+			// Code size: 51 (0x33)
 			.maxstack 8
-			.locals init (
-				[0] object
-			)
 
 			IL_0000: ldarg.1
-			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0006: stloc.0
-			IL_0007: ldloc.0
-			IL_0008: ldstr "push"
-			IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0001: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0006: dup
+			IL_0007: ldstr "code"
+			IL_000c: ldarg.2
+			IL_000d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0012: dup
-			IL_0013: ldstr "code"
-			IL_0018: ldarg.2
+			IL_0013: ldstr "source"
+			IL_0018: ldarg.3
 			IL_0019: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_001e: dup
-			IL_001f: ldstr "source"
-			IL_0024: ldarg.3
-			IL_0025: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_002a: dup
-			IL_002b: ldstr "reason"
-			IL_0030: ldarg.s reason
-			IL_0032: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003c: pop
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_001f: ldstr "reason"
+			IL_0024: ldarg.s reason
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_002b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0030: pop
+			IL_0031: ldnull
+			IL_0032: ret
 		} // end of method pushIssue::__js_call__
 
 	} // end of class pushIssue
@@ -5946,7 +5938,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6bd3
+					// Method begins at RVA 0x6baf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5966,7 +5958,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6bdc
+					// Method begins at RVA 0x6bb8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5984,7 +5976,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6bca
+				// Method begins at RVA 0x6ba6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6012,7 +6004,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6bf7
+						// Method begins at RVA 0x6bd3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6030,7 +6022,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6bee
+					// Method begins at RVA 0x6bca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6048,7 +6040,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6be5
+				// Method begins at RVA 0x6bc1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6068,8 +6060,8 @@
 				class Modules.test262_metadataParser/Scope scope,
 				object newTarget,
 				object 'value',
-				object source,
-				object issues
+				string source,
+				class [JavaScriptRuntime]JavaScriptRuntime.Array issues
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -6077,7 +6069,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4ffc
+			// Method begins at RVA 0x4fdc
 			// Header size: 12
 			// Code size: 499 (0x1f3)
 			.maxstack 8
@@ -6331,7 +6323,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6c09
+					// Method begins at RVA 0x6be5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6351,7 +6343,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6c12
+					// Method begins at RVA 0x6bee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6369,7 +6361,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6c00
+				// Method begins at RVA 0x6bdc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6389,8 +6381,8 @@
 				class Modules.test262_metadataParser/Scope scope,
 				object newTarget,
 				object 'value',
-				object source,
-				object issues
+				string source,
+				class [JavaScriptRuntime]JavaScriptRuntime.Array issues
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -6398,7 +6390,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x51fc
+			// Method begins at RVA 0x51dc
 			// Header size: 12
 			// Code size: 265 (0x109)
 			.maxstack 8
@@ -6554,7 +6546,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6c24
+					// Method begins at RVA 0x6c00
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6574,7 +6566,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6c2d
+					// Method begins at RVA 0x6c09
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6594,7 +6586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6c36
+					// Method begins at RVA 0x6c12
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6614,7 +6606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6c5a
+					// Method begins at RVA 0x6c36
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6632,7 +6624,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6c1b
+				// Method begins at RVA 0x6bf7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6660,7 +6652,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6c51
+						// Method begins at RVA 0x6c2d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6678,7 +6670,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6c48
+					// Method begins at RVA 0x6c24
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6696,7 +6688,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6c3f
+				// Method begins at RVA 0x6c1b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6716,7 +6708,7 @@
 				class Modules.test262_metadataParser/Scope scope,
 				object newTarget,
 				object rawNegative,
-				object issues
+				class [JavaScriptRuntime]JavaScriptRuntime.Array issues
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -6724,7 +6716,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5314
+			// Method begins at RVA 0x52f4
 			// Header size: 12
 			// Code size: 1148 (0x47c)
 			.maxstack 8
@@ -7247,7 +7239,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6c90
+						// Method begins at RVA 0x6c6c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7267,7 +7259,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6c99
+						// Method begins at RVA 0x6c75
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7287,7 +7279,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6ca2
+						// Method begins at RVA 0x6c7e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7305,7 +7297,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6c87
+					// Method begins at RVA 0x6c63
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7325,7 +7317,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6cab
+					// Method begins at RVA 0x6c87
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7345,7 +7337,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6cb4
+					// Method begins at RVA 0x6c90
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7363,7 +7355,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6c63
+				// Method begins at RVA 0x6c3f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7391,7 +7383,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6c7e
+						// Method begins at RVA 0x6c5a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7409,7 +7401,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6c75
+					// Method begins at RVA 0x6c51
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7427,7 +7419,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6c6c
+				// Method begins at RVA 0x6c48
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7455,7 +7447,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6ccf
+						// Method begins at RVA 0x6cab
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7473,7 +7465,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6cc6
+					// Method begins at RVA 0x6ca2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7491,7 +7483,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6cbd
+				// Method begins at RVA 0x6c99
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7510,8 +7502,8 @@
 			object __js_call__ (
 				class Modules.test262_metadataParser/Scope scope,
 				object newTarget,
-				object 'flags',
-				object includes,
+				class [JavaScriptRuntime]JavaScriptRuntime.Array 'flags',
+				class [JavaScriptRuntime]JavaScriptRuntime.Array includes,
 				object fileName
 			) cil managed 
 		{
@@ -7520,9 +7512,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x579c
+			// Method begins at RVA 0x577c
 			// Header size: 12
-			// Code size: 1709 (0x6ad)
+			// Code size: 1705 (0x6a9)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7962,261 +7954,261 @@
 				IL_03fd: stloc.s 33
 				IL_03ff: ldloc.s 33
 				IL_0401: ldarg.3
-				IL_0402: ldstr "length"
-				IL_0407: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_040c: clt
-				IL_040e: brfalse IL_048e
+				IL_0402: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+				IL_0407: conv.r8
+				IL_0408: clt
+				IL_040a: brfalse IL_048a
 
-				IL_0413: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44::.ctor()
-				IL_0418: stloc.s 24
-				IL_041a: ldarg.0
-				IL_041b: ldfld object Modules.test262_metadataParser/Scope::contains
-				IL_0420: stloc.s 32
-				IL_0422: ldc.i4.1
-				IL_0423: newarr [System.Runtime]System.Object
-				IL_0428: dup
-				IL_0429: ldc.i4.0
-				IL_042a: ldarg.0
-				IL_042b: stelem.ref
-				IL_042c: stloc.s 31
-				IL_042e: ldloc.s 32
-				IL_0430: ldloc.s 31
-				IL_0432: ldloc.s 21
-				IL_0434: ldarg.3
-				IL_0435: ldloc.s 23
-				IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_0441: stloc.s 32
-				IL_0443: ldloc.s 32
-				IL_0445: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_044a: ldc.i4.0
-				IL_044b: ceq
-				IL_044d: stloc.s 34
-				IL_044f: ldloc.s 34
-				IL_0451: brfalse IL_047b
+				IL_040f: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44::.ctor()
+				IL_0414: stloc.s 24
+				IL_0416: ldarg.0
+				IL_0417: ldfld object Modules.test262_metadataParser/Scope::contains
+				IL_041c: stloc.s 32
+				IL_041e: ldc.i4.1
+				IL_041f: newarr [System.Runtime]System.Object
+				IL_0424: dup
+				IL_0425: ldc.i4.0
+				IL_0426: ldarg.0
+				IL_0427: stelem.ref
+				IL_0428: stloc.s 31
+				IL_042a: ldloc.s 32
+				IL_042c: ldloc.s 31
+				IL_042e: ldloc.s 21
+				IL_0430: ldarg.3
+				IL_0431: ldloc.s 23
+				IL_0433: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_043d: stloc.s 32
+				IL_043f: ldloc.s 32
+				IL_0441: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0446: ldc.i4.0
+				IL_0447: ceq
+				IL_0449: stloc.s 34
+				IL_044b: ldloc.s 34
+				IL_044d: brfalse IL_0477
 
-				IL_0456: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44/Block_L365C49::.ctor()
-				IL_045b: stloc.s 25
-				IL_045d: ldloc.s 21
-				IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0464: stloc.s 32
-				IL_0466: ldloc.s 32
-				IL_0468: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_046d: ldarg.3
-				IL_046e: ldloc.s 23
-				IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0475: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_047a: pop
+				IL_0452: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44/Block_L365C49::.ctor()
+				IL_0457: stloc.s 25
+				IL_0459: ldloc.s 21
+				IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0460: stloc.s 32
+				IL_0462: ldloc.s 32
+				IL_0464: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0469: ldarg.3
+				IL_046a: ldloc.s 23
+				IL_046c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0471: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0476: pop
 
-				IL_047b: ldloc.s 23
-				IL_047d: ldc.r8 1
-				IL_0486: add
-				IL_0487: stloc.s 23
-				IL_0489: br IL_03fb
+				IL_0477: ldloc.s 23
+				IL_0479: ldc.r8 1
+				IL_0482: add
+				IL_0483: stloc.s 23
+				IL_0485: br IL_03fb
 			// end loop
 
-			IL_048e: ldc.i4.1
-			IL_048f: newarr [System.Runtime]System.Object
-			IL_0494: dup
-			IL_0495: ldc.i4.0
+			IL_048a: ldc.i4.1
+			IL_048b: newarr [System.Runtime]System.Object
+			IL_0490: dup
+			IL_0491: ldc.i4.0
+			IL_0492: ldarg.0
+			IL_0493: stelem.ref
+			IL_0494: stloc.s 31
 			IL_0496: ldarg.0
-			IL_0497: stelem.ref
-			IL_0498: stloc.s 31
-			IL_049a: ldarg.0
-			IL_049b: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_04a0: ldloc.s 31
-			IL_04a2: ldarg.3
-			IL_04a3: ldstr "agent.js"
-			IL_04a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04ad: stloc.s 32
-			IL_04af: ldloc.s 32
-			IL_04b1: stloc.s 26
-			IL_04b3: ldc.i4.1
-			IL_04b4: newarr [System.Runtime]System.Object
-			IL_04b9: dup
-			IL_04ba: ldc.i4.0
+			IL_0497: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_049c: ldloc.s 31
+			IL_049e: ldarg.3
+			IL_049f: ldstr "agent.js"
+			IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04a9: stloc.s 32
+			IL_04ab: ldloc.s 32
+			IL_04ad: stloc.s 26
+			IL_04af: ldc.i4.1
+			IL_04b0: newarr [System.Runtime]System.Object
+			IL_04b5: dup
+			IL_04b6: ldc.i4.0
+			IL_04b7: ldarg.0
+			IL_04b8: stelem.ref
+			IL_04b9: stloc.s 31
 			IL_04bb: ldarg.0
-			IL_04bc: stelem.ref
-			IL_04bd: stloc.s 31
-			IL_04bf: ldarg.0
-			IL_04c0: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_04c5: ldloc.s 31
-			IL_04c7: ldarg.2
-			IL_04c8: ldstr "CanBlockIsFalse"
-			IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04d2: stloc.s 32
-			IL_04d4: ldloc.s 32
-			IL_04d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04db: stloc.s 34
-			IL_04dd: ldloc.s 34
-			IL_04df: brfalse IL_04f0
+			IL_04bc: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_04c1: ldloc.s 31
+			IL_04c3: ldarg.2
+			IL_04c4: ldstr "CanBlockIsFalse"
+			IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04ce: stloc.s 32
+			IL_04d0: ldloc.s 32
+			IL_04d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04d7: stloc.s 34
+			IL_04d9: ldloc.s 34
+			IL_04db: brfalse IL_04ec
 
-			IL_04e4: ldstr "false"
-			IL_04e9: stloc.s 27
-			IL_04eb: br IL_0538
+			IL_04e0: ldstr "false"
+			IL_04e5: stloc.s 27
+			IL_04e7: br IL_0534
 
-			IL_04f0: ldc.i4.1
-			IL_04f1: newarr [System.Runtime]System.Object
-			IL_04f6: dup
-			IL_04f7: ldc.i4.0
+			IL_04ec: ldc.i4.1
+			IL_04ed: newarr [System.Runtime]System.Object
+			IL_04f2: dup
+			IL_04f3: ldc.i4.0
+			IL_04f4: ldarg.0
+			IL_04f5: stelem.ref
+			IL_04f6: stloc.s 31
 			IL_04f8: ldarg.0
-			IL_04f9: stelem.ref
-			IL_04fa: stloc.s 31
-			IL_04fc: ldarg.0
-			IL_04fd: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0502: ldloc.s 31
-			IL_0504: ldarg.2
-			IL_0505: ldstr "CanBlockIsTrue"
-			IL_050a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_050f: stloc.s 32
-			IL_0511: ldloc.s 32
-			IL_0513: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0518: stloc.s 34
-			IL_051a: ldloc.s 34
-			IL_051c: brfalse IL_052d
+			IL_04f9: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_04fe: ldloc.s 31
+			IL_0500: ldarg.2
+			IL_0501: ldstr "CanBlockIsTrue"
+			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_050b: stloc.s 32
+			IL_050d: ldloc.s 32
+			IL_050f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0514: stloc.s 34
+			IL_0516: ldloc.s 34
+			IL_0518: brfalse IL_0529
 
-			IL_0521: ldstr "true"
-			IL_0526: stloc.s 28
-			IL_0528: br IL_0534
+			IL_051d: ldstr "true"
+			IL_0522: stloc.s 28
+			IL_0524: br IL_0530
 
-			IL_052d: ldstr "unspecified"
-			IL_0532: stloc.s 28
+			IL_0529: ldstr "unspecified"
+			IL_052e: stloc.s 28
 
-			IL_0534: ldloc.s 28
-			IL_0536: stloc.s 27
+			IL_0530: ldloc.s 28
+			IL_0532: stloc.s 27
 
-			IL_0538: ldloc.s 27
-			IL_053a: stloc.s 29
-			IL_053c: ldloc.0
-			IL_053d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0542: stloc.s 34
-			IL_0544: ldloc.s 34
-			IL_0546: brfalse IL_0557
+			IL_0534: ldloc.s 27
+			IL_0536: stloc.s 29
+			IL_0538: ldloc.0
+			IL_0539: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_053e: stloc.s 34
+			IL_0540: ldloc.s 34
+			IL_0542: brfalse IL_0553
 
-			IL_054b: ldstr "module"
-			IL_0550: stloc.s 30
-			IL_0552: br IL_055e
+			IL_0547: ldstr "module"
+			IL_054c: stloc.s 30
+			IL_054e: br IL_055a
 
-			IL_0557: ldstr "script"
-			IL_055c: stloc.s 30
+			IL_0553: ldstr "script"
+			IL_0558: stloc.s 30
 
-			IL_055e: ldloc.s 20
-			IL_0560: ldstr "length"
-			IL_0565: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_056a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_056f: ldc.r8 0.0
-			IL_0578: cgt
-			IL_057a: stloc.s 34
-			IL_057c: ldloc.2
-			IL_057d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0582: stloc.s 43
-			IL_0584: ldloc.s 43
-			IL_0586: brtrue IL_05b6
+			IL_055a: ldloc.s 20
+			IL_055c: ldstr "length"
+			IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0566: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_056b: ldc.r8 0.0
+			IL_0574: cgt
+			IL_0576: stloc.s 34
+			IL_0578: ldloc.2
+			IL_0579: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_057e: stloc.s 43
+			IL_0580: ldloc.s 43
+			IL_0582: brtrue IL_05b2
 
-			IL_058b: ldc.i4.1
-			IL_058c: newarr [System.Runtime]System.Object
-			IL_0591: dup
-			IL_0592: ldc.i4.0
+			IL_0587: ldc.i4.1
+			IL_0588: newarr [System.Runtime]System.Object
+			IL_058d: dup
+			IL_058e: ldc.i4.0
+			IL_058f: ldarg.0
+			IL_0590: stelem.ref
+			IL_0591: stloc.s 31
 			IL_0593: ldarg.0
-			IL_0594: stelem.ref
-			IL_0595: stloc.s 31
-			IL_0597: ldarg.0
-			IL_0598: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_059d: ldloc.s 31
-			IL_059f: ldarg.3
-			IL_05a0: ldarg.0
-			IL_05a1: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05ab: stloc.s 32
-			IL_05ad: ldloc.s 32
-			IL_05af: stloc.s 44
-			IL_05b1: br IL_05b9
+			IL_0594: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0599: ldloc.s 31
+			IL_059b: ldarg.3
+			IL_059c: ldarg.0
+			IL_059d: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05a7: stloc.s 32
+			IL_05a9: ldloc.s 32
+			IL_05ab: stloc.s 44
+			IL_05ad: br IL_05b5
 
-			IL_05b6: ldloc.2
-			IL_05b7: stloc.s 44
+			IL_05b2: ldloc.2
+			IL_05b3: stloc.s 44
 
-			IL_05b9: ldloc.s 26
-			IL_05bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05c0: stloc.s 43
-			IL_05c2: ldloc.s 43
-			IL_05c4: brtrue IL_05ed
+			IL_05b5: ldloc.s 26
+			IL_05b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05bc: stloc.s 43
+			IL_05be: ldloc.s 43
+			IL_05c0: brtrue IL_05e9
 
-			IL_05c9: ldloc.s 29
-			IL_05cb: stloc.s 45
-			IL_05cd: ldloc.s 45
-			IL_05cf: ldstr "unspecified"
-			IL_05d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_05d9: stloc.s 43
-			IL_05db: ldloc.s 43
-			IL_05dd: box [System.Runtime]System.Boolean
-			IL_05e2: stloc.s 36
-			IL_05e4: ldloc.s 36
-			IL_05e6: stloc.s 46
-			IL_05e8: br IL_05f1
+			IL_05c5: ldloc.s 29
+			IL_05c7: stloc.s 45
+			IL_05c9: ldloc.s 45
+			IL_05cb: ldstr "unspecified"
+			IL_05d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_05d5: stloc.s 43
+			IL_05d7: ldloc.s 43
+			IL_05d9: box [System.Runtime]System.Boolean
+			IL_05de: stloc.s 36
+			IL_05e0: ldloc.s 36
+			IL_05e2: stloc.s 46
+			IL_05e4: br IL_05ed
 
-			IL_05ed: ldloc.s 26
-			IL_05ef: stloc.s 46
+			IL_05e9: ldloc.s 26
+			IL_05eb: stloc.s 46
 
-			IL_05f1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05f6: dup
-			IL_05f7: ldstr "sourceType"
-			IL_05fc: ldloc.s 30
-			IL_05fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0603: dup
-			IL_0604: ldstr "strictMode"
-			IL_0609: ldloc.s 12
-			IL_060b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0610: dup
-			IL_0611: ldstr "defaultHarnessIncludes"
-			IL_0616: ldloc.s 20
-			IL_0618: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_061d: dup
-			IL_061e: ldstr "harnessIncludes"
-			IL_0623: ldloc.s 21
-			IL_0625: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_062a: dup
-			IL_062b: ldstr "requiresDefaultHarness"
-			IL_0630: ldloc.s 34
-			IL_0632: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0637: dup
-			IL_0638: ldstr "requiresAsyncHarness"
-			IL_063d: ldloc.s 44
-			IL_063f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0644: dup
-			IL_0645: ldstr "requiresAgent"
-			IL_064a: ldloc.s 46
-			IL_064c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0651: dup
-			IL_0652: ldstr "canBlock"
-			IL_0657: ldloc.s 29
-			IL_0659: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_065e: dup
-			IL_065f: ldstr "isModule"
-			IL_0664: ldloc.0
-			IL_0665: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_066a: dup
-			IL_066b: ldstr "isRaw"
-			IL_0670: ldloc.1
-			IL_0671: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0676: dup
-			IL_0677: ldstr "isAsync"
-			IL_067c: ldloc.2
-			IL_067d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0682: dup
-			IL_0683: ldstr "isGenerated"
-			IL_0688: ldloc.3
-			IL_0689: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_068e: dup
-			IL_068f: ldstr "isNonDeterministic"
-			IL_0694: ldloc.s 4
-			IL_0696: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_069b: dup
-			IL_069c: ldstr "isFixture"
-			IL_06a1: ldloc.s 5
-			IL_06a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_06a8: stloc.s 47
-			IL_06aa: ldloc.s 47
-			IL_06ac: ret
+			IL_05ed: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05f2: dup
+			IL_05f3: ldstr "sourceType"
+			IL_05f8: ldloc.s 30
+			IL_05fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05ff: dup
+			IL_0600: ldstr "strictMode"
+			IL_0605: ldloc.s 12
+			IL_0607: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_060c: dup
+			IL_060d: ldstr "defaultHarnessIncludes"
+			IL_0612: ldloc.s 20
+			IL_0614: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0619: dup
+			IL_061a: ldstr "harnessIncludes"
+			IL_061f: ldloc.s 21
+			IL_0621: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0626: dup
+			IL_0627: ldstr "requiresDefaultHarness"
+			IL_062c: ldloc.s 34
+			IL_062e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0633: dup
+			IL_0634: ldstr "requiresAsyncHarness"
+			IL_0639: ldloc.s 44
+			IL_063b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0640: dup
+			IL_0641: ldstr "requiresAgent"
+			IL_0646: ldloc.s 46
+			IL_0648: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_064d: dup
+			IL_064e: ldstr "canBlock"
+			IL_0653: ldloc.s 29
+			IL_0655: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_065a: dup
+			IL_065b: ldstr "isModule"
+			IL_0660: ldloc.0
+			IL_0661: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0666: dup
+			IL_0667: ldstr "isRaw"
+			IL_066c: ldloc.1
+			IL_066d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0672: dup
+			IL_0673: ldstr "isAsync"
+			IL_0678: ldloc.2
+			IL_0679: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_067e: dup
+			IL_067f: ldstr "isGenerated"
+			IL_0684: ldloc.3
+			IL_0685: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_068a: dup
+			IL_068b: ldstr "isNonDeterministic"
+			IL_0690: ldloc.s 4
+			IL_0692: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0697: dup
+			IL_0698: ldstr "isFixture"
+			IL_069d: ldloc.s 5
+			IL_069f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_06a4: stloc.s 47
+			IL_06a6: ldloc.s 47
+			IL_06a8: ret
 		} // end of method buildExecutionMetadata::__js_call__
 
 	} // end of class buildExecutionMetadata
@@ -8236,7 +8228,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6ce1
+					// Method begins at RVA 0x6cbd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8256,7 +8248,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6cea
+					// Method begins at RVA 0x6cc6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8276,7 +8268,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6cf3
+					// Method begins at RVA 0x6ccf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8296,7 +8288,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6cfc
+					// Method begins at RVA 0x6cd8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8316,7 +8308,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6d05
+					// Method begins at RVA 0x6ce1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8336,7 +8328,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6d0e
+					// Method begins at RVA 0x6cea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8356,7 +8348,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6d17
+					// Method begins at RVA 0x6cf3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8374,7 +8366,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6cd8
+				// Method begins at RVA 0x6cb4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8403,7 +8395,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5e58
+			// Method begins at RVA 0x5e34
 			// Header size: 12
 			// Code size: 864 (0x360)
 			.maxstack 8
@@ -8824,7 +8816,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6d5f
+					// Method begins at RVA 0x6d3b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8842,7 +8834,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6d20
+				// Method begins at RVA 0x6cfc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8870,7 +8862,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6d3b
+						// Method begins at RVA 0x6d17
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8888,7 +8880,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6d32
+					// Method begins at RVA 0x6d0e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8906,7 +8898,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6d29
+				// Method begins at RVA 0x6d05
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8934,7 +8926,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6d56
+						// Method begins at RVA 0x6d32
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8952,7 +8944,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6d4d
+					// Method begins at RVA 0x6d29
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8970,7 +8962,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6d44
+				// Method begins at RVA 0x6d20
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8998,7 +8990,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x61c4
+			// Method begins at RVA 0x61a0
 			// Header size: 12
 			// Code size: 1922 (0x782)
 			.maxstack 8
@@ -9823,7 +9815,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6d68
+				// Method begins at RVA 0x6d44
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -9850,7 +9842,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x6954
+			// Method begins at RVA 0x6930
 			// Header size: 12
 			// Code size: 69 (0x45)
 			.maxstack 8
@@ -9950,7 +9942,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x6a08
+			// Method begins at RVA 0x69e4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -10114,8 +10106,8 @@
 		IL_012c: ldc.i4.0
 		IL_012d: ldelem.ref
 		IL_012e: castclass Modules.test262_metadataParser/Scope
-		IL_0133: ldftn object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object, object)
-		IL_0139: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes4::.ctor(object, native int)
+		IL_0133: ldftn object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64, object)
+		IL_0139: newobj instance void class [System.Runtime]System.Func`6<object, object, object, float64, object, object>::.ctor(object, native int)
 		IL_013e: ldc.i4.4
 		IL_013f: conv.r8
 		IL_0140: ldstr "parseBlockScalar"
@@ -10135,8 +10127,8 @@
 		IL_015e: ldc.i4.0
 		IL_015f: ldelem.ref
 		IL_0160: castclass Modules.test262_metadataParser/Scope
-		IL_0165: ldftn object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-		IL_016b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_0165: ldftn object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+		IL_016b: newobj instance void class [System.Runtime]System.Func`5<object, object, object, float64, object>::.ctor(object, native int)
 		IL_0170: ldc.i4.3
 		IL_0171: conv.r8
 		IL_0172: ldstr "parseIndentedValue"
@@ -10156,8 +10148,8 @@
 		IL_0190: ldc.i4.0
 		IL_0191: ldelem.ref
 		IL_0192: castclass Modules.test262_metadataParser/Scope
-		IL_0197: ldftn object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-		IL_019d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_0197: ldftn object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+		IL_019d: newobj instance void class [System.Runtime]System.Func`5<object, object, object, float64, object>::.ctor(object, native int)
 		IL_01a2: ldc.i4.3
 		IL_01a3: conv.r8
 		IL_01a4: ldstr "parseYamlSubsetLines"
@@ -10250,8 +10242,8 @@
 		IL_027c: ldloc.2
 		IL_027d: stfld object Modules.test262_metadataParser/Scope::contains
 		IL_0282: ldnull
-		IL_0283: ldftn object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-		IL_0289: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes4::.ctor(object, native int)
+		IL_0283: ldftn object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+		IL_0289: newobj instance void class [System.Runtime]System.Func`6<object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object, object>::.ctor(object, native int)
 		IL_028e: ldc.i4.4
 		IL_028f: conv.r8
 		IL_0290: ldstr "pushIssue"
@@ -10271,8 +10263,8 @@
 		IL_02ae: ldc.i4.0
 		IL_02af: ldelem.ref
 		IL_02b0: castclass Modules.test262_metadataParser/Scope
-		IL_02b5: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-		IL_02bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_02b5: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+		IL_02bb: newobj instance void class [System.Runtime]System.Func`5<object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array>::.ctor(object, native int)
 		IL_02c0: ldc.i4.3
 		IL_02c1: conv.r8
 		IL_02c2: ldstr "toStringArray"
@@ -10292,8 +10284,8 @@
 		IL_02e0: ldc.i4.0
 		IL_02e1: ldelem.ref
 		IL_02e2: castclass Modules.test262_metadataParser/Scope
-		IL_02e7: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-		IL_02ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_02e7: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+		IL_02ed: newobj instance void class [System.Runtime]System.Func`5<object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array, object>::.ctor(object, native int)
 		IL_02f2: ldc.i4.3
 		IL_02f3: conv.r8
 		IL_02f4: ldstr "toNullableString"
@@ -10313,8 +10305,8 @@
 		IL_0312: ldc.i4.0
 		IL_0313: ldelem.ref
 		IL_0314: castclass Modules.test262_metadataParser/Scope
-		IL_0319: ldftn object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
-		IL_031f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0319: ldftn object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+		IL_031f: newobj instance void class [System.Runtime]System.Func`4<object, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object>::.ctor(object, native int)
 		IL_0324: ldc.i4.2
 		IL_0325: conv.r8
 		IL_0326: ldstr "normalizeNegative"
@@ -10334,8 +10326,8 @@
 		IL_0344: ldc.i4.0
 		IL_0345: ldelem.ref
 		IL_0346: castclass Modules.test262_metadataParser/Scope
-		IL_034b: ldftn object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-		IL_0351: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_034b: ldftn object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+		IL_0351: newobj instance void class [System.Runtime]System.Func`5<object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, object>::.ctor(object, native int)
 		IL_0356: ldc.i4.3
 		IL_0357: conv.r8
 		IL_0358: ldstr "buildExecutionMetadata"
@@ -10540,7 +10532,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x6d71
+		// Method begins at RVA 0x6d4d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
@@ -272,7 +272,7 @@
 			object __js_call__ (
 				object newTarget,
 				object mod,
-				object name
+				string name
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -1624,8 +1624,8 @@
 		IL_0117: ldloc.s 6
 		IL_0119: stloc.1
 		IL_011a: ldnull
-		IL_011b: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0121: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_011b: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get::__js_call__(object, object, string)
+		IL_0121: newobj instance void class [System.Runtime]System.Func`4<object, object, string, object>::.ctor(object, native int)
 		IL_0126: ldc.i4.2
 		IL_0127: conv.r8
 		IL_0128: ldstr "__jroc_esm_get"
@@ -1696,7 +1696,7 @@
 		IL_01d0: ldnull
 		IL_01d1: ldloc.s 5
 		IL_01d3: ldstr "run"
-		IL_01d8: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get::__js_call__(object, object, object)
+		IL_01d8: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get::__js_call__(object, object, string)
 		IL_01dd: stloc.s 7
 		IL_01df: ldc.i4.0
 		IL_01e0: newarr [System.Runtime]System.Object
@@ -3219,7 +3219,7 @@
 			object __js_call__ (
 				class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object getter
 			) cil managed 
 		{
@@ -3422,8 +3422,8 @@
 		IL_00e5: ldc.i4.0
 		IL_00e6: ldelem.ref
 		IL_00e7: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-		IL_00ec: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, object, object)
-		IL_00f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00ec: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, string, object)
+		IL_00f2: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_00f7: ldc.i4.2
 		IL_00f8: conv.r8
 		IL_00f9: ldstr "__jroc_esm_export"
@@ -3461,7 +3461,7 @@
 		IL_014a: ldnull
 		IL_014b: ldstr "run"
 		IL_0150: ldloc.s 5
-		IL_0152: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, object, object)
+		IL_0152: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, string, object)
 		IL_0157: pop
 		IL_0158: ret
 	} // end of method Async_TopLevelAwait_ImportedNamedFunction_Dependency::__js_module_init__

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
@@ -2125,7 +2125,7 @@
 			object __js_call__ (
 				class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object getter
 			) cil managed 
 		{
@@ -2365,8 +2365,8 @@
 		IL_0120: ldc.i4.0
 		IL_0121: ldelem.ref
 		IL_0122: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0127: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object, object)
-		IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0127: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, string, object)
+		IL_012d: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_0132: ldc.i4.2
 		IL_0133: conv.r8
 		IL_0134: ldstr "__jroc_esm_export"

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
@@ -272,7 +272,7 @@
 			object __js_call__ (
 				object newTarget,
 				object mod,
-				object name
+				string name
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -1494,8 +1494,8 @@
 		IL_005d: ldloc.s 6
 		IL_005f: stloc.1
 		IL_0060: ldnull
-		IL_0061: ldftn object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0067: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0061: ldftn object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, string)
+		IL_0067: newobj instance void class [System.Runtime]System.Func`4<object, object, string, object>::.ctor(object, native int)
 		IL_006c: ldc.i4.2
 		IL_006d: conv.r8
 		IL_006e: ldstr "__jroc_esm_get"
@@ -3056,7 +3056,7 @@
 			object __js_call__ (
 				class Modules.Import_ExportNamedFrom_LibB/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object getter
 			) cil managed 
 		{
@@ -3246,8 +3246,8 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_00bf: ldftn object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object, object)
-		IL_00c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00bf: ldftn object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, string, object)
+		IL_00c5: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_00ca: ldc.i4.2
 		IL_00cb: conv.r8
 		IL_00cc: ldstr "__jroc_esm_export"

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
@@ -272,7 +272,7 @@
 			object __js_call__ (
 				object newTarget,
 				object mod,
-				object name
+				string name
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -1494,8 +1494,8 @@
 		IL_005d: ldloc.s 6
 		IL_005f: stloc.1
 		IL_0060: ldnull
-		IL_0061: ldftn object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0067: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0061: ldftn object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, string)
+		IL_0067: newobj instance void class [System.Runtime]System.Func`4<object, object, string, object>::.ctor(object, native int)
 		IL_006c: ldc.i4.2
 		IL_006d: conv.r8
 		IL_006e: ldstr "__jroc_esm_get"
@@ -7044,7 +7044,7 @@
 			object __js_call__ (
 				class Modules.Import_ExportStarFromMultiHop_LibA/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object getter
 			) cil managed 
 		{
@@ -7243,8 +7243,8 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_00bf: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object, object)
-		IL_00c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00bf: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, string, object)
+		IL_00c5: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_00ca: ldc.i4.2
 		IL_00cb: conv.r8
 		IL_00cc: ldstr "__jroc_esm_export"

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
@@ -272,7 +272,7 @@
 			object __js_call__ (
 				object newTarget,
 				object mod,
-				object name
+				string name
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -1502,8 +1502,8 @@
 		IL_005d: ldloc.s 11
 		IL_005f: stloc.1
 		IL_0060: ldnull
-		IL_0061: ldftn object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0067: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0061: ldftn object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, string)
+		IL_0067: newobj instance void class [System.Runtime]System.Func`4<object, object, string, object>::.ctor(object, native int)
 		IL_006c: ldc.i4.2
 		IL_006d: conv.r8
 		IL_006e: ldstr "__jroc_esm_get"
@@ -3495,7 +3495,7 @@
 			object __js_call__ (
 				class Modules.Import_ImportMeta_Url_Lib/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object getter
 			) cil managed 
 		{
@@ -3716,8 +3716,8 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_00bf: ldftn object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
-		IL_00c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00bf: ldftn object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, string, object)
+		IL_00c5: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_00ca: ldc.i4.2
 		IL_00cb: conv.r8
 		IL_00cc: ldstr "__jroc_esm_export"

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
@@ -272,7 +272,7 @@
 			object __js_call__ (
 				object newTarget,
 				object mod,
-				object name
+				string name
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -1495,8 +1495,8 @@
 		IL_005d: ldloc.s 7
 		IL_005f: stloc.1
 		IL_0060: ldnull
-		IL_0061: ldftn object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0067: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0061: ldftn object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, string)
+		IL_0067: newobj instance void class [System.Runtime]System.Func`4<object, object, string, object>::.ctor(object, native int)
 		IL_006c: ldc.i4.2
 		IL_006d: conv.r8
 		IL_006e: ldstr "__jroc_esm_get"
@@ -2074,7 +2074,7 @@
 			IL_0013: ldloc.0
 			IL_0014: ldstr "b"
 			IL_0019: tail.
-			IL_001b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get::__js_call__(object, object, object)
+			IL_001b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get::__js_call__(object, object, string)
 			IL_0020: ret
 
 			IL_0021: ldnull
@@ -2348,7 +2348,7 @@
 			object __js_call__ (
 				object newTarget,
 				object mod,
-				object name
+				string name
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -3419,7 +3419,7 @@
 			object __js_call__ (
 				class Modules.Import_LiveBindings_Cycle_A/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object getter
 			) cil managed 
 		{
@@ -3619,8 +3619,8 @@
 		IL_00c5: ldloc.s 4
 		IL_00c7: stloc.1
 		IL_00c8: ldnull
-		IL_00c9: ldftn object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get::__js_call__(object, object, object)
-		IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00c9: ldftn object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get::__js_call__(object, object, string)
+		IL_00cf: newobj instance void class [System.Runtime]System.Func`4<object, object, string, object>::.ctor(object, native int)
 		IL_00d4: ldc.i4.2
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "__jroc_esm_get"
@@ -3660,8 +3660,8 @@
 		IL_0125: ldc.i4.0
 		IL_0126: ldelem.ref
 		IL_0127: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_012c: ldftn object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object, object)
-		IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_012c: ldftn object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, string, object)
+		IL_0132: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_0137: ldc.i4.2
 		IL_0138: conv.r8
 		IL_0139: ldstr "__jroc_esm_export"
@@ -4052,7 +4052,7 @@
 			IL_0013: ldloc.0
 			IL_0014: ldstr "a"
 			IL_0019: tail.
-			IL_001b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get::__js_call__(object, object, object)
+			IL_001b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get::__js_call__(object, object, string)
 			IL_0020: ret
 
 			IL_0021: ldnull
@@ -4326,7 +4326,7 @@
 			object __js_call__ (
 				object newTarget,
 				object mod,
-				object name
+				string name
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -5397,7 +5397,7 @@
 			object __js_call__ (
 				class Modules.Import_LiveBindings_Cycle_B/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object getter
 			) cil managed 
 		{
@@ -5597,8 +5597,8 @@
 		IL_00c5: ldloc.s 4
 		IL_00c7: stloc.1
 		IL_00c8: ldnull
-		IL_00c9: ldftn object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get::__js_call__(object, object, object)
-		IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00c9: ldftn object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get::__js_call__(object, object, string)
+		IL_00cf: newobj instance void class [System.Runtime]System.Func`4<object, object, string, object>::.ctor(object, native int)
 		IL_00d4: ldc.i4.2
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "__jroc_esm_get"
@@ -5638,8 +5638,8 @@
 		IL_0125: ldc.i4.0
 		IL_0126: ldelem.ref
 		IL_0127: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_012c: ldftn object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object, object)
-		IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_012c: ldftn object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, string, object)
+		IL_0132: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_0137: ldc.i4.2
 		IL_0138: conv.r8
 		IL_0139: ldstr "__jroc_esm_export"

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
@@ -272,7 +272,7 @@
 			object __js_call__ (
 				object newTarget,
 				object mod,
-				object name
+				string name
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -1494,8 +1494,8 @@
 		IL_005d: ldloc.s 6
 		IL_005f: stloc.1
 		IL_0060: ldnull
-		IL_0061: ldftn object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0067: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0061: ldftn object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, string)
+		IL_0067: newobj instance void class [System.Runtime]System.Func`4<object, object, string, object>::.ctor(object, native int)
 		IL_006c: ldc.i4.2
 		IL_006d: conv.r8
 		IL_006e: ldstr "__jroc_esm_get"
@@ -3126,7 +3126,7 @@
 			object __js_call__ (
 				class Modules.Import_LiveBindings_Named_Lib/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object getter
 			) cil managed 
 		{
@@ -3342,8 +3342,8 @@
 		IL_00ec: ldc.i4.0
 		IL_00ed: ldelem.ref
 		IL_00ee: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_00f3: ldftn object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object, object)
-		IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00f3: ldftn object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, string, object)
+		IL_00f9: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_00fe: ldc.i4.2
 		IL_00ff: conv.r8
 		IL_0100: ldstr "__jroc_esm_export"

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
@@ -3381,7 +3381,7 @@
 			object __js_call__ (
 				class Modules.Import_Namespace_Esm_Basic_Lib/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object getter
 			) cil managed 
 		{
@@ -3620,8 +3620,8 @@
 		IL_0120: ldc.i4.0
 		IL_0121: ldelem.ref
 		IL_0122: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0127: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object, object)
-		IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0127: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, string, object)
+		IL_012d: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_0132: ldc.i4.2
 		IL_0133: conv.r8
 		IL_0134: ldstr "__jroc_esm_export"

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
@@ -272,7 +272,7 @@
 			object __js_call__ (
 				object newTarget,
 				object mod,
-				object name
+				string name
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -1498,8 +1498,8 @@
 		IL_005d: ldloc.s 7
 		IL_005f: stloc.1
 		IL_0060: ldnull
-		IL_0061: ldftn object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0067: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0061: ldftn object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, string)
+		IL_0067: newobj instance void class [System.Runtime]System.Func`4<object, object, string, object>::.ctor(object, native int)
 		IL_006c: ldc.i4.2
 		IL_006d: conv.r8
 		IL_006e: ldstr "__jroc_esm_get"
@@ -3139,7 +3139,7 @@
 			object __js_call__ (
 				class Modules.Import_Namespace_FromCjs_Stable_A/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object getter
 			) cil managed 
 		{
@@ -3331,8 +3331,8 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_00bf: ldftn object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object, object)
-		IL_00c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00bf: ldftn object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, string, object)
+		IL_00c5: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_00ca: ldc.i4.2
 		IL_00cb: conv.r8
 		IL_00cc: ldstr "__jroc_esm_export"
@@ -4942,7 +4942,7 @@
 			object __js_call__ (
 				class Modules.Import_Namespace_FromCjs_Stable_B/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object getter
 			) cil managed 
 		{
@@ -5134,8 +5134,8 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_00bf: ldftn object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object, object)
-		IL_00c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00bf: ldftn object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, string, object)
+		IL_00c5: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_00ca: ldc.i4.2
 		IL_00cb: conv.r8
 		IL_00cc: ldstr "__jroc_esm_export"

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
@@ -1661,7 +1661,7 @@
 			object __js_call__ (
 				class Modules.Import_RequireEsmModule_Lib/Scope scope,
 				object newTarget,
-				object name,
+				string name,
 				object getter
 			) cil managed 
 		{
@@ -1871,8 +1871,8 @@
 		IL_00dc: ldc.i4.0
 		IL_00dd: ldelem.ref
 		IL_00de: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_00e3: ldftn object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object, object)
-		IL_00e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00e3: ldftn object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, string, object)
+		IL_00e9: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_00ee: ldc.i4.2
 		IL_00ef: conv.r8
 		IL_00f0: ldstr "__jroc_esm_export"

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
@@ -272,7 +272,7 @@
 			object __js_call__ (
 				object newTarget,
 				object mod,
-				object name
+				string name
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -1496,8 +1496,8 @@
 		IL_005d: ldloc.s 8
 		IL_005f: stloc.1
 		IL_0060: ldnull
-		IL_0061: ldftn object Modules.Import_StaticImport_FromCjs/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0067: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0061: ldftn object Modules.Import_StaticImport_FromCjs/__jroc_esm_get::__js_call__(object, object, string)
+		IL_0067: newobj instance void class [System.Runtime]System.Func`4<object, object, string, object>::.ctor(object, native int)
 		IL_006c: ldc.i4.2
 		IL_006d: conv.r8
 		IL_006e: ldstr "__jroc_esm_get"

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
@@ -232,7 +232,7 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object newTarget,
-				object _name,
+				string _name,
 				object fn
 			) cil managed 
 		{
@@ -1246,8 +1246,8 @@
 		IL_0060: ldloc.s 6
 		IL_0062: stloc.3
 		IL_0063: ldnull
-		IL_0064: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_006a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0064: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
+		IL_006a: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_006f: ldc.i4.2
 		IL_0070: conv.r8
 		IL_0071: ldstr "test"

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -232,7 +232,7 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object newTarget,
-				object _name,
+				string _name,
 				object fn
 			) cil managed 
 		{
@@ -7014,8 +7014,8 @@
 		IL_0060: ldloc.s 6
 		IL_0062: stloc.3
 		IL_0063: ldnull
-		IL_0064: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_006a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0064: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_006a: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_006f: ldc.i4.2
 		IL_0070: conv.r8
 		IL_0071: ldstr "test"

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63bc
+				// Method begins at RVA 0x63e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63c5
+				// Method begins at RVA 0x63f1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x63d7
+					// Method begins at RVA 0x6403
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63ce
+				// Method begins at RVA 0x63fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x63e9
+					// Method begins at RVA 0x6415
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63e0
+				// Method begins at RVA 0x640c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -232,7 +232,7 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object newTarget,
-				object _name,
+				string _name,
 				object fn
 			) cil managed 
 		{
@@ -279,7 +279,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x63fb
+					// Method begins at RVA 0x6427
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -299,7 +299,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6404
+					// Method begins at RVA 0x6430
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -319,7 +319,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x640d
+					// Method begins at RVA 0x6439
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -339,7 +339,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6416
+					// Method begins at RVA 0x6442
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -359,7 +359,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x641f
+					// Method begins at RVA 0x644b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -379,7 +379,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6428
+					// Method begins at RVA 0x6454
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -403,7 +403,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x643a
+						// Method begins at RVA 0x6466
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -421,7 +421,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6431
+					// Method begins at RVA 0x645d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -439,7 +439,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63f2
+				// Method begins at RVA 0x641e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -908,7 +908,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6443
+				// Method begins at RVA 0x646f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1087,7 +1087,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6455
+					// Method begins at RVA 0x6481
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1105,7 +1105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x644c
+				// Method begins at RVA 0x6478
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1381,7 +1381,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x645e
+				// Method begins at RVA 0x648a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1458,7 +1458,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6470
+					// Method begins at RVA 0x649c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1476,7 +1476,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6467
+				// Method begins at RVA 0x6493
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1494,8 +1494,8 @@
 		.method public hidebysig static 
 			class [JavaScriptRuntime]JavaScriptRuntime.Array __js_call__ (
 				object newTarget,
-				object M1,
-				object M2
+				class [JavaScriptRuntime]JavaScriptRuntime.Array M1,
+				class [JavaScriptRuntime]JavaScriptRuntime.Array M2
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -1590,7 +1590,7 @@
 					IL_00d0: stloc.s 9
 					IL_00d2: ldarg.2
 					IL_00d3: ldc.r8 0.0
-					IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_00dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 					IL_00e1: ldloc.2
 					IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
 					IL_00e7: stloc.s 10
@@ -1610,7 +1610,7 @@
 					IL_0113: stloc.s 10
 					IL_0115: ldarg.2
 					IL_0116: ldc.r8 1
-					IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_011f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 					IL_0124: ldloc.2
 					IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
 					IL_012a: stloc.s 9
@@ -1632,7 +1632,7 @@
 					IL_0159: stloc.s 9
 					IL_015b: ldarg.2
 					IL_015c: ldc.r8 2
-					IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_0165: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 					IL_016a: ldloc.2
 					IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
 					IL_0170: stloc.s 10
@@ -1654,7 +1654,7 @@
 					IL_019f: stloc.s 10
 					IL_01a1: ldarg.2
 					IL_01a2: ldc.r8 3
-					IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_01ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 					IL_01b0: ldloc.2
 					IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
 					IL_01b6: stloc.s 9
@@ -1720,7 +1720,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6479
+				// Method begins at RVA 0x64a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1738,7 +1738,7 @@
 		.method public hidebysig static 
 			class [JavaScriptRuntime]JavaScriptRuntime.Array __js_call__ (
 				object newTarget,
-				object M,
+				class [JavaScriptRuntime]JavaScriptRuntime.Array M,
 				object V
 			) cil managed 
 		{
@@ -1895,7 +1895,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6482
+				// Method begins at RVA 0x64ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1913,7 +1913,7 @@
 		.method public hidebysig static 
 			class [JavaScriptRuntime]JavaScriptRuntime.Array __js_call__ (
 				object newTarget,
-				object M,
+				class [JavaScriptRuntime]JavaScriptRuntime.Array M,
 				object V
 			) cil managed 
 		{
@@ -2054,7 +2054,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6494
+					// Method begins at RVA 0x64c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2072,7 +2072,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x648b
+				// Method begins at RVA 0x64b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2244,7 +2244,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x649d
+				// Method begins at RVA 0x64c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2263,7 +2263,7 @@
 			class [JavaScriptRuntime]JavaScriptRuntime.Array __js_call__ (
 				class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope scope,
 				object newTarget,
-				object M,
+				class [JavaScriptRuntime]JavaScriptRuntime.Array M,
 				object Dx,
 				object Dy,
 				object Dz
@@ -2276,7 +2276,7 @@
 			)
 			// Method begins at RVA 0x3404
 			// Header size: 12
-			// Code size: 369 (0x171)
+			// Code size: 379 (0x17b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -2381,13 +2381,15 @@
 			IL_0162: stloc.s 4
 			IL_0164: ldnull
 			IL_0165: ldloc.0
-			IL_0166: ldarg.2
-			IL_0167: tail.
-			IL_0169: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, object, object)
-			IL_016e: ret
+			IL_0166: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_016b: ldarg.2
+			IL_016c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0171: tail.
+			IL_0173: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_0178: ret
 
-			IL_016f: ldnull
-			IL_0170: ret
+			IL_0179: ldnull
+			IL_017a: ret
 		} // end of method Translate::__js_call__
 
 	} // end of class Translate
@@ -2403,7 +2405,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64a6
+				// Method begins at RVA 0x64d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2431,9 +2433,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x3584
+			// Method begins at RVA 0x358c
 			// Header size: 12
-			// Code size: 464 (0x1d0)
+			// Code size: 474 (0x1da)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2581,13 +2583,15 @@
 			IL_01c1: stloc.s 10
 			IL_01c3: ldnull
 			IL_01c4: ldloc.3
-			IL_01c5: ldarg.2
-			IL_01c6: tail.
-			IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, object, object)
-			IL_01cd: ret
+			IL_01c5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01ca: ldarg.2
+			IL_01cb: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01d0: tail.
+			IL_01d2: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_01d7: ret
 
-			IL_01ce: ldnull
-			IL_01cf: ret
+			IL_01d8: ldnull
+			IL_01d9: ret
 		} // end of method RotateX::__js_call__
 
 	} // end of class RotateX
@@ -2603,7 +2607,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64af
+				// Method begins at RVA 0x64db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2631,9 +2635,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x3760
+			// Method begins at RVA 0x3774
 			// Header size: 12
-			// Code size: 464 (0x1d0)
+			// Code size: 474 (0x1da)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2781,13 +2785,15 @@
 			IL_01c1: stloc.s 10
 			IL_01c3: ldnull
 			IL_01c4: ldloc.3
-			IL_01c5: ldarg.2
-			IL_01c6: tail.
-			IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, object, object)
-			IL_01cd: ret
+			IL_01c5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01ca: ldarg.2
+			IL_01cb: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01d0: tail.
+			IL_01d2: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_01d7: ret
 
-			IL_01ce: ldnull
-			IL_01cf: ret
+			IL_01d8: ldnull
+			IL_01d9: ret
 		} // end of method RotateY::__js_call__
 
 	} // end of class RotateY
@@ -2803,7 +2809,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64b8
+				// Method begins at RVA 0x64e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2831,9 +2837,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x393c
+			// Method begins at RVA 0x395c
 			// Header size: 12
-			// Code size: 464 (0x1d0)
+			// Code size: 474 (0x1da)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2981,13 +2987,15 @@
 			IL_01c1: stloc.s 10
 			IL_01c3: ldnull
 			IL_01c4: ldloc.3
-			IL_01c5: ldarg.2
-			IL_01c6: tail.
-			IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, object, object)
-			IL_01cd: ret
+			IL_01c5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01ca: ldarg.2
+			IL_01cb: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01d0: tail.
+			IL_01d2: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_01d7: ret
 
-			IL_01ce: ldnull
-			IL_01cf: ret
+			IL_01d8: ldnull
+			IL_01d9: ret
 		} // end of method RotateZ::__js_call__
 
 	} // end of class RotateZ
@@ -3011,7 +3019,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x64d3
+						// Method begins at RVA 0x64ff
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3031,7 +3039,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x64dc
+						// Method begins at RVA 0x6508
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3051,7 +3059,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x64e5
+						// Method begins at RVA 0x6511
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3071,7 +3079,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x64ee
+						// Method begins at RVA 0x651a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3089,7 +3097,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x64ca
+					// Method begins at RVA 0x64f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3113,7 +3121,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6500
+						// Method begins at RVA 0x652c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3133,7 +3141,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6509
+						// Method begins at RVA 0x6535
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3153,7 +3161,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6512
+						// Method begins at RVA 0x653e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3173,7 +3181,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x651b
+						// Method begins at RVA 0x6547
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3191,7 +3199,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x64f7
+					// Method begins at RVA 0x6523
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3215,7 +3223,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x652d
+						// Method begins at RVA 0x6559
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3235,7 +3243,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6536
+						// Method begins at RVA 0x6562
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3255,7 +3263,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x653f
+						// Method begins at RVA 0x656b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3275,7 +3283,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6548
+						// Method begins at RVA 0x6574
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3293,7 +3301,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6524
+					// Method begins at RVA 0x6550
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3317,7 +3325,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x655a
+						// Method begins at RVA 0x6586
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3337,7 +3345,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6563
+						// Method begins at RVA 0x658f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3357,7 +3365,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x656c
+						// Method begins at RVA 0x6598
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3377,7 +3385,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6575
+						// Method begins at RVA 0x65a1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3395,7 +3403,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6551
+					// Method begins at RVA 0x657d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3419,7 +3427,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6587
+						// Method begins at RVA 0x65b3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3439,7 +3447,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6590
+						// Method begins at RVA 0x65bc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3459,7 +3467,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6599
+						// Method begins at RVA 0x65c5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3479,7 +3487,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65a2
+						// Method begins at RVA 0x65ce
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3497,7 +3505,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x657e
+					// Method begins at RVA 0x65aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3521,7 +3529,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65b4
+						// Method begins at RVA 0x65e0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3541,7 +3549,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65bd
+						// Method begins at RVA 0x65e9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3561,7 +3569,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65c6
+						// Method begins at RVA 0x65f2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3581,7 +3589,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65cf
+						// Method begins at RVA 0x65fb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3599,7 +3607,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65ab
+					// Method begins at RVA 0x65d7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3617,7 +3625,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64c1
+				// Method begins at RVA 0x64ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3643,7 +3651,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x3b18
+			// Method begins at RVA 0x3b44
 			// Header size: 12
 			// Code size: 5096 (0x13e8)
 			.maxstack 8
@@ -5197,7 +5205,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65e1
+					// Method begins at RVA 0x660d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5215,7 +5223,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65d8
+				// Method begins at RVA 0x6604
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5241,7 +5249,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x4f0c
+			// Method begins at RVA 0x4f38
 			// Header size: 12
 			// Code size: 1124 (0x464)
 			.maxstack 8
@@ -5669,7 +5677,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65f3
+					// Method begins at RVA 0x661f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5687,7 +5695,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65ea
+				// Method begins at RVA 0x6616
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5714,7 +5722,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x537c
+			// Method begins at RVA 0x53a8
 			// Header size: 12
 			// Code size: 4037 (0xfc5)
 			.maxstack 8
@@ -6987,7 +6995,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65fc
+				// Method begins at RVA 0x6628
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7013,7 +7021,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x6350
+			// Method begins at RVA 0x637c
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -7106,7 +7114,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x63b3
+			// Method begins at RVA 0x63df
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -7186,8 +7194,8 @@
 		IL_0060: ldloc.s 8
 		IL_0062: stloc.3
 		IL_0063: ldnull
-		IL_0064: ldftn object Modules.Compile_Resources_Dromaeo_3d_Cube/test::__js_call__(object, object, object)
-		IL_006a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0064: ldftn object Modules.Compile_Resources_Dromaeo_3d_Cube/test::__js_call__(object, string, object)
+		IL_006a: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_006f: ldc.i4.2
 		IL_0070: conv.r8
 		IL_0071: ldstr "test"
@@ -7266,8 +7274,8 @@
 		IL_012c: ldloc.s 8
 		IL_012e: stfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
 		IL_0133: ldnull
-		IL_0134: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, object, object)
-		IL_013a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0134: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+		IL_013a: newobj instance void class [System.Runtime]System.Func`4<object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array>::.ctor(object, native int)
 		IL_013f: ldc.i4.2
 		IL_0140: conv.r8
 		IL_0141: ldstr "MMulti"
@@ -7279,8 +7287,8 @@
 		IL_0150: ldloc.s 8
 		IL_0152: stfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
 		IL_0157: ldnull
-		IL_0158: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti::__js_call__(object, object, object)
-		IL_015e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0158: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+		IL_015e: newobj instance void class [System.Runtime]System.Func`4<object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, class [JavaScriptRuntime]JavaScriptRuntime.Array>::.ctor(object, native int)
 		IL_0163: ldc.i4.2
 		IL_0164: conv.r8
 		IL_0165: ldstr "VMulti"
@@ -7292,8 +7300,8 @@
 		IL_0174: ldloc.s 8
 		IL_0176: stfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
 		IL_017b: ldnull
-		IL_017c: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2::__js_call__(object, object, object)
-		IL_0182: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_017c: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+		IL_0182: newobj instance void class [System.Runtime]System.Func`4<object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, class [JavaScriptRuntime]JavaScriptRuntime.Array>::.ctor(object, native int)
 		IL_0187: ldc.i4.2
 		IL_0188: conv.r8
 		IL_0189: ldstr "VMulti2"
@@ -7325,8 +7333,8 @@
 		IL_01c9: ldc.i4.0
 		IL_01ca: ldelem.ref
 		IL_01cb: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_01d0: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object, object, object)
-		IL_01d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes4::.ctor(object, native int)
+		IL_01d0: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, object, object)
+		IL_01d6: newobj instance void class [System.Runtime]System.Func`6<object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, object, object, class [JavaScriptRuntime]JavaScriptRuntime.Array>::.ctor(object, native int)
 		IL_01db: ldc.i4.4
 		IL_01dc: conv.r8
 		IL_01dd: ldstr "Translate"
@@ -7591,7 +7599,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x6605
+		// Method begins at RVA 0x6631
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
@@ -78,7 +78,7 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object newTarget,
-				object label,
+				string label,
 				object action
 			) cil managed 
 		{
@@ -4074,8 +4074,8 @@
 		IL_0000: newobj instance void Modules.Require_Crypto_ErrorPaths/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0007: ldftn object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_0012: ldc.i4.2
 		IL_0013: conv.r8
 		IL_0014: ldstr "logError"

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
@@ -78,7 +78,7 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object newTarget,
-				object label,
+				string label,
 				object action
 			) cil managed 
 		{
@@ -664,8 +664,8 @@
 		IL_0000: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0007: ldftn object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_0012: ldc.i4.2
 		IL_0013: conv.r8
 		IL_0014: ldstr "logError"

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
@@ -79,7 +79,7 @@
 			object __js_call__ (
 				class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope scope,
 				object newTarget,
-				object label,
+				string label,
 				object action
 			) cil managed 
 		{
@@ -1040,8 +1040,8 @@
 		IL_0015: ldc.i4.0
 		IL_0016: ldelem.ref
 		IL_0017: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_001c: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0022: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_001c: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
+		IL_0022: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_0027: ldc.i4.2
 		IL_0028: conv.r8
 		IL_0029: ldstr "logThrow"

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
@@ -79,7 +79,7 @@
 			object __js_call__ (
 				class Modules.Proxy_Validation_EdgeCases/Scope scope,
 				object newTarget,
-				object label,
+				string label,
 				object fn
 			) cil managed 
 		{
@@ -1382,8 +1382,8 @@
 		IL_0015: ldc.i4.0
 		IL_0016: ldelem.ref
 		IL_0017: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_001c: ldftn object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_0022: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_001c: ldftn object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+		IL_0022: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_0027: ldc.i4.2
 		IL_0028: conv.r8
 		IL_0029: ldstr "log"

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
@@ -79,7 +79,7 @@
 			object __js_call__ (
 				class Modules.String_Repeat_Basic/Scope scope,
 				object newTarget,
-				object s,
+				string s,
 				object n
 			) cil managed 
 		{
@@ -287,8 +287,8 @@
 		IL_0010: ldc.i4.0
 		IL_0011: ldelem.ref
 		IL_0012: castclass Modules.String_Repeat_Basic/Scope
-		IL_0017: ldftn object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0017: ldftn object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
+		IL_001d: newobj instance void class [System.Runtime]System.Func`4<object, string, object, object>::.ctor(object, native int)
 		IL_0022: ldc.i4.2
 		IL_0023: conv.r8
 		IL_0024: ldstr "logRepeat"

--- a/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
+++ b/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
@@ -571,6 +571,35 @@ public class SymbolTableTypeInferenceTests
     }
 
     [Fact]
+    public void SymbolTable_InferTypes_StableParameters_FunctionDeclaration_PartialEvidenceInfersStablePositions()
+    {
+        var source = @"
+                function translate(matrix, dx, dy, dz) {
+                    return matrix[0][0] + dx + dy + dz;
+                }
+
+                const identity = [[1, 0], [0, 1]];
+                const origin = { v: [1, 2, 3] };
+
+                translate(identity, -origin.v[0], -origin.v[1], -origin.v[2]);
+                translate(identity, origin.v[0], origin.v[1], origin.v[2]);
+            ";
+
+        var symbolTable = BuildSymbolTable(source);
+        var functionScope = FindFirstScope(symbolTable.Root, s =>
+            s.Kind == ScopeKind.Function
+            && s.Parent?.Kind == ScopeKind.Global
+            && string.Equals(s.Name, "translate", StringComparison.Ordinal));
+
+        Assert.NotNull(functionScope);
+        Assert.Single(functionScope!.StableParameterClrTypes);
+        AssertStableParameterType(functionScope, 0, "matrix", typeof(JavaScriptRuntime.Array));
+        AssertObjectParameter(functionScope, "dx");
+        AssertObjectParameter(functionScope, "dy");
+        AssertObjectParameter(functionScope, "dz");
+    }
+
+    [Fact]
     public void SymbolTable_InferTypes_StableParameters_EscapedArrowKeepsObjectParameters()
     {
         var source = @"
@@ -755,6 +784,38 @@ public class SymbolTableTypeInferenceTests
             methodScope!,
             ("a", typeof(double)),
             ("b", typeof(double)));
+    }
+
+    [Fact]
+    public void SymbolTable_InferTypes_Dromaeo3dCube_TranslateAndMMultiInferPartialArrayParameters()
+    {
+        const string resourceName = "Jroc.Tests.Integration.JavaScript.Compile_Resources_Dromaeo_3d_Cube.js";
+        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName);
+        Assert.NotNull(stream);
+
+        using var reader = new StreamReader(stream!);
+        var source = reader.ReadToEnd();
+        var symbolTable = BuildSymbolTable(source);
+
+        var translateScope = FindFirstScope(symbolTable.Root, s =>
+            s.Kind == ScopeKind.Function
+            && s.Parent?.Kind == ScopeKind.Global
+            && string.Equals(s.Name, "Translate", StringComparison.Ordinal));
+        var mMultiScope = FindFirstScope(symbolTable.Root, s =>
+            s.Kind == ScopeKind.Function
+            && s.Parent?.Kind == ScopeKind.Global
+            && string.Equals(s.Name, "MMulti", StringComparison.Ordinal));
+
+        Assert.NotNull(translateScope);
+        Assert.NotNull(mMultiScope);
+
+        AssertStableParameterType(translateScope!, 0, "M", typeof(JavaScriptRuntime.Array));
+        AssertObjectParameter(translateScope!, "Dx");
+        AssertObjectParameter(translateScope!, "Dy");
+        AssertObjectParameter(translateScope!, "Dz");
+
+        AssertStableParameterType(mMultiScope!, 0, "M1", typeof(JavaScriptRuntime.Array));
+        AssertStableParameterType(mMultiScope!, 1, "M2", typeof(JavaScriptRuntime.Array));
     }
 
     [Fact]
@@ -1175,6 +1236,20 @@ public class SymbolTableTypeInferenceTests
             Assert.True(binding!.IsStableType);
             Assert.Equal(clrType, binding.ClrType);
         }
+    }
+
+    private static void AssertStableParameterType(
+        Jroc.SymbolTables.Scope scope,
+        int index,
+        string name,
+        Type clrType)
+    {
+        Assert.True(scope.StableParameterClrTypes.TryGetValue(index, out var actualType), $"Expected stable parameter type for '{name}' at index {index}.");
+        Assert.Equal(clrType, actualType);
+
+        Assert.True(scope.Bindings.TryGetValue(name, out var binding), $"Expected binding for parameter '{name}'.");
+        Assert.True(binding!.IsStableType);
+        Assert.Equal(clrType, binding.ClrType);
     }
 
     private static void AssertObjectParameter(Jroc.SymbolTables.Scope scope, string parameterName)

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
@@ -36,7 +36,7 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object newTarget,
-				object label,
+				string label,
 				object before,
 				object result,
 				object after
@@ -623,8 +623,8 @@
 		IL_0000: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, object, object, object, object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes4::.ctor(object, native int)
+		IL_0007: ldftn object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`6<object, string, object, object, object, object>::.ctor(object, native int)
 		IL_0012: ldc.i4.4
 		IL_0013: conv.r8
 		IL_0014: ldstr "logCase"

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
@@ -36,7 +36,7 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object newTarget,
-				object label,
+				string label,
 				object before,
 				object result,
 				object after
@@ -609,8 +609,8 @@
 		IL_0000: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, object, object, object, object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes4::.ctor(object, native int)
+		IL_0007: ldftn object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`6<object, string, object, object, object, object>::.ctor(object, native int)
 		IL_0012: ldc.i4.4
 		IL_0013: conv.r8
 		IL_0014: ldstr "logCase"

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
@@ -36,7 +36,7 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object newTarget,
-				object label,
+				string label,
 				object before,
 				object result,
 				object after
@@ -623,8 +623,8 @@
 		IL_0000: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, object, object, object, object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes4::.ctor(object, native int)
+		IL_0007: ldftn object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`6<object, string, object, object, object, object>::.ctor(object, native int)
 		IL_0012: ldc.i4.4
 		IL_0013: conv.r8
 		IL_0014: ldstr "logCase"

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
@@ -36,7 +36,7 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object newTarget,
-				object label,
+				string label,
 				object before,
 				object result,
 				object after
@@ -609,8 +609,8 @@
 		IL_0000: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, object, object, object, object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes4::.ctor(object, native int)
+		IL_0007: ldftn object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`6<object, string, object, object, object, object>::.ctor(object, native int)
 		IL_0012: ldc.i4.4
 		IL_0013: conv.r8
 		IL_0014: ldstr "logCase"


### PR DESCRIPTION
## Summary
- implement sparse stable parameter inference for direct-call specialization
- keep whole-callable invalidation for escaped/dynamic/spread/unsafe call cases while disabling only individual unknown/conflicting parameter positions
- add focused symbol-table coverage plus Dromaeo 3D cube assertions/snapshot updates showing `Translate(M, Dx, Dy, Dz)` and `MMulti(...)` keep stable array parameter signatures
- add an Unreleased changelog entry for issue #1333

## Testing
- `dotnet test .\tests\Jroc.Tests\Jroc.Tests.csproj --no-restore --filter "FullyQualifiedName~SymbolTableTypeInferenceTests|FullyQualifiedName~Jroc.Tests.Integration.GeneratorTests.Compile_Resources_Dromaeo_3d_Cube|FullyQualifiedName~Jroc.Tests.Integration.ExecutionTests.Compile_Resources_Dromaeo_3d_Cube" --nologo`

Fixes #1333