### PR TITLE
feat(runtime): add runtime intrinsic catalog

### DIFF
--- a/src/JavaScriptRuntime/IntrinsicObjectRegistry.cs
+++ b/src/JavaScriptRuntime/IntrinsicObjectRegistry.cs
@@ -23,6 +23,11 @@ namespace JavaScriptRuntime
             return map.TryGetValue(name, out var info) ? info : null;
         }
 
+        public static IReadOnlyCollection<IntrinsicObjectInfo> GetAll()
+        {
+            return EnsureMap().Values.ToArray();
+        }
+
         private static Dictionary<string, IntrinsicObjectInfo> EnsureMap()
         {
             var map = _byName;

--- a/src/JavaScriptRuntime/RuntimeIntrinsicCatalog.cs
+++ b/src/JavaScriptRuntime/RuntimeIntrinsicCatalog.cs
@@ -24,8 +24,6 @@ public interface IRuntimeIntrinsicCatalog
 
 public sealed class RuntimeIntrinsicCatalog : IRuntimeIntrinsicCatalog
 {
-    private static readonly RuntimeGlobalPropertyAttributes BuiltInGlobalAttributes = new();
-
     private readonly ReadOnlyDictionary<string, RuntimeGlobalBindingDescriptor> _globals;
     private readonly ReadOnlyDictionary<string, RuntimeIntrinsicObjectDescriptor> _intrinsicObjects;
     private readonly ReadOnlyDictionary<string, RuntimeModuleBindingDescriptor> _modules;
@@ -119,9 +117,10 @@ public sealed class RuntimeIntrinsicCatalog : IRuntimeIntrinsicCatalog
 
     private static Dictionary<string, RuntimeGlobalBindingDescriptor> BuildBuiltInGlobalBindings()
     {
+        var builtInGlobalAttributes = new RuntimeGlobalPropertyAttributes();
         var globals = new Dictionary<string, RuntimeGlobalBindingDescriptor>(StringComparer.Ordinal)
         {
-            ["undefined"] = RuntimeGlobalBindingDescriptor.ForValue("undefined", null, BuiltInGlobalAttributes)
+            ["undefined"] = RuntimeGlobalBindingDescriptor.ForValue("undefined", null, builtInGlobalAttributes)
         };
 
         foreach (var property in typeof(GlobalThis).GetProperties(BindingFlags.Public | BindingFlags.Static))
@@ -134,20 +133,20 @@ public sealed class RuntimeIntrinsicCatalog : IRuntimeIntrinsicCatalog
             globals[property.Name] = RuntimeGlobalBindingDescriptor.ForFactory(
                 property.Name,
                 () => property.GetValue(null),
-                BuiltInGlobalAttributes);
+                builtInGlobalAttributes);
         }
 
-        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.setTimeout), () => (Func<object, object, object[], object>)GlobalThis.setTimeout);
-        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.clearTimeout), () => (Func<object, object?>)GlobalThis.clearTimeout);
-        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.setImmediate), () => (Func<object, object[], object>)GlobalThis.setImmediate);
-        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.setInterval), () => (Func<object, object, object[], object>)GlobalThis.setInterval);
-        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.clearImmediate), () => (Func<object, object?>)GlobalThis.clearImmediate);
-        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.clearInterval), () => (Func<object, object?>)GlobalThis.clearInterval);
-        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.gc), () => (Func<object?>)GlobalThis.gc);
-        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.parseInt), () => (Func<object?, object?, double>)GlobalThis.parseInt);
-        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.parseFloat), () => (Func<object?, double>)GlobalThis.parseFloat);
-        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.isFinite), () => (Func<object?, bool>)GlobalThis.isFinite);
-        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.isNaN), () => (Func<object?, bool>)GlobalThis.isNaN);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.setTimeout), () => (Func<object, object, object[], object>)GlobalThis.setTimeout, builtInGlobalAttributes);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.clearTimeout), () => (Func<object, object?>)GlobalThis.clearTimeout, builtInGlobalAttributes);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.setImmediate), () => (Func<object, object[], object>)GlobalThis.setImmediate, builtInGlobalAttributes);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.setInterval), () => (Func<object, object, object[], object>)GlobalThis.setInterval, builtInGlobalAttributes);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.clearImmediate), () => (Func<object, object?>)GlobalThis.clearImmediate, builtInGlobalAttributes);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.clearInterval), () => (Func<object, object?>)GlobalThis.clearInterval, builtInGlobalAttributes);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.gc), () => (Func<object?>)GlobalThis.gc, builtInGlobalAttributes);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.parseInt), () => (Func<object?, object?, double>)GlobalThis.parseInt, builtInGlobalAttributes);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.parseFloat), () => (Func<object?, double>)GlobalThis.parseFloat, builtInGlobalAttributes);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.isFinite), () => (Func<object?, bool>)GlobalThis.isFinite, builtInGlobalAttributes);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.isNaN), () => (Func<object?, bool>)GlobalThis.isNaN, builtInGlobalAttributes);
 
         return globals;
     }
@@ -238,9 +237,10 @@ public sealed class RuntimeIntrinsicCatalog : IRuntimeIntrinsicCatalog
     private static void AddBuiltInGlobalFunction(
         Dictionary<string, RuntimeGlobalBindingDescriptor> globals,
         string name,
-        Func<object?> valueFactory)
+        Func<object?> valueFactory,
+        RuntimeGlobalPropertyAttributes propertyAttributes)
     {
-        globals[name] = RuntimeGlobalBindingDescriptor.ForFactory(name, valueFactory, BuiltInGlobalAttributes);
+        globals[name] = RuntimeGlobalBindingDescriptor.ForFactory(name, valueFactory, propertyAttributes);
     }
 
     private static string NormalizeModuleSpecifier(string specifier)

--- a/src/JavaScriptRuntime/RuntimeIntrinsicCatalog.cs
+++ b/src/JavaScriptRuntime/RuntimeIntrinsicCatalog.cs
@@ -1,0 +1,250 @@
+using System.Collections.ObjectModel;
+using System.Reflection;
+
+namespace JavaScriptRuntime;
+
+public interface IRuntimeIntrinsicCatalog
+{
+    IReadOnlyCollection<string> GlobalNames { get; }
+
+    IReadOnlyCollection<string> IntrinsicObjectNames { get; }
+
+    IReadOnlyCollection<string> ModuleSpecifiers { get; }
+
+    IReadOnlyCollection<string> KnownGlobalNames { get; }
+
+    bool TryGetGlobalBinding(string name, out RuntimeGlobalBindingDescriptor? descriptor);
+
+    bool TryGetIntrinsicObject(string name, out RuntimeIntrinsicObjectDescriptor? descriptor);
+
+    bool TryGetModuleBinding(string specifier, out RuntimeModuleBindingDescriptor? descriptor);
+
+    bool TryGetKnownGlobal(string name, out RuntimeKnownGlobalDescriptor? descriptor);
+}
+
+public sealed class RuntimeIntrinsicCatalog : IRuntimeIntrinsicCatalog
+{
+    private static readonly RuntimeGlobalPropertyAttributes BuiltInGlobalAttributes = new();
+
+    private readonly ReadOnlyDictionary<string, RuntimeGlobalBindingDescriptor> _globals;
+    private readonly ReadOnlyDictionary<string, RuntimeIntrinsicObjectDescriptor> _intrinsicObjects;
+    private readonly ReadOnlyDictionary<string, RuntimeModuleBindingDescriptor> _modules;
+    private readonly ReadOnlyDictionary<string, RuntimeKnownGlobalDescriptor> _knownGlobals;
+
+    public RuntimeIntrinsicCatalog()
+        : this(HostRuntimeIntrinsicDescriptors.Empty)
+    {
+    }
+
+    public RuntimeIntrinsicCatalog(HostRuntimeIntrinsicDescriptors? hostDescriptors)
+    {
+        hostDescriptors ??= HostRuntimeIntrinsicDescriptors.Empty;
+
+        var globals = BuildBuiltInGlobalBindings();
+        var intrinsicObjects = BuildBuiltInIntrinsicObjects();
+        var modules = BuildBuiltInModuleBindings();
+        var knownGlobals = BuildBuiltInKnownGlobals(globals);
+
+        ApplyHostGlobalBindings(globals, knownGlobals, hostDescriptors.GlobalBindings);
+        AddHostEntries(
+            intrinsicObjects,
+            hostDescriptors.IntrinsicObjects,
+            descriptor => descriptor.Name,
+            "intrinsic object");
+        AddHostEntries(
+            modules,
+            hostDescriptors.ModuleBindings,
+            descriptor => NormalizeModuleSpecifier(descriptor.Specifier),
+            "module");
+        AddHostKnownGlobals(knownGlobals, hostDescriptors.KnownGlobals);
+
+        _globals = new ReadOnlyDictionary<string, RuntimeGlobalBindingDescriptor>(globals);
+        _intrinsicObjects = new ReadOnlyDictionary<string, RuntimeIntrinsicObjectDescriptor>(intrinsicObjects);
+        _modules = new ReadOnlyDictionary<string, RuntimeModuleBindingDescriptor>(modules);
+        _knownGlobals = new ReadOnlyDictionary<string, RuntimeKnownGlobalDescriptor>(knownGlobals);
+    }
+
+    public IReadOnlyCollection<string> GlobalNames => _globals.Keys;
+
+    public IReadOnlyCollection<string> IntrinsicObjectNames => _intrinsicObjects.Keys;
+
+    public IReadOnlyCollection<string> ModuleSpecifiers => _modules.Keys;
+
+    public IReadOnlyCollection<string> KnownGlobalNames => _knownGlobals.Keys;
+
+    public bool TryGetGlobalBinding(string name, out RuntimeGlobalBindingDescriptor? descriptor)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            descriptor = null;
+            return false;
+        }
+
+        return _globals.TryGetValue(name, out descriptor);
+    }
+
+    public bool TryGetIntrinsicObject(string name, out RuntimeIntrinsicObjectDescriptor? descriptor)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            descriptor = null;
+            return false;
+        }
+
+        return _intrinsicObjects.TryGetValue(name, out descriptor);
+    }
+
+    public bool TryGetModuleBinding(string specifier, out RuntimeModuleBindingDescriptor? descriptor)
+    {
+        var key = NormalizeModuleSpecifier(specifier);
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            descriptor = null;
+            return false;
+        }
+
+        return _modules.TryGetValue(key, out descriptor);
+    }
+
+    public bool TryGetKnownGlobal(string name, out RuntimeKnownGlobalDescriptor? descriptor)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            descriptor = null;
+            return false;
+        }
+
+        return _knownGlobals.TryGetValue(name, out descriptor);
+    }
+
+    private static Dictionary<string, RuntimeGlobalBindingDescriptor> BuildBuiltInGlobalBindings()
+    {
+        var globals = new Dictionary<string, RuntimeGlobalBindingDescriptor>(StringComparer.Ordinal)
+        {
+            ["undefined"] = RuntimeGlobalBindingDescriptor.ForValue("undefined", null, BuiltInGlobalAttributes)
+        };
+
+        foreach (var property in typeof(GlobalThis).GetProperties(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (property.GetMethod == null || property.GetIndexParameters().Length != 0)
+            {
+                continue;
+            }
+
+            globals[property.Name] = RuntimeGlobalBindingDescriptor.ForFactory(
+                property.Name,
+                () => property.GetValue(null),
+                BuiltInGlobalAttributes);
+        }
+
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.setTimeout), () => (Func<object, object, object[], object>)GlobalThis.setTimeout);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.clearTimeout), () => (Func<object, object?>)GlobalThis.clearTimeout);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.setImmediate), () => (Func<object, object[], object>)GlobalThis.setImmediate);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.setInterval), () => (Func<object, object, object[], object>)GlobalThis.setInterval);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.clearImmediate), () => (Func<object, object?>)GlobalThis.clearImmediate);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.clearInterval), () => (Func<object, object?>)GlobalThis.clearInterval);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.gc), () => (Func<object?>)GlobalThis.gc);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.parseInt), () => (Func<object?, object?, double>)GlobalThis.parseInt);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.parseFloat), () => (Func<object?, double>)GlobalThis.parseFloat);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.isFinite), () => (Func<object?, bool>)GlobalThis.isFinite);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.isNaN), () => (Func<object?, bool>)GlobalThis.isNaN);
+
+        return globals;
+    }
+
+    private static Dictionary<string, RuntimeIntrinsicObjectDescriptor> BuildBuiltInIntrinsicObjects()
+    {
+        var intrinsicObjects = new Dictionary<string, RuntimeIntrinsicObjectDescriptor>(StringComparer.Ordinal);
+        foreach (var info in IntrinsicObjectRegistry.GetAll())
+        {
+            intrinsicObjects[info.Name] = new RuntimeIntrinsicObjectDescriptor(info.Name, info.Type, info.CallKind);
+        }
+
+        return intrinsicObjects;
+    }
+
+    private static Dictionary<string, RuntimeModuleBindingDescriptor> BuildBuiltInModuleBindings()
+    {
+        var modules = new Dictionary<string, RuntimeModuleBindingDescriptor>(StringComparer.OrdinalIgnoreCase);
+        foreach (var name in Node.NodeModuleRegistry.GetSupportedModuleNames())
+        {
+            if (Node.NodeModuleRegistry.TryGetModuleType(name, out var moduleType) && moduleType != null)
+            {
+                modules[NormalizeModuleSpecifier(name)] = RuntimeModuleBindingDescriptor.ForType(name, moduleType);
+            }
+        }
+
+        return modules;
+    }
+
+    private static Dictionary<string, RuntimeKnownGlobalDescriptor> BuildBuiltInKnownGlobals(
+        IReadOnlyDictionary<string, RuntimeGlobalBindingDescriptor> globals)
+    {
+        var knownGlobals = new Dictionary<string, RuntimeKnownGlobalDescriptor>(StringComparer.Ordinal);
+        foreach (var global in globals.Values)
+        {
+            knownGlobals[global.Name] = new RuntimeKnownGlobalDescriptor(global.Name);
+        }
+
+        return knownGlobals;
+    }
+
+    private static void ApplyHostGlobalBindings(
+        Dictionary<string, RuntimeGlobalBindingDescriptor> globals,
+        Dictionary<string, RuntimeKnownGlobalDescriptor> knownGlobals,
+        IReadOnlyList<RuntimeGlobalBindingDescriptor> hostGlobals)
+    {
+        foreach (var descriptor in hostGlobals)
+        {
+            if (globals.ContainsKey(descriptor.Name)
+                && descriptor.OverwritePolicy == RuntimeGlobalOverwritePolicy.PreserveExisting)
+            {
+                continue;
+            }
+
+            globals[descriptor.Name] = descriptor;
+            knownGlobals[descriptor.Name] = new RuntimeKnownGlobalDescriptor(descriptor.Name);
+        }
+    }
+
+    private static void AddHostKnownGlobals(
+        Dictionary<string, RuntimeKnownGlobalDescriptor> knownGlobals,
+        IReadOnlyList<RuntimeKnownGlobalDescriptor> hostKnownGlobals)
+    {
+        foreach (var descriptor in hostKnownGlobals)
+        {
+            knownGlobals[descriptor.Name] = descriptor;
+        }
+    }
+
+    private static void AddHostEntries<T>(
+        Dictionary<string, T> entries,
+        IReadOnlyList<T> hostEntries,
+        Func<T, string> getKey,
+        string entryKind)
+    {
+        foreach (var descriptor in hostEntries)
+        {
+            var key = getKey(descriptor);
+            if (entries.ContainsKey(key))
+            {
+                throw new InvalidOperationException($"Host runtime intrinsic {entryKind} '{key}' duplicates an existing {entryKind}.");
+            }
+
+            entries[key] = descriptor;
+        }
+    }
+
+    private static void AddBuiltInGlobalFunction(
+        Dictionary<string, RuntimeGlobalBindingDescriptor> globals,
+        string name,
+        Func<object?> valueFactory)
+    {
+        globals[name] = RuntimeGlobalBindingDescriptor.ForFactory(name, valueFactory, BuiltInGlobalAttributes);
+    }
+
+    private static string NormalizeModuleSpecifier(string specifier)
+    {
+        return Node.NodeModuleRegistry.NormalizeModuleName(specifier);
+    }
+}

--- a/tests/Jroc.Tests/RuntimeIntrinsicCatalogTests.cs
+++ b/tests/Jroc.Tests/RuntimeIntrinsicCatalogTests.cs
@@ -1,0 +1,107 @@
+using JavaScriptRuntime;
+
+namespace Jroc.Tests;
+
+public class RuntimeIntrinsicCatalogTests
+{
+    [Fact]
+    public void DefaultCatalog_ResolvesBuiltInGlobalsIntrinsicObjectsAndNodeModules()
+    {
+        var catalog = new RuntimeIntrinsicCatalog();
+
+        Assert.True(catalog.TryGetGlobalBinding("Array", out var arrayGlobal));
+        Assert.NotNull(arrayGlobal);
+        Assert.Equal("Array", arrayGlobal.Name);
+
+        Assert.True(catalog.TryGetKnownGlobal("undefined", out var undefinedGlobal));
+        Assert.NotNull(undefinedGlobal);
+        Assert.Equal("undefined", undefinedGlobal.Name);
+
+        Assert.True(catalog.TryGetIntrinsicObject("Array", out var arrayIntrinsic));
+        Assert.NotNull(arrayIntrinsic);
+        Assert.Equal(typeof(JavaScriptRuntime.Array), arrayIntrinsic.Type);
+        Assert.Equal(IntrinsicCallKind.ArrayConstruct, arrayIntrinsic.CallKind);
+
+        Assert.True(catalog.TryGetModuleBinding("node:fs", out var fsModule));
+        Assert.NotNull(fsModule);
+        Assert.Equal(typeof(JavaScriptRuntime.Node.FS), fsModule.ModuleType);
+    }
+
+    [Fact]
+    public void Catalog_MergesHostProvidedEntries()
+    {
+        var descriptors = new HostRuntimeIntrinsicDescriptorsBuilder()
+            .AddGlobalValue("assert", 1)
+            .AddIntrinsicObject("HostThing", typeof(HostIntrinsicObject))
+            .AddModuleType("host:module", typeof(HostModule))
+            .AddKnownGlobal("$262", typeof(object), isConstant: true)
+            .Build();
+
+        var catalog = new RuntimeIntrinsicCatalog(descriptors);
+
+        Assert.True(catalog.TryGetGlobalBinding("assert", out var assertGlobal));
+        Assert.NotNull(assertGlobal);
+        Assert.Equal(1, assertGlobal.CreateValue());
+
+        Assert.True(catalog.TryGetIntrinsicObject("HostThing", out var hostIntrinsic));
+        Assert.NotNull(hostIntrinsic);
+        Assert.Equal(typeof(HostIntrinsicObject), hostIntrinsic.Type);
+
+        Assert.True(catalog.TryGetModuleBinding("host:module", out var hostModule));
+        Assert.NotNull(hostModule);
+        Assert.Equal(typeof(HostModule), hostModule.ModuleType);
+
+        Assert.True(catalog.TryGetKnownGlobal("$262", out var test262Global));
+        Assert.NotNull(test262Global);
+        Assert.Equal(typeof(object), test262Global.ValueType);
+        Assert.True(test262Global.IsConstant);
+    }
+
+    [Fact]
+    public void HostGlobalDuplicate_PreservesBuiltInByDefaultAndCanExplicitlyReplace()
+    {
+        var preserveDescriptors = new HostRuntimeIntrinsicDescriptorsBuilder()
+            .AddGlobalValue("Array", "host array")
+            .Build();
+
+        var preserveCatalog = new RuntimeIntrinsicCatalog(preserveDescriptors);
+
+        Assert.True(preserveCatalog.TryGetGlobalBinding("Array", out var preservedArray));
+        Assert.NotNull(preservedArray);
+        Assert.NotEqual("host array", preservedArray.CreateValue());
+
+        var replaceDescriptors = new HostRuntimeIntrinsicDescriptorsBuilder()
+            .AddGlobalValue("Array", "host array", overwritePolicy: RuntimeGlobalOverwritePolicy.ReplaceExisting)
+            .Build();
+
+        var replaceCatalog = new RuntimeIntrinsicCatalog(replaceDescriptors);
+
+        Assert.True(replaceCatalog.TryGetGlobalBinding("Array", out var replacedArray));
+        Assert.NotNull(replacedArray);
+        Assert.Equal("host array", replacedArray.CreateValue());
+    }
+
+    [Fact]
+    public void HostIntrinsicAndModuleDuplicates_AreRejected()
+    {
+        var duplicateIntrinsic = new HostRuntimeIntrinsicDescriptorsBuilder()
+            .AddIntrinsicObject("Array", typeof(HostIntrinsicObject))
+            .Build();
+
+        Assert.Throws<InvalidOperationException>(() => new RuntimeIntrinsicCatalog(duplicateIntrinsic));
+
+        var duplicateModule = new HostRuntimeIntrinsicDescriptorsBuilder()
+            .AddModuleType("node:fs", typeof(HostModule))
+            .Build();
+
+        Assert.Throws<InvalidOperationException>(() => new RuntimeIntrinsicCatalog(duplicateModule));
+    }
+
+    private sealed class HostIntrinsicObject
+    {
+    }
+
+    private sealed class HostModule
+    {
+    }
+}


### PR DESCRIPTION
## Summary

Implements #1374 by adding a composite runtime intrinsic catalog that merges built-in runtime intrinsics with host-provided descriptors from #1373.

## Changes

- Added `IRuntimeIntrinsicCatalog` and `RuntimeIntrinsicCatalog`.
- Composes built-in global bindings from `GlobalThis`, intrinsic object types from `IntrinsicObjectRegistry`, and Node module bindings from `NodeModuleRegistry`.
- Merges host-provided global, intrinsic object, module, and known-global descriptors.
- Keeps built-in-only behavior as the default with no host descriptors.
- Makes duplicate behavior explicit:
  - Host global duplicates preserve built-ins by default and can replace only with `RuntimeGlobalOverwritePolicy.ReplaceExisting`.
  - Host intrinsic object/module duplicates are rejected.
- Added focused tests for built-ins, host merges, and duplicate behavior.

## Validation

```powershell
dotnet test .\tests\Jroc.Tests\Jroc.Tests.csproj --no-restore --filter "FullyQualifiedName~RuntimeIntrinsicCatalogTests|FullyQualifiedName~HostRuntimeIntrinsicDescriptorsTests" --nologo
```

Resolves #1374
