### PR TITLE
feat(test262): add native C# harness helpers

### DIFF
--- a/tests/Jroc.Test262.Tests/Integration/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/Integration/ExecutionTests.cs
@@ -90,6 +90,33 @@ public class ExecutionTests
                     pinPath)));
     }
 
+    [Fact]
+    public async Task Compile_Scripts_Test262NativeHostHelpers()
+    {
+        var sourceFilePath = Path.Combine(
+            FindRepositoryRoot(),
+            "tests",
+            "Jroc.Test262.Tests",
+            "Integration",
+            "ExecutionTests.cs");
+
+        var result = Test262SharedAssertHarness.CompileAndExecute(
+            nameof(Compile_Scripts_Test262NativeHostHelpers),
+            "Integration",
+            GetJavaScriptAndSourcePath,
+            sourceFilePath,
+            enableIRMetrics: true,
+            useNativeHostHelpers: true);
+
+        var settings = new VerifySettings(_verifySettings);
+        var directory = Path.GetDirectoryName(sourceFilePath)
+            ?? throw new InvalidOperationException("Could not resolve source directory.");
+        var snapshotsDirectory = Path.Combine(directory, "Snapshots");
+        Directory.CreateDirectory(snapshotsDirectory);
+        settings.UseDirectory(snapshotsDirectory);
+        await Verify(result.Output, settings);
+    }
+
     private async Task ExecutionTest(
         string testName,
         string[]? additionalScripts = null,
@@ -126,6 +153,13 @@ public class ExecutionTests
                 "JavaScript",
                 "test262MetadataParser_testHarness.js"),
             nameof(Compile_Scripts_Test262Bootstrap) => Path.Combine(repoRoot, "scripts", "test262", "bootstrap.js"),
+            nameof(Compile_Scripts_Test262NativeHostHelpers) => Path.Combine(
+                repoRoot,
+                "tests",
+                "Jroc.Test262.Tests",
+                "Integration",
+                "JavaScript",
+                "test262NativeHostHelpers.js"),
             "test262/metadataParser" => Path.Combine(repoRoot, "scripts", "test262", "metadataParser.js"),
             _ => throw new ArgumentOutOfRangeException(nameof(testName), testName, "Unknown integration test script.")
         };

--- a/tests/Jroc.Test262.Tests/Integration/JavaScript/test262NativeHostHelpers.js
+++ b/tests/Jroc.Test262.Tests/Integration/JavaScript/test262NativeHostHelpers.js
@@ -1,0 +1,40 @@
+/*---
+description: Native C# test262 harness helpers are available as host globals
+---*/
+
+assert(true, 'assert should be callable');
+assert.sameValue(1, 1, 'sameValue should use SameValue semantics');
+assert.notSameValue(1, 2, 'notSameValue should use SameValue semantics');
+assert.strictEqual('abc', 'abc', 'strictEqual should alias sameValue');
+assert.notStrictEqual('abc', 'def', 'notStrictEqual should alias notSameValue');
+assert.compareArray([1, 2, 3], [1, 2, 3], 'compareArray should compare indexed elements');
+
+var value = {};
+Object.defineProperty(value, 'answer', {
+    value: 42,
+    writable: false,
+    enumerable: true,
+    configurable: false
+});
+
+verifyProperty(value, 'answer', {
+    value: 42,
+    writable: false,
+    enumerable: true,
+    configurable: false
+});
+verifyNotWritable(value, 'answer');
+verifyEnumerable(value, 'answer');
+verifyNotConfigurable(value, 'answer');
+
+assert.throws(Test262Error, function() {
+    $ERROR('native error');
+}, '$ERROR should throw Test262Error');
+
+var constructed = new Test262Error('constructed error');
+assert.sameValue(constructed.name, 'Test262Error');
+assert.sameValue(constructed.message, 'constructed error');
+
+assert.throws(Test262Error, function() {
+    $262.detachArrayBuffer();
+}, 'unsupported $262 APIs should fail clearly');

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/ExecutionTests.Compile_Scripts_Test262NativeHostHelpers.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/ExecutionTests.Compile_Scripts_Test262NativeHostHelpers.verified.txt
@@ -1,0 +1,14 @@
+﻿true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/tests/Jroc.Testing/InMemoryTestCompiler.cs
+++ b/tests/Jroc.Testing/InMemoryTestCompiler.cs
@@ -18,6 +18,7 @@ public static class InMemoryTestCompiler
         bool enableIRMetrics = false,
         bool allowUnhandledException = false,
         Action<ServiceContainer>? addMocks = null,
+        HostRuntimeIntrinsicDescriptors? hostRuntimeIntrinsics = null,
         int timeoutMs = 30000)
     {
         var (script, sourcePath) = getJavaScriptAndSourcePath(testName);
@@ -114,7 +115,8 @@ public static class InMemoryTestCompiler
                     SourceText = entrySourceText,
                     FileSystem = fileSystem,
                     RootModuleIdOverride = rootModuleIdOverride,
-                    EmitPdb = true
+                    EmitPdb = true,
+                    HostRuntimeIntrinsics = hostRuntimeIntrinsics ?? HostRuntimeIntrinsicDescriptors.Empty
                 });
         }
         finally
@@ -126,7 +128,7 @@ public static class InMemoryTestCompiler
         }
 
         using var loadedAssembly = JrocInMemoryAssemblyLoader.Load(artifact);
-        var output = ExecuteLoadedAssembly(loadedAssembly.Assembly, testName, allowUnhandledException, addMocks, timeoutMs);
+        var output = ExecuteLoadedAssembly(loadedAssembly.Assembly, testName, allowUnhandledException, addMocks, hostRuntimeIntrinsics, timeoutMs);
         return new InMemoryTestExecutionResult(output, loadedAssembly.LoadContextWeakReference);
     }
 
@@ -135,6 +137,7 @@ public static class InMemoryTestCompiler
         string testName,
         bool allowUnhandledException,
         Action<ServiceContainer>? addMocks,
+        HostRuntimeIntrinsicDescriptors? hostRuntimeIntrinsics,
         int timeoutMs)
     {
         var output = new InMemoryConsoleOutput();
@@ -145,6 +148,11 @@ public static class InMemoryTestCompiler
             ErrorOutput = output
         });
         serviceProvider.RegisterInstance<IEnvironment>(new CapturingEnvironment());
+        if (hostRuntimeIntrinsics is not null)
+        {
+            serviceProvider.Replace(hostRuntimeIntrinsics);
+        }
+
         addMocks?.Invoke(serviceProvider);
 
         ExceptionDispatchInfo? threadException = null;

--- a/tests/Jroc.Testing/Test262HostRuntimeIntrinsics.cs
+++ b/tests/Jroc.Testing/Test262HostRuntimeIntrinsics.cs
@@ -1,0 +1,311 @@
+using System.Dynamic;
+using JavaScriptRuntime;
+
+namespace Jroc.Tests;
+
+public static class Test262HostRuntimeIntrinsics
+{
+    public static HostRuntimeIntrinsicDescriptors Create()
+        => new HostRuntimeIntrinsicDescriptorsBuilder()
+            .AddGlobalFactory("assert", CreateAssert)
+            .AddGlobalFactory("Test262Error", CreateTest262ErrorConstructor)
+            .AddGlobalValue("$ERROR", (Action<object?>)(message => throw CreateTest262Error(message)))
+            .AddGlobalValue("$DONE", (Action<object?>)(error =>
+            {
+                if (error is not null)
+                {
+                    throw error as Exception ?? new Error(ToMessage(error));
+                }
+            }))
+            .AddGlobalFactory("$262", Create262Object)
+            .AddGlobalValue("compareArray", (Func<object?, object?, bool>)CompareArray)
+            .AddGlobalValue("verifyProperty", (Action<object?, object?, object?>)VerifyProperty)
+            .AddGlobalValue("verifyWritable", (Action<object?, object?>)((target, name) => VerifyAttribute(target, name, "writable", true)))
+            .AddGlobalValue("verifyNotWritable", (Action<object?, object?>)((target, name) => VerifyAttribute(target, name, "writable", false)))
+            .AddGlobalValue("verifyEnumerable", (Action<object?, object?>)((target, name) => VerifyAttribute(target, name, "enumerable", true)))
+            .AddGlobalValue("verifyNotEnumerable", (Action<object?, object?>)((target, name) => VerifyAttribute(target, name, "enumerable", false)))
+            .AddGlobalValue("verifyConfigurable", (Action<object?, object?>)((target, name) => VerifyAttribute(target, name, "configurable", true)))
+            .AddGlobalValue("verifyNotConfigurable", (Action<object?, object?>)((target, name) => VerifyAttribute(target, name, "configurable", false)))
+            .Build();
+
+    private static object CreateAssert()
+    {
+        var assert = (Action<object?, object?>)((condition, message) =>
+        {
+            var passed = TypeUtilities.ToBoolean(condition);
+            Log(passed);
+            if (!passed)
+            {
+                ThrowAssertion(message, "Assertion failed");
+            }
+        });
+
+        var sameValue = (Action<object?, object?, object?>)((actual, expected, message) =>
+        {
+            var passed = JavaScriptRuntime.Object.@is(actual, expected);
+            Log(passed);
+            if (!passed)
+            {
+                ThrowAssertion(message, "Expected SameValue");
+            }
+        });
+
+        var notSameValue = (Action<object?, object?, object?>)((actual, unexpected, message) =>
+        {
+            var passed = !JavaScriptRuntime.Object.@is(actual, unexpected);
+            Log(passed);
+            if (!passed)
+            {
+                ThrowAssertion(message, "Expected values to differ");
+            }
+        });
+
+        var throws = (Action<object?, object?, object?>)((expectedErrorConstructor, fn, message) =>
+        {
+            var passed = false;
+            try
+            {
+                Closure.InvokeWithArgs(fn!, RuntimeServices.EmptyScopes);
+            }
+            catch (Exception error)
+            {
+                passed = IsExpectedError(error, expectedErrorConstructor);
+            }
+
+            Log(passed);
+            if (!passed)
+            {
+                ThrowAssertion(message, "Expected function to throw");
+            }
+        });
+
+        var compareArray = (Action<object?, object?, object?>)((actual, expected, message) =>
+        {
+            var passed = CompareArray(actual, expected);
+            Log(passed);
+            if (!passed)
+            {
+                ThrowAssertion(message, "Expected arrays to match");
+            }
+        });
+
+        InitializeFunction(assert, "assert", 2);
+        InitializeFunction(sameValue, "sameValue", 3);
+        InitializeFunction(notSameValue, "notSameValue", 3);
+        InitializeFunction(throws, "throws", 3);
+        InitializeFunction(compareArray, "compareArray", 3);
+
+        ObjectRuntime.SetItem(assert, "sameValue", sameValue);
+        ObjectRuntime.SetItem(assert, "notSameValue", notSameValue);
+        ObjectRuntime.SetItem(assert, "strictEqual", sameValue);
+        ObjectRuntime.SetItem(assert, "notStrictEqual", notSameValue);
+        ObjectRuntime.SetItem(assert, "throws", throws);
+        ObjectRuntime.SetItem(assert, "compareArray", compareArray);
+
+        return assert;
+    }
+
+    private static object CreateTest262ErrorConstructor()
+    {
+        Func<object[], object?[], object?> constructor = (_, args) =>
+        {
+            var instance = RuntimeServices.GetCurrentThis();
+            if (instance is null)
+            {
+                return CreateTest262Error(args.Length > 0 ? args[0] : null);
+            }
+
+            ObjectRuntime.SetItem(instance, "name", "Test262Error");
+            ObjectRuntime.SetItem(instance, "message", ToMessage(args.Length > 0 ? args[0] : null));
+            return null;
+        };
+
+        InitializeFunction(constructor, "Test262Error", 1);
+
+        var prototype = new ExpandoObject();
+        ObjectRuntime.SetItem(prototype, "constructor", constructor);
+        ObjectRuntime.SetItem(constructor, "prototype", prototype);
+
+        return constructor;
+    }
+
+    private static object Create262Object()
+    {
+        var result = new ExpandoObject();
+        ObjectRuntime.SetItem(result, "createRealm", Unsupported262("$262.createRealm"));
+        ObjectRuntime.SetItem(result, "detachArrayBuffer", Unsupported262("$262.detachArrayBuffer"));
+        ObjectRuntime.SetItem(result, "evalScript", Unsupported262("$262.evalScript"));
+        ObjectRuntime.SetItem(result, "gc", Unsupported262("$262.gc"));
+        return result;
+    }
+
+    private static Action Unsupported262(string name)
+    {
+        return () => throw CreateTest262Error($"{name} is not supported by the JROC C# test262 harness.");
+    }
+
+    private static void VerifyProperty(object? target, object? name, object? expectedDescriptor)
+    {
+        var actualDescriptor = JavaScriptRuntime.Object.getOwnPropertyDescriptor(target!, name);
+        var passed = actualDescriptor is not null;
+        if (passed && HasOwn(expectedDescriptor, "value"))
+        {
+            passed = JavaScriptRuntime.Object.@is(
+                ObjectRuntime.GetItem(actualDescriptor!, "value"),
+                ObjectRuntime.GetItem(expectedDescriptor!, "value"));
+        }
+
+        if (passed && HasOwn(expectedDescriptor, "writable"))
+        {
+            passed = JavaScriptRuntime.Object.@is(
+                ObjectRuntime.GetItem(actualDescriptor!, "writable"),
+                ObjectRuntime.GetItem(expectedDescriptor!, "writable"));
+        }
+
+        if (passed && HasOwn(expectedDescriptor, "enumerable"))
+        {
+            passed = JavaScriptRuntime.Object.@is(
+                ObjectRuntime.GetItem(actualDescriptor!, "enumerable"),
+                ObjectRuntime.GetItem(expectedDescriptor!, "enumerable"));
+        }
+
+        if (passed && HasOwn(expectedDescriptor, "configurable"))
+        {
+            passed = JavaScriptRuntime.Object.@is(
+                ObjectRuntime.GetItem(actualDescriptor!, "configurable"),
+                ObjectRuntime.GetItem(expectedDescriptor!, "configurable"));
+        }
+
+        if (passed && HasOwn(expectedDescriptor, "get"))
+        {
+            passed = JavaScriptRuntime.Object.@is(
+                ObjectRuntime.GetItem(actualDescriptor!, "get"),
+                ObjectRuntime.GetItem(expectedDescriptor!, "get"));
+        }
+
+        if (passed && HasOwn(expectedDescriptor, "set"))
+        {
+            passed = JavaScriptRuntime.Object.@is(
+                ObjectRuntime.GetItem(actualDescriptor!, "set"),
+                ObjectRuntime.GetItem(expectedDescriptor!, "set"));
+        }
+
+        Log(passed);
+        if (!passed)
+        {
+            ThrowAssertion($"verifyProperty failed for {ToMessage(name)}");
+        }
+    }
+
+    private static void VerifyAttribute(object? target, object? name, string attributeName, bool expectedValue)
+    {
+        var actualDescriptor = JavaScriptRuntime.Object.getOwnPropertyDescriptor(target!, name);
+        var passed = actualDescriptor is not null
+            && JavaScriptRuntime.Object.@is(ObjectRuntime.GetItem(actualDescriptor!, attributeName), expectedValue);
+
+        Log(passed);
+        if (!passed)
+        {
+            ThrowAssertion($"verify{(expectedValue ? string.Empty : "Not")}{Capitalize(attributeName)} failed for {ToMessage(name)}");
+        }
+    }
+
+    private static bool CompareArray(object? actual, object? expected)
+    {
+        if (actual is null || expected is null)
+        {
+            return false;
+        }
+
+        var actualLength = ToLength(ObjectRuntime.GetItem(actual, "length"));
+        var expectedLength = ToLength(ObjectRuntime.GetItem(expected, "length"));
+        if (actualLength != expectedLength)
+        {
+            return false;
+        }
+
+        for (var i = 0L; i < actualLength; i++)
+        {
+            if (!JavaScriptRuntime.Object.@is(ObjectRuntime.GetItem(actual, (double)i), ObjectRuntime.GetItem(expected, (double)i)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsExpectedError(Exception error, object? expectedErrorConstructor)
+    {
+        if (expectedErrorConstructor is null)
+        {
+            return false;
+        }
+
+        var expectedName = ObjectRuntime.GetItem(expectedErrorConstructor, "name") as string;
+        if (!string.IsNullOrEmpty(expectedName)
+            && string.Equals(GetErrorName(error), expectedName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string GetErrorName(Exception error)
+        => error switch
+        {
+            Error jsError => jsError.name,
+            _ => error.GetType().Name
+        };
+
+    private static bool HasOwn(object? target, string name)
+        => target is not null && target is not JsNull && JavaScriptRuntime.Object.hasOwn(target, name);
+
+    private static long ToLength(object? value)
+    {
+        var number = TypeUtilities.ToNumber(value);
+        if (double.IsNaN(number) || number <= 0)
+        {
+            return 0;
+        }
+
+        if (double.IsPositiveInfinity(number))
+        {
+            return long.MaxValue;
+        }
+
+        return (long)global::System.Math.Min(global::System.Math.Floor(number), long.MaxValue);
+    }
+
+    private static void ThrowAssertion(object? message, string fallback = "Assertion failed")
+        => throw CreateTest262Error(string.IsNullOrEmpty(ToMessage(message)) ? fallback : ToMessage(message));
+
+    private static Test262Error CreateTest262Error(object? message)
+        => new(ToMessage(message));
+
+    private static void InitializeFunction(Delegate function, string name, double length)
+        => Function.InitializeFunctionInstance(function, length, name, requiresInvocationContext: false);
+
+    private static void Log(bool value)
+        => GlobalThis.console.log(value);
+
+    private static string ToMessage(object? value)
+        => value switch
+        {
+            null or JsNull => string.Empty,
+            _ => DotNet2JSConversions.ToString(value)
+        };
+
+    private static string Capitalize(string value)
+        => string.IsNullOrEmpty(value) ? value : char.ToUpperInvariant(value[0]) + value[1..];
+
+    private sealed class Test262Error : Error
+    {
+        public Test262Error(string message)
+            : base(message)
+        {
+            Name = "Test262Error";
+        }
+    }
+}

--- a/tests/Jroc.Testing/Test262SharedAssertHarness.cs
+++ b/tests/Jroc.Testing/Test262SharedAssertHarness.cs
@@ -13,11 +13,15 @@ public static class Test262SharedAssertHarness
         bool enableIRMetrics = false,
         bool allowUnhandledException = false,
         Action<ServiceContainer>? addMocks = null,
+        bool useNativeHostHelpers = false,
         int timeoutMs = 30000)
     {
         var (entryScript, entrySourcePath) = getJavaScriptAndSourcePath(testName);
         var metadata = ParseFrontmatter(entryScript);
-        var preparedEntryScript = BuildPreparedEntryScript(entryScript, metadata, callerSourceFilePath);
+        var preparedEntryScript = BuildPreparedEntryScript(entryScript, metadata, callerSourceFilePath, useNativeHostHelpers);
+        var hostRuntimeIntrinsics = useNativeHostHelpers
+            ? Test262HostRuntimeIntrinsics.Create()
+            : null;
 
         return InMemoryTestCompiler.CompileAndExecute(
             testName,
@@ -32,10 +36,15 @@ public static class Test262SharedAssertHarness
             enableIRMetrics: enableIRMetrics,
             allowUnhandledException: allowUnhandledException,
             addMocks: addMocks,
+            hostRuntimeIntrinsics: hostRuntimeIntrinsics,
             timeoutMs: timeoutMs);
     }
 
-    private static string BuildPreparedEntryScript(string entryScript, FrontmatterMetadata metadata, string callerSourceFilePath)
+    private static string BuildPreparedEntryScript(
+        string entryScript,
+        FrontmatterMetadata metadata,
+        string callerSourceFilePath,
+        bool useNativeHostHelpers)
     {
         var (prefix, remainder, hasUseStrictDirective) = SplitDirectivePrologue(entryScript);
         var scriptBuilder = new System.Text.StringBuilder();
@@ -46,7 +55,9 @@ public static class Test262SharedAssertHarness
             scriptBuilder.AppendLine("\"use strict\";");
         }
 
-        var helperFiles = new List<string> { "assert.js" };
+        var helperFiles = useNativeHostHelpers
+            ? new List<string>()
+            : new List<string> { "assert.js" };
         helperFiles.AddRange(GetInlineHarnessFileNames(metadata.Includes));
 
         foreach (var helperFile in helperFiles.Distinct(StringComparer.Ordinal))


### PR DESCRIPTION
## Summary

- adds `Test262HostRuntimeIntrinsics`, a C# host-extension descriptor factory for representative test262 harness helpers
- wires optional host intrinsics through the in-memory test compiler at compile time and runtime
- adds an opt-in shared-harness mode and integration fixture proving native C# helpers can replace `assert.js` for a representative helper group

## Validation

- `dotnet test .\tests\Jroc.Test262.Tests\Jroc.Test262.Tests.csproj --no-restore --filter "FullyQualifiedName~Compile_Scripts_Test262NativeHostHelpers|FullyQualifiedName~Jroc.Test262.Tests.language.types.reference.ExecutionTests" --nologo`

Resolves #1377