### PR TITLE
feat(compiler): consume runtime intrinsic catalog

### DIFF
--- a/src/Compiler/Compiler.cs
+++ b/src/Compiler/Compiler.cs
@@ -10,7 +10,7 @@ public class Compiler
     private readonly string? outputDirectory;
     private readonly bool diagnosticsEnabled;
 
-    private readonly SymbolTableBuilder _symbolTableBuilder = new SymbolTableBuilder();
+    private readonly SymbolTableBuilder _symbolTableBuilder;
 
     private readonly ModuleLoader _moduleLoader;
 
@@ -22,6 +22,7 @@ public class Compiler
         IServiceProvider serviceProvider,
         CompilerOptions options,
         ModuleLoader moduleLoader,
+        SymbolTableBuilder symbolTableBuilder,
         ICompilerOutput ux,
         Microsoft.Extensions.Logging.ILogger<Compiler> diagnosticLogger)
     {
@@ -29,6 +30,7 @@ public class Compiler
         this.diagnosticsEnabled = options.DiagnosticsEnabled;
         this.analyzeUnused = options.AnalyzeUnused;
         this._moduleLoader = moduleLoader;
+        this._symbolTableBuilder = symbolTableBuilder;
         this._serviceProvider = serviceProvider;
         this._ux = ux;
         this._diagnosticLogger = diagnosticLogger;

--- a/src/Compiler/CompilerOptions.cs
+++ b/src/Compiler/CompilerOptions.cs
@@ -18,6 +18,12 @@ public class CompilerOptions
     public bool GenerateModuleExportContracts { get; set; } = true;
 
     /// <summary>
+    /// Host-provided runtime intrinsics that should be visible during compilation.
+    /// </summary>
+    public JavaScriptRuntime.HostRuntimeIntrinsicDescriptors HostRuntimeIntrinsics { get; set; } =
+        JavaScriptRuntime.HostRuntimeIntrinsicDescriptors.Empty;
+
+    /// <summary>
     /// Computed per compilation. When true, the compiler emits a runtime prologue that enables
     /// prototype-chain behavior. This is automatically determined based on whether the code
     /// uses prototype-related features (e.g. __proto__, Object.getPrototypeOf, Object.setPrototypeOf).

--- a/src/Compiler/CompilerServices.cs
+++ b/src/Compiler/CompilerServices.cs
@@ -9,6 +9,7 @@ using Jroc.Services.VariableBindings;
 using Jroc.Services;
 using Jroc.DebugSymbols;
 using Jroc.Diagnostics;
+using Jroc.SymbolTables;
  
 namespace Jroc;
  
@@ -39,6 +40,9 @@ public static class CompilerServices
 
         // compiler and compiler options
         services.AddSingleton(options);
+        services.AddSingleton(options.HostRuntimeIntrinsics);
+        services.AddSingleton<JavaScriptRuntime.IRuntimeIntrinsicCatalog>(
+            _ => new JavaScriptRuntime.RuntimeIntrinsicCatalog(options.HostRuntimeIntrinsics));
 
         services.AddLogging(builder =>
         {
@@ -63,6 +67,7 @@ public static class CompilerServices
         });
 
         services.AddSingleton<Compiler>();
+        services.AddSingleton<SymbolTableBuilder>();
 
         // Debug symbol collection (Portable PDB)
         services.AddSingleton<DebugSymbolRegistry>();

--- a/src/Compiler/IL/LIRToILCompiler.IntrinsicStaticCalls.cs
+++ b/src/Compiler/IL/LIRToILCompiler.IntrinsicStaticCalls.cs
@@ -15,11 +15,7 @@ internal sealed partial class LIRToILCompiler
         TempLocalAllocation allocation,
         MethodDescriptor methodDescriptor)
     {
-        var intrinsicType = JavaScriptRuntime.IntrinsicObjectRegistry.Get(instruction.IntrinsicName);
-        if (intrinsicType == null)
-        {
-            throw new InvalidOperationException($"Unknown intrinsic type: {instruction.IntrinsicName}");
-        }
+        var intrinsicType = GetIntrinsicRuntimeType(instruction.IntrinsicName);
 
         var allMethods = intrinsicType.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
         var chosen = allMethods
@@ -68,11 +64,7 @@ internal sealed partial class LIRToILCompiler
         TempLocalAllocation allocation,
         MethodDescriptor methodDescriptor)
     {
-        var intrinsicType = JavaScriptRuntime.IntrinsicObjectRegistry.Get(instruction.IntrinsicName);
-        if (intrinsicType == null)
-        {
-            throw new InvalidOperationException($"Unknown intrinsic type: {instruction.IntrinsicName}");
-        }
+        var intrinsicType = GetIntrinsicRuntimeType(instruction.IntrinsicName);
 
         var allMethods = intrinsicType.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
         var chosen = allMethods
@@ -112,11 +104,7 @@ internal sealed partial class LIRToILCompiler
         TempLocalAllocation allocation,
         MethodDescriptor methodDescriptor)
     {
-        var intrinsicType = JavaScriptRuntime.IntrinsicObjectRegistry.Get(instruction.IntrinsicName);
-        if (intrinsicType == null)
-        {
-            throw new InvalidOperationException($"Unknown intrinsic type: {instruction.IntrinsicName}");
-        }
+        var intrinsicType = GetIntrinsicRuntimeType(instruction.IntrinsicName);
 
         // Resolve the static method using the same heuristics as the legacy pipeline:
         // 1. Exact arity match first
@@ -187,11 +175,7 @@ internal sealed partial class LIRToILCompiler
         TempLocalAllocation allocation,
         MethodDescriptor methodDescriptor)
     {
-        var intrinsicType = JavaScriptRuntime.IntrinsicObjectRegistry.Get(instruction.IntrinsicName);
-        if (intrinsicType == null)
-        {
-            throw new InvalidOperationException($"Unknown intrinsic type: {instruction.IntrinsicName}");
-        }
+        var intrinsicType = GetIntrinsicRuntimeType(instruction.IntrinsicName);
 
         var allMethods = intrinsicType.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
         var methods = allMethods.Where(mi => string.Equals(mi.Name, instruction.MethodName, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -251,11 +235,7 @@ internal sealed partial class LIRToILCompiler
         TempLocalAllocation allocation,
         MethodDescriptor methodDescriptor)
     {
-        var intrinsicType = JavaScriptRuntime.IntrinsicObjectRegistry.Get(instruction.IntrinsicName);
-        if (intrinsicType == null)
-        {
-            throw new InvalidOperationException($"Unknown intrinsic type: {instruction.IntrinsicName}");
-        }
+        var intrinsicType = GetIntrinsicRuntimeType(instruction.IntrinsicName);
 
         // Resolve the static method (same logic as EmitIntrinsicStaticCall)
         var allMethods = intrinsicType.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);

--- a/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
+++ b/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
@@ -509,7 +509,7 @@ internal sealed partial class LIRToILCompiler
                 }
                 break;
             case LIRGetIntrinsicGlobal getIntrinsicGlobal:
-                // Emit inline: call IntrinsicObjectRegistry.GetOrDefault
+                // Emit inline: call GlobalThis.GetFunctionValue("name")
                 EmitLoadIntrinsicGlobalVariable(getIntrinsicGlobal.Name, ilEncoder);
                 break;
             case LIRGetIntrinsicGlobalFunction getIntrinsicGlobalFunction:
@@ -2164,8 +2164,7 @@ internal sealed partial class LIRToILCompiler
 
     private void EmitNewIntrinsicObjectCore(LIRNewIntrinsicObject newIntrinsic, InstructionEncoder ilEncoder, TempLocalAllocation allocation, MethodDescriptor methodDescriptor)
     {
-        var intrinsicType = JavaScriptRuntime.IntrinsicObjectRegistry.Get(newIntrinsic.IntrinsicName)
-            ?? throw new InvalidOperationException($"Unknown intrinsic type: {newIntrinsic.IntrinsicName}");
+        var intrinsicType = GetIntrinsicRuntimeType(newIntrinsic.IntrinsicName);
 
         bool isStaticClass = intrinsicType.IsAbstract && intrinsicType.IsSealed;
         if (isStaticClass)

--- a/src/Compiler/IL/LIRToILCompiler.cs
+++ b/src/Compiler/IL/LIRToILCompiler.cs
@@ -31,6 +31,7 @@ internal sealed partial class LIRToILCompiler
     private readonly BaseClassLibraryReferences _bclReferences;
     private readonly MemberReferenceRegistry _memberRefRegistry;
     private readonly ScopeMetadataRegistry _scopeMetadataRegistry;
+    private readonly JavaScriptRuntime.IRuntimeIntrinsicCatalog _runtimeIntrinsicCatalog;
     private MethodBodyIR? _methodBody;
     private bool _compiled;
 
@@ -689,12 +690,23 @@ internal sealed partial class LIRToILCompiler
         ScopeMetadataRegistry scopeMetadataRegistry,
         IServiceProvider serviceProvider)
     {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
         _serviceProvider = serviceProvider;
         _metadataBuilder = metadataBuilder;
         _typeReferenceRegistry = typeReferenceRegistry;
         _bclReferences = bclReferences;
         _memberRefRegistry = memberReferenceRegistry;
         _scopeMetadataRegistry = scopeMetadataRegistry;
+        _runtimeIntrinsicCatalog = serviceProvider.GetService(typeof(JavaScriptRuntime.IRuntimeIntrinsicCatalog)) as JavaScriptRuntime.IRuntimeIntrinsicCatalog
+            ?? new JavaScriptRuntime.RuntimeIntrinsicCatalog();
+    }
+
+    private Type GetIntrinsicRuntimeType(string intrinsicName)
+    {
+        return _runtimeIntrinsicCatalog.TryGetIntrinsicObject(intrinsicName, out var intrinsic) && intrinsic != null
+            ? intrinsic.Type
+            : throw new InvalidOperationException($"Unknown intrinsic type: {intrinsicName}");
     }
 
     // Public API moved to LIRToILCompiler.PublicApi.cs

--- a/src/Compiler/IR/HIR/HIRBuilder.cs
+++ b/src/Compiler/IR/HIR/HIRBuilder.cs
@@ -919,6 +919,9 @@ public static class HIRBuilder
 
 class HIRMethodBuilder
 {
+    private static readonly JavaScriptRuntime.IRuntimeIntrinsicCatalog DefaultRuntimeIntrinsicCatalog =
+        new JavaScriptRuntime.RuntimeIntrinsicCatalog();
+
     /// <summary>
     /// JavaScript global constants that can be compiled as literals when not shadowed.
     /// </summary>
@@ -3398,7 +3401,10 @@ class HIRMethodBuilder
                 bool isBooleanCtor = string.Equals(calleeName, "Boolean", StringComparison.Ordinal);
                 bool isNumberCtor = string.Equals(calleeName, "Number", StringComparison.Ordinal);
                 bool isFunctionCtor = string.Equals(calleeName, "Function", StringComparison.Ordinal);
-                var intrinsicType = JavaScriptRuntime.IntrinsicObjectRegistry.Get(calleeName);
+                var intrinsicType = DefaultRuntimeIntrinsicCatalog.TryGetIntrinsicObject(calleeName, out var intrinsic)
+                    && intrinsic != null
+                    ? intrinsic.Type
+                    : null;
 
                 var globalThisProperty = typeof(JavaScriptRuntime.GlobalThis).GetProperty(
                     calleeName,

--- a/src/Compiler/IR/LIR/HIRToLIRLower.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLower.cs
@@ -21,6 +21,7 @@ public sealed partial class HIRToLIRLowerer
     private readonly HIRExpression? _superClassExpression;
     private readonly bool _isAsync;
     private readonly bool _isDerivedConstructor;
+    private readonly JavaScriptRuntime.IRuntimeIntrinsicCatalog _runtimeIntrinsicCatalog;
     private bool _superConstructorCalled;
 
     // Source-level variables map to the current SSA value (TempVariable) at the current program point.
@@ -90,7 +91,7 @@ public sealed partial class HIRToLIRLowerer
 
     private readonly bool _isGenerator;
 
-    private HIRToLIRLowerer(Scope? scope, EnvironmentLayout? environmentLayout, EnvironmentLayoutBuilder? environmentLayoutBuilder, Jroc.Services.ClassRegistry? classRegistry, CallableKind callableKind, IReadOnlyList<HIRPattern> parameters, HIRExpression? superClassExpression = null, bool isAsync = false, bool isGenerator = false, bool isDerivedConstructor = false, TwoPhase.CallableRegistry? callableRegistry = null, bool preserveNonClassDoubleReturn = false)
+    private HIRToLIRLowerer(Scope? scope, EnvironmentLayout? environmentLayout, EnvironmentLayoutBuilder? environmentLayoutBuilder, Jroc.Services.ClassRegistry? classRegistry, CallableKind callableKind, IReadOnlyList<HIRPattern> parameters, HIRExpression? superClassExpression = null, bool isAsync = false, bool isGenerator = false, bool isDerivedConstructor = false, TwoPhase.CallableRegistry? callableRegistry = null, bool preserveNonClassDoubleReturn = false, JavaScriptRuntime.IRuntimeIntrinsicCatalog? runtimeIntrinsicCatalog = null)
     {
         _scope = scope;
         _environmentLayout = environmentLayout;
@@ -103,10 +104,11 @@ public sealed partial class HIRToLIRLowerer
         _isGenerator = isGenerator;
         _isDerivedConstructor = isDerivedConstructor;
         _preserveNonClassDoubleReturn = preserveNonClassDoubleReturn;
+        _runtimeIntrinsicCatalog = runtimeIntrinsicCatalog ?? new JavaScriptRuntime.RuntimeIntrinsicCatalog();
         InitializeParameters(parameters);
     }
 
-    internal static bool TryLower(HIRMethod hirMethod, Scope? scope, Services.VariableBindings.ScopeMetadataRegistry? scopeMetadataRegistry, Jroc.Services.ScopesAbi.CallableKind callableKind, bool hasScopesParameter, Jroc.Services.ClassRegistry? classRegistry, out MethodBodyIR? lirMethod, bool isAsync = false, bool isGenerator = false, TwoPhase.CallableId? callableId = null, bool isDerivedConstructor = false, TwoPhase.CallableRegistry? callableRegistry = null)
+    internal static bool TryLower(HIRMethod hirMethod, Scope? scope, Services.VariableBindings.ScopeMetadataRegistry? scopeMetadataRegistry, Jroc.Services.ScopesAbi.CallableKind callableKind, bool hasScopesParameter, Jroc.Services.ClassRegistry? classRegistry, out MethodBodyIR? lirMethod, bool isAsync = false, bool isGenerator = false, TwoPhase.CallableId? callableId = null, bool isDerivedConstructor = false, TwoPhase.CallableRegistry? callableRegistry = null, JavaScriptRuntime.IRuntimeIntrinsicCatalog? runtimeIntrinsicCatalog = null)
     {
         lirMethod = null;
 
@@ -140,7 +142,7 @@ public sealed partial class HIRToLIRLowerer
             && !hasScopesParameter
             && callableId?.JsParamCount == 0;
 
-        var lowerer = new HIRToLIRLowerer(scope, environmentLayout, environmentLayoutBuilder, classRegistry, callableKind, hirMethod.Parameters, hirMethod.SuperClassExpression, isAsync, isGenerator, isDerivedConstructor, callableRegistry, preserveNonClassDoubleReturn);
+        var lowerer = new HIRToLIRLowerer(scope, environmentLayout, environmentLayoutBuilder, classRegistry, callableKind, hirMethod.Parameters, hirMethod.SuperClassExpression, isAsync, isGenerator, isDerivedConstructor, callableRegistry, preserveNonClassDoubleReturn, runtimeIntrinsicCatalog);
         lowerer.CollectStringBuilderAccumulatorCandidates(hirMethod.Body.Statements);
 
         // If default parameter initialization failed, fall back to legacy emitter
@@ -395,7 +397,7 @@ public sealed partial class HIRToLIRLowerer
 
         try
         {
-            return JavaScriptRuntime.IntrinsicObjectRegistry.GetInfo(superId.Name) != null
+            return _runtimeIntrinsicCatalog.TryGetIntrinsicObject(superId.Name, out _)
                 ? superId.Name
                 : null;
         }

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
@@ -243,7 +243,9 @@ public sealed partial class HIRToLIRLowerer
                     return true;
                 }
 
-                var intrinsicInfo = JavaScriptRuntime.IntrinsicObjectRegistry.GetInfo(name);
+                var intrinsicInfo = _runtimeIntrinsicCatalog.TryGetIntrinsicObject(name, out var catalogIntrinsic) && catalogIntrinsic != null
+                    ? catalogIntrinsic
+                    : null;
                 if (intrinsicInfo != null && intrinsicInfo.CallKind != JavaScriptRuntime.IntrinsicCallKind.None)
                 {
                     switch (intrinsicInfo.CallKind)
@@ -766,7 +768,9 @@ public sealed partial class HIRToLIRLowerer
                 || IsStableGlobalMathBinding(calleeGlobalVar.Name);
 
             // Try to resolve the intrinsic type via IntrinsicObjectRegistry
-            var intrinsicType = JavaScriptRuntime.IntrinsicObjectRegistry.Get(intrinsicName);
+            var intrinsicType = _runtimeIntrinsicCatalog.TryGetIntrinsicObject(intrinsicName, out var intrinsic) && intrinsic != null
+                ? intrinsic.Type
+                : null;
             if (intrinsicType != null && canUseIntrinsicStatic)
             {
                 // Check if there's a matching static method

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionNew.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionNew.cs
@@ -147,7 +147,9 @@ public sealed partial class HIRToLIRLowerer
         }
 
         // PL3.3g: generic intrinsic constructor support (Date/RegExp/Set/Promise/Int32Array/etc.)
-        var intrinsicType = JavaScriptRuntime.IntrinsicObjectRegistry.Get(ctorName);
+        var intrinsicType = _runtimeIntrinsicCatalog.TryGetIntrinsicObject(ctorName, out var intrinsic) && intrinsic != null
+            ? intrinsic.Type
+            : null;
         if (intrinsicType != null)
         {
             bool isStaticClass = intrinsicType.IsAbstract && intrinsicType.IsSealed;

--- a/src/Compiler/JrocInMemoryCompileRequest.cs
+++ b/src/Compiler/JrocInMemoryCompileRequest.cs
@@ -17,4 +17,7 @@ public sealed record JrocInMemoryCompileRequest(string EntryFilePath)
     public bool AnalyzeUnused { get; init; }
 
     public bool GenerateModuleExportContracts { get; init; } = true;
+
+    public JavaScriptRuntime.HostRuntimeIntrinsicDescriptors HostRuntimeIntrinsics { get; init; } =
+        JavaScriptRuntime.HostRuntimeIntrinsicDescriptors.Empty;
 }

--- a/src/Compiler/JrocInMemoryCompiler.cs
+++ b/src/Compiler/JrocInMemoryCompiler.cs
@@ -84,7 +84,8 @@ public static class JrocInMemoryCompiler
             Verbose = request.Verbose,
             DiagnosticFilePath = request.DiagnosticFilePath,
             AnalyzeUnused = request.AnalyzeUnused,
-            GenerateModuleExportContracts = request.GenerateModuleExportContracts
+            GenerateModuleExportContracts = request.GenerateModuleExportContracts,
+            HostRuntimeIntrinsics = request.HostRuntimeIntrinsics
         };
 
         var effectiveFileSystem = CreateEffectiveFileSystem(request);

--- a/src/Compiler/JsMethodCompiler.cs
+++ b/src/Compiler/JsMethodCompiler.cs
@@ -130,6 +130,7 @@ internal sealed class JsMethodCompiler
     private readonly AnonymousCallableTypeMetadataRegistry _anonymousCallableTypeMetadataRegistry;
     private readonly Services.NestedTypeRelationshipRegistry _nestedTypeRelationshipRegistry;
     private readonly Services.ModuleTypeMetadataRegistry _moduleTypeRegistry;
+    private readonly JavaScriptRuntime.IRuntimeIntrinsicCatalog _runtimeIntrinsicCatalog;
 
     public JsMethodCompiler(
         MetadataBuilder metadataBuilder,
@@ -141,6 +142,7 @@ internal sealed class JsMethodCompiler
         AnonymousCallableTypeMetadataRegistry anonymousCallableTypeMetadataRegistry,
         Services.NestedTypeRelationshipRegistry nestedTypeRelationshipRegistry,
         Services.ModuleTypeMetadataRegistry moduleTypeRegistry,
+        JavaScriptRuntime.IRuntimeIntrinsicCatalog runtimeIntrinsicCatalog,
         IServiceProvider serviceProvider)
     {
         _metadataBuilder = metadataBuilder;
@@ -152,6 +154,7 @@ internal sealed class JsMethodCompiler
         _anonymousCallableTypeMetadataRegistry = anonymousCallableTypeMetadataRegistry;
         _nestedTypeRelationshipRegistry = nestedTypeRelationshipRegistry;
         _moduleTypeRegistry = moduleTypeRegistry;
+        _runtimeIntrinsicCatalog = runtimeIntrinsicCatalog;
         _serviceProvider = serviceProvider;
     }
 
@@ -1004,7 +1007,7 @@ internal sealed class JsMethodCompiler
 
         var classRegistry = _serviceProvider.GetService<Jroc.Services.ClassRegistry>();
         var callableRegistry = _serviceProvider.GetService<CallableRegistry>();
-        if (!HIRToLIRLowerer.TryLower(hirMethod!, scope, _scopeMetadataRegistry, callableKind, hasScopesParameter, classRegistry, out var lirMethod, isAsync: isAsyncCallable, isGenerator: isGeneratorCallable, callableId: callableId, isDerivedConstructor: isDerivedConstructor, callableRegistry: callableRegistry))
+        if (!HIRToLIRLowerer.TryLower(hirMethod!, scope, _scopeMetadataRegistry, callableKind, hasScopesParameter, classRegistry, out var lirMethod, isAsync: isAsyncCallable, isGenerator: isGeneratorCallable, callableId: callableId, isDerivedConstructor: isDerivedConstructor, callableRegistry: callableRegistry, runtimeIntrinsicCatalog: _runtimeIntrinsicCatalog))
         {
             IR.IRPipelineMetrics.RecordFailureIfUnset($"HIR->LIR lowering failed for scope '{scope.GetQualifiedName()}' (kind={scope.Kind}) node={node.Type}");
             return false;

--- a/src/Compiler/ModuleLoader.cs
+++ b/src/Compiler/ModuleLoader.cs
@@ -23,6 +23,7 @@ public class ModuleLoader
     private readonly JavaScriptAstValidator _validator;
     private readonly IFileSystem _fileSystem;
     private readonly NodeModuleResolver _moduleResolver;
+    private readonly JavaScriptRuntime.IRuntimeIntrinsicCatalog _runtimeIntrinsicCatalog;
     private readonly ICompilerOutput _ux;
     private readonly Microsoft.Extensions.Logging.ILogger<ModuleLoader> _diagnosticLogger;
 
@@ -34,9 +35,27 @@ public class ModuleLoader
         NodeModuleResolver moduleResolver,
         ICompilerOutput ux,
         Microsoft.Extensions.Logging.ILogger<ModuleLoader>? diagnosticLogger = null)
+        : this(
+            options,
+            fileSystem,
+            moduleResolver,
+            new JavaScriptRuntime.RuntimeIntrinsicCatalog(options.HostRuntimeIntrinsics),
+            ux,
+            diagnosticLogger)
+    {
+    }
+
+    public ModuleLoader(
+        CompilerOptions options,
+        IFileSystem fileSystem,
+        NodeModuleResolver moduleResolver,
+        JavaScriptRuntime.IRuntimeIntrinsicCatalog runtimeIntrinsicCatalog,
+        ICompilerOutput ux,
+        Microsoft.Extensions.Logging.ILogger<ModuleLoader>? diagnosticLogger = null)
     {
         _diagnosticsEnabled = options.DiagnosticsEnabled;
-        _validator = new JavaScriptAstValidator();
+        _runtimeIntrinsicCatalog = runtimeIntrinsicCatalog;
+        _validator = new JavaScriptAstValidator(runtimeIntrinsicCatalog);
         _fileSystem = fileSystem;
         _moduleResolver = moduleResolver;
         _ux = ux;
@@ -2211,14 +2230,14 @@ function __jroc_esm_export(name, getter) {
         return s;
     }
 
-    private static bool IsBuiltInModuleSpecifier(string specifier)
+    private bool IsBuiltInModuleSpecifier(string specifier)
     {
         if (string.IsNullOrWhiteSpace(specifier))
         {
             return false;
         }
 
-        return JavaScriptRuntime.Node.NodeModuleRegistry.TryGetModuleType(specifier, out _);
+        return _runtimeIntrinsicCatalog.TryGetModuleBinding(specifier, out _);
     }
 
     private static bool IsBarePackageSpecifier(string specifier)

--- a/src/Compiler/Services/ILGenerators/ClassesGenerator.cs
+++ b/src/Compiler/Services/ILGenerators/ClassesGenerator.cs
@@ -329,10 +329,14 @@ namespace Jroc.Services.ILGenerators
                     // and emitted as a CLR base type reference.
                     try
                     {
-                        var intrinsicType = JavaScriptRuntime.IntrinsicObjectRegistry.Get(superId.Name);
-                        if (intrinsicType != null && intrinsicType.IsClass && !intrinsicType.IsSealed)
+                        var runtimeIntrinsicCatalog = _serviceProvider.GetService(typeof(JavaScriptRuntime.IRuntimeIntrinsicCatalog)) as JavaScriptRuntime.IRuntimeIntrinsicCatalog;
+                        if (runtimeIntrinsicCatalog != null
+                            && runtimeIntrinsicCatalog.TryGetIntrinsicObject(superId.Name, out var intrinsic)
+                            && intrinsic != null
+                            && intrinsic.Type.IsClass
+                            && !intrinsic.Type.IsSealed)
                         {
-                            baseTypeHandle = _bcl.TypeReferenceRegistry.GetOrAdd(intrinsicType);
+                            baseTypeHandle = _bcl.TypeReferenceRegistry.GetOrAdd(intrinsic.Type);
                         }
                     }
                     catch

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
@@ -2100,7 +2100,9 @@ public partial class SymbolTableBuilder
             // If the callee name maps to an intrinsic runtime type, infer that CLR type.
             // This enables strongly-typed class fields for patterns like: this.buf = new Int32Array(n)
             // (and similar intrinsic constructors).
-            return JavaScriptRuntime.IntrinsicObjectRegistry.Get(calleeId.Name);
+            return _runtimeIntrinsicCatalog.TryGetIntrinsicObject(calleeId.Name, out var intrinsic) && intrinsic != null
+                ? intrinsic.Type
+                : null;
         }
 
         Type? InferClassFieldExpressionClrType(Node expr)
@@ -2469,7 +2471,9 @@ public partial class SymbolTableBuilder
                 // new <Intrinsic>(...) (e.g., Int32Array)
                 if (ne.Callee is Identifier intrinsicCtorId)
                 {
-                    return JavaScriptRuntime.IntrinsicObjectRegistry.Get(intrinsicCtorId.Name);
+                    return _runtimeIntrinsicCatalog.TryGetIntrinsicObject(intrinsicCtorId.Name, out var intrinsic) && intrinsic != null
+                        ? intrinsic.Type
+                        : null;
                 }
 
                 return null;

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.cs
@@ -19,6 +19,17 @@ namespace Jroc.SymbolTables
         private readonly HashSet<Node> _visitedFunctionExpressions = new();
         private readonly HashSet<Node> _visitedClasses = new();
         private readonly JavaScriptParser _parser = new();
+        private readonly JavaScriptRuntime.IRuntimeIntrinsicCatalog _runtimeIntrinsicCatalog;
+
+        public SymbolTableBuilder()
+            : this(new JavaScriptRuntime.RuntimeIntrinsicCatalog())
+        {
+        }
+
+        public SymbolTableBuilder(JavaScriptRuntime.IRuntimeIntrinsicCatalog runtimeIntrinsicCatalog)
+        {
+            _runtimeIntrinsicCatalog = runtimeIntrinsicCatalog ?? throw new ArgumentNullException(nameof(runtimeIntrinsicCatalog));
+        }
 
         private static string BuildClassRegistryNamespace(Scope globalScope, Scope currentScope, Node classNode, bool forceUniqueSuffix)
         {
@@ -357,7 +368,7 @@ namespace Jroc.SymbolTables
         /// Recursively checks if an AST node contains any identifier that isn't in the local variables set.
         /// Stops at nested function boundaries.
         /// </summary>
-        private static bool ContainsFreeVariable(Node? node, HashSet<string> localVariables)
+        private bool ContainsFreeVariable(Node? node, HashSet<string> localVariables)
         {
             if (node == null) return false;
 
@@ -658,7 +669,7 @@ namespace Jroc.SymbolTables
         /// <summary>
         /// Checks if an identifier is a known global intrinsic that doesn't require scope access.
         /// </summary>
-        private static bool IsKnownGlobalIntrinsic(string name)
+        private bool IsKnownGlobalIntrinsic(string name)
         {
             if (string.IsNullOrEmpty(name)) return false;
 
@@ -669,7 +680,10 @@ namespace Jroc.SymbolTables
                 return true;
             }
 
-            return KnownGlobalIntrinsicNames.Value.Contains(name);
+            return KnownGlobalIntrinsicNames.Value.Contains(name)
+                || _runtimeIntrinsicCatalog.TryGetGlobalBinding(name, out _)
+                || _runtimeIntrinsicCatalog.TryGetKnownGlobal(name, out _)
+                || _runtimeIntrinsicCatalog.TryGetIntrinsicObject(name, out _);
         }
 
         private static readonly Lazy<HashSet<string>> KnownGlobalIntrinsicNames =
@@ -722,9 +736,11 @@ namespace Jroc.SymbolTables
             return JavaScriptRuntime.Node.NodeModuleRegistry.NormalizeModuleName(s);
         }
 
-        private static Type? ResolveNodeModuleType(string key)
+        private Type? ResolveNodeModuleType(string key)
         {
-            return JavaScriptRuntime.Node.NodeModuleRegistry.TryGetModuleType(key, out var type) ? type : null;
+            return _runtimeIntrinsicCatalog.TryGetModuleBinding(key, out var descriptor) && descriptor != null
+                ? descriptor.ModuleType
+                : null;
         }
 
         private static string SanitizeForMetadata(string name)
@@ -736,7 +752,7 @@ namespace Jroc.SymbolTables
             return result;
         }
 
-        private static void TryAssignClrTypeForRequireInit(VariableDeclarator decl, BindingInfo binding)
+        private void TryAssignClrTypeForRequireInit(VariableDeclarator decl, BindingInfo binding)
         {
             // Pattern: const name = require('path') or require("path")
             var init = decl.Init;

--- a/src/Compiler/Validation/JavaScriptAstValidator.cs
+++ b/src/Compiler/Validation/JavaScriptAstValidator.cs
@@ -12,6 +12,8 @@ namespace Jroc.Validation;
 
 public class JavaScriptAstValidator : IAstValidator
 {
+    private readonly JavaScriptRuntime.IRuntimeIntrinsicCatalog _runtimeIntrinsicCatalog;
+
     private static readonly HashSet<string> SupportedDirectEvalLiteralSources = new(StringComparer.Ordinal)
     {
         // Deliberately narrow direct-eval support for test262 lexical-environment ports.
@@ -25,22 +27,15 @@ public class JavaScriptAstValidator : IAstValidator
         "o = {set foo(arg){}};"
     };
 
-    private static readonly Lazy<HashSet<string>> SupportedRequireModules = new(() =>
+    public JavaScriptAstValidator()
+        : this(new JavaScriptRuntime.RuntimeIntrinsicCatalog())
     {
-        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        try
-        {
-            foreach (var name in JavaScriptRuntime.Node.NodeModuleRegistry.GetSupportedModuleNames())
-            {
-                if (!string.IsNullOrWhiteSpace(name))
-                {
-                    set.Add(name);
-                }
-            }
-        }
-        catch { /* Ignore reflection errors; result will be empty set */ }
-        return set;
-    });
+    }
+
+    public JavaScriptAstValidator(JavaScriptRuntime.IRuntimeIntrinsicCatalog runtimeIntrinsicCatalog)
+    {
+        _runtimeIntrinsicCatalog = runtimeIntrinsicCatalog ?? throw new ArgumentNullException(nameof(runtimeIntrinsicCatalog));
+    }
 
     public ValidationResult Validate(Acornima.Ast.Program ast)
     {
@@ -930,7 +925,11 @@ public class JavaScriptAstValidator : IAstValidator
                             }
 
                             // Locals and known built-in constants are always allowed.
-                            if (IsDeclared(name) || KnownGlobalConstants.Value.Contains(name))
+                            if (IsDeclared(name)
+                                || KnownGlobalConstants.Value.Contains(name)
+                                || _runtimeIntrinsicCatalog.TryGetGlobalBinding(name, out _)
+                                || _runtimeIntrinsicCatalog.TryGetKnownGlobal(name, out _)
+                                || _runtimeIntrinsicCatalog.TryGetIntrinsicObject(name, out _))
                             {
                                 break;
                             }
@@ -1551,7 +1550,7 @@ public class JavaScriptAstValidator : IAstValidator
                     // Explicit node: prefix indicates a Node built-in module.
                     // If it is not supported by the runtime, report an error.
                     if (modName.TrimStart().StartsWith("node:", StringComparison.OrdinalIgnoreCase)
-                        && !SupportedRequireModules.Value.Contains(normalizedName))
+                        && !_runtimeIntrinsicCatalog.TryGetModuleBinding(normalizedName, out _))
                     {
                         result.Errors.Add($"Module '{modName}' is not yet supported (line {node.Location.Start.Line})");
                         result.IsValid = false;

--- a/tests/Jroc.Tests/CompilerRuntimeIntrinsicCatalogTests.cs
+++ b/tests/Jroc.Tests/CompilerRuntimeIntrinsicCatalogTests.cs
@@ -1,0 +1,97 @@
+using JavaScriptRuntime;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Jroc.Tests;
+
+public sealed class CompilerRuntimeIntrinsicCatalogTests
+{
+    [Fact]
+    public void CompileToArtifact_AllowsHostRegisteredGlobalReference()
+    {
+        var outputPath = Path.Combine(Path.GetTempPath(), "Jroc.Tests", "CompilerRuntimeIntrinsicCatalog", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputPath);
+
+        try
+        {
+            var jsPath = Path.Combine(outputPath, "host-global.js");
+            var mockFs = new MockFileSystem();
+            mockFs.AddFile(jsPath, "\"use strict\";\nexports.value = assert;\n");
+
+            var options = new CompilerOptions
+            {
+                OutputDirectory = outputPath,
+                HostRuntimeIntrinsics = new HostRuntimeIntrinsicDescriptorsBuilder()
+                    .AddGlobalValue("assert", new object())
+                    .Build()
+            };
+
+            var logger = new TestLogger();
+            var serviceProvider = CompilerServices.BuildServiceProvider(options, mockFs, logger);
+            var compiler = serviceProvider.GetRequiredService<Compiler>();
+
+            var artifact = compiler.CompileToArtifact(jsPath);
+
+            Assert.NotNull(artifact);
+            Assert.DoesNotContain("assert is not defined", logger.Errors, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { Directory.Delete(outputPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void CompileToArtifact_LowersHostRegisteredIntrinsicConstructor()
+    {
+        var outputPath = Path.Combine(Path.GetTempPath(), "Jroc.Tests", "CompilerRuntimeIntrinsicCatalog", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputPath);
+
+        try
+        {
+            var jsPath = Path.Combine(outputPath, "host-intrinsic.js");
+            var mockFs = new MockFileSystem();
+            mockFs.AddFile(jsPath, "\"use strict\";\nexports.value = new HostThing();\n");
+
+            var options = new CompilerOptions
+            {
+                OutputDirectory = outputPath,
+                HostRuntimeIntrinsics = new HostRuntimeIntrinsicDescriptorsBuilder()
+                    .AddIntrinsicObject("HostThing", typeof(HostThing))
+                    .Build()
+            };
+
+            var logger = new TestLogger();
+            var serviceProvider = CompilerServices.BuildServiceProvider(options, mockFs, logger);
+            var compiler = serviceProvider.GetRequiredService<Compiler>();
+
+            var artifact = compiler.CompileToArtifact(jsPath);
+
+            Assert.NotNull(artifact);
+            AssertAssemblyReferencesType(artifact, nameof(HostThing));
+            Assert.DoesNotContain("HostThing is not defined", logger.Errors, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { Directory.Delete(outputPath, recursive: true); } catch { }
+        }
+    }
+
+    private static void AssertAssemblyReferencesType(JrocCompiledAssemblyArtifact artifact, string typeName)
+    {
+        using var peStream = new MemoryStream(artifact.PeBytes, writable: false);
+        using var peReader = new PEReader(peStream);
+        var metadataReader = peReader.GetMetadataReader();
+
+        var referencesType = metadataReader.TypeReferences
+            .Select(metadataReader.GetTypeReference)
+            .Any(typeRef => string.Equals(metadataReader.GetString(typeRef.Name), typeName, StringComparison.Ordinal));
+
+        Assert.True(referencesType, $"Expected compiled assembly to reference host intrinsic type '{typeName}'.");
+    }
+}
+
+public sealed class HostThing
+{
+}

--- a/tests/Jroc.Tests/CompilerRuntimeIntrinsicCatalogTests.cs
+++ b/tests/Jroc.Tests/CompilerRuntimeIntrinsicCatalogTests.cs
@@ -1,4 +1,5 @@
 using JavaScriptRuntime;
+using Jroc.Runtime;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -40,6 +41,36 @@ public sealed class CompilerRuntimeIntrinsicCatalogTests
         {
             try { Directory.Delete(outputPath, recursive: true); } catch { }
         }
+    }
+
+    [Fact]
+    public void CompileAndLoadModule_AllowsScriptToInvokeCSharpHostAssert()
+    {
+        var callCount = 0;
+        var hostIntrinsics = new HostRuntimeIntrinsicDescriptorsBuilder()
+            .AddGlobalValue(
+                "assert",
+                (Action<object>)(message =>
+                {
+                    callCount++;
+                    Assert.Equal("called from JavaScript", message);
+                }))
+            .Build();
+
+        using var module = JrocInMemoryCompiler.CompileAndLoadModule(
+            new JrocInMemoryCompileRequest(Path.Combine(Path.GetTempPath(), "host-assert-module.js"))
+            {
+                SourceText = "\"use strict\";\nassert(\"called from JavaScript\");\nexports.ok = true;\n",
+                HostRuntimeIntrinsics = hostIntrinsics
+            },
+            options: new JsModuleLoadOptions
+            {
+                HostRuntimeIntrinsics = hostIntrinsics
+            });
+
+        dynamic exports = module.Exports;
+        Assert.True((bool)exports.ok);
+        Assert.Equal(1, callCount);
     }
 
     [Fact]

--- a/tests/Jroc.Tests/SymbolTable/IntrinsicDiscoveryTests.cs
+++ b/tests/Jroc.Tests/SymbolTable/IntrinsicDiscoveryTests.cs
@@ -10,11 +10,11 @@ public class IntrinsicDiscoveryTests
     {
         var method = typeof(SymbolTableBuilder).GetMethod(
             "IsKnownGlobalIntrinsic",
-            BindingFlags.NonPublic | BindingFlags.Static);
+            BindingFlags.NonPublic | BindingFlags.Instance);
 
         Assert.NotNull(method);
 
-        return (bool)method!.Invoke(null, new object[] { name })!;
+        return (bool)method!.Invoke(new SymbolTableBuilder(), new object[] { name })!;
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

Implements #1376 by making the compiler consume the runtime intrinsic catalog introduced by #1374.

## Changes

- Added `CompilerOptions.HostRuntimeIntrinsics`.
- Registered `HostRuntimeIntrinsicDescriptors` and `IRuntimeIntrinsicCatalog` in compiler services.
- Injected the catalog into module validation, symbol table building/type inference, HIR->LIR lowering, and LIR->IL intrinsic emission.
- Replaced compiler-side direct static intrinsic/module registry lookups with catalog lookups.
- Preserved default behavior with `HostRuntimeIntrinsicDescriptors.Empty`.
- Added focused compiler tests showing:
  - host-registered globals compile as ambient global references;
  - host-registered intrinsic constructors lower to host CLR type references in emitted metadata.

## Validation

```powershell
dotnet test .\tests\Jroc.Tests\Jroc.Tests.csproj --no-restore --filter "FullyQualifiedName~CompilerRuntimeIntrinsicCatalogTests|FullyQualifiedName~RuntimeIntrinsicCatalogTests|FullyQualifiedName~HostRuntimeIntrinsicDescriptorsTests" --nologo
```

Resolves #1376
