### PR TITLE
feat(runtime): seed host globals on globalThis

### DIFF
--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -1188,13 +1188,13 @@ namespace JavaScriptRuntime
         {
             var serviceProvider = ServiceProvider;
             if (serviceProvider == null
-                || !serviceProvider.TryResolve<GlobalThisOptions>(out var options)
-                || options == null)
+                || !serviceProvider.TryResolve<HostRuntimeIntrinsicDescriptors>(out var hostRuntimeIntrinsics)
+                || hostRuntimeIntrinsics == null)
             {
                 return;
             }
 
-            foreach (var descriptor in options.HostRuntimeIntrinsics.GlobalBindings)
+            foreach (var descriptor in hostRuntimeIntrinsics.GlobalBindings)
             {
                 if (dict.ContainsKey(descriptor.Name)
                     && descriptor.OverwritePolicy == RuntimeGlobalOverwritePolicy.PreserveExisting)

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -902,6 +902,18 @@ namespace JavaScriptRuntime
             });
         }
 
+        private void DefineDataProperty(string key, object? value, RuntimeGlobalPropertyAttributes attributes)
+        {
+            PropertyDescriptorStore.DefineOrUpdate(this, key, new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = attributes.Enumerable,
+                Configurable = attributes.Configurable,
+                Writable = attributes.Writable,
+                Value = value
+            });
+        }
+
 
         private static void DefineIntrinsicDataProperty(object target, string key, object? value)
         {
@@ -1168,6 +1180,32 @@ namespace JavaScriptRuntime
 
             dict.TryAdd(nameof(GlobalThis.isNaN), _isNaNValue);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.isNaN), dict[nameof(GlobalThis.isNaN)]);
+
+            ApplyHostGlobalBindings(dict);
+        }
+
+        private void ApplyHostGlobalBindings(IDictionary<string, object?> dict)
+        {
+            var serviceProvider = ServiceProvider;
+            if (serviceProvider == null
+                || !serviceProvider.TryResolve<GlobalThisOptions>(out var options)
+                || options == null)
+            {
+                return;
+            }
+
+            foreach (var descriptor in options.HostRuntimeIntrinsics.GlobalBindings)
+            {
+                if (dict.ContainsKey(descriptor.Name)
+                    && descriptor.OverwritePolicy == RuntimeGlobalOverwritePolicy.PreserveExisting)
+                {
+                    continue;
+                }
+
+                var value = descriptor.CreateValue();
+                dict[descriptor.Name] = value;
+                DefineDataProperty(descriptor.Name, value, descriptor.PropertyAttributes);
+            }
         }
 
         /// <summary>

--- a/src/JavaScriptRuntime/GlobalThisOptions.cs
+++ b/src/JavaScriptRuntime/GlobalThisOptions.cs
@@ -2,5 +2,13 @@ namespace JavaScriptRuntime;
 
 public sealed class GlobalThisOptions
 {
+    /// <summary>
+    /// Gets a value indicating whether the non-standard <c>gc</c> testing helper is exposed on the global object.
+    /// </summary>
     public bool ExposeGc { get; init; }
+
+    /// <summary>
+    /// Gets the host-provided runtime intrinsics applied when the global object is created.
+    /// </summary>
+    public HostRuntimeIntrinsicDescriptors HostRuntimeIntrinsics { get; init; } = HostRuntimeIntrinsicDescriptors.Empty;
 }

--- a/src/JavaScriptRuntime/GlobalThisOptions.cs
+++ b/src/JavaScriptRuntime/GlobalThisOptions.cs
@@ -6,9 +6,4 @@ public sealed class GlobalThisOptions
     /// Gets a value indicating whether the non-standard <c>gc</c> testing helper is exposed on the global object.
     /// </summary>
     public bool ExposeGc { get; init; }
-
-    /// <summary>
-    /// Gets the host-provided runtime intrinsics applied when the global object is created.
-    /// </summary>
-    public HostRuntimeIntrinsicDescriptors HostRuntimeIntrinsics { get; init; } = HostRuntimeIntrinsicDescriptors.Empty;
 }

--- a/src/JavaScriptRuntime/Hosting/JsModuleLoadOptions.cs
+++ b/src/JavaScriptRuntime/Hosting/JsModuleLoadOptions.cs
@@ -1,3 +1,4 @@
+using JavaScriptRuntime;
 using JavaScriptRuntime.Node;
 
 namespace Jroc.Runtime;
@@ -14,4 +15,9 @@ public sealed class JsModuleLoadOptions
     /// Optional host-controlled process launcher used for hosted <c>child_process.fork()</c> calls.
     /// </summary>
     public IChildProcessLauncher? ChildProcessLauncher { get; init; }
+
+    /// <summary>
+    /// Optional host-provided runtime intrinsics applied to the hosted JavaScript global object.
+    /// </summary>
+    public HostRuntimeIntrinsicDescriptors HostRuntimeIntrinsics { get; init; } = HostRuntimeIntrinsicDescriptors.Empty;
 }

--- a/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
+++ b/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
@@ -239,6 +239,16 @@ internal sealed class JsRuntimeInstance : IDisposable
                 compiledAssemblyPath: _options?.CompiledAssemblyPath);
             _serviceProvider = serviceProvider;
 
+            if (_options?.HostRuntimeIntrinsics != null)
+            {
+                var existingOptions = serviceProvider.Resolve<GlobalThisOptions>();
+                serviceProvider.Replace(new GlobalThisOptions
+                {
+                    ExposeGc = existingOptions.ExposeGc,
+                    HostRuntimeIntrinsics = _options.HostRuntimeIntrinsics
+                });
+            }
+
             if (_options?.ChildProcessLauncher != null)
             {
                 serviceProvider.RegisterInstance<IChildProcessLauncher>(_options.ChildProcessLauncher);

--- a/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
+++ b/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
@@ -241,12 +241,7 @@ internal sealed class JsRuntimeInstance : IDisposable
 
             if (_options?.HostRuntimeIntrinsics != null)
             {
-                var existingOptions = serviceProvider.Resolve<GlobalThisOptions>();
-                serviceProvider.Replace(new GlobalThisOptions
-                {
-                    ExposeGc = existingOptions.ExposeGc,
-                    HostRuntimeIntrinsics = _options.HostRuntimeIntrinsics
-                });
+                serviceProvider.Replace(_options.HostRuntimeIntrinsics);
             }
 
             if (_options?.ChildProcessLauncher != null)

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -1158,6 +1158,7 @@ public class RuntimeServices
     {
         var container = new ServiceContainer();
         container.RegisterInstance(new GlobalThisOptions());
+        container.RegisterInstance(HostRuntimeIntrinsicDescriptors.Empty);
         container.RegisterInstance(new ConsoleOutputSinks());
         
         // Register default engine dependencies

--- a/tests/Jroc.Tests/GlobalThisTests.cs
+++ b/tests/Jroc.Tests/GlobalThisTests.cs
@@ -89,6 +89,129 @@ public class GlobalThisTests
     }
 
     [Fact]
+    public void GlobalObject_AppliesHostGlobalBindingsWithConfiguredPropertyAttributes()
+    {
+        var serviceProvider = RuntimeServices.BuildServiceProvider();
+        serviceProvider.Replace(new GlobalThisOptions
+        {
+            HostRuntimeIntrinsics = new HostRuntimeIntrinsicDescriptorsBuilder()
+                .AddGlobalValue(
+                    "assert",
+                    "native assert",
+                    new RuntimeGlobalPropertyAttributes(
+                        Enumerable: true,
+                        Configurable: false,
+                        Writable: false))
+                .Build()
+        });
+
+        try
+        {
+            GlobalThis.ServiceProvider = serviceProvider;
+
+            var globalObject = (GlobalThis)GlobalThis.globalThis;
+            Assert.Equal("native assert", globalObject["assert"]);
+
+            Assert.True(PropertyDescriptorStore.TryGetOwn(globalObject, "assert", out var descriptor));
+            Assert.Equal("native assert", descriptor.Value);
+            Assert.True(descriptor.Enumerable);
+            Assert.False(descriptor.Configurable);
+            Assert.False(descriptor.Writable);
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void GlobalObject_HostGlobalBindingsDoNotReplaceBuiltInsByDefault()
+    {
+        var serviceProvider = RuntimeServices.BuildServiceProvider();
+        serviceProvider.Replace(new GlobalThisOptions
+        {
+            HostRuntimeIntrinsics = new HostRuntimeIntrinsicDescriptorsBuilder()
+                .AddGlobalValue(nameof(GlobalThis.Array), "host array")
+                .Build()
+        });
+
+        try
+        {
+            GlobalThis.ServiceProvider = serviceProvider;
+
+            var globalObject = (GlobalThis)GlobalThis.globalThis;
+            Assert.Same(GlobalThis.Array, globalObject[nameof(GlobalThis.Array)]);
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void GlobalObject_HostGlobalBindingsCanExplicitlyReplaceBuiltIns()
+    {
+        var serviceProvider = RuntimeServices.BuildServiceProvider();
+        serviceProvider.Replace(new GlobalThisOptions
+        {
+            HostRuntimeIntrinsics = new HostRuntimeIntrinsicDescriptorsBuilder()
+                .AddGlobalValue(
+                    nameof(GlobalThis.Array),
+                    "host array",
+                    overwritePolicy: RuntimeGlobalOverwritePolicy.ReplaceExisting)
+                .Build()
+        });
+
+        try
+        {
+            GlobalThis.ServiceProvider = serviceProvider;
+
+            var globalObject = (GlobalThis)GlobalThis.globalThis;
+            Assert.Equal("host array", globalObject[nameof(GlobalThis.Array)]);
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void GlobalObject_HostGlobalFactoriesCreateValuesPerRuntime()
+    {
+        var factoryCalls = 0;
+        var hostIntrinsics = new HostRuntimeIntrinsicDescriptorsBuilder()
+            .AddGlobalFactory("assert", () => ++factoryCalls)
+            .Build();
+
+        var firstServiceProvider = RuntimeServices.BuildServiceProvider();
+        firstServiceProvider.Replace(new GlobalThisOptions
+        {
+            HostRuntimeIntrinsics = hostIntrinsics
+        });
+
+        var secondServiceProvider = RuntimeServices.BuildServiceProvider();
+        secondServiceProvider.Replace(new GlobalThisOptions
+        {
+            HostRuntimeIntrinsics = hostIntrinsics
+        });
+
+        try
+        {
+            GlobalThis.ServiceProvider = firstServiceProvider;
+            var firstGlobalObject = (GlobalThis)GlobalThis.globalThis;
+            Assert.Equal(1, firstGlobalObject["assert"]);
+
+            GlobalThis.ServiceProvider = secondServiceProvider;
+            var secondGlobalObject = (GlobalThis)GlobalThis.globalThis;
+            Assert.Equal(2, secondGlobalObject["assert"]);
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
     public void GlobalObject_ExposesTypeErrorConstructor_WithPrototypeBackReferences()
     {
         var serviceProvider = RuntimeServices.BuildServiceProvider();

--- a/tests/Jroc.Tests/GlobalThisTests.cs
+++ b/tests/Jroc.Tests/GlobalThisTests.cs
@@ -92,9 +92,8 @@ public class GlobalThisTests
     public void GlobalObject_AppliesHostGlobalBindingsWithConfiguredPropertyAttributes()
     {
         var serviceProvider = RuntimeServices.BuildServiceProvider();
-        serviceProvider.Replace(new GlobalThisOptions
-        {
-            HostRuntimeIntrinsics = new HostRuntimeIntrinsicDescriptorsBuilder()
+        serviceProvider.Replace(
+            new HostRuntimeIntrinsicDescriptorsBuilder()
                 .AddGlobalValue(
                     "assert",
                     "native assert",
@@ -102,8 +101,7 @@ public class GlobalThisTests
                         Enumerable: true,
                         Configurable: false,
                         Writable: false))
-                .Build()
-        });
+                .Build());
 
         try
         {
@@ -128,12 +126,10 @@ public class GlobalThisTests
     public void GlobalObject_HostGlobalBindingsDoNotReplaceBuiltInsByDefault()
     {
         var serviceProvider = RuntimeServices.BuildServiceProvider();
-        serviceProvider.Replace(new GlobalThisOptions
-        {
-            HostRuntimeIntrinsics = new HostRuntimeIntrinsicDescriptorsBuilder()
+        serviceProvider.Replace(
+            new HostRuntimeIntrinsicDescriptorsBuilder()
                 .AddGlobalValue(nameof(GlobalThis.Array), "host array")
-                .Build()
-        });
+                .Build());
 
         try
         {
@@ -152,15 +148,13 @@ public class GlobalThisTests
     public void GlobalObject_HostGlobalBindingsCanExplicitlyReplaceBuiltIns()
     {
         var serviceProvider = RuntimeServices.BuildServiceProvider();
-        serviceProvider.Replace(new GlobalThisOptions
-        {
-            HostRuntimeIntrinsics = new HostRuntimeIntrinsicDescriptorsBuilder()
+        serviceProvider.Replace(
+            new HostRuntimeIntrinsicDescriptorsBuilder()
                 .AddGlobalValue(
                     nameof(GlobalThis.Array),
                     "host array",
                     overwritePolicy: RuntimeGlobalOverwritePolicy.ReplaceExisting)
-                .Build()
-        });
+                .Build());
 
         try
         {
@@ -184,16 +178,10 @@ public class GlobalThisTests
             .Build();
 
         var firstServiceProvider = RuntimeServices.BuildServiceProvider();
-        firstServiceProvider.Replace(new GlobalThisOptions
-        {
-            HostRuntimeIntrinsics = hostIntrinsics
-        });
+        firstServiceProvider.Replace(hostIntrinsics);
 
         var secondServiceProvider = RuntimeServices.BuildServiceProvider();
-        secondServiceProvider.Replace(new GlobalThisOptions
-        {
-            HostRuntimeIntrinsics = hostIntrinsics
-        });
+        secondServiceProvider.Replace(hostIntrinsics);
 
         try
         {


### PR DESCRIPTION
## Summary

Implements #1375 by allowing hosts to seed `globalThis` with custom global bindings through runtime options.

## Changes

- Added `GlobalThisOptions.HostRuntimeIntrinsics`.
- Added `JsModuleLoadOptions.HostRuntimeIntrinsics` so hosted module loads can provide global bindings.
- Applies host global descriptors after built-in global seeding.
- Honors descriptor property flags through `PropertyDescriptorStore`.
- Preserves built-in globals by default and allows explicit replacement with `RuntimeGlobalOverwritePolicy.ReplaceExisting`.
- Added focused tests for custom globals, descriptor flags, overwrite behavior, and per-runtime factory values.

## Validation

```powershell
dotnet test .\tests\Jroc.Tests\Jroc.Tests.csproj --no-restore --filter "FullyQualifiedName~GlobalThisTests|FullyQualifiedName~RuntimeIntrinsicCatalogTests|FullyQualifiedName~HostRuntimeIntrinsicDescriptorsTests" --nologo
```

Resolves #1375
