### PR TITLE
perf(compiler): infer stable float64 types for top-level loop variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf/compiler: extend stable CLR type inference to block scopes at module top level (for-loop head scopes and block statements), so top-level `let`/`const` loop variables like `x`/`y` in `stopwatch-modern.js` compile to unboxed float64 locals instead of boxed objects.
 - tests/docs/test262: expand ECMA-262 Section 21.1 Number coverage with newly ported constructor, constructor-property, prototype, prototype-method, and instance-shape test262 cases; implement the covered Number prototype method surface and refresh the Section 21.1 support docs.
 
 ## v0.11.12 - 2026-07-06

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
@@ -1101,11 +1101,36 @@ public partial class SymbolTableBuilder
             return false;
         }
 
+        // Check if this is a block scope that reaches the Global (module) scope only
+        // through other block scopes (e.g., a top-level for-loop head scope or block
+        // statement). These are analyzed the same way as blocks inside functions.
+        // Valid: global -> block -> block
+        // Invalid: global -> function -> block (covered by isBlockScopeInFunction)
+        bool isBlockScopeInGlobal(Scope? scope)
+        {
+            if (scope == null || scope.Kind != ScopeKind.Block)
+                return false;
+
+            var current = scope.Parent;
+            while (current != null)
+            {
+                if (current.Kind == ScopeKind.Global)
+                    return true;
+
+                if (current.Kind != ScopeKind.Block)
+                    return false;
+
+                current = current.Parent;
+            }
+            return false;
+        }
+
         if (scope.Kind != ScopeKind.Global &&
             isClassMethod(scope) == false &&
             isBlockScopeInClassMethod(scope) == false &&
             isFunctionOrArrowFunction(scope) == false &&
-            isBlockScopeInFunction(scope) == false)
+            isBlockScopeInFunction(scope) == false &&
+            isBlockScopeInGlobal(scope) == false)
         {
             return;
         }

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x223d
+					// Method begins at RVA 0x2211
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x21f0
+				// Method begins at RVA 0x21c4
 				// Header size: 12
 				// Code size: 34 (0x22)
 				.maxstack 8
@@ -90,7 +90,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2246
+					// Method begins at RVA 0x221a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -114,7 +114,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x221e
+				// Method begins at RVA 0x21f2
 				// Header size: 1
 				// Code size: 12 (0xc)
 				.maxstack 8
@@ -143,7 +143,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2234
+				// Method begins at RVA 0x2208
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -170,7 +170,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x215c
+			// Method begins at RVA 0x2130
 			// Header size: 12
 			// Code size: 133 (0x85)
 			.maxstack 8
@@ -261,7 +261,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x222b
+			// Method begins at RVA 0x21ff
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -285,7 +285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2258
+				// Method begins at RVA 0x222c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x224f
+			// Method begins at RVA 0x2223
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -329,18 +329,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 256 (0x100)
+		// Code size: 211 (0xd3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Map_NestedParam/Scope,
 			[1] object,
 			[2] object,
-			[3] object,
+			[3] float64,
 			[4] class Modules.Array_Map_NestedParam/Scope_For_L13C5/Block_L13C40,
 			[5] object,
 			[6] object[],
-			[7] object,
-			[8] float64
+			[7] float64
 		)
 
 		IL_0000: newobj instance void Modules.Array_Map_NestedParam/Scope::.ctor()
@@ -385,55 +384,40 @@
 		IL_006d: ldloc.s 5
 		IL_006f: stloc.2
 		IL_0070: ldc.r8 0.0
-		IL_0079: box [System.Runtime]System.Double
-		IL_007e: stloc.3
-		// loop start (head: IL_007f)
-			IL_007f: ldloc.3
-			IL_0080: stloc.s 7
-			IL_0082: ldloc.2
-			IL_0083: ldstr "length"
-			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_008d: stloc.s 5
-			IL_008f: ldloc.s 7
-			IL_0091: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0096: stloc.s 8
-			IL_0098: ldloc.s 8
-			IL_009a: ldloc.s 5
-			IL_009c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00a1: clt
-			IL_00a3: brfalse IL_00ff
+		IL_0079: stloc.3
+		// loop start (head: IL_007a)
+			IL_007a: ldloc.3
+			IL_007b: stloc.s 7
+			IL_007d: ldloc.s 7
+			IL_007f: ldloc.2
+			IL_0080: ldstr "length"
+			IL_0085: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_008a: clt
+			IL_008c: brfalse IL_00d2
 
-			IL_00a8: newobj instance void Modules.Array_Map_NestedParam/Scope_For_L13C5/Block_L13C40::.ctor()
-			IL_00ad: stloc.s 4
-			IL_00af: ldstr "console"
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b9: stloc.s 5
-			IL_00bb: ldloc.s 5
-			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c2: stloc.s 5
-			IL_00c4: ldloc.s 5
-			IL_00c6: ldstr "log"
-			IL_00cb: ldloc.2
-			IL_00cc: ldloc.3
-			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00d7: pop
-			IL_00d8: ldloc.3
-			IL_00d9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00de: stloc.s 8
-			IL_00e0: ldloc.s 8
-			IL_00e2: ldc.r8 1
-			IL_00eb: add
-			IL_00ec: stloc.s 8
-			IL_00ee: ldloc.s 8
-			IL_00f0: box [System.Runtime]System.Double
-			IL_00f5: stloc.s 7
-			IL_00f7: ldloc.s 7
-			IL_00f9: stloc.3
-			IL_00fa: br IL_007f
+			IL_0091: newobj instance void Modules.Array_Map_NestedParam/Scope_For_L13C5/Block_L13C40::.ctor()
+			IL_0096: stloc.s 4
+			IL_0098: ldstr "console"
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00a2: stloc.s 5
+			IL_00a4: ldloc.s 5
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ab: stloc.s 5
+			IL_00ad: ldloc.s 5
+			IL_00af: ldstr "log"
+			IL_00b4: ldloc.2
+			IL_00b5: ldloc.3
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00c0: pop
+			IL_00c1: ldloc.3
+			IL_00c2: ldc.r8 1
+			IL_00cb: add
+			IL_00cc: stloc.3
+			IL_00cd: br IL_007a
 		// end loop
 
-		IL_00ff: ret
+		IL_00d2: ret
 	} // end of method Array_Map_NestedParam::__js_module_init__
 
 } // end of class Modules.Array_Map_NestedParam
@@ -445,7 +429,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2261
+		// Method begins at RVA 0x2235
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_DoWhile_LabeledBreak.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_DoWhile_LabeledBreak.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2171
+				// Method begins at RVA 0x214d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x218c
+						// Method begins at RVA 0x2168
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2183
+					// Method begins at RVA 0x215f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x217a
+				// Method begins at RVA 0x2156
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -100,7 +100,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2168
+			// Method begins at RVA 0x2144
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -126,17 +126,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 268 (0x10c)
+		// Code size: 232 (0xe8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_DoWhile_LabeledBreak/Scope,
 			[1] float64,
 			[2] class Modules.ControlFlow_DoWhile_LabeledBreak/Scope/Block_L5C10,
-			[3] object,
+			[3] float64,
 			[4] class Modules.ControlFlow_DoWhile_LabeledBreak/Scope/Scope_For_L7C7/Block_L7C30,
 			[5] class Modules.ControlFlow_DoWhile_LabeledBreak/Scope/Scope_For_L7C7/Block_L7C30/Block_L9C17,
-			[6] object,
-			[7] float64,
+			[6] float64,
+			[7] object,
 			[8] object
 		)
 
@@ -152,83 +152,71 @@
 			IL_0020: add
 			IL_0021: stloc.1
 			IL_0022: ldc.r8 0.0
-			IL_002b: box [System.Runtime]System.Double
-			IL_0030: stloc.3
-			// loop start (head: IL_0031)
-				IL_0031: ldloc.3
-				IL_0032: stloc.s 6
-				IL_0034: ldloc.s 6
-				IL_0036: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_003b: stloc.s 7
-				IL_003d: ldloc.s 7
-				IL_003f: ldc.r8 1
-				IL_0048: clt
-				IL_004a: brfalse IL_00ca
+			IL_002b: stloc.3
+			// loop start (head: IL_002c)
+				IL_002c: ldloc.3
+				IL_002d: stloc.s 6
+				IL_002f: ldloc.s 6
+				IL_0031: ldc.r8 1
+				IL_003a: clt
+				IL_003c: brfalse IL_00a6
 
-				IL_004f: newobj instance void Modules.ControlFlow_DoWhile_LabeledBreak/Scope/Scope_For_L7C7/Block_L7C30::.ctor()
-				IL_0054: stloc.s 4
-				IL_0056: ldstr "console"
-				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0060: stloc.s 8
-				IL_0062: ldloc.s 8
-				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0069: stloc.s 8
-				IL_006b: ldloc.1
-				IL_006c: box [System.Runtime]System.Double
-				IL_0071: stloc.s 6
-				IL_0073: ldloc.s 8
-				IL_0075: ldstr "log"
-				IL_007a: ldloc.s 6
-				IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0081: pop
-				IL_0082: ldloc.1
-				IL_0083: stloc.s 7
-				IL_0085: ldloc.s 7
-				IL_0087: ldc.r8 2
-				IL_0090: ceq
-				IL_0092: brfalse IL_00a3
+				IL_0041: newobj instance void Modules.ControlFlow_DoWhile_LabeledBreak/Scope/Scope_For_L7C7/Block_L7C30::.ctor()
+				IL_0046: stloc.s 4
+				IL_0048: ldstr "console"
+				IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0052: stloc.s 7
+				IL_0054: ldloc.s 7
+				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_005b: stloc.s 7
+				IL_005d: ldloc.1
+				IL_005e: box [System.Runtime]System.Double
+				IL_0063: stloc.s 8
+				IL_0065: ldloc.s 7
+				IL_0067: ldstr "log"
+				IL_006c: ldloc.s 8
+				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0073: pop
+				IL_0074: ldloc.1
+				IL_0075: stloc.s 6
+				IL_0077: ldloc.s 6
+				IL_0079: ldc.r8 2
+				IL_0082: ceq
+				IL_0084: brfalse IL_0095
 
-				IL_0097: newobj instance void Modules.ControlFlow_DoWhile_LabeledBreak/Scope/Scope_For_L7C7/Block_L7C30/Block_L9C17::.ctor()
-				IL_009c: stloc.s 5
-				IL_009e: br IL_00e4
+				IL_0089: newobj instance void Modules.ControlFlow_DoWhile_LabeledBreak/Scope/Scope_For_L7C7/Block_L7C30/Block_L9C17::.ctor()
+				IL_008e: stloc.s 5
+				IL_0090: br IL_00c0
 
-				IL_00a3: ldloc.3
-				IL_00a4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00a9: stloc.s 7
-				IL_00ab: ldloc.s 7
-				IL_00ad: ldc.r8 1
-				IL_00b6: add
-				IL_00b7: stloc.s 7
-				IL_00b9: ldloc.s 7
-				IL_00bb: box [System.Runtime]System.Double
-				IL_00c0: stloc.s 6
-				IL_00c2: ldloc.s 6
-				IL_00c4: stloc.3
-				IL_00c5: br IL_0031
+				IL_0095: ldloc.3
+				IL_0096: ldc.r8 1
+				IL_009f: add
+				IL_00a0: stloc.3
+				IL_00a1: br IL_002c
 			// end loop
 
-			IL_00ca: ldloc.1
-			IL_00cb: stloc.s 7
-			IL_00cd: ldloc.s 7
-			IL_00cf: ldc.r8 5
-			IL_00d8: clt
-			IL_00da: brfalse IL_00e4
+			IL_00a6: ldloc.1
+			IL_00a7: stloc.s 6
+			IL_00a9: ldloc.s 6
+			IL_00ab: ldc.r8 5
+			IL_00b4: clt
+			IL_00b6: brfalse IL_00c0
 
-			IL_00df: br IL_0010
+			IL_00bb: br IL_0010
 		// end loop
 
-		IL_00e4: ldstr "console"
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ee: stloc.s 8
-		IL_00f0: ldloc.s 8
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f7: stloc.s 8
-		IL_00f9: ldloc.s 8
-		IL_00fb: ldstr "log"
-		IL_0100: ldstr "done"
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_010a: pop
-		IL_010b: ret
+		IL_00c0: ldstr "console"
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ca: stloc.s 7
+		IL_00cc: ldloc.s 7
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d3: stloc.s 7
+		IL_00d5: ldloc.s 7
+		IL_00d7: ldstr "log"
+		IL_00dc: ldstr "done"
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e6: pop
+		IL_00e7: ret
 	} // end of method ControlFlow_DoWhile_LabeledBreak::__js_module_init__
 
 } // end of class Modules.ControlFlow_DoWhile_LabeledBreak
@@ -240,7 +228,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2195
+		// Method begins at RVA 0x2171
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_DoWhile_LabeledContinue.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_DoWhile_LabeledContinue.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x214a
+				// Method begins at RVA 0x2126
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2165
+						// Method begins at RVA 0x2141
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x215c
+					// Method begins at RVA 0x2138
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2153
+				// Method begins at RVA 0x212f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -100,7 +100,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2141
+			// Method begins at RVA 0x211d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -126,17 +126,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 229 (0xe5)
+		// Code size: 193 (0xc1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_DoWhile_LabeledContinue/Scope,
 			[1] float64,
 			[2] class Modules.ControlFlow_DoWhile_LabeledContinue/Scope/Block_L5C10,
-			[3] object,
+			[3] float64,
 			[4] class Modules.ControlFlow_DoWhile_LabeledContinue/Scope/Scope_For_L7C7/Block_L7C30,
 			[5] class Modules.ControlFlow_DoWhile_LabeledContinue/Scope/Scope_For_L7C7/Block_L7C30/Block_L8C17,
-			[6] object,
-			[7] float64,
+			[6] float64,
+			[7] object,
 			[8] object
 		)
 
@@ -152,72 +152,60 @@
 			IL_0020: add
 			IL_0021: stloc.1
 			IL_0022: ldc.r8 0.0
-			IL_002b: box [System.Runtime]System.Double
-			IL_0030: stloc.3
-			// loop start (head: IL_0031)
-				IL_0031: ldloc.3
-				IL_0032: stloc.s 6
-				IL_0034: ldloc.s 6
-				IL_0036: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_003b: stloc.s 7
-				IL_003d: ldloc.s 7
-				IL_003f: ldc.r8 1
-				IL_0048: clt
-				IL_004a: brfalse IL_00ca
+			IL_002b: stloc.3
+			// loop start (head: IL_002c)
+				IL_002c: ldloc.3
+				IL_002d: stloc.s 6
+				IL_002f: ldloc.s 6
+				IL_0031: ldc.r8 1
+				IL_003a: clt
+				IL_003c: brfalse IL_00a6
 
-				IL_004f: newobj instance void Modules.ControlFlow_DoWhile_LabeledContinue/Scope/Scope_For_L7C7/Block_L7C30::.ctor()
-				IL_0054: stloc.s 4
-				IL_0056: ldloc.1
-				IL_0057: stloc.s 7
-				IL_0059: ldloc.s 7
-				IL_005b: ldc.r8 2
-				IL_0064: ceq
-				IL_0066: brfalse IL_0077
+				IL_0041: newobj instance void Modules.ControlFlow_DoWhile_LabeledContinue/Scope/Scope_For_L7C7/Block_L7C30::.ctor()
+				IL_0046: stloc.s 4
+				IL_0048: ldloc.1
+				IL_0049: stloc.s 6
+				IL_004b: ldloc.s 6
+				IL_004d: ldc.r8 2
+				IL_0056: ceq
+				IL_0058: brfalse IL_0069
 
-				IL_006b: newobj instance void Modules.ControlFlow_DoWhile_LabeledContinue/Scope/Scope_For_L7C7/Block_L7C30/Block_L8C17::.ctor()
-				IL_0070: stloc.s 5
-				IL_0072: br IL_00ca
+				IL_005d: newobj instance void Modules.ControlFlow_DoWhile_LabeledContinue/Scope/Scope_For_L7C7/Block_L7C30/Block_L8C17::.ctor()
+				IL_0062: stloc.s 5
+				IL_0064: br IL_00a6
 
-				IL_0077: ldstr "console"
-				IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0081: stloc.s 8
-				IL_0083: ldloc.s 8
-				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_008a: stloc.s 8
-				IL_008c: ldloc.1
-				IL_008d: box [System.Runtime]System.Double
-				IL_0092: stloc.s 6
-				IL_0094: ldloc.s 8
-				IL_0096: ldstr "log"
-				IL_009b: ldloc.s 6
-				IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00a2: pop
-				IL_00a3: ldloc.3
-				IL_00a4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00a9: stloc.s 7
-				IL_00ab: ldloc.s 7
-				IL_00ad: ldc.r8 1
-				IL_00b6: add
-				IL_00b7: stloc.s 7
-				IL_00b9: ldloc.s 7
-				IL_00bb: box [System.Runtime]System.Double
-				IL_00c0: stloc.s 6
-				IL_00c2: ldloc.s 6
-				IL_00c4: stloc.3
-				IL_00c5: br IL_0031
+				IL_0069: ldstr "console"
+				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0073: stloc.s 7
+				IL_0075: ldloc.s 7
+				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_007c: stloc.s 7
+				IL_007e: ldloc.1
+				IL_007f: box [System.Runtime]System.Double
+				IL_0084: stloc.s 8
+				IL_0086: ldloc.s 7
+				IL_0088: ldstr "log"
+				IL_008d: ldloc.s 8
+				IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0094: pop
+				IL_0095: ldloc.3
+				IL_0096: ldc.r8 1
+				IL_009f: add
+				IL_00a0: stloc.3
+				IL_00a1: br IL_002c
 			// end loop
 
-			IL_00ca: ldloc.1
-			IL_00cb: stloc.s 7
-			IL_00cd: ldloc.s 7
-			IL_00cf: ldc.r8 3
-			IL_00d8: clt
-			IL_00da: brfalse IL_00e4
+			IL_00a6: ldloc.1
+			IL_00a7: stloc.s 6
+			IL_00a9: ldloc.s 6
+			IL_00ab: ldc.r8 3
+			IL_00b4: clt
+			IL_00b6: brfalse IL_00c0
 
-			IL_00df: br IL_0010
+			IL_00bb: br IL_0010
 		// end loop
 
-		IL_00e4: ret
+		IL_00c0: ret
 	} // end of method ControlFlow_DoWhile_LabeledContinue::__js_module_init__
 
 } // end of class Modules.ControlFlow_DoWhile_LabeledContinue
@@ -229,7 +217,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x216e
+		// Method begins at RVA 0x214a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_LabeledBreak.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_LabeledBreak.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2182
+			// Method begins at RVA 0x215e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2194
+				// Method begins at RVA 0x2170
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21af
+						// Method begins at RVA 0x218b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -84,7 +84,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21a6
+					// Method begins at RVA 0x2182
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x219d
+				// Method begins at RVA 0x2179
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -120,7 +120,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x218b
+			// Method begins at RVA 0x2167
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -146,7 +146,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 294 (0x126)
+		// Code size: 258 (0x102)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForIn_LabeledBreak/Scope,
@@ -154,13 +154,12 @@
 			[2] object,
 			[3] object,
 			[4] class Modules.ControlFlow_ForIn_LabeledBreak/Scope_ForIn_L5C12/Block_L5C26,
-			[5] object,
+			[5] float64,
 			[6] class Modules.ControlFlow_ForIn_LabeledBreak/Scope_ForIn_L5C12/Scope_For_L6C7/Block_L6C30,
 			[7] class Modules.ControlFlow_ForIn_LabeledBreak/Scope_ForIn_L5C12/Scope_For_L6C7/Block_L6C30/Block_L8C19,
 			[8] object,
 			[9] bool,
-			[10] object,
-			[11] float64
+			[10] float64
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForIn_LabeledBreak/Scope::.ctor()
@@ -190,7 +189,7 @@
 			IL_0059: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 			IL_005e: stloc.s 9
 			IL_0060: ldloc.s 9
-			IL_0062: brtrue IL_0125
+			IL_0062: brtrue IL_0101
 
 			IL_0067: ldloc.s 8
 			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -200,64 +199,52 @@
 			IL_0073: newobj instance void Modules.ControlFlow_ForIn_LabeledBreak/Scope_ForIn_L5C12/Block_L5C26::.ctor()
 			IL_0078: stloc.s 4
 			IL_007a: ldc.r8 0.0
-			IL_0083: box [System.Runtime]System.Double
-			IL_0088: stloc.s 5
-			// loop start (head: IL_008a)
-				IL_008a: ldloc.s 5
-				IL_008c: stloc.s 10
-				IL_008e: ldloc.s 10
-				IL_0090: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0095: stloc.s 11
-				IL_0097: ldloc.s 11
-				IL_0099: ldc.r8 1
-				IL_00a2: clt
-				IL_00a4: brfalse IL_0120
+			IL_0083: stloc.s 5
+			// loop start (head: IL_0085)
+				IL_0085: ldloc.s 5
+				IL_0087: stloc.s 10
+				IL_0089: ldloc.s 10
+				IL_008b: ldc.r8 1
+				IL_0094: clt
+				IL_0096: brfalse IL_00fc
 
-				IL_00a9: newobj instance void Modules.ControlFlow_ForIn_LabeledBreak/Scope_ForIn_L5C12/Scope_For_L6C7/Block_L6C30::.ctor()
-				IL_00ae: stloc.s 6
-				IL_00b0: ldstr "console"
-				IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00ba: stloc.s 8
-				IL_00bc: ldloc.s 8
-				IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00c3: stloc.s 8
-				IL_00c5: ldloc.s 8
-				IL_00c7: ldstr "log"
-				IL_00cc: ldloc.3
-				IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00d2: pop
-				IL_00d3: ldloc.3
-				IL_00d4: stloc.s 8
-				IL_00d6: ldloc.s 8
-				IL_00d8: ldstr "b"
-				IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00e2: stloc.s 9
-				IL_00e4: ldloc.s 9
-				IL_00e6: brfalse IL_00f7
+				IL_009b: newobj instance void Modules.ControlFlow_ForIn_LabeledBreak/Scope_ForIn_L5C12/Scope_For_L6C7/Block_L6C30::.ctor()
+				IL_00a0: stloc.s 6
+				IL_00a2: ldstr "console"
+				IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00ac: stloc.s 8
+				IL_00ae: ldloc.s 8
+				IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00b5: stloc.s 8
+				IL_00b7: ldloc.s 8
+				IL_00b9: ldstr "log"
+				IL_00be: ldloc.3
+				IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00c4: pop
+				IL_00c5: ldloc.3
+				IL_00c6: stloc.s 8
+				IL_00c8: ldloc.s 8
+				IL_00ca: ldstr "b"
+				IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00d4: stloc.s 9
+				IL_00d6: ldloc.s 9
+				IL_00d8: brfalse IL_00e9
 
-				IL_00eb: newobj instance void Modules.ControlFlow_ForIn_LabeledBreak/Scope_ForIn_L5C12/Scope_For_L6C7/Block_L6C30/Block_L8C19::.ctor()
-				IL_00f0: stloc.s 7
-				IL_00f2: br IL_0125
+				IL_00dd: newobj instance void Modules.ControlFlow_ForIn_LabeledBreak/Scope_ForIn_L5C12/Scope_For_L6C7/Block_L6C30/Block_L8C19::.ctor()
+				IL_00e2: stloc.s 7
+				IL_00e4: br IL_0101
 
-				IL_00f7: ldloc.s 5
-				IL_00f9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00fe: stloc.s 11
-				IL_0100: ldloc.s 11
-				IL_0102: ldc.r8 1
-				IL_010b: add
-				IL_010c: stloc.s 11
-				IL_010e: ldloc.s 11
-				IL_0110: box [System.Runtime]System.Double
-				IL_0115: stloc.s 10
-				IL_0117: ldloc.s 10
-				IL_0119: stloc.s 5
-				IL_011b: br IL_008a
+				IL_00e9: ldloc.s 5
+				IL_00eb: ldc.r8 1
+				IL_00f4: add
+				IL_00f5: stloc.s 5
+				IL_00f7: br IL_0085
 			// end loop
 
-			IL_0120: br IL_004f
+			IL_00fc: br IL_004f
 		// end loop
 
-		IL_0125: ret
+		IL_0101: ret
 	} // end of method ControlFlow_ForIn_LabeledBreak::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForIn_LabeledBreak
@@ -269,7 +256,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b8
+		// Method begins at RVA 0x2194
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_LabeledContinue.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_LabeledContinue.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2182
+			// Method begins at RVA 0x215e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2194
+				// Method begins at RVA 0x2170
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21af
+						// Method begins at RVA 0x218b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -84,7 +84,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21a6
+					// Method begins at RVA 0x2182
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x219d
+				// Method begins at RVA 0x2179
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -120,7 +120,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x218b
+			// Method begins at RVA 0x2167
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -146,7 +146,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 294 (0x126)
+		// Code size: 258 (0x102)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForIn_LabeledContinue/Scope,
@@ -154,13 +154,12 @@
 			[2] object,
 			[3] object,
 			[4] class Modules.ControlFlow_ForIn_LabeledContinue/Scope_ForIn_L5C12/Block_L5C26,
-			[5] object,
+			[5] float64,
 			[6] class Modules.ControlFlow_ForIn_LabeledContinue/Scope_ForIn_L5C12/Scope_For_L6C7/Block_L6C30,
 			[7] class Modules.ControlFlow_ForIn_LabeledContinue/Scope_ForIn_L5C12/Scope_For_L6C7/Block_L6C30/Block_L7C19,
 			[8] object,
 			[9] bool,
-			[10] object,
-			[11] float64
+			[10] float64
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForIn_LabeledContinue/Scope::.ctor()
@@ -190,7 +189,7 @@
 			IL_0059: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 			IL_005e: stloc.s 9
 			IL_0060: ldloc.s 9
-			IL_0062: brtrue IL_0125
+			IL_0062: brtrue IL_0101
 
 			IL_0067: ldloc.s 8
 			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -200,64 +199,52 @@
 			IL_0073: newobj instance void Modules.ControlFlow_ForIn_LabeledContinue/Scope_ForIn_L5C12/Block_L5C26::.ctor()
 			IL_0078: stloc.s 4
 			IL_007a: ldc.r8 0.0
-			IL_0083: box [System.Runtime]System.Double
-			IL_0088: stloc.s 5
-			// loop start (head: IL_008a)
-				IL_008a: ldloc.s 5
-				IL_008c: stloc.s 10
-				IL_008e: ldloc.s 10
-				IL_0090: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0095: stloc.s 11
-				IL_0097: ldloc.s 11
-				IL_0099: ldc.r8 1
-				IL_00a2: clt
-				IL_00a4: brfalse IL_0120
+			IL_0083: stloc.s 5
+			// loop start (head: IL_0085)
+				IL_0085: ldloc.s 5
+				IL_0087: stloc.s 10
+				IL_0089: ldloc.s 10
+				IL_008b: ldc.r8 1
+				IL_0094: clt
+				IL_0096: brfalse IL_00fc
 
-				IL_00a9: newobj instance void Modules.ControlFlow_ForIn_LabeledContinue/Scope_ForIn_L5C12/Scope_For_L6C7/Block_L6C30::.ctor()
-				IL_00ae: stloc.s 6
-				IL_00b0: ldloc.3
-				IL_00b1: stloc.s 8
-				IL_00b3: ldloc.s 8
-				IL_00b5: ldstr "b"
-				IL_00ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00bf: stloc.s 9
-				IL_00c1: ldloc.s 9
-				IL_00c3: brfalse IL_00d4
+				IL_009b: newobj instance void Modules.ControlFlow_ForIn_LabeledContinue/Scope_ForIn_L5C12/Scope_For_L6C7/Block_L6C30::.ctor()
+				IL_00a0: stloc.s 6
+				IL_00a2: ldloc.3
+				IL_00a3: stloc.s 8
+				IL_00a5: ldloc.s 8
+				IL_00a7: ldstr "b"
+				IL_00ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00b1: stloc.s 9
+				IL_00b3: ldloc.s 9
+				IL_00b5: brfalse IL_00c6
 
-				IL_00c8: newobj instance void Modules.ControlFlow_ForIn_LabeledContinue/Scope_ForIn_L5C12/Scope_For_L6C7/Block_L6C30/Block_L7C19::.ctor()
-				IL_00cd: stloc.s 7
-				IL_00cf: br IL_0120
+				IL_00ba: newobj instance void Modules.ControlFlow_ForIn_LabeledContinue/Scope_ForIn_L5C12/Scope_For_L6C7/Block_L6C30/Block_L7C19::.ctor()
+				IL_00bf: stloc.s 7
+				IL_00c1: br IL_00fc
 
-				IL_00d4: ldstr "console"
-				IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00de: stloc.s 8
-				IL_00e0: ldloc.s 8
-				IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00e7: stloc.s 8
-				IL_00e9: ldloc.s 8
-				IL_00eb: ldstr "log"
-				IL_00f0: ldloc.3
-				IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00f6: pop
-				IL_00f7: ldloc.s 5
-				IL_00f9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00fe: stloc.s 11
-				IL_0100: ldloc.s 11
-				IL_0102: ldc.r8 1
-				IL_010b: add
-				IL_010c: stloc.s 11
-				IL_010e: ldloc.s 11
-				IL_0110: box [System.Runtime]System.Double
-				IL_0115: stloc.s 10
-				IL_0117: ldloc.s 10
-				IL_0119: stloc.s 5
-				IL_011b: br IL_008a
+				IL_00c6: ldstr "console"
+				IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00d0: stloc.s 8
+				IL_00d2: ldloc.s 8
+				IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00d9: stloc.s 8
+				IL_00db: ldloc.s 8
+				IL_00dd: ldstr "log"
+				IL_00e2: ldloc.3
+				IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00e8: pop
+				IL_00e9: ldloc.s 5
+				IL_00eb: ldc.r8 1
+				IL_00f4: add
+				IL_00f5: stloc.s 5
+				IL_00f7: br IL_0085
 			// end loop
 
-			IL_0120: br IL_004f
+			IL_00fc: br IL_004f
 		// end loop
 
-		IL_0125: ret
+		IL_0101: ret
 	} // end of method ControlFlow_ForIn_LabeledContinue::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForIn_LabeledContinue
@@ -269,7 +256,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b8
+		// Method begins at RVA 0x2194
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_Break_AtThree.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_Break_AtThree.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2100
+			// Method begins at RVA 0x20db
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2112
+				// Method begins at RVA 0x20ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2109
+			// Method begins at RVA 0x20e4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,75 +82,62 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 164 (0xa4)
+		// Code size: 127 (0x7f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_Break_AtThree/Scope,
-			[1] object,
+			[1] float64,
 			[2] class Modules.ControlFlow_ForLoop_Break_AtThree/Scope_For_L3C5/Block_L3C29,
-			[3] object,
-			[4] float64,
-			[5] bool,
-			[6] object
+			[3] float64,
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_Break_AtThree/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldc.r8 0.0
-		IL_000f: box [System.Runtime]System.Double
-		IL_0014: stloc.1
-		// loop start (head: IL_0015)
-			IL_0015: ldloc.1
-			IL_0016: stloc.3
-			IL_0017: ldloc.3
-			IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001d: stloc.s 4
-			IL_001f: ldloc.s 4
-			IL_0021: ldc.r8 10
-			IL_002a: clt
-			IL_002c: brfalse IL_00a3
+		IL_000f: stloc.1
+		// loop start (head: IL_0010)
+			IL_0010: ldloc.1
+			IL_0011: stloc.3
+			IL_0012: ldloc.3
+			IL_0013: ldc.r8 10
+			IL_001c: clt
+			IL_001e: brfalse IL_007e
 
-			IL_0031: newobj instance void Modules.ControlFlow_ForLoop_Break_AtThree/Scope_For_L3C5/Block_L3C29::.ctor()
-			IL_0036: stloc.2
-			IL_0037: ldloc.1
-			IL_0038: stloc.3
-			IL_0039: ldloc.3
-			IL_003a: ldc.r8 3
-			IL_0043: box [System.Runtime]System.Double
-			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_004d: stloc.s 5
-			IL_004f: ldloc.s 5
-			IL_0051: brfalse IL_005b
+			IL_0023: newobj instance void Modules.ControlFlow_ForLoop_Break_AtThree/Scope_For_L3C5/Block_L3C29::.ctor()
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: stloc.3
+			IL_002b: ldloc.3
+			IL_002c: ldc.r8 3
+			IL_0035: ceq
+			IL_0037: brfalse IL_0041
 
-			IL_0056: br IL_00a3
+			IL_003c: br IL_007e
 
-			IL_005b: ldstr "console"
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0065: stloc.s 6
-			IL_0067: ldloc.s 6
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006e: stloc.s 6
-			IL_0070: ldloc.s 6
-			IL_0072: ldstr "log"
-			IL_0077: ldloc.1
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_007d: pop
-			IL_007e: ldloc.1
-			IL_007f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0084: stloc.s 4
-			IL_0086: ldloc.s 4
-			IL_0088: ldc.r8 1
-			IL_0091: add
-			IL_0092: stloc.s 4
-			IL_0094: ldloc.s 4
-			IL_0096: box [System.Runtime]System.Double
-			IL_009b: stloc.3
-			IL_009c: ldloc.3
-			IL_009d: stloc.1
-			IL_009e: br IL_0015
+			IL_0041: ldstr "console"
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_004b: stloc.s 4
+			IL_004d: ldloc.s 4
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0054: stloc.s 4
+			IL_0056: ldloc.1
+			IL_0057: box [System.Runtime]System.Double
+			IL_005c: stloc.s 5
+			IL_005e: ldloc.s 4
+			IL_0060: ldstr "log"
+			IL_0065: ldloc.s 5
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_006c: pop
+			IL_006d: ldloc.1
+			IL_006e: ldc.r8 1
+			IL_0077: add
+			IL_0078: stloc.1
+			IL_0079: br IL_0010
 		// end loop
 
-		IL_00a3: ret
+		IL_007e: ret
 	} // end of method ControlFlow_ForLoop_Break_AtThree::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_Break_AtThree
@@ -162,7 +149,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x211b
+		// Method begins at RVA 0x20f6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_Continue_SkipEven.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_Continue_SkipEven.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x210b
+			// Method begins at RVA 0x20e7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x211d
+				// Method begins at RVA 0x20f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2114
+			// Method begins at RVA 0x20f0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,79 +82,67 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 175 (0xaf)
+		// Code size: 139 (0x8b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_Continue_SkipEven/Scope,
-			[1] object,
+			[1] float64,
 			[2] class Modules.ControlFlow_ForLoop_Continue_SkipEven/Scope_For_L3C5/Block_L3C29,
-			[3] object,
-			[4] float64,
+			[3] float64,
+			[4] object,
 			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_Continue_SkipEven/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldc.r8 0.0
-		IL_000f: box [System.Runtime]System.Double
-		IL_0014: stloc.1
-		// loop start (head: IL_0015)
-			IL_0015: ldloc.1
-			IL_0016: stloc.3
-			IL_0017: ldloc.3
-			IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001d: stloc.s 4
-			IL_001f: ldloc.s 4
-			IL_0021: ldc.r8 10
-			IL_002a: clt
-			IL_002c: brfalse IL_00ae
+		IL_000f: stloc.1
+		// loop start (head: IL_0010)
+			IL_0010: ldloc.1
+			IL_0011: stloc.3
+			IL_0012: ldloc.3
+			IL_0013: ldc.r8 10
+			IL_001c: clt
+			IL_001e: brfalse IL_008a
 
-			IL_0031: newobj instance void Modules.ControlFlow_ForLoop_Continue_SkipEven/Scope_For_L3C5/Block_L3C29::.ctor()
-			IL_0036: stloc.2
-			IL_0037: ldloc.1
-			IL_0038: stloc.3
-			IL_0039: ldloc.3
-			IL_003a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_003f: stloc.s 4
-			IL_0041: ldloc.s 4
-			IL_0043: ldc.r8 2
-			IL_004c: rem
-			IL_004d: stloc.s 4
-			IL_004f: ldloc.s 4
-			IL_0051: ldc.r8 0.0
-			IL_005a: ceq
-			IL_005c: brfalse IL_0066
+			IL_0023: newobj instance void Modules.ControlFlow_ForLoop_Continue_SkipEven/Scope_For_L3C5/Block_L3C29::.ctor()
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: stloc.3
+			IL_002b: ldloc.3
+			IL_002c: ldc.r8 2
+			IL_0035: rem
+			IL_0036: stloc.3
+			IL_0037: ldloc.3
+			IL_0038: ldc.r8 0.0
+			IL_0041: ceq
+			IL_0043: brfalse IL_004d
 
-			IL_0061: br IL_0089
+			IL_0048: br IL_0079
 
-			IL_0066: ldstr "console"
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0070: stloc.s 5
-			IL_0072: ldloc.s 5
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0079: stloc.s 5
-			IL_007b: ldloc.s 5
-			IL_007d: ldstr "log"
-			IL_0082: ldloc.1
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0088: pop
+			IL_004d: ldstr "console"
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0057: stloc.s 4
+			IL_0059: ldloc.s 4
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0060: stloc.s 4
+			IL_0062: ldloc.1
+			IL_0063: box [System.Runtime]System.Double
+			IL_0068: stloc.s 5
+			IL_006a: ldloc.s 4
+			IL_006c: ldstr "log"
+			IL_0071: ldloc.s 5
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0078: pop
 
-			IL_0089: ldloc.1
-			IL_008a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_008f: stloc.s 4
-			IL_0091: ldloc.s 4
-			IL_0093: ldc.r8 1
-			IL_009c: add
-			IL_009d: stloc.s 4
-			IL_009f: ldloc.s 4
-			IL_00a1: box [System.Runtime]System.Double
-			IL_00a6: stloc.3
-			IL_00a7: ldloc.3
-			IL_00a8: stloc.1
-			IL_00a9: br IL_0015
+			IL_0079: ldloc.1
+			IL_007a: ldc.r8 1
+			IL_0083: add
+			IL_0084: stloc.1
+			IL_0085: br IL_0010
 		// end loop
 
-		IL_00ae: ret
+		IL_008a: ret
 	} // end of method ControlFlow_ForLoop_Continue_SkipEven::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_Continue_SkipEven
@@ -166,7 +154,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2126
+		// Method begins at RVA 0x2102
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_CountDownFromFive.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_CountDownFromFive.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20dc
+			// Method begins at RVA 0x20c3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20ee
+				// Method begins at RVA 0x20d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20e5
+			// Method begins at RVA 0x20cc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,62 +82,53 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 128 (0x80)
+		// Code size: 103 (0x67)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_CountDownFromFive/Scope,
-			[1] object,
+			[1] float64,
 			[2] class Modules.ControlFlow_ForLoop_CountDownFromFive/Scope_For_L3C5/Block_L3C28,
-			[3] object,
-			[4] float64,
+			[3] float64,
+			[4] object,
 			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_CountDownFromFive/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldc.r8 5
-		IL_000f: box [System.Runtime]System.Double
-		IL_0014: stloc.1
-		// loop start (head: IL_0015)
-			IL_0015: ldloc.1
-			IL_0016: stloc.3
-			IL_0017: ldloc.3
-			IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001d: stloc.s 4
-			IL_001f: ldloc.s 4
-			IL_0021: ldc.r8 0.0
-			IL_002a: cgt
-			IL_002c: brfalse IL_007f
+		IL_000f: stloc.1
+		// loop start (head: IL_0010)
+			IL_0010: ldloc.1
+			IL_0011: stloc.3
+			IL_0012: ldloc.3
+			IL_0013: ldc.r8 0.0
+			IL_001c: cgt
+			IL_001e: brfalse IL_0066
 
-			IL_0031: newobj instance void Modules.ControlFlow_ForLoop_CountDownFromFive/Scope_For_L3C5/Block_L3C28::.ctor()
-			IL_0036: stloc.2
-			IL_0037: ldstr "console"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0041: stloc.s 5
-			IL_0043: ldloc.s 5
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004a: stloc.s 5
-			IL_004c: ldloc.s 5
-			IL_004e: ldstr "log"
-			IL_0053: ldloc.1
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0059: pop
-			IL_005a: ldloc.1
-			IL_005b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0060: stloc.s 4
-			IL_0062: ldloc.s 4
-			IL_0064: ldc.r8 1
-			IL_006d: sub
-			IL_006e: stloc.s 4
-			IL_0070: ldloc.s 4
-			IL_0072: box [System.Runtime]System.Double
-			IL_0077: stloc.3
-			IL_0078: ldloc.3
-			IL_0079: stloc.1
-			IL_007a: br IL_0015
+			IL_0023: newobj instance void Modules.ControlFlow_ForLoop_CountDownFromFive/Scope_For_L3C5/Block_L3C28::.ctor()
+			IL_0028: stloc.2
+			IL_0029: ldstr "console"
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0033: stloc.s 4
+			IL_0035: ldloc.s 4
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003c: stloc.s 4
+			IL_003e: ldloc.1
+			IL_003f: box [System.Runtime]System.Double
+			IL_0044: stloc.s 5
+			IL_0046: ldloc.s 4
+			IL_0048: ldstr "log"
+			IL_004d: ldloc.s 5
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0054: pop
+			IL_0055: ldloc.1
+			IL_0056: ldc.r8 1
+			IL_005f: sub
+			IL_0060: stloc.1
+			IL_0061: br IL_0010
 		// end loop
 
-		IL_007f: ret
+		IL_0066: ret
 	} // end of method ControlFlow_ForLoop_CountDownFromFive::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_CountDownFromFive
@@ -149,7 +140,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f7
+		// Method begins at RVA 0x20de
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_CountToFive.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_CountToFive.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20fc
+			// Method begins at RVA 0x20d1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x210e
+				// Method begins at RVA 0x20e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2105
+			// Method begins at RVA 0x20da
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,74 +82,59 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 160 (0xa0)
+		// Code size: 117 (0x75)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_CountToFive/Scope,
-			[1] object,
+			[1] float64,
 			[2] class Modules.ControlFlow_ForLoop_CountToFive/Scope_For_L3C5/Block_L3C28,
-			[3] object,
-			[4] float64,
+			[3] float64,
+			[4] object,
 			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_CountToFive/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldc.r8 0.0
-		IL_000f: box [System.Runtime]System.Double
-		IL_0014: stloc.1
-		// loop start (head: IL_0015)
-			IL_0015: ldloc.1
-			IL_0016: stloc.3
-			IL_0017: ldloc.3
-			IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001d: stloc.s 4
-			IL_001f: ldloc.s 4
-			IL_0021: ldc.r8 5
-			IL_002a: clt
-			IL_002c: brfalse IL_009f
+		IL_000f: stloc.1
+		// loop start (head: IL_0010)
+			IL_0010: ldloc.1
+			IL_0011: stloc.3
+			IL_0012: ldloc.3
+			IL_0013: ldc.r8 5
+			IL_001c: clt
+			IL_001e: brfalse IL_0074
 
-			IL_0031: newobj instance void Modules.ControlFlow_ForLoop_CountToFive/Scope_For_L3C5/Block_L3C28::.ctor()
-			IL_0036: stloc.2
-			IL_0037: ldstr "console"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0041: stloc.s 5
-			IL_0043: ldloc.s 5
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004a: stloc.s 5
-			IL_004c: ldloc.1
-			IL_004d: stloc.3
-			IL_004e: ldloc.3
-			IL_004f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0054: stloc.s 4
-			IL_0056: ldloc.s 4
-			IL_0058: ldc.r8 1
-			IL_0061: add
-			IL_0062: stloc.s 4
-			IL_0064: ldloc.s 4
-			IL_0066: box [System.Runtime]System.Double
-			IL_006b: stloc.3
-			IL_006c: ldloc.s 5
-			IL_006e: ldstr "log"
-			IL_0073: ldloc.3
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0079: pop
-			IL_007a: ldloc.1
-			IL_007b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0080: stloc.s 4
-			IL_0082: ldloc.s 4
-			IL_0084: ldc.r8 1
-			IL_008d: add
-			IL_008e: stloc.s 4
-			IL_0090: ldloc.s 4
-			IL_0092: box [System.Runtime]System.Double
-			IL_0097: stloc.3
-			IL_0098: ldloc.3
-			IL_0099: stloc.1
-			IL_009a: br IL_0015
+			IL_0023: newobj instance void Modules.ControlFlow_ForLoop_CountToFive/Scope_For_L3C5/Block_L3C28::.ctor()
+			IL_0028: stloc.2
+			IL_0029: ldstr "console"
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0033: stloc.s 4
+			IL_0035: ldloc.s 4
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003c: stloc.s 4
+			IL_003e: ldloc.1
+			IL_003f: stloc.3
+			IL_0040: ldloc.3
+			IL_0041: ldc.r8 1
+			IL_004a: add
+			IL_004b: stloc.3
+			IL_004c: ldloc.3
+			IL_004d: box [System.Runtime]System.Double
+			IL_0052: stloc.s 5
+			IL_0054: ldloc.s 4
+			IL_0056: ldstr "log"
+			IL_005b: ldloc.s 5
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0062: pop
+			IL_0063: ldloc.1
+			IL_0064: ldc.r8 1
+			IL_006d: add
+			IL_006e: stloc.1
+			IL_006f: br IL_0010
 		// end loop
 
-		IL_009f: ret
+		IL_0074: ret
 	} // end of method ControlFlow_ForLoop_CountToFive::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_CountToFive
@@ -161,7 +146,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2117
+		// Method begins at RVA 0x20ec
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_GreaterThanOrEqual.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_GreaterThanOrEqual.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20df
+			// Method begins at RVA 0x20c6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20f1
+				// Method begins at RVA 0x20d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20e8
+			// Method begins at RVA 0x20cf
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,64 +82,55 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 131 (0x83)
+		// Code size: 106 (0x6a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_GreaterThanOrEqual/Scope,
-			[1] object,
+			[1] float64,
 			[2] class Modules.ControlFlow_ForLoop_GreaterThanOrEqual/Scope_For_L3C5/Block_L3C29,
-			[3] object,
-			[4] float64,
+			[3] float64,
+			[4] object,
 			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_GreaterThanOrEqual/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldc.r8 0.0
-		IL_000f: box [System.Runtime]System.Double
-		IL_0014: stloc.1
-		// loop start (head: IL_0015)
-			IL_0015: ldloc.1
-			IL_0016: stloc.3
-			IL_0017: ldloc.3
-			IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001d: stloc.s 4
-			IL_001f: ldloc.s 4
-			IL_0021: ldc.r8 5
-			IL_002a: cgt
-			IL_002c: ldc.i4.0
-			IL_002d: ceq
-			IL_002f: brfalse IL_0082
+		IL_000f: stloc.1
+		// loop start (head: IL_0010)
+			IL_0010: ldloc.1
+			IL_0011: stloc.3
+			IL_0012: ldloc.3
+			IL_0013: ldc.r8 5
+			IL_001c: cgt
+			IL_001e: ldc.i4.0
+			IL_001f: ceq
+			IL_0021: brfalse IL_0069
 
-			IL_0034: newobj instance void Modules.ControlFlow_ForLoop_GreaterThanOrEqual/Scope_For_L3C5/Block_L3C29::.ctor()
-			IL_0039: stloc.2
-			IL_003a: ldstr "console"
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0044: stloc.s 5
-			IL_0046: ldloc.s 5
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004d: stloc.s 5
-			IL_004f: ldloc.s 5
-			IL_0051: ldstr "log"
-			IL_0056: ldloc.1
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005c: pop
-			IL_005d: ldloc.1
-			IL_005e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0063: stloc.s 4
-			IL_0065: ldloc.s 4
-			IL_0067: ldc.r8 1
-			IL_0070: add
-			IL_0071: stloc.s 4
-			IL_0073: ldloc.s 4
-			IL_0075: box [System.Runtime]System.Double
-			IL_007a: stloc.3
-			IL_007b: ldloc.3
-			IL_007c: stloc.1
-			IL_007d: br IL_0015
+			IL_0026: newobj instance void Modules.ControlFlow_ForLoop_GreaterThanOrEqual/Scope_For_L3C5/Block_L3C29::.ctor()
+			IL_002b: stloc.2
+			IL_002c: ldstr "console"
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0036: stloc.s 4
+			IL_0038: ldloc.s 4
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003f: stloc.s 4
+			IL_0041: ldloc.1
+			IL_0042: box [System.Runtime]System.Double
+			IL_0047: stloc.s 5
+			IL_0049: ldloc.s 4
+			IL_004b: ldstr "log"
+			IL_0050: ldloc.s 5
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0057: pop
+			IL_0058: ldloc.1
+			IL_0059: ldc.r8 1
+			IL_0062: add
+			IL_0063: stloc.1
+			IL_0064: br IL_0010
 		// end loop
 
-		IL_0082: ret
+		IL_0069: ret
 	} // end of method ControlFlow_ForLoop_GreaterThanOrEqual::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_GreaterThanOrEqual
@@ -151,7 +142,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20fa
+		// Method begins at RVA 0x20e1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LabeledBreak.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LabeledBreak.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2168
+			// Method begins at RVA 0x211d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x217a
+				// Method begins at RVA 0x212f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2195
+						// Method begins at RVA 0x214a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -84,7 +84,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x218c
+					// Method begins at RVA 0x2141
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2183
+				// Method begins at RVA 0x2138
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -120,7 +120,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2171
+			// Method begins at RVA 0x2126
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -146,111 +146,86 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 268 (0x10c)
+		// Code size: 193 (0xc1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_LabeledBreak/Scope,
-			[1] object,
+			[1] float64,
 			[2] class Modules.ControlFlow_ForLoop_LabeledBreak/Scope_For_L3C12/Block_L3C35,
-			[3] object,
+			[3] float64,
 			[4] class Modules.ControlFlow_ForLoop_LabeledBreak/Scope_For_L3C12/Scope_For_L4C7/Block_L4C30,
 			[5] class Modules.ControlFlow_ForLoop_LabeledBreak/Scope_For_L3C12/Scope_For_L4C7/Block_L4C30/Block_L6C17,
-			[6] object,
-			[7] float64,
-			[8] object,
-			[9] bool
+			[6] float64,
+			[7] object,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_LabeledBreak/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldc.r8 0.0
-		IL_000f: box [System.Runtime]System.Double
-		IL_0014: stloc.1
-		// loop start (head: IL_0015)
-			IL_0015: ldloc.1
-			IL_0016: stloc.s 6
-			IL_0018: ldloc.s 6
-			IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001f: stloc.s 7
-			IL_0021: ldloc.s 7
-			IL_0023: ldc.r8 3
-			IL_002c: clt
-			IL_002e: brfalse IL_010b
+		IL_000f: stloc.1
+		// loop start (head: IL_0010)
+			IL_0010: ldloc.1
+			IL_0011: stloc.s 6
+			IL_0013: ldloc.s 6
+			IL_0015: ldc.r8 3
+			IL_001e: clt
+			IL_0020: brfalse IL_00c0
 
-			IL_0033: newobj instance void Modules.ControlFlow_ForLoop_LabeledBreak/Scope_For_L3C12/Block_L3C35::.ctor()
-			IL_0038: stloc.2
-			IL_0039: ldc.r8 0.0
-			IL_0042: box [System.Runtime]System.Double
-			IL_0047: stloc.3
-			// loop start (head: IL_0048)
-				IL_0048: ldloc.3
-				IL_0049: stloc.s 6
-				IL_004b: ldloc.s 6
-				IL_004d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0052: stloc.s 7
-				IL_0054: ldloc.s 7
-				IL_0056: ldc.r8 1
-				IL_005f: clt
-				IL_0061: brfalse IL_00e4
+			IL_0025: newobj instance void Modules.ControlFlow_ForLoop_LabeledBreak/Scope_For_L3C12/Block_L3C35::.ctor()
+			IL_002a: stloc.2
+			IL_002b: ldc.r8 0.0
+			IL_0034: stloc.3
+			// loop start (head: IL_0035)
+				IL_0035: ldloc.3
+				IL_0036: stloc.s 6
+				IL_0038: ldloc.s 6
+				IL_003a: ldc.r8 1
+				IL_0043: clt
+				IL_0045: brfalse IL_00af
 
-				IL_0066: newobj instance void Modules.ControlFlow_ForLoop_LabeledBreak/Scope_For_L3C12/Scope_For_L4C7/Block_L4C30::.ctor()
-				IL_006b: stloc.s 4
-				IL_006d: ldstr "console"
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0077: stloc.s 8
-				IL_0079: ldloc.s 8
-				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0080: stloc.s 8
-				IL_0082: ldloc.s 8
-				IL_0084: ldstr "log"
-				IL_0089: ldloc.1
-				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_008f: pop
-				IL_0090: ldloc.1
-				IL_0091: stloc.s 6
-				IL_0093: ldloc.s 6
-				IL_0095: ldc.r8 1
-				IL_009e: box [System.Runtime]System.Double
-				IL_00a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00a8: stloc.s 9
-				IL_00aa: ldloc.s 9
-				IL_00ac: brfalse IL_00bd
+				IL_004a: newobj instance void Modules.ControlFlow_ForLoop_LabeledBreak/Scope_For_L3C12/Scope_For_L4C7/Block_L4C30::.ctor()
+				IL_004f: stloc.s 4
+				IL_0051: ldstr "console"
+				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_005b: stloc.s 7
+				IL_005d: ldloc.s 7
+				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0064: stloc.s 7
+				IL_0066: ldloc.1
+				IL_0067: box [System.Runtime]System.Double
+				IL_006c: stloc.s 8
+				IL_006e: ldloc.s 7
+				IL_0070: ldstr "log"
+				IL_0075: ldloc.s 8
+				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_007c: pop
+				IL_007d: ldloc.1
+				IL_007e: stloc.s 6
+				IL_0080: ldloc.s 6
+				IL_0082: ldc.r8 1
+				IL_008b: ceq
+				IL_008d: brfalse IL_009e
 
-				IL_00b1: newobj instance void Modules.ControlFlow_ForLoop_LabeledBreak/Scope_For_L3C12/Scope_For_L4C7/Block_L4C30/Block_L6C17::.ctor()
-				IL_00b6: stloc.s 5
-				IL_00b8: br IL_010b
+				IL_0092: newobj instance void Modules.ControlFlow_ForLoop_LabeledBreak/Scope_For_L3C12/Scope_For_L4C7/Block_L4C30/Block_L6C17::.ctor()
+				IL_0097: stloc.s 5
+				IL_0099: br IL_00c0
 
-				IL_00bd: ldloc.3
-				IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00c3: stloc.s 7
-				IL_00c5: ldloc.s 7
-				IL_00c7: ldc.r8 1
-				IL_00d0: add
-				IL_00d1: stloc.s 7
-				IL_00d3: ldloc.s 7
-				IL_00d5: box [System.Runtime]System.Double
-				IL_00da: stloc.s 6
-				IL_00dc: ldloc.s 6
-				IL_00de: stloc.3
-				IL_00df: br IL_0048
+				IL_009e: ldloc.3
+				IL_009f: ldc.r8 1
+				IL_00a8: add
+				IL_00a9: stloc.3
+				IL_00aa: br IL_0035
 			// end loop
 
-			IL_00e4: ldloc.1
-			IL_00e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00ea: stloc.s 7
-			IL_00ec: ldloc.s 7
-			IL_00ee: ldc.r8 1
-			IL_00f7: add
-			IL_00f8: stloc.s 7
-			IL_00fa: ldloc.s 7
-			IL_00fc: box [System.Runtime]System.Double
-			IL_0101: stloc.s 6
-			IL_0103: ldloc.s 6
-			IL_0105: stloc.1
-			IL_0106: br IL_0015
+			IL_00af: ldloc.1
+			IL_00b0: ldc.r8 1
+			IL_00b9: add
+			IL_00ba: stloc.1
+			IL_00bb: br IL_0010
 		// end loop
 
-		IL_010b: ret
+		IL_00c0: ret
 	} // end of method ControlFlow_ForLoop_LabeledBreak::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_LabeledBreak
@@ -262,7 +237,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x219e
+		// Method begins at RVA 0x2153
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LabeledContinue.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LabeledContinue.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2168
+			// Method begins at RVA 0x211d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x217a
+				// Method begins at RVA 0x212f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2195
+						// Method begins at RVA 0x214a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -84,7 +84,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x218c
+					// Method begins at RVA 0x2141
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2183
+				// Method begins at RVA 0x2138
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -120,7 +120,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2171
+			// Method begins at RVA 0x2126
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -146,111 +146,86 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 268 (0x10c)
+		// Code size: 193 (0xc1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_LabeledContinue/Scope,
-			[1] object,
+			[1] float64,
 			[2] class Modules.ControlFlow_ForLoop_LabeledContinue/Scope_For_L3C12/Block_L3C35,
-			[3] object,
+			[3] float64,
 			[4] class Modules.ControlFlow_ForLoop_LabeledContinue/Scope_For_L3C12/Scope_For_L4C7/Block_L4C30,
 			[5] class Modules.ControlFlow_ForLoop_LabeledContinue/Scope_For_L3C12/Scope_For_L4C7/Block_L4C30/Block_L5C17,
-			[6] object,
-			[7] float64,
-			[8] bool,
-			[9] object
+			[6] float64,
+			[7] object,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_LabeledContinue/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldc.r8 0.0
-		IL_000f: box [System.Runtime]System.Double
-		IL_0014: stloc.1
-		// loop start (head: IL_0015)
-			IL_0015: ldloc.1
-			IL_0016: stloc.s 6
-			IL_0018: ldloc.s 6
-			IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001f: stloc.s 7
-			IL_0021: ldloc.s 7
-			IL_0023: ldc.r8 3
-			IL_002c: clt
-			IL_002e: brfalse IL_010b
+		IL_000f: stloc.1
+		// loop start (head: IL_0010)
+			IL_0010: ldloc.1
+			IL_0011: stloc.s 6
+			IL_0013: ldloc.s 6
+			IL_0015: ldc.r8 3
+			IL_001e: clt
+			IL_0020: brfalse IL_00c0
 
-			IL_0033: newobj instance void Modules.ControlFlow_ForLoop_LabeledContinue/Scope_For_L3C12/Block_L3C35::.ctor()
-			IL_0038: stloc.2
-			IL_0039: ldc.r8 0.0
-			IL_0042: box [System.Runtime]System.Double
-			IL_0047: stloc.3
-			// loop start (head: IL_0048)
-				IL_0048: ldloc.3
-				IL_0049: stloc.s 6
-				IL_004b: ldloc.s 6
-				IL_004d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0052: stloc.s 7
-				IL_0054: ldloc.s 7
+			IL_0025: newobj instance void Modules.ControlFlow_ForLoop_LabeledContinue/Scope_For_L3C12/Block_L3C35::.ctor()
+			IL_002a: stloc.2
+			IL_002b: ldc.r8 0.0
+			IL_0034: stloc.3
+			// loop start (head: IL_0035)
+				IL_0035: ldloc.3
+				IL_0036: stloc.s 6
+				IL_0038: ldloc.s 6
+				IL_003a: ldc.r8 1
+				IL_0043: clt
+				IL_0045: brfalse IL_00af
+
+				IL_004a: newobj instance void Modules.ControlFlow_ForLoop_LabeledContinue/Scope_For_L3C12/Scope_For_L4C7/Block_L4C30::.ctor()
+				IL_004f: stloc.s 4
+				IL_0051: ldloc.1
+				IL_0052: stloc.s 6
+				IL_0054: ldloc.s 6
 				IL_0056: ldc.r8 1
-				IL_005f: clt
-				IL_0061: brfalse IL_00e4
+				IL_005f: ceq
+				IL_0061: brfalse IL_0072
 
-				IL_0066: newobj instance void Modules.ControlFlow_ForLoop_LabeledContinue/Scope_For_L3C12/Scope_For_L4C7/Block_L4C30::.ctor()
-				IL_006b: stloc.s 4
-				IL_006d: ldloc.1
-				IL_006e: stloc.s 6
-				IL_0070: ldloc.s 6
-				IL_0072: ldc.r8 1
-				IL_007b: box [System.Runtime]System.Double
-				IL_0080: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0085: stloc.s 8
-				IL_0087: ldloc.s 8
-				IL_0089: brfalse IL_009a
+				IL_0066: newobj instance void Modules.ControlFlow_ForLoop_LabeledContinue/Scope_For_L3C12/Scope_For_L4C7/Block_L4C30/Block_L5C17::.ctor()
+				IL_006b: stloc.s 5
+				IL_006d: br IL_00af
 
-				IL_008e: newobj instance void Modules.ControlFlow_ForLoop_LabeledContinue/Scope_For_L3C12/Scope_For_L4C7/Block_L4C30/Block_L5C17::.ctor()
-				IL_0093: stloc.s 5
-				IL_0095: br IL_00e4
-
-				IL_009a: ldstr "console"
-				IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00a4: stloc.s 9
-				IL_00a6: ldloc.s 9
-				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ad: stloc.s 9
-				IL_00af: ldloc.s 9
-				IL_00b1: ldstr "log"
-				IL_00b6: ldloc.1
-				IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00bc: pop
-				IL_00bd: ldloc.3
-				IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00c3: stloc.s 7
-				IL_00c5: ldloc.s 7
-				IL_00c7: ldc.r8 1
-				IL_00d0: add
-				IL_00d1: stloc.s 7
-				IL_00d3: ldloc.s 7
-				IL_00d5: box [System.Runtime]System.Double
-				IL_00da: stloc.s 6
-				IL_00dc: ldloc.s 6
-				IL_00de: stloc.3
-				IL_00df: br IL_0048
+				IL_0072: ldstr "console"
+				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_007c: stloc.s 7
+				IL_007e: ldloc.s 7
+				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0085: stloc.s 7
+				IL_0087: ldloc.1
+				IL_0088: box [System.Runtime]System.Double
+				IL_008d: stloc.s 8
+				IL_008f: ldloc.s 7
+				IL_0091: ldstr "log"
+				IL_0096: ldloc.s 8
+				IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_009d: pop
+				IL_009e: ldloc.3
+				IL_009f: ldc.r8 1
+				IL_00a8: add
+				IL_00a9: stloc.3
+				IL_00aa: br IL_0035
 			// end loop
 
-			IL_00e4: ldloc.1
-			IL_00e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00ea: stloc.s 7
-			IL_00ec: ldloc.s 7
-			IL_00ee: ldc.r8 1
-			IL_00f7: add
-			IL_00f8: stloc.s 7
-			IL_00fa: ldloc.s 7
-			IL_00fc: box [System.Runtime]System.Double
-			IL_0101: stloc.s 6
-			IL_0103: ldloc.s 6
-			IL_0105: stloc.1
-			IL_0106: br IL_0015
+			IL_00af: ldloc.1
+			IL_00b0: ldc.r8 1
+			IL_00b9: add
+			IL_00ba: stloc.1
+			IL_00bb: br IL_0010
 		// end loop
 
-		IL_010b: ret
+		IL_00c0: ret
 	} // end of method ControlFlow_ForLoop_LabeledContinue::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_LabeledContinue
@@ -262,7 +237,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x219e
+		// Method begins at RVA 0x2153
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LessThanOrEqual.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForLoop_LessThanOrEqual.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20df
+			// Method begins at RVA 0x20c6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20f1
+				// Method begins at RVA 0x20d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20e8
+			// Method begins at RVA 0x20cf
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,64 +82,55 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 131 (0x83)
+		// Code size: 106 (0x6a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForLoop_LessThanOrEqual/Scope,
-			[1] object,
+			[1] float64,
 			[2] class Modules.ControlFlow_ForLoop_LessThanOrEqual/Scope_For_L3C5/Block_L3C29,
-			[3] object,
-			[4] float64,
+			[3] float64,
+			[4] object,
 			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForLoop_LessThanOrEqual/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldc.r8 0.0
-		IL_000f: box [System.Runtime]System.Double
-		IL_0014: stloc.1
-		// loop start (head: IL_0015)
-			IL_0015: ldloc.1
-			IL_0016: stloc.3
-			IL_0017: ldloc.3
-			IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001d: stloc.s 4
-			IL_001f: ldloc.s 4
-			IL_0021: ldc.r8 5
-			IL_002a: cgt
-			IL_002c: ldc.i4.0
-			IL_002d: ceq
-			IL_002f: brfalse IL_0082
+		IL_000f: stloc.1
+		// loop start (head: IL_0010)
+			IL_0010: ldloc.1
+			IL_0011: stloc.3
+			IL_0012: ldloc.3
+			IL_0013: ldc.r8 5
+			IL_001c: cgt
+			IL_001e: ldc.i4.0
+			IL_001f: ceq
+			IL_0021: brfalse IL_0069
 
-			IL_0034: newobj instance void Modules.ControlFlow_ForLoop_LessThanOrEqual/Scope_For_L3C5/Block_L3C29::.ctor()
-			IL_0039: stloc.2
-			IL_003a: ldstr "console"
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0044: stloc.s 5
-			IL_0046: ldloc.s 5
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004d: stloc.s 5
-			IL_004f: ldloc.s 5
-			IL_0051: ldstr "log"
-			IL_0056: ldloc.1
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_005c: pop
-			IL_005d: ldloc.1
-			IL_005e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0063: stloc.s 4
-			IL_0065: ldloc.s 4
-			IL_0067: ldc.r8 1
-			IL_0070: add
-			IL_0071: stloc.s 4
-			IL_0073: ldloc.s 4
-			IL_0075: box [System.Runtime]System.Double
-			IL_007a: stloc.3
-			IL_007b: ldloc.3
-			IL_007c: stloc.1
-			IL_007d: br IL_0015
+			IL_0026: newobj instance void Modules.ControlFlow_ForLoop_LessThanOrEqual/Scope_For_L3C5/Block_L3C29::.ctor()
+			IL_002b: stloc.2
+			IL_002c: ldstr "console"
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0036: stloc.s 4
+			IL_0038: ldloc.s 4
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003f: stloc.s 4
+			IL_0041: ldloc.1
+			IL_0042: box [System.Runtime]System.Double
+			IL_0047: stloc.s 5
+			IL_0049: ldloc.s 4
+			IL_004b: ldstr "log"
+			IL_0050: ldloc.s 5
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0057: pop
+			IL_0058: ldloc.1
+			IL_0059: ldc.r8 1
+			IL_0062: add
+			IL_0063: stloc.1
+			IL_0064: br IL_0010
 		// end loop
 
-		IL_0082: ret
+		IL_0069: ret
 	} // end of method ControlFlow_ForLoop_LessThanOrEqual::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForLoop_LessThanOrEqual
@@ -151,7 +142,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20fa
+		// Method begins at RVA 0x20e1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_LabeledBreak.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_LabeledBreak.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x2188
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21be
+				// Method begins at RVA 0x219a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21d9
+						// Method begins at RVA 0x21b5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -84,7 +84,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d0
+					// Method begins at RVA 0x21ac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c7
+				// Method begins at RVA 0x21a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -120,7 +120,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b5
+			// Method begins at RVA 0x2191
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -146,7 +146,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 317 (0x13d)
+		// Code size: 281 (0x119)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForOf_LabeledBreak/Scope,
@@ -156,13 +156,12 @@
 			[4] bool,
 			[5] object,
 			[6] class Modules.ControlFlow_ForOf_LabeledBreak/Scope_ForOf_L5C12/Block_L5C28,
-			[7] object,
+			[7] float64,
 			[8] class Modules.ControlFlow_ForOf_LabeledBreak/Scope_ForOf_L5C12/Scope_For_L6C7/Block_L6C30,
 			[9] class Modules.ControlFlow_ForOf_LabeledBreak/Scope_ForOf_L5C12/Scope_For_L6C7/Block_L6C30/Block_L8C19,
 			[10] object,
 			[11] bool,
-			[12] object,
-			[13] float64
+			[12] float64
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForOf_LabeledBreak/Scope::.ctor()
@@ -196,7 +195,7 @@
 				IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 				IL_0049: stloc.s 11
 				IL_004b: ldloc.s 11
-				IL_004d: brtrue IL_0121
+				IL_004d: brtrue IL_00fd
 
 				IL_0052: ldloc.s 10
 				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -206,88 +205,76 @@
 				IL_005f: newobj instance void Modules.ControlFlow_ForOf_LabeledBreak/Scope_ForOf_L5C12/Block_L5C28::.ctor()
 				IL_0064: stloc.s 6
 				IL_0066: ldc.r8 0.0
-				IL_006f: box [System.Runtime]System.Double
-				IL_0074: stloc.s 7
-				// loop start (head: IL_0076)
-					IL_0076: ldloc.s 7
-					IL_0078: stloc.s 12
-					IL_007a: ldloc.s 12
-					IL_007c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0081: stloc.s 13
-					IL_0083: ldloc.s 13
-					IL_0085: ldc.r8 1
-					IL_008e: clt
-					IL_0090: brfalse IL_010e
+				IL_006f: stloc.s 7
+				// loop start (head: IL_0071)
+					IL_0071: ldloc.s 7
+					IL_0073: stloc.s 12
+					IL_0075: ldloc.s 12
+					IL_0077: ldc.r8 1
+					IL_0080: clt
+					IL_0082: brfalse IL_00ea
 
-					IL_0095: newobj instance void Modules.ControlFlow_ForOf_LabeledBreak/Scope_ForOf_L5C12/Scope_For_L6C7/Block_L6C30::.ctor()
-					IL_009a: stloc.s 8
-					IL_009c: ldstr "console"
-					IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_00a6: stloc.s 10
-					IL_00a8: ldloc.s 10
-					IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_00af: stloc.s 10
-					IL_00b1: ldloc.s 10
-					IL_00b3: ldstr "log"
-					IL_00b8: ldloc.s 5
-					IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00bf: pop
-					IL_00c0: ldloc.s 5
-					IL_00c2: stloc.s 10
-					IL_00c4: ldloc.s 10
-					IL_00c6: ldstr "b"
-					IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-					IL_00d0: stloc.s 11
-					IL_00d2: ldloc.s 11
-					IL_00d4: brfalse IL_00e5
+					IL_0087: newobj instance void Modules.ControlFlow_ForOf_LabeledBreak/Scope_ForOf_L5C12/Scope_For_L6C7/Block_L6C30::.ctor()
+					IL_008c: stloc.s 8
+					IL_008e: ldstr "console"
+					IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+					IL_0098: stloc.s 10
+					IL_009a: ldloc.s 10
+					IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_00a1: stloc.s 10
+					IL_00a3: ldloc.s 10
+					IL_00a5: ldstr "log"
+					IL_00aa: ldloc.s 5
+					IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_00b1: pop
+					IL_00b2: ldloc.s 5
+					IL_00b4: stloc.s 10
+					IL_00b6: ldloc.s 10
+					IL_00b8: ldstr "b"
+					IL_00bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+					IL_00c2: stloc.s 11
+					IL_00c4: ldloc.s 11
+					IL_00c6: brfalse IL_00d7
 
-					IL_00d9: newobj instance void Modules.ControlFlow_ForOf_LabeledBreak/Scope_ForOf_L5C12/Scope_For_L6C7/Block_L6C30/Block_L8C19::.ctor()
-					IL_00de: stloc.s 9
-					IL_00e0: br IL_0113
+					IL_00cb: newobj instance void Modules.ControlFlow_ForOf_LabeledBreak/Scope_ForOf_L5C12/Scope_For_L6C7/Block_L6C30/Block_L8C19::.ctor()
+					IL_00d0: stloc.s 9
+					IL_00d2: br IL_00ef
 
-					IL_00e5: ldloc.s 7
-					IL_00e7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_00ec: stloc.s 13
-					IL_00ee: ldloc.s 13
-					IL_00f0: ldc.r8 1
-					IL_00f9: add
-					IL_00fa: stloc.s 13
-					IL_00fc: ldloc.s 13
-					IL_00fe: box [System.Runtime]System.Double
-					IL_0103: stloc.s 12
-					IL_0105: ldloc.s 12
-					IL_0107: stloc.s 7
-					IL_0109: br IL_0076
+					IL_00d7: ldloc.s 7
+					IL_00d9: ldc.r8 1
+					IL_00e2: add
+					IL_00e3: stloc.s 7
+					IL_00e5: br IL_0071
 				// end loop
 
-				IL_010e: br IL_003a
+				IL_00ea: br IL_003a
 			// end loop
 
-			IL_0113: ldloc.2
-			IL_0114: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-			IL_0119: ldc.i4.1
-			IL_011a: stloc.s 4
-			IL_011c: leave IL_013c
+			IL_00ef: ldloc.2
+			IL_00f0: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+			IL_00f5: ldc.i4.1
+			IL_00f6: stloc.s 4
+			IL_00f8: leave IL_0118
 
-			IL_0121: ldc.i4.1
-			IL_0122: stloc.3
-			IL_0123: leave IL_013c
+			IL_00fd: ldc.i4.1
+			IL_00fe: stloc.3
+			IL_00ff: leave IL_0118
 		} // end .try
 		finally
 		{
-			IL_0128: ldloc.3
-			IL_0129: brtrue IL_013b
+			IL_0104: ldloc.3
+			IL_0105: brtrue IL_0117
 
-			IL_012e: ldloc.s 4
-			IL_0130: brtrue IL_013b
+			IL_010a: ldloc.s 4
+			IL_010c: brtrue IL_0117
 
-			IL_0135: ldloc.2
-			IL_0136: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+			IL_0111: ldloc.2
+			IL_0112: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-			IL_013b: endfinally
+			IL_0117: endfinally
 		} // end handler
 
-		IL_013c: ret
+		IL_0118: ret
 	} // end of method ControlFlow_ForOf_LabeledBreak::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_LabeledBreak
@@ -299,7 +286,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e2
+		// Method begins at RVA 0x21be
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_LabeledContinue.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_LabeledContinue.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x2188
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21be
+				// Method begins at RVA 0x219a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21d9
+						// Method begins at RVA 0x21b5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -84,7 +84,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d0
+					// Method begins at RVA 0x21ac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c7
+				// Method begins at RVA 0x21a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -120,7 +120,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b5
+			// Method begins at RVA 0x2191
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -146,7 +146,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 317 (0x13d)
+		// Code size: 281 (0x119)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForOf_LabeledContinue/Scope,
@@ -156,13 +156,12 @@
 			[4] bool,
 			[5] object,
 			[6] class Modules.ControlFlow_ForOf_LabeledContinue/Scope_ForOf_L5C12/Block_L5C28,
-			[7] object,
+			[7] float64,
 			[8] class Modules.ControlFlow_ForOf_LabeledContinue/Scope_ForOf_L5C12/Scope_For_L6C7/Block_L6C30,
 			[9] class Modules.ControlFlow_ForOf_LabeledContinue/Scope_ForOf_L5C12/Scope_For_L6C7/Block_L6C30/Block_L7C19,
 			[10] object,
 			[11] bool,
-			[12] object,
-			[13] float64
+			[12] float64
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForOf_LabeledContinue/Scope::.ctor()
@@ -196,7 +195,7 @@
 				IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 				IL_0049: stloc.s 11
 				IL_004b: ldloc.s 11
-				IL_004d: brtrue IL_0121
+				IL_004d: brtrue IL_00fd
 
 				IL_0052: ldloc.s 10
 				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -206,87 +205,75 @@
 				IL_005f: newobj instance void Modules.ControlFlow_ForOf_LabeledContinue/Scope_ForOf_L5C12/Block_L5C28::.ctor()
 				IL_0064: stloc.s 6
 				IL_0066: ldc.r8 0.0
-				IL_006f: box [System.Runtime]System.Double
-				IL_0074: stloc.s 7
-				// loop start (head: IL_0076)
-					IL_0076: ldloc.s 7
-					IL_0078: stloc.s 12
-					IL_007a: ldloc.s 12
-					IL_007c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0081: stloc.s 13
-					IL_0083: ldloc.s 13
-					IL_0085: ldc.r8 1
-					IL_008e: clt
-					IL_0090: brfalse IL_010e
+				IL_006f: stloc.s 7
+				// loop start (head: IL_0071)
+					IL_0071: ldloc.s 7
+					IL_0073: stloc.s 12
+					IL_0075: ldloc.s 12
+					IL_0077: ldc.r8 1
+					IL_0080: clt
+					IL_0082: brfalse IL_00ea
 
-					IL_0095: newobj instance void Modules.ControlFlow_ForOf_LabeledContinue/Scope_ForOf_L5C12/Scope_For_L6C7/Block_L6C30::.ctor()
-					IL_009a: stloc.s 8
-					IL_009c: ldloc.s 5
-					IL_009e: stloc.s 10
-					IL_00a0: ldloc.s 10
-					IL_00a2: ldstr "b"
-					IL_00a7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-					IL_00ac: stloc.s 11
-					IL_00ae: ldloc.s 11
-					IL_00b0: brfalse IL_00c1
+					IL_0087: newobj instance void Modules.ControlFlow_ForOf_LabeledContinue/Scope_ForOf_L5C12/Scope_For_L6C7/Block_L6C30::.ctor()
+					IL_008c: stloc.s 8
+					IL_008e: ldloc.s 5
+					IL_0090: stloc.s 10
+					IL_0092: ldloc.s 10
+					IL_0094: ldstr "b"
+					IL_0099: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+					IL_009e: stloc.s 11
+					IL_00a0: ldloc.s 11
+					IL_00a2: brfalse IL_00b3
 
-					IL_00b5: newobj instance void Modules.ControlFlow_ForOf_LabeledContinue/Scope_ForOf_L5C12/Scope_For_L6C7/Block_L6C30/Block_L7C19::.ctor()
-					IL_00ba: stloc.s 9
-					IL_00bc: br IL_010e
+					IL_00a7: newobj instance void Modules.ControlFlow_ForOf_LabeledContinue/Scope_ForOf_L5C12/Scope_For_L6C7/Block_L6C30/Block_L7C19::.ctor()
+					IL_00ac: stloc.s 9
+					IL_00ae: br IL_00ea
 
-					IL_00c1: ldstr "console"
-					IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_00cb: stloc.s 10
-					IL_00cd: ldloc.s 10
-					IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_00d4: stloc.s 10
-					IL_00d6: ldloc.s 10
-					IL_00d8: ldstr "log"
-					IL_00dd: ldloc.s 5
-					IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00e4: pop
-					IL_00e5: ldloc.s 7
-					IL_00e7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_00ec: stloc.s 13
-					IL_00ee: ldloc.s 13
-					IL_00f0: ldc.r8 1
-					IL_00f9: add
-					IL_00fa: stloc.s 13
-					IL_00fc: ldloc.s 13
-					IL_00fe: box [System.Runtime]System.Double
-					IL_0103: stloc.s 12
-					IL_0105: ldloc.s 12
-					IL_0107: stloc.s 7
-					IL_0109: br IL_0076
+					IL_00b3: ldstr "console"
+					IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+					IL_00bd: stloc.s 10
+					IL_00bf: ldloc.s 10
+					IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_00c6: stloc.s 10
+					IL_00c8: ldloc.s 10
+					IL_00ca: ldstr "log"
+					IL_00cf: ldloc.s 5
+					IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_00d6: pop
+					IL_00d7: ldloc.s 7
+					IL_00d9: ldc.r8 1
+					IL_00e2: add
+					IL_00e3: stloc.s 7
+					IL_00e5: br IL_0071
 				// end loop
 
-				IL_010e: br IL_003a
+				IL_00ea: br IL_003a
 			// end loop
-			IL_0113: ldloc.2
-			IL_0114: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-			IL_0119: ldc.i4.1
-			IL_011a: stloc.s 4
-			IL_011c: leave IL_013c
+			IL_00ef: ldloc.2
+			IL_00f0: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+			IL_00f5: ldc.i4.1
+			IL_00f6: stloc.s 4
+			IL_00f8: leave IL_0118
 
-			IL_0121: ldc.i4.1
-			IL_0122: stloc.3
-			IL_0123: leave IL_013c
+			IL_00fd: ldc.i4.1
+			IL_00fe: stloc.3
+			IL_00ff: leave IL_0118
 		} // end .try
 		finally
 		{
-			IL_0128: ldloc.3
-			IL_0129: brtrue IL_013b
+			IL_0104: ldloc.3
+			IL_0105: brtrue IL_0117
 
-			IL_012e: ldloc.s 4
-			IL_0130: brtrue IL_013b
+			IL_010a: ldloc.s 4
+			IL_010c: brtrue IL_0117
 
-			IL_0135: ldloc.2
-			IL_0136: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+			IL_0111: ldloc.2
+			IL_0112: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-			IL_013b: endfinally
+			IL_0117: endfinally
 		} // end handler
 
-		IL_013c: ret
+		IL_0118: ret
 	} // end of method ControlFlow_ForOf_LabeledContinue::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_LabeledContinue
@@ -298,7 +285,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e2
+		// Method begins at RVA 0x21be
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_If_Truthiness.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_If_Truthiness.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ef
+			// Method begins at RVA 0x21c7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x220a
+					// Method begins at RVA 0x21e2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2213
+					// Method begins at RVA 0x21eb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2201
+				// Method begins at RVA 0x21d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21f8
+			// Method begins at RVA 0x21d0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -124,23 +124,21 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 403 (0x193)
+		// Code size: 363 (0x16b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_If_Truthiness/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[2] object,
+			[2] float64,
 			[3] class Modules.ControlFlow_If_Truthiness/Scope_For_L4C5/Block_L4C40,
 			[4] class Modules.ControlFlow_If_Truthiness/Scope_For_L4C5/Block_L4C40/Block_L5C17,
 			[5] class Modules.ControlFlow_If_Truthiness/Scope_For_L4C5/Block_L4C40/Block_L7C9,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[9] object,
-			[10] float64,
-			[11] float64,
-			[12] bool,
-			[13] object
+			[9] float64,
+			[10] bool,
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_If_Truthiness/Scope::.ctor()
@@ -198,77 +196,63 @@
 		IL_00bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 		IL_00c0: stloc.1
 		IL_00c1: ldc.r8 0.0
-		IL_00ca: box [System.Runtime]System.Double
-		IL_00cf: stloc.2
-		// loop start (head: IL_00d0)
-			IL_00d0: ldloc.2
-			IL_00d1: stloc.s 9
-			IL_00d3: ldloc.1
-			IL_00d4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_00d9: stloc.s 10
-			IL_00db: ldloc.s 9
-			IL_00dd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00e2: stloc.s 11
-			IL_00e4: ldloc.s 11
-			IL_00e6: ldloc.s 10
-			IL_00e8: clt
-			IL_00ea: brfalse IL_0192
+		IL_00ca: stloc.2
+		// loop start (head: IL_00cb)
+			IL_00cb: ldloc.2
+			IL_00cc: stloc.s 9
+			IL_00ce: ldloc.s 9
+			IL_00d0: ldloc.1
+			IL_00d1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_00d6: clt
+			IL_00d8: brfalse IL_016a
 
-			IL_00ef: newobj instance void Modules.ControlFlow_If_Truthiness/Scope_For_L4C5/Block_L4C40::.ctor()
-			IL_00f4: stloc.3
-			IL_00f5: ldloc.1
-			IL_00f6: ldloc.2
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_00fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0101: stloc.s 12
-			IL_0103: ldloc.s 12
-			IL_0105: brfalse IL_013d
+			IL_00dd: newobj instance void Modules.ControlFlow_If_Truthiness/Scope_For_L4C5/Block_L4C40::.ctor()
+			IL_00e2: stloc.3
+			IL_00e3: ldloc.1
+			IL_00e4: ldloc.2
+			IL_00e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_00ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00ef: stloc.s 10
+			IL_00f1: ldloc.s 10
+			IL_00f3: brfalse IL_012b
 
-			IL_010a: newobj instance void Modules.ControlFlow_If_Truthiness/Scope_For_L4C5/Block_L4C40/Block_L5C17::.ctor()
-			IL_010f: stloc.s 4
-			IL_0111: ldstr "console"
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_011b: stloc.s 13
-			IL_011d: ldloc.s 13
-			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0124: stloc.s 13
-			IL_0126: ldloc.s 13
-			IL_0128: ldstr "log"
-			IL_012d: ldstr "T"
-			IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0137: pop
-			IL_0138: br IL_016b
+			IL_00f8: newobj instance void Modules.ControlFlow_If_Truthiness/Scope_For_L4C5/Block_L4C40/Block_L5C17::.ctor()
+			IL_00fd: stloc.s 4
+			IL_00ff: ldstr "console"
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0109: stloc.s 11
+			IL_010b: ldloc.s 11
+			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0112: stloc.s 11
+			IL_0114: ldloc.s 11
+			IL_0116: ldstr "log"
+			IL_011b: ldstr "T"
+			IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0125: pop
+			IL_0126: br IL_0159
 
-			IL_013d: newobj instance void Modules.ControlFlow_If_Truthiness/Scope_For_L4C5/Block_L4C40/Block_L7C9::.ctor()
-			IL_0142: stloc.s 5
-			IL_0144: ldstr "console"
-			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_014e: stloc.s 13
-			IL_0150: ldloc.s 13
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0157: stloc.s 13
-			IL_0159: ldloc.s 13
-			IL_015b: ldstr "log"
-			IL_0160: ldstr "F"
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_016a: pop
+			IL_012b: newobj instance void Modules.ControlFlow_If_Truthiness/Scope_For_L4C5/Block_L4C40/Block_L7C9::.ctor()
+			IL_0130: stloc.s 5
+			IL_0132: ldstr "console"
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_013c: stloc.s 11
+			IL_013e: ldloc.s 11
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0145: stloc.s 11
+			IL_0147: ldloc.s 11
+			IL_0149: ldstr "log"
+			IL_014e: ldstr "F"
+			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0158: pop
 
-			IL_016b: ldloc.2
-			IL_016c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0171: stloc.s 10
-			IL_0173: ldloc.s 10
-			IL_0175: ldc.r8 1
-			IL_017e: add
-			IL_017f: stloc.s 10
-			IL_0181: ldloc.s 10
-			IL_0183: box [System.Runtime]System.Double
-			IL_0188: stloc.s 9
-			IL_018a: ldloc.s 9
-			IL_018c: stloc.2
-			IL_018d: br IL_00d0
+			IL_0159: ldloc.2
+			IL_015a: ldc.r8 1
+			IL_0163: add
+			IL_0164: stloc.2
+			IL_0165: br IL_00cb
 		// end loop
 
-		IL_0192: ret
+		IL_016a: ret
 	} // end of method ControlFlow_If_Truthiness::__js_module_init__
 
 } // end of class Modules.ControlFlow_If_Truthiness
@@ -280,7 +264,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x221c
+		// Method begins at RVA 0x21f4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_While_LabeledBreak.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_While_LabeledBreak.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2184
+				// Method begins at RVA 0x2154
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x219f
+						// Method begins at RVA 0x216f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2196
+					// Method begins at RVA 0x2166
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x218d
+				// Method begins at RVA 0x215d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -100,7 +100,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217b
+			// Method begins at RVA 0x214b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -126,19 +126,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 287 (0x11f)
+		// Code size: 239 (0xef)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_While_LabeledBreak/Scope,
 			[1] float64,
 			[2] class Modules.ControlFlow_While_LabeledBreak/Scope/Block_L5C20,
-			[3] object,
+			[3] float64,
 			[4] class Modules.ControlFlow_While_LabeledBreak/Scope/Scope_For_L6C7/Block_L6C30,
 			[5] class Modules.ControlFlow_While_LabeledBreak/Scope/Scope_For_L6C7/Block_L6C30/Block_L7C17,
-			[6] object,
-			[7] float64,
-			[8] bool,
-			[9] object
+			[6] float64,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_While_LabeledBreak/Scope::.ctor()
@@ -147,92 +145,77 @@
 		IL_000f: stloc.1
 		// loop start (head: IL_0010)
 			IL_0010: ldc.i4.1
-			IL_0011: brfalse IL_00f7
+			IL_0011: brfalse IL_00c7
 
 			IL_0016: newobj instance void Modules.ControlFlow_While_LabeledBreak/Scope/Block_L5C20::.ctor()
 			IL_001b: stloc.2
 			IL_001c: ldc.r8 0.0
-			IL_0025: box [System.Runtime]System.Double
-			IL_002a: stloc.3
-			// loop start (head: IL_002b)
-				IL_002b: ldloc.3
-				IL_002c: stloc.s 6
-				IL_002e: ldloc.s 6
-				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0035: stloc.s 7
-				IL_0037: ldloc.s 7
-				IL_0039: ldc.r8 2
-				IL_0042: clt
-				IL_0044: brfalse IL_00cb
+			IL_0025: stloc.3
+			// loop start (head: IL_0026)
+				IL_0026: ldloc.3
+				IL_0027: stloc.s 6
+				IL_0029: ldloc.s 6
+				IL_002b: ldc.r8 2
+				IL_0034: clt
+				IL_0036: brfalse IL_009b
 
-				IL_0049: newobj instance void Modules.ControlFlow_While_LabeledBreak/Scope/Scope_For_L6C7/Block_L6C30::.ctor()
-				IL_004e: stloc.s 4
-				IL_0050: ldloc.3
-				IL_0051: stloc.s 6
-				IL_0053: ldloc.s 6
-				IL_0055: ldc.r8 1
-				IL_005e: box [System.Runtime]System.Double
-				IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0068: stloc.s 8
-				IL_006a: ldloc.s 8
-				IL_006c: brfalse IL_00a4
+				IL_003b: newobj instance void Modules.ControlFlow_While_LabeledBreak/Scope/Scope_For_L6C7/Block_L6C30::.ctor()
+				IL_0040: stloc.s 4
+				IL_0042: ldloc.3
+				IL_0043: stloc.s 6
+				IL_0045: ldloc.s 6
+				IL_0047: ldc.r8 1
+				IL_0050: ceq
+				IL_0052: brfalse IL_008a
 
-				IL_0071: newobj instance void Modules.ControlFlow_While_LabeledBreak/Scope/Scope_For_L6C7/Block_L6C30/Block_L7C17::.ctor()
-				IL_0076: stloc.s 5
-				IL_0078: ldstr "console"
-				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0082: stloc.s 9
-				IL_0084: ldloc.s 9
-				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_008b: stloc.s 9
-				IL_008d: ldloc.s 9
-				IL_008f: ldstr "log"
-				IL_0094: ldstr "a"
-				IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_009e: pop
-				IL_009f: br IL_00f7
+				IL_0057: newobj instance void Modules.ControlFlow_While_LabeledBreak/Scope/Scope_For_L6C7/Block_L6C30/Block_L7C17::.ctor()
+				IL_005c: stloc.s 5
+				IL_005e: ldstr "console"
+				IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0068: stloc.s 7
+				IL_006a: ldloc.s 7
+				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0071: stloc.s 7
+				IL_0073: ldloc.s 7
+				IL_0075: ldstr "log"
+				IL_007a: ldstr "a"
+				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0084: pop
+				IL_0085: br IL_00c7
 
-				IL_00a4: ldloc.3
-				IL_00a5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00aa: stloc.s 7
-				IL_00ac: ldloc.s 7
-				IL_00ae: ldc.r8 1
-				IL_00b7: add
-				IL_00b8: stloc.s 7
-				IL_00ba: ldloc.s 7
-				IL_00bc: box [System.Runtime]System.Double
-				IL_00c1: stloc.s 6
-				IL_00c3: ldloc.s 6
-				IL_00c5: stloc.3
-				IL_00c6: br IL_002b
+				IL_008a: ldloc.3
+				IL_008b: ldc.r8 1
+				IL_0094: add
+				IL_0095: stloc.3
+				IL_0096: br IL_0026
 			// end loop
 
-			IL_00cb: ldstr "console"
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00d5: stloc.s 9
-			IL_00d7: ldloc.s 9
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00de: stloc.s 9
-			IL_00e0: ldloc.s 9
-			IL_00e2: ldstr "log"
-			IL_00e7: ldstr "x"
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00f1: pop
-			IL_00f2: br IL_0010
+			IL_009b: ldstr "console"
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00a5: stloc.s 7
+			IL_00a7: ldloc.s 7
+			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ae: stloc.s 7
+			IL_00b0: ldloc.s 7
+			IL_00b2: ldstr "log"
+			IL_00b7: ldstr "x"
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00c1: pop
+			IL_00c2: br IL_0010
 		// end loop
 
-		IL_00f7: ldstr "console"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0101: stloc.s 9
-		IL_0103: ldloc.s 9
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010a: stloc.s 9
-		IL_010c: ldloc.s 9
-		IL_010e: ldstr "log"
-		IL_0113: ldstr "b"
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_011d: pop
-		IL_011e: ret
+		IL_00c7: ldstr "console"
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d1: stloc.s 7
+		IL_00d3: ldloc.s 7
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00da: stloc.s 7
+		IL_00dc: ldloc.s 7
+		IL_00de: ldstr "log"
+		IL_00e3: ldstr "b"
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ed: pop
+		IL_00ee: ret
 	} // end of method ControlFlow_While_LabeledBreak::__js_module_init__
 
 } // end of class Modules.ControlFlow_While_LabeledBreak
@@ -244,7 +227,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21a8
+		// Method begins at RVA 0x2178
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_While_LabeledContinue.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_While_LabeledContinue.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x214a
+				// Method begins at RVA 0x2126
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2165
+						// Method begins at RVA 0x2141
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x215c
+					// Method begins at RVA 0x2138
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2153
+				// Method begins at RVA 0x212f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -100,7 +100,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2141
+			// Method begins at RVA 0x211d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -126,13 +126,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 229 (0xe5)
+		// Code size: 193 (0xc1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_While_LabeledContinue/Scope,
 			[1] float64,
 			[2] class Modules.ControlFlow_While_LabeledContinue/Scope/Block_L5C21,
-			[3] object,
+			[3] float64,
 			[4] class Modules.ControlFlow_While_LabeledContinue/Scope/Scope_For_L7C7/Block_L7C30,
 			[5] class Modules.ControlFlow_While_LabeledContinue/Scope/Scope_For_L7C7/Block_L7C30/Block_L8C17,
 			[6] float64,
@@ -150,7 +150,7 @@
 			IL_0013: ldloc.s 6
 			IL_0015: ldc.r8 3
 			IL_001e: clt
-			IL_0020: brfalse IL_00e4
+			IL_0020: brfalse IL_00c0
 
 			IL_0025: newobj instance void Modules.ControlFlow_While_LabeledContinue/Scope/Block_L5C21::.ctor()
 			IL_002a: stloc.2
@@ -159,65 +159,53 @@
 			IL_0035: add
 			IL_0036: stloc.1
 			IL_0037: ldc.r8 0.0
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: stloc.3
-			// loop start (head: IL_0046)
-				IL_0046: ldloc.3
-				IL_0047: stloc.s 7
-				IL_0049: ldloc.s 7
-				IL_004b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0050: stloc.s 6
-				IL_0052: ldloc.s 6
-				IL_0054: ldc.r8 1
-				IL_005d: clt
-				IL_005f: brfalse IL_00df
+			IL_0040: stloc.3
+			// loop start (head: IL_0041)
+				IL_0041: ldloc.3
+				IL_0042: stloc.s 6
+				IL_0044: ldloc.s 6
+				IL_0046: ldc.r8 1
+				IL_004f: clt
+				IL_0051: brfalse IL_00bb
 
-				IL_0064: newobj instance void Modules.ControlFlow_While_LabeledContinue/Scope/Scope_For_L7C7/Block_L7C30::.ctor()
-				IL_0069: stloc.s 4
-				IL_006b: ldloc.1
-				IL_006c: stloc.s 6
-				IL_006e: ldloc.s 6
-				IL_0070: ldc.r8 2
-				IL_0079: ceq
-				IL_007b: brfalse IL_008c
+				IL_0056: newobj instance void Modules.ControlFlow_While_LabeledContinue/Scope/Scope_For_L7C7/Block_L7C30::.ctor()
+				IL_005b: stloc.s 4
+				IL_005d: ldloc.1
+				IL_005e: stloc.s 6
+				IL_0060: ldloc.s 6
+				IL_0062: ldc.r8 2
+				IL_006b: ceq
+				IL_006d: brfalse IL_007e
 
-				IL_0080: newobj instance void Modules.ControlFlow_While_LabeledContinue/Scope/Scope_For_L7C7/Block_L7C30/Block_L8C17::.ctor()
-				IL_0085: stloc.s 5
-				IL_0087: br IL_0010
+				IL_0072: newobj instance void Modules.ControlFlow_While_LabeledContinue/Scope/Scope_For_L7C7/Block_L7C30/Block_L8C17::.ctor()
+				IL_0077: stloc.s 5
+				IL_0079: br IL_0010
 
-				IL_008c: ldstr "console"
-				IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0096: stloc.s 8
-				IL_0098: ldloc.s 8
-				IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_009f: stloc.s 8
-				IL_00a1: ldloc.1
-				IL_00a2: box [System.Runtime]System.Double
-				IL_00a7: stloc.s 7
-				IL_00a9: ldloc.s 8
-				IL_00ab: ldstr "log"
-				IL_00b0: ldloc.s 7
-				IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00b7: pop
-				IL_00b8: ldloc.3
-				IL_00b9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00be: stloc.s 6
-				IL_00c0: ldloc.s 6
-				IL_00c2: ldc.r8 1
-				IL_00cb: add
-				IL_00cc: stloc.s 6
-				IL_00ce: ldloc.s 6
-				IL_00d0: box [System.Runtime]System.Double
-				IL_00d5: stloc.s 7
-				IL_00d7: ldloc.s 7
-				IL_00d9: stloc.3
-				IL_00da: br IL_0046
+				IL_007e: ldstr "console"
+				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0088: stloc.s 7
+				IL_008a: ldloc.s 7
+				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0091: stloc.s 7
+				IL_0093: ldloc.1
+				IL_0094: box [System.Runtime]System.Double
+				IL_0099: stloc.s 8
+				IL_009b: ldloc.s 7
+				IL_009d: ldstr "log"
+				IL_00a2: ldloc.s 8
+				IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00a9: pop
+				IL_00aa: ldloc.3
+				IL_00ab: ldc.r8 1
+				IL_00b4: add
+				IL_00b5: stloc.3
+				IL_00b6: br IL_0041
 			// end loop
 
-			IL_00df: br IL_0010
+			IL_00bb: br IL_0010
 		// end loop
 
-		IL_00e4: ret
+		IL_00c0: ret
 	} // end of method ControlFlow_While_LabeledContinue::__js_module_init__
 
 } // end of class Modules.ControlFlow_While_LabeledContinue
@@ -229,7 +217,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x216e
+		// Method begins at RVA 0x214a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Literals/Snapshots/GeneratorTests.Array_Spread_Copy.verified.txt
+++ b/tests/Jroc.Tests/Literals/Snapshots/GeneratorTests.Array_Spread_Copy.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x213e
+			// Method begins at RVA 0x2116
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2150
+				// Method begins at RVA 0x2128
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2147
+			// Method begins at RVA 0x211f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,19 +82,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 226 (0xe2)
+		// Code size: 186 (0xba)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Spread_Copy/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[3] object,
+			[3] float64,
 			[4] class Modules.Array_Spread_Copy/Scope_For_L5C5/Block_L5C35,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[6] object,
-			[7] float64,
-			[8] float64,
-			[9] object
+			[6] float64,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Array_Spread_Copy/Scope::.ctor()
@@ -123,53 +121,39 @@
 		IL_0059: ldloc.s 5
 		IL_005b: stloc.2
 		IL_005c: ldc.r8 0.0
-		IL_0065: box [System.Runtime]System.Double
-		IL_006a: stloc.3
-		// loop start (head: IL_006b)
-			IL_006b: ldloc.3
-			IL_006c: stloc.s 6
-			IL_006e: ldloc.2
-			IL_006f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0074: stloc.s 7
-			IL_0076: ldloc.s 6
-			IL_0078: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_007d: stloc.s 8
-			IL_007f: ldloc.s 8
-			IL_0081: ldloc.s 7
-			IL_0083: clt
-			IL_0085: brfalse IL_00e1
+		IL_0065: stloc.3
+		// loop start (head: IL_0066)
+			IL_0066: ldloc.3
+			IL_0067: stloc.s 6
+			IL_0069: ldloc.s 6
+			IL_006b: ldloc.2
+			IL_006c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0071: clt
+			IL_0073: brfalse IL_00b9
 
-			IL_008a: newobj instance void Modules.Array_Spread_Copy/Scope_For_L5C5/Block_L5C35::.ctor()
-			IL_008f: stloc.s 4
-			IL_0091: ldstr "console"
-			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_009b: stloc.s 9
-			IL_009d: ldloc.s 9
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a4: stloc.s 9
-			IL_00a6: ldloc.s 9
-			IL_00a8: ldstr "log"
-			IL_00ad: ldloc.2
-			IL_00ae: ldloc.3
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00b9: pop
-			IL_00ba: ldloc.3
-			IL_00bb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00c0: stloc.s 7
-			IL_00c2: ldloc.s 7
-			IL_00c4: ldc.r8 1
-			IL_00cd: add
-			IL_00ce: stloc.s 7
-			IL_00d0: ldloc.s 7
-			IL_00d2: box [System.Runtime]System.Double
-			IL_00d7: stloc.s 6
-			IL_00d9: ldloc.s 6
-			IL_00db: stloc.3
-			IL_00dc: br IL_006b
+			IL_0078: newobj instance void Modules.Array_Spread_Copy/Scope_For_L5C5/Block_L5C35::.ctor()
+			IL_007d: stloc.s 4
+			IL_007f: ldstr "console"
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0089: stloc.s 7
+			IL_008b: ldloc.s 7
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0092: stloc.s 7
+			IL_0094: ldloc.s 7
+			IL_0096: ldstr "log"
+			IL_009b: ldloc.2
+			IL_009c: ldloc.3
+			IL_009d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00a7: pop
+			IL_00a8: ldloc.3
+			IL_00a9: ldc.r8 1
+			IL_00b2: add
+			IL_00b3: stloc.3
+			IL_00b4: br IL_0066
 		// end loop
 
-		IL_00e1: ret
+		IL_00b9: ret
 	} // end of method Array_Spread_Copy::__js_module_init__
 
 } // end of class Modules.Array_Spread_Copy
@@ -181,7 +165,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2159
+		// Method begins at RVA 0x2131
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x227e
+				// Method begins at RVA 0x2256
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2265
+			// Method begins at RVA 0x223d
 			// Header size: 1
 			// Code size: 15 (0xf)
 			.maxstack 8
@@ -76,7 +76,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2275
+			// Method begins at RVA 0x224d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -100,7 +100,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2290
+				// Method begins at RVA 0x2268
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2287
+			// Method begins at RVA 0x225f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -144,7 +144,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 521 (0x209)
+		// Code size: 481 (0x1e1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Pipe_Basic/Scope,
@@ -153,13 +153,11 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] object,
+			[6] float64,
 			[7] class Modules.Stream_Pipe_Basic/Scope_For_L28C5/Block_L28C45,
 			[8] object,
-			[9] object,
-			[10] float64,
-			[11] float64,
-			[12] object
+			[9] float64,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Pipe_Basic/Scope::.ctor()
@@ -277,64 +275,50 @@
 		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0155: pop
 		IL_0156: ldc.r8 0.0
-		IL_015f: box [System.Runtime]System.Double
-		IL_0164: stloc.s 6
-		// loop start (head: IL_0166)
-			IL_0166: ldloc.s 6
-			IL_0168: stloc.s 9
-			IL_016a: ldloc.0
-			IL_016b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Basic/Scope::writtenData
-			IL_0170: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0175: stloc.s 10
-			IL_0177: ldloc.s 9
-			IL_0179: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_017e: stloc.s 11
-			IL_0180: ldloc.s 11
-			IL_0182: ldloc.s 10
-			IL_0184: clt
-			IL_0186: brfalse IL_0208
+		IL_015f: stloc.s 6
+		// loop start (head: IL_0161)
+			IL_0161: ldloc.s 6
+			IL_0163: stloc.s 9
+			IL_0165: ldloc.s 9
+			IL_0167: ldloc.0
+			IL_0168: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Basic/Scope::writtenData
+			IL_016d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0172: clt
+			IL_0174: brfalse IL_01e0
 
-			IL_018b: newobj instance void Modules.Stream_Pipe_Basic/Scope_For_L28C5/Block_L28C45::.ctor()
-			IL_0190: stloc.s 7
-			IL_0192: ldstr "console"
-			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_019c: stloc.s 8
-			IL_019e: ldloc.s 8
-			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a5: stloc.s 8
-			IL_01a7: ldstr "Chunk "
-			IL_01ac: ldloc.s 6
-			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01b3: stloc.s 12
-			IL_01b5: ldloc.s 12
-			IL_01b7: ldstr ":"
-			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01c1: stloc.s 12
-			IL_01c3: ldloc.s 8
-			IL_01c5: ldstr "log"
-			IL_01ca: ldloc.s 12
-			IL_01cc: ldloc.0
-			IL_01cd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Basic/Scope::writtenData
-			IL_01d2: ldloc.s 6
-			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01de: pop
-			IL_01df: ldloc.s 6
-			IL_01e1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01e6: stloc.s 10
-			IL_01e8: ldloc.s 10
-			IL_01ea: ldc.r8 1
-			IL_01f3: add
-			IL_01f4: stloc.s 10
-			IL_01f6: ldloc.s 10
-			IL_01f8: box [System.Runtime]System.Double
-			IL_01fd: stloc.s 9
-			IL_01ff: ldloc.s 9
-			IL_0201: stloc.s 6
-			IL_0203: br IL_0166
+			IL_0179: newobj instance void Modules.Stream_Pipe_Basic/Scope_For_L28C5/Block_L28C45::.ctor()
+			IL_017e: stloc.s 7
+			IL_0180: ldstr "console"
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_018a: stloc.s 8
+			IL_018c: ldloc.s 8
+			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0193: stloc.s 8
+			IL_0195: ldstr "Chunk "
+			IL_019a: ldloc.s 6
+			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01a1: stloc.s 10
+			IL_01a3: ldloc.s 10
+			IL_01a5: ldstr ":"
+			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01af: stloc.s 10
+			IL_01b1: ldloc.s 8
+			IL_01b3: ldstr "log"
+			IL_01b8: ldloc.s 10
+			IL_01ba: ldloc.0
+			IL_01bb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Basic/Scope::writtenData
+			IL_01c0: ldloc.s 6
+			IL_01c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01cc: pop
+			IL_01cd: ldloc.s 6
+			IL_01cf: ldc.r8 1
+			IL_01d8: add
+			IL_01d9: stloc.s 6
+			IL_01db: br IL_0161
 		// end loop
 
-		IL_0208: ret
+		IL_01e0: ret
 	} // end of method Stream_Pipe_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Pipe_Basic
@@ -346,7 +330,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2299
+		// Method begins at RVA 0x2271
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_CustomWrite.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_CustomWrite.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2254
+				// Method begins at RVA 0x222c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x220c
+			// Method begins at RVA 0x21e4
 			// Header size: 12
 			// Code size: 51 (0x33)
 			.maxstack 8
@@ -91,7 +91,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x224b
+			// Method begins at RVA 0x2223
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -115,7 +115,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2266
+				// Method begins at RVA 0x223e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x225d
+			// Method begins at RVA 0x2235
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -159,20 +159,18 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 429 (0x1ad)
+		// Code size: 389 (0x185)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Writable_CustomWrite/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object,
+			[4] float64,
 			[5] class Modules.Stream_Writable_CustomWrite/Scope_For_L22C5/Block_L22C45,
 			[6] object,
-			[7] object,
-			[8] float64,
-			[9] float64,
-			[10] object
+			[7] float64,
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Writable_CustomWrite/Scope::.ctor()
@@ -261,64 +259,50 @@
 		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_00f9: pop
 		IL_00fa: ldc.r8 0.0
-		IL_0103: box [System.Runtime]System.Double
-		IL_0108: stloc.s 4
-		// loop start (head: IL_010a)
-			IL_010a: ldloc.s 4
-			IL_010c: stloc.s 7
-			IL_010e: ldloc.0
-			IL_010f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_CustomWrite/Scope::writtenData
-			IL_0114: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0119: stloc.s 8
-			IL_011b: ldloc.s 7
-			IL_011d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0122: stloc.s 9
-			IL_0124: ldloc.s 9
-			IL_0126: ldloc.s 8
-			IL_0128: clt
-			IL_012a: brfalse IL_01ac
+		IL_0103: stloc.s 4
+		// loop start (head: IL_0105)
+			IL_0105: ldloc.s 4
+			IL_0107: stloc.s 7
+			IL_0109: ldloc.s 7
+			IL_010b: ldloc.0
+			IL_010c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_CustomWrite/Scope::writtenData
+			IL_0111: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0116: clt
+			IL_0118: brfalse IL_0184
 
-			IL_012f: newobj instance void Modules.Stream_Writable_CustomWrite/Scope_For_L22C5/Block_L22C45::.ctor()
-			IL_0134: stloc.s 5
-			IL_0136: ldstr "console"
-			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0140: stloc.s 6
-			IL_0142: ldloc.s 6
-			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0149: stloc.s 6
-			IL_014b: ldstr "Chunk "
-			IL_0150: ldloc.s 4
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0157: stloc.s 10
-			IL_0159: ldloc.s 10
-			IL_015b: ldstr ":"
-			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0165: stloc.s 10
-			IL_0167: ldloc.s 6
-			IL_0169: ldstr "log"
-			IL_016e: ldloc.s 10
-			IL_0170: ldloc.0
-			IL_0171: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_CustomWrite/Scope::writtenData
-			IL_0176: ldloc.s 4
-			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0182: pop
-			IL_0183: ldloc.s 4
-			IL_0185: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_018a: stloc.s 8
-			IL_018c: ldloc.s 8
-			IL_018e: ldc.r8 1
-			IL_0197: add
-			IL_0198: stloc.s 8
-			IL_019a: ldloc.s 8
-			IL_019c: box [System.Runtime]System.Double
-			IL_01a1: stloc.s 7
-			IL_01a3: ldloc.s 7
-			IL_01a5: stloc.s 4
-			IL_01a7: br IL_010a
+			IL_011d: newobj instance void Modules.Stream_Writable_CustomWrite/Scope_For_L22C5/Block_L22C45::.ctor()
+			IL_0122: stloc.s 5
+			IL_0124: ldstr "console"
+			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_012e: stloc.s 6
+			IL_0130: ldloc.s 6
+			IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0137: stloc.s 6
+			IL_0139: ldstr "Chunk "
+			IL_013e: ldloc.s 4
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0145: stloc.s 8
+			IL_0147: ldloc.s 8
+			IL_0149: ldstr ":"
+			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0153: stloc.s 8
+			IL_0155: ldloc.s 6
+			IL_0157: ldstr "log"
+			IL_015c: ldloc.s 8
+			IL_015e: ldloc.0
+			IL_015f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_CustomWrite/Scope::writtenData
+			IL_0164: ldloc.s 4
+			IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0170: pop
+			IL_0171: ldloc.s 4
+			IL_0173: ldc.r8 1
+			IL_017c: add
+			IL_017d: stloc.s 4
+			IL_017f: br IL_0105
 		// end loop
 
-		IL_01ac: ret
+		IL_0184: ret
 	} // end of method Stream_Writable_CustomWrite::__js_module_init__
 
 } // end of class Modules.Stream_Writable_CustomWrite
@@ -330,7 +314,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x226f
+		// Method begins at RVA 0x2247
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Scheduling_StarvationTest.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Scheduling_StarvationTest.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22be
+					// Method begins at RVA 0x22a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2260
+				// Method begins at RVA 0x2244
 				// Header size: 12
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -85,7 +85,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22b5
+					// Method begins at RVA 0x2299
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -105,7 +105,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22c7
+					// Method begins at RVA 0x22ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -126,7 +126,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ac
+				// Method begins at RVA 0x2290
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -150,7 +150,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2134
+			// Method begins at RVA 0x2118
 			// Header size: 12
 			// Code size: 286 (0x11e)
 			.maxstack 8
@@ -272,7 +272,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2291
+			// Method begins at RVA 0x2275
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -296,7 +296,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a3
+				// Method begins at RVA 0x2287
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -314,7 +314,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x229a
+			// Method begins at RVA 0x227e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -340,15 +340,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 213 (0xd5)
+		// Code size: 186 (0xba)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Scheduling_StarvationTest/Scope,
-			[1] object,
+			[1] float64,
 			[2] class Modules.Promise_Scheduling_StarvationTest/Scope_For_L6C5/Block_L6C31,
 			[3] object,
-			[4] object,
-			[5] float64,
+			[4] float64,
+			[5] object,
 			[6] object
 		)
 
@@ -366,67 +366,58 @@
 		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0028: pop
 		IL_0029: ldc.r8 0.0
-		IL_0032: box [System.Runtime]System.Double
-		IL_0037: stloc.1
-		// loop start (head: IL_0038)
-			IL_0038: ldloc.1
-			IL_0039: stloc.s 4
-			IL_003b: ldloc.s 4
-			IL_003d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0042: stloc.s 5
-			IL_0044: ldloc.s 5
-			IL_0046: ldc.r8 2048
-			IL_004f: clt
-			IL_0051: brfalse IL_00d4
+		IL_0032: stloc.1
+		// loop start (head: IL_0033)
+			IL_0033: ldloc.1
+			IL_0034: stloc.s 4
+			IL_0036: ldloc.s 4
+			IL_0038: ldc.r8 2048
+			IL_0041: clt
+			IL_0043: brfalse IL_00b9
 
-			IL_0056: newobj instance void Modules.Promise_Scheduling_StarvationTest/Scope_For_L6C5/Block_L6C31::.ctor()
-			IL_005b: stloc.2
-			IL_005c: ldloc.1
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-			IL_0062: stloc.3
-			IL_0063: ldloc.3
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0069: stloc.3
-			IL_006a: ldnull
-			IL_006b: ldftn object Modules.Promise_Scheduling_StarvationTest/ArrowFunction_L7C29::__js_call__(object, object)
-			IL_0071: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0076: ldc.i4.1
-			IL_0077: newarr [System.Runtime]System.Object
-			IL_007c: dup
-			IL_007d: ldc.i4.0
-			IL_007e: ldloc.0
-			IL_007f: stelem.ref
-			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_008a: ldc.i4.1
-			IL_008b: conv.r8
-			IL_008c: ldstr ""
-			IL_0091: ldc.i4.0
-			IL_0092: ldc.i4.0
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_009d: stloc.s 6
-			IL_009f: ldloc.3
-			IL_00a0: ldstr "then"
-			IL_00a5: ldloc.s 6
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ac: pop
-			IL_00ad: ldloc.1
-			IL_00ae: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00b3: stloc.s 5
-			IL_00b5: ldloc.s 5
-			IL_00b7: ldc.r8 1
-			IL_00c0: add
-			IL_00c1: stloc.s 5
-			IL_00c3: ldloc.s 5
-			IL_00c5: box [System.Runtime]System.Double
-			IL_00ca: stloc.s 4
-			IL_00cc: ldloc.s 4
-			IL_00ce: stloc.1
-			IL_00cf: br IL_0038
+			IL_0048: newobj instance void Modules.Promise_Scheduling_StarvationTest/Scope_For_L6C5/Block_L6C31::.ctor()
+			IL_004d: stloc.2
+			IL_004e: ldloc.1
+			IL_004f: box [System.Runtime]System.Double
+			IL_0054: stloc.s 5
+			IL_0056: ldloc.s 5
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+			IL_005d: stloc.3
+			IL_005e: ldloc.3
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0064: stloc.3
+			IL_0065: ldnull
+			IL_0066: ldftn object Modules.Promise_Scheduling_StarvationTest/ArrowFunction_L7C29::__js_call__(object, object)
+			IL_006c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0071: ldc.i4.1
+			IL_0072: newarr [System.Runtime]System.Object
+			IL_0077: dup
+			IL_0078: ldc.i4.0
+			IL_0079: ldloc.0
+			IL_007a: stelem.ref
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0085: ldc.i4.1
+			IL_0086: conv.r8
+			IL_0087: ldstr ""
+			IL_008c: ldc.i4.0
+			IL_008d: ldc.i4.0
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0098: stloc.s 6
+			IL_009a: ldloc.3
+			IL_009b: ldstr "then"
+			IL_00a0: ldloc.s 6
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00a7: pop
+			IL_00a8: ldloc.1
+			IL_00a9: ldc.r8 1
+			IL_00b2: add
+			IL_00b3: stloc.1
+			IL_00b4: br IL_0033
 		// end loop
 
-		IL_00d4: ret
+		IL_00b9: ret
 	} // end of method Promise_Scheduling_StarvationTest::__js_module_init__
 
 } // end of class Modules.Promise_Scheduling_StarvationTest
@@ -438,7 +429,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22d0
+		// Method begins at RVA 0x22b4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_Combined_TernaryInsideLoop.verified.txt
+++ b/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_Combined_TernaryInsideLoop.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x215f
+			// Method begins at RVA 0x2132
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2171
+				// Method begins at RVA 0x2144
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2168
+			// Method begins at RVA 0x213b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,17 +82,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 259 (0x103)
+		// Code size: 214 (0xd6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ShapeCoverage_Combined_TernaryInsideLoop/Scope,
 			[1] object,
-			[2] object,
+			[2] float64,
 			[3] class Modules.ShapeCoverage_Combined_TernaryInsideLoop/Scope_For_L8C5/Block_L8C28,
 			[4] object,
 			[5] object,
-			[6] object,
-			[7] float64,
+			[6] float64,
+			[7] object,
 			[8] object,
 			[9] object
 		)
@@ -103,91 +103,76 @@
 		IL_000f: box [System.Runtime]System.Double
 		IL_0014: stloc.1
 		IL_0015: ldc.r8 0.0
-		IL_001e: box [System.Runtime]System.Double
-		IL_0023: stloc.2
-		// loop start (head: IL_0024)
-			IL_0024: ldloc.2
-			IL_0025: stloc.s 6
-			IL_0027: ldloc.s 6
-			IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002e: stloc.s 7
-			IL_0030: ldloc.s 7
-			IL_0032: ldc.r8 5
-			IL_003b: clt
-			IL_003d: brfalse IL_00df
+		IL_001e: stloc.2
+		// loop start (head: IL_001f)
+			IL_001f: ldloc.2
+			IL_0020: stloc.s 6
+			IL_0022: ldloc.s 6
+			IL_0024: ldc.r8 5
+			IL_002d: clt
+			IL_002f: brfalse IL_00b2
 
-			IL_0042: newobj instance void Modules.ShapeCoverage_Combined_TernaryInsideLoop/Scope_For_L8C5/Block_L8C28::.ctor()
-			IL_0047: stloc.3
-			IL_0048: ldloc.2
+			IL_0034: newobj instance void Modules.ShapeCoverage_Combined_TernaryInsideLoop/Scope_For_L8C5/Block_L8C28::.ctor()
+			IL_0039: stloc.3
+			IL_003a: ldloc.2
+			IL_003b: stloc.s 6
+			IL_003d: ldloc.s 6
+			IL_003f: ldc.r8 2
+			IL_0048: rem
 			IL_0049: stloc.s 6
 			IL_004b: ldloc.s 6
-			IL_004d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0052: stloc.s 7
-			IL_0054: ldloc.s 7
-			IL_0056: ldc.r8 2
-			IL_005f: rem
-			IL_0060: stloc.s 7
-			IL_0062: ldloc.s 7
-			IL_0064: ldc.r8 0.0
-			IL_006d: ceq
-			IL_006f: brfalse IL_007c
+			IL_004d: ldc.r8 0.0
+			IL_0056: ceq
+			IL_0058: brfalse IL_006e
 
-			IL_0074: ldloc.2
-			IL_0075: stloc.s 4
-			IL_0077: br IL_00a3
+			IL_005d: ldloc.2
+			IL_005e: box [System.Runtime]System.Double
+			IL_0063: stloc.s 7
+			IL_0065: ldloc.s 7
+			IL_0067: stloc.s 4
+			IL_0069: br IL_008c
 
-			IL_007c: ldloc.2
+			IL_006e: ldloc.2
+			IL_006f: stloc.s 6
+			IL_0071: ldloc.s 6
+			IL_0073: ldc.r8 2
+			IL_007c: mul
 			IL_007d: stloc.s 6
 			IL_007f: ldloc.s 6
-			IL_0081: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0081: box [System.Runtime]System.Double
 			IL_0086: stloc.s 7
 			IL_0088: ldloc.s 7
-			IL_008a: ldc.r8 2
-			IL_0093: mul
-			IL_0094: stloc.s 7
-			IL_0096: ldloc.s 7
-			IL_0098: box [System.Runtime]System.Double
-			IL_009d: stloc.s 6
-			IL_009f: ldloc.s 6
-			IL_00a1: stloc.s 4
+			IL_008a: stloc.s 4
 
-			IL_00a3: ldloc.s 4
-			IL_00a5: stloc.s 5
-			IL_00a7: ldloc.1
-			IL_00a8: stloc.s 6
-			IL_00aa: ldloc.s 6
-			IL_00ac: ldloc.s 5
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00b3: stloc.s 8
-			IL_00b5: ldloc.s 8
-			IL_00b7: stloc.1
-			IL_00b8: ldloc.2
-			IL_00b9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00be: stloc.s 7
-			IL_00c0: ldloc.s 7
-			IL_00c2: ldc.r8 1
-			IL_00cb: add
-			IL_00cc: stloc.s 7
-			IL_00ce: ldloc.s 7
-			IL_00d0: box [System.Runtime]System.Double
-			IL_00d5: stloc.s 6
-			IL_00d7: ldloc.s 6
-			IL_00d9: stloc.2
-			IL_00da: br IL_0024
+			IL_008c: ldloc.s 4
+			IL_008e: stloc.s 5
+			IL_0090: ldloc.1
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
+			IL_0095: ldloc.s 5
+			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_009c: stloc.s 8
+			IL_009e: ldloc.s 8
+			IL_00a0: stloc.1
+			IL_00a1: ldloc.2
+			IL_00a2: ldc.r8 1
+			IL_00ab: add
+			IL_00ac: stloc.2
+			IL_00ad: br IL_001f
 		// end loop
 
-		IL_00df: ldstr "console"
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e9: stloc.s 9
-		IL_00eb: ldloc.s 9
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f2: stloc.s 9
-		IL_00f4: ldloc.s 9
-		IL_00f6: ldstr "log"
-		IL_00fb: ldloc.1
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0101: pop
-		IL_0102: ret
+		IL_00b2: ldstr "console"
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00bc: stloc.s 9
+		IL_00be: ldloc.s 9
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c5: stloc.s 9
+		IL_00c7: ldloc.s 9
+		IL_00c9: ldstr "log"
+		IL_00ce: ldloc.1
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00d4: pop
+		IL_00d5: ret
 	} // end of method ShapeCoverage_Combined_TernaryInsideLoop::__js_module_init__
 
 } // end of class Modules.ShapeCoverage_Combined_TernaryInsideLoop
@@ -199,7 +184,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x217a
+		// Method begins at RVA 0x214d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_LoopCarried_ConditionalUpdateInLoop.verified.txt
+++ b/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_LoopCarried_ConditionalUpdateInLoop.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2149
+			// Method begins at RVA 0x2113
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2164
+					// Method begins at RVA 0x212e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x215b
+				// Method begins at RVA 0x2125
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2152
+			// Method begins at RVA 0x211c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -104,18 +104,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 237 (0xed)
+		// Code size: 183 (0xb7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ShapeCoverage_LoopCarried_ConditionalUpdateInLoop/Scope,
 			[1] object,
-			[2] object,
+			[2] float64,
 			[3] class Modules.ShapeCoverage_LoopCarried_ConditionalUpdateInLoop/Scope_For_L7C5/Block_L7C28,
 			[4] class Modules.ShapeCoverage_LoopCarried_ConditionalUpdateInLoop/Scope_For_L7C5/Block_L7C28/Block_L8C19,
-			[5] object,
-			[6] float64,
-			[7] float64,
-			[8] object
+			[5] float64,
+			[6] object,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.ShapeCoverage_LoopCarried_ConditionalUpdateInLoop/Scope::.ctor()
@@ -124,82 +123,64 @@
 		IL_000f: box [System.Runtime]System.Double
 		IL_0014: stloc.1
 		IL_0015: ldc.r8 0.0
-		IL_001e: box [System.Runtime]System.Double
-		IL_0023: stloc.2
-		// loop start (head: IL_0024)
-			IL_0024: ldloc.2
-			IL_0025: stloc.s 5
-			IL_0027: ldloc.s 5
-			IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002e: stloc.s 6
-			IL_0030: ldloc.s 6
-			IL_0032: ldc.r8 5
-			IL_003b: clt
-			IL_003d: brfalse IL_00c9
+		IL_001e: stloc.2
+		// loop start (head: IL_001f)
+			IL_001f: ldloc.2
+			IL_0020: stloc.s 5
+			IL_0022: ldloc.s 5
+			IL_0024: ldc.r8 5
+			IL_002d: clt
+			IL_002f: brfalse IL_0093
 
-			IL_0042: newobj instance void Modules.ShapeCoverage_LoopCarried_ConditionalUpdateInLoop/Scope_For_L7C5/Block_L7C28::.ctor()
-			IL_0047: stloc.3
-			IL_0048: ldloc.2
+			IL_0034: newobj instance void Modules.ShapeCoverage_LoopCarried_ConditionalUpdateInLoop/Scope_For_L7C5/Block_L7C28::.ctor()
+			IL_0039: stloc.3
+			IL_003a: ldloc.2
+			IL_003b: stloc.s 5
+			IL_003d: ldloc.s 5
+			IL_003f: ldc.r8 2
+			IL_0048: rem
 			IL_0049: stloc.s 5
 			IL_004b: ldloc.s 5
-			IL_004d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0052: stloc.s 6
-			IL_0054: ldloc.s 6
-			IL_0056: ldc.r8 2
-			IL_005f: rem
-			IL_0060: stloc.s 6
-			IL_0062: ldloc.s 6
-			IL_0064: ldc.r8 0.0
-			IL_006d: ceq
-			IL_006f: brfalse IL_00a2
+			IL_004d: ldc.r8 0.0
+			IL_0056: ceq
+			IL_0058: brfalse IL_0082
 
-			IL_0074: newobj instance void Modules.ShapeCoverage_LoopCarried_ConditionalUpdateInLoop/Scope_For_L7C5/Block_L7C28/Block_L8C19::.ctor()
-			IL_0079: stloc.s 4
-			IL_007b: ldloc.1
-			IL_007c: stloc.s 5
-			IL_007e: ldloc.s 5
-			IL_0080: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0085: stloc.s 6
-			IL_0087: ldloc.2
-			IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_008d: stloc.s 7
-			IL_008f: ldloc.s 6
-			IL_0091: ldloc.s 7
-			IL_0093: add
-			IL_0094: stloc.s 7
-			IL_0096: ldloc.s 7
-			IL_0098: box [System.Runtime]System.Double
-			IL_009d: stloc.s 5
-			IL_009f: ldloc.s 5
-			IL_00a1: stloc.1
+			IL_005d: newobj instance void Modules.ShapeCoverage_LoopCarried_ConditionalUpdateInLoop/Scope_For_L7C5/Block_L7C28/Block_L8C19::.ctor()
+			IL_0062: stloc.s 4
+			IL_0064: ldloc.1
+			IL_0065: stloc.s 6
+			IL_0067: ldloc.s 6
+			IL_0069: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_006e: stloc.s 5
+			IL_0070: ldloc.s 5
+			IL_0072: ldloc.2
+			IL_0073: add
+			IL_0074: stloc.s 5
+			IL_0076: ldloc.s 5
+			IL_0078: box [System.Runtime]System.Double
+			IL_007d: stloc.s 6
+			IL_007f: ldloc.s 6
+			IL_0081: stloc.1
 
-			IL_00a2: ldloc.2
-			IL_00a3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00a8: stloc.s 7
-			IL_00aa: ldloc.s 7
-			IL_00ac: ldc.r8 1
-			IL_00b5: add
-			IL_00b6: stloc.s 7
-			IL_00b8: ldloc.s 7
-			IL_00ba: box [System.Runtime]System.Double
-			IL_00bf: stloc.s 5
-			IL_00c1: ldloc.s 5
-			IL_00c3: stloc.2
-			IL_00c4: br IL_0024
+			IL_0082: ldloc.2
+			IL_0083: ldc.r8 1
+			IL_008c: add
+			IL_008d: stloc.2
+			IL_008e: br IL_001f
 		// end loop
 
-		IL_00c9: ldstr "console"
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d3: stloc.s 8
-		IL_00d5: ldloc.s 8
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00dc: stloc.s 8
-		IL_00de: ldloc.s 8
-		IL_00e0: ldstr "log"
-		IL_00e5: ldloc.1
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00eb: pop
-		IL_00ec: ret
+		IL_0093: ldstr "console"
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_009d: stloc.s 7
+		IL_009f: ldloc.s 7
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a6: stloc.s 7
+		IL_00a8: ldloc.s 7
+		IL_00aa: ldstr "log"
+		IL_00af: ldloc.1
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00b5: pop
+		IL_00b6: ret
 	} // end of method ShapeCoverage_LoopCarried_ConditionalUpdateInLoop::__js_module_init__
 
 } // end of class Modules.ShapeCoverage_LoopCarried_ConditionalUpdateInLoop
@@ -211,7 +192,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x216d
+		// Method begins at RVA 0x2137
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_LoopCarried_UpdatedEveryIteration.verified.txt
+++ b/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_LoopCarried_UpdatedEveryIteration.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2119
+			// Method begins at RVA 0x20ec
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x212b
+				// Method begins at RVA 0x20fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2122
+			// Method begins at RVA 0x20f5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,17 +82,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 189 (0xbd)
+		// Code size: 144 (0x90)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ShapeCoverage_LoopCarried_UpdatedEveryIteration/Scope,
 			[1] object,
-			[2] object,
+			[2] float64,
 			[3] class Modules.ShapeCoverage_LoopCarried_UpdatedEveryIteration/Scope_For_L7C5/Block_L7C29,
-			[4] object,
-			[5] float64,
-			[6] float64,
-			[7] object
+			[4] float64,
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.ShapeCoverage_LoopCarried_UpdatedEveryIteration/Scope::.ctor()
@@ -101,67 +100,52 @@
 		IL_000f: box [System.Runtime]System.Double
 		IL_0014: stloc.1
 		IL_0015: ldc.r8 1
-		IL_001e: box [System.Runtime]System.Double
-		IL_0023: stloc.2
-		// loop start (head: IL_0024)
-			IL_0024: ldloc.2
-			IL_0025: stloc.s 4
-			IL_0027: ldloc.s 4
-			IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002e: stloc.s 5
-			IL_0030: ldloc.s 5
-			IL_0032: ldc.r8 5
-			IL_003b: cgt
-			IL_003d: ldc.i4.0
-			IL_003e: ceq
-			IL_0040: brfalse IL_0099
+		IL_001e: stloc.2
+		// loop start (head: IL_001f)
+			IL_001f: ldloc.2
+			IL_0020: stloc.s 4
+			IL_0022: ldloc.s 4
+			IL_0024: ldc.r8 5
+			IL_002d: cgt
+			IL_002f: ldc.i4.0
+			IL_0030: ceq
+			IL_0032: brfalse IL_006c
 
-			IL_0045: newobj instance void Modules.ShapeCoverage_LoopCarried_UpdatedEveryIteration/Scope_For_L7C5/Block_L7C29::.ctor()
-			IL_004a: stloc.3
-			IL_004b: ldloc.1
-			IL_004c: stloc.s 4
-			IL_004e: ldloc.s 4
-			IL_0050: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0055: stloc.s 5
-			IL_0057: ldloc.2
-			IL_0058: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_005d: stloc.s 6
-			IL_005f: ldloc.s 5
-			IL_0061: ldloc.s 6
-			IL_0063: add
-			IL_0064: stloc.s 6
-			IL_0066: ldloc.s 6
-			IL_0068: box [System.Runtime]System.Double
-			IL_006d: stloc.s 4
-			IL_006f: ldloc.s 4
-			IL_0071: stloc.1
-			IL_0072: ldloc.2
-			IL_0073: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0078: stloc.s 6
-			IL_007a: ldloc.s 6
-			IL_007c: ldc.r8 1
-			IL_0085: add
-			IL_0086: stloc.s 6
-			IL_0088: ldloc.s 6
-			IL_008a: box [System.Runtime]System.Double
-			IL_008f: stloc.s 4
-			IL_0091: ldloc.s 4
-			IL_0093: stloc.2
-			IL_0094: br IL_0024
+			IL_0037: newobj instance void Modules.ShapeCoverage_LoopCarried_UpdatedEveryIteration/Scope_For_L7C5/Block_L7C29::.ctor()
+			IL_003c: stloc.3
+			IL_003d: ldloc.1
+			IL_003e: stloc.s 5
+			IL_0040: ldloc.s 5
+			IL_0042: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0047: stloc.s 4
+			IL_0049: ldloc.s 4
+			IL_004b: ldloc.2
+			IL_004c: add
+			IL_004d: stloc.s 4
+			IL_004f: ldloc.s 4
+			IL_0051: box [System.Runtime]System.Double
+			IL_0056: stloc.s 5
+			IL_0058: ldloc.s 5
+			IL_005a: stloc.1
+			IL_005b: ldloc.2
+			IL_005c: ldc.r8 1
+			IL_0065: add
+			IL_0066: stloc.2
+			IL_0067: br IL_001f
 		// end loop
 
-		IL_0099: ldstr "console"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a3: stloc.s 7
-		IL_00a5: ldloc.s 7
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ac: stloc.s 7
-		IL_00ae: ldloc.s 7
-		IL_00b0: ldstr "log"
-		IL_00b5: ldloc.1
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00bb: pop
-		IL_00bc: ret
+		IL_006c: ldstr "console"
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0076: stloc.s 6
+		IL_0078: ldloc.s 6
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007f: stloc.s 6
+		IL_0081: ldloc.s 6
+		IL_0083: ldstr "log"
+		IL_0088: ldloc.1
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_008e: pop
+		IL_008f: ret
 	} // end of method ShapeCoverage_LoopCarried_UpdatedEveryIteration::__js_module_init__
 
 } // end of class Modules.ShapeCoverage_LoopCarried_UpdatedEveryIteration
@@ -173,7 +157,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2134
+		// Method begins at RVA 0x2107
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_FromArray_CopyAndCoerce.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_FromArray_CopyAndCoerce.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2178
+			// Method begins at RVA 0x214f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -34,7 +34,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2181
+			// Method begins at RVA 0x2158
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -60,17 +60,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 284 (0x11c)
+		// Code size: 243 (0xf3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_FromArray_CopyAndCoerce/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
-			[2] object,
+			[2] float64,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[5] object,
-			[6] float64,
-			[7] float64
+			[6] float64
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_FromArray_CopyAndCoerce/Scope::.ctor()
@@ -115,53 +114,38 @@
 		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0096: pop
 		IL_0097: ldc.r8 0.0
-		IL_00a0: box [System.Runtime]System.Double
-		IL_00a5: stloc.2
-		// loop start (head: IL_00a6)
-			IL_00a6: ldloc.2
-			IL_00a7: stloc.3
-			IL_00a8: ldloc.1
-			IL_00a9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-			IL_00ae: stloc.s 6
-			IL_00b0: ldloc.3
-			IL_00b1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00b6: stloc.s 7
-			IL_00b8: ldloc.s 7
-			IL_00ba: ldloc.s 6
-			IL_00bc: clt
-			IL_00be: brfalse IL_011b
+		IL_00a0: stloc.2
+		// loop start (head: IL_00a1)
+			IL_00a1: ldloc.2
+			IL_00a2: stloc.s 6
+			IL_00a4: ldloc.s 6
+			IL_00a6: ldloc.1
+			IL_00a7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+			IL_00ac: clt
+			IL_00ae: brfalse IL_00f2
 
-			IL_00c3: ldstr "console"
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00cd: stloc.s 5
-			IL_00cf: ldloc.s 5
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d6: stloc.s 5
-			IL_00d8: ldloc.s 5
-			IL_00da: ldstr "log"
-			IL_00df: ldloc.1
-			IL_00e0: ldloc.2
-			IL_00e1: unbox.any [System.Runtime]System.Double
-			IL_00e6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_00eb: box [System.Runtime]System.Double
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00f5: pop
-			IL_00f6: ldloc.2
-			IL_00f7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00fc: stloc.s 6
-			IL_00fe: ldloc.s 6
-			IL_0100: ldc.r8 1
-			IL_0109: add
-			IL_010a: stloc.s 6
-			IL_010c: ldloc.s 6
-			IL_010e: box [System.Runtime]System.Double
-			IL_0113: stloc.3
-			IL_0114: ldloc.3
-			IL_0115: stloc.2
-			IL_0116: br IL_00a6
+			IL_00b3: ldstr "console"
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00bd: stloc.s 5
+			IL_00bf: ldloc.s 5
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c6: stloc.s 5
+			IL_00c8: ldloc.s 5
+			IL_00ca: ldstr "log"
+			IL_00cf: ldloc.1
+			IL_00d0: ldloc.2
+			IL_00d1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_00d6: box [System.Runtime]System.Double
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e0: pop
+			IL_00e1: ldloc.2
+			IL_00e2: ldc.r8 1
+			IL_00eb: add
+			IL_00ec: stloc.2
+			IL_00ed: br IL_00a1
 		// end loop
 
-		IL_011b: ret
+		IL_00f2: ret
 	} // end of method Int32Array_FromArray_CopyAndCoerce::__js_module_init__
 
 } // end of class Modules.Int32Array_FromArray_CopyAndCoerce
@@ -173,7 +157,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218a
+		// Method begins at RVA 0x2161
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_BoundsChecks.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_BoundsChecks.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24e1
+				// Method begins at RVA 0x2489
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ea
+				// Method begins at RVA 0x2492
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f3
+				// Method begins at RVA 0x249b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24fc
+				// Method begins at RVA 0x24a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24b4
+			// Method begins at RVA 0x245c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24c6
+				// Method begins at RVA 0x246e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24bd
+			// Method begins at RVA 0x2465
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d8
+				// Method begins at RVA 0x2480
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +180,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24cf
+			// Method begins at RVA 0x2477
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -206,15 +206,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1083 (0x43b)
+		// Code size: 993 (0x3e1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Set_BoundsChecks/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
-			[2] object,
+			[2] float64,
 			[3] class Modules.Int32Array_Set_BoundsChecks/Scope_For_L5C5/Block_L5C40,
 			[4] object,
-			[5] object,
+			[5] float64,
 			[6] class Modules.Int32Array_Set_BoundsChecks/Scope_For_L11C5/Block_L11C40,
 			[7] class Modules.Int32Array_Set_BoundsChecks/Scope/Block_L15C4,
 			[8] class [System.Runtime]System.Exception,
@@ -230,9 +230,7 @@
 			[18] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[19] object,
 			[20] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[21] object,
-			[22] float64,
-			[23] float64
+			[21] float64
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope::.ctor()
@@ -281,298 +279,268 @@
 		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_00ba: pop
 		IL_00bb: ldc.r8 0.0
-		IL_00c4: box [System.Runtime]System.Double
-		IL_00c9: stloc.2
-		// loop start (head: IL_00ca)
-			IL_00ca: ldloc.2
-			IL_00cb: stloc.s 21
-			IL_00cd: ldloc.1
-			IL_00ce: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-			IL_00d3: stloc.s 22
-			IL_00d5: ldloc.s 21
-			IL_00d7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00dc: stloc.s 23
-			IL_00de: ldloc.s 23
-			IL_00e0: ldloc.s 22
-			IL_00e2: clt
-			IL_00e4: brfalse IL_0149
+		IL_00c4: stloc.2
+		// loop start (head: IL_00c5)
+			IL_00c5: ldloc.2
+			IL_00c6: stloc.s 21
+			IL_00c8: ldloc.s 21
+			IL_00ca: ldloc.1
+			IL_00cb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+			IL_00d0: clt
+			IL_00d2: brfalse IL_011c
 
-			IL_00e9: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope_For_L5C5/Block_L5C40::.ctor()
-			IL_00ee: stloc.3
-			IL_00ef: ldstr "console"
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00f9: stloc.s 19
-			IL_00fb: ldloc.s 19
-			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0102: stloc.s 19
-			IL_0104: ldloc.s 19
-			IL_0106: ldstr "log"
-			IL_010b: ldloc.1
-			IL_010c: ldloc.2
-			IL_010d: unbox.any [System.Runtime]System.Double
-			IL_0112: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0117: box [System.Runtime]System.Double
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0121: pop
-			IL_0122: ldloc.2
-			IL_0123: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0128: stloc.s 22
-			IL_012a: ldloc.s 22
-			IL_012c: ldc.r8 1
-			IL_0135: add
-			IL_0136: stloc.s 22
-			IL_0138: ldloc.s 22
-			IL_013a: box [System.Runtime]System.Double
-			IL_013f: stloc.s 21
-			IL_0141: ldloc.s 21
-			IL_0143: stloc.2
-			IL_0144: br IL_00ca
+			IL_00d7: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope_For_L5C5/Block_L5C40::.ctor()
+			IL_00dc: stloc.3
+			IL_00dd: ldstr "console"
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00e7: stloc.s 19
+			IL_00e9: ldloc.s 19
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f0: stloc.s 19
+			IL_00f2: ldloc.s 19
+			IL_00f4: ldstr "log"
+			IL_00f9: ldloc.1
+			IL_00fa: ldloc.2
+			IL_00fb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_0100: box [System.Runtime]System.Double
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_010a: pop
+			IL_010b: ldloc.2
+			IL_010c: ldc.r8 1
+			IL_0115: add
+			IL_0116: stloc.2
+			IL_0117: br IL_00c5
 		// end loop
 
-		IL_0149: ldloc.1
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014f: stloc.s 19
-		IL_0151: ldloc.s 19
-		IL_0153: ldstr "subarray"
-		IL_0158: ldc.r8 1
-		IL_0161: box [System.Runtime]System.Double
-		IL_0166: ldc.r8 3
-		IL_016f: box [System.Runtime]System.Double
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0179: stloc.s 19
-		IL_017b: ldloc.s 19
-		IL_017d: stloc.s 4
-		IL_017f: ldloc.1
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0185: stloc.s 19
-		IL_0187: ldloc.s 19
-		IL_0189: ldstr "set"
-		IL_018e: ldloc.s 4
-		IL_0190: ldc.r8 0.0
-		IL_0199: box [System.Runtime]System.Double
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01a3: pop
-		IL_01a4: ldc.r8 0.0
-		IL_01ad: box [System.Runtime]System.Double
-		IL_01b2: stloc.s 5
-		// loop start (head: IL_01b4)
-			IL_01b4: ldloc.s 5
-			IL_01b6: stloc.s 21
+		IL_011c: ldloc.1
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0122: stloc.s 19
+		IL_0124: ldloc.s 19
+		IL_0126: ldstr "subarray"
+		IL_012b: ldc.r8 1
+		IL_0134: box [System.Runtime]System.Double
+		IL_0139: ldc.r8 3
+		IL_0142: box [System.Runtime]System.Double
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_014c: stloc.s 19
+		IL_014e: ldloc.s 19
+		IL_0150: stloc.s 4
+		IL_0152: ldloc.1
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0158: stloc.s 19
+		IL_015a: ldloc.s 19
+		IL_015c: ldstr "set"
+		IL_0161: ldloc.s 4
+		IL_0163: ldc.r8 0.0
+		IL_016c: box [System.Runtime]System.Double
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0176: pop
+		IL_0177: ldc.r8 0.0
+		IL_0180: stloc.s 5
+		// loop start (head: IL_0182)
+			IL_0182: ldloc.s 5
+			IL_0184: stloc.s 21
+			IL_0186: ldloc.s 21
+			IL_0188: ldloc.1
+			IL_0189: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+			IL_018e: clt
+			IL_0190: brfalse IL_01de
+
+			IL_0195: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope_For_L11C5/Block_L11C40::.ctor()
+			IL_019a: stloc.s 6
+			IL_019c: ldstr "console"
+			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01a6: stloc.s 19
+			IL_01a8: ldloc.s 19
+			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01af: stloc.s 19
+			IL_01b1: ldloc.s 19
+			IL_01b3: ldstr "log"
 			IL_01b8: ldloc.1
-			IL_01b9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-			IL_01be: stloc.s 22
-			IL_01c0: ldloc.s 21
-			IL_01c2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01c7: stloc.s 23
-			IL_01c9: ldloc.s 23
-			IL_01cb: ldloc.s 22
-			IL_01cd: clt
-			IL_01cf: brfalse IL_0238
-
-			IL_01d4: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope_For_L11C5/Block_L11C40::.ctor()
-			IL_01d9: stloc.s 6
-			IL_01db: ldstr "console"
-			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01e5: stloc.s 19
-			IL_01e7: ldloc.s 19
-			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ee: stloc.s 19
-			IL_01f0: ldloc.s 19
-			IL_01f2: ldstr "log"
-			IL_01f7: ldloc.1
-			IL_01f8: ldloc.s 5
-			IL_01fa: unbox.any [System.Runtime]System.Double
-			IL_01ff: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0204: box [System.Runtime]System.Double
-			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_020e: pop
-			IL_020f: ldloc.s 5
-			IL_0211: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0216: stloc.s 22
-			IL_0218: ldloc.s 22
-			IL_021a: ldc.r8 1
-			IL_0223: add
-			IL_0224: stloc.s 22
-			IL_0226: ldloc.s 22
-			IL_0228: box [System.Runtime]System.Double
-			IL_022d: stloc.s 21
-			IL_022f: ldloc.s 21
-			IL_0231: stloc.s 5
-			IL_0233: br IL_01b4
+			IL_01b9: ldloc.s 5
+			IL_01bb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_01c0: box [System.Runtime]System.Double
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01ca: pop
+			IL_01cb: ldloc.s 5
+			IL_01cd: ldc.r8 1
+			IL_01d6: add
+			IL_01d7: stloc.s 5
+			IL_01d9: br IL_0182
 		// end loop
 		.try
 		{
-			IL_0238: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L15C4::.ctor()
-			IL_023d: stloc.s 7
-			IL_023f: ldloc.1
-			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0245: stloc.s 19
-			IL_0247: ldc.i4.3
-			IL_0248: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_024d: dup
-			IL_024e: ldc.r8 7
-			IL_0257: box [System.Runtime]System.Double
-			IL_025c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0261: dup
-			IL_0262: ldc.r8 6
-			IL_026b: box [System.Runtime]System.Double
-			IL_0270: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0275: dup
-			IL_0276: ldc.r8 5
-			IL_027f: box [System.Runtime]System.Double
-			IL_0284: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0289: stloc.s 20
-			IL_028b: ldloc.s 19
-			IL_028d: ldstr "set"
-			IL_0292: ldloc.s 20
-			IL_0294: ldc.r8 2
-			IL_029d: box [System.Runtime]System.Double
-			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02a7: pop
-			IL_02a8: leave IL_034b
+			IL_01de: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L15C4::.ctor()
+			IL_01e3: stloc.s 7
+			IL_01e5: ldloc.1
+			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01eb: stloc.s 19
+			IL_01ed: ldc.i4.3
+			IL_01ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01f3: dup
+			IL_01f4: ldc.r8 7
+			IL_01fd: box [System.Runtime]System.Double
+			IL_0202: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0207: dup
+			IL_0208: ldc.r8 6
+			IL_0211: box [System.Runtime]System.Double
+			IL_0216: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_021b: dup
+			IL_021c: ldc.r8 5
+			IL_0225: box [System.Runtime]System.Double
+			IL_022a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_022f: stloc.s 20
+			IL_0231: ldloc.s 19
+			IL_0233: ldstr "set"
+			IL_0238: ldloc.s 20
+			IL_023a: ldc.r8 2
+			IL_0243: box [System.Runtime]System.Double
+			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_024d: pop
+			IL_024e: leave IL_02f1
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02ad: stloc.s 8
-			IL_02af: ldloc.s 8
-			IL_02b1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02b6: dup
-			IL_02b7: brtrue IL_02cd
+			IL_0253: stloc.s 8
+			IL_0255: ldloc.s 8
+			IL_0257: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_025c: dup
+			IL_025d: brtrue IL_0273
 
-			IL_02bc: pop
-			IL_02bd: ldloc.s 8
-			IL_02bf: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02c4: dup
-			IL_02c5: brtrue IL_02d9
+			IL_0262: pop
+			IL_0263: ldloc.s 8
+			IL_0265: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_026a: dup
+			IL_026b: brtrue IL_027f
 
-			IL_02ca: pop
-			IL_02cb: rethrow
+			IL_0270: pop
+			IL_0271: rethrow
 
-			IL_02cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02d2: stloc.s 9
-			IL_02d4: br IL_02db
+			IL_0273: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0278: stloc.s 9
+			IL_027a: br IL_0281
 
-			IL_02d9: stloc.s 9
+			IL_027f: stloc.s 9
 
-			IL_02db: ldloc.s 9
-			IL_02dd: stloc.s 19
-			IL_02df: ldloc.s 19
-			IL_02e1: stloc.s 10
-			IL_02e3: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L17C12::.ctor()
-			IL_02e8: stloc.s 11
-			IL_02ea: ldstr "console"
-			IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02f4: stloc.s 19
-			IL_02f6: ldloc.s 19
-			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02fd: stloc.s 19
-			IL_02ff: ldloc.s 19
-			IL_0301: ldstr "log"
-			IL_0306: ldloc.s 10
-			IL_0308: ldstr "name"
-			IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0317: pop
-			IL_0318: ldstr "console"
-			IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0322: stloc.s 19
-			IL_0324: ldloc.s 19
-			IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_032b: stloc.s 19
-			IL_032d: ldloc.s 19
-			IL_032f: ldstr "log"
-			IL_0334: ldloc.s 10
-			IL_0336: ldstr "message"
-			IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0345: pop
-			IL_0346: leave IL_034b
+			IL_0281: ldloc.s 9
+			IL_0283: stloc.s 19
+			IL_0285: ldloc.s 19
+			IL_0287: stloc.s 10
+			IL_0289: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L17C12::.ctor()
+			IL_028e: stloc.s 11
+			IL_0290: ldstr "console"
+			IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_029a: stloc.s 19
+			IL_029c: ldloc.s 19
+			IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02a3: stloc.s 19
+			IL_02a5: ldloc.s 19
+			IL_02a7: ldstr "log"
+			IL_02ac: ldloc.s 10
+			IL_02ae: ldstr "name"
+			IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02bd: pop
+			IL_02be: ldstr "console"
+			IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02c8: stloc.s 19
+			IL_02ca: ldloc.s 19
+			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02d1: stloc.s 19
+			IL_02d3: ldloc.s 19
+			IL_02d5: ldstr "log"
+			IL_02da: ldloc.s 10
+			IL_02dc: ldstr "message"
+			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02eb: pop
+			IL_02ec: leave IL_02f1
 		} // end handler
 		.try
 		{
-			IL_034b: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L22C4::.ctor()
-			IL_0350: stloc.s 12
-			IL_0352: ldloc.1
-			IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0358: stloc.s 19
-			IL_035a: ldc.i4.1
-			IL_035b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0360: dup
-			IL_0361: ldc.r8 1
-			IL_036a: box [System.Runtime]System.Double
-			IL_036f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0374: stloc.s 20
-			IL_0376: ldloc.s 19
-			IL_0378: ldstr "set"
-			IL_037d: ldloc.s 20
-			IL_037f: ldc.r8 1
-			IL_0388: neg
-			IL_0389: box [System.Runtime]System.Double
-			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0393: pop
-			IL_0394: leave IL_0437
+			IL_02f1: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L22C4::.ctor()
+			IL_02f6: stloc.s 12
+			IL_02f8: ldloc.1
+			IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02fe: stloc.s 19
+			IL_0300: ldc.i4.1
+			IL_0301: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0306: dup
+			IL_0307: ldc.r8 1
+			IL_0310: box [System.Runtime]System.Double
+			IL_0315: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_031a: stloc.s 20
+			IL_031c: ldloc.s 19
+			IL_031e: ldstr "set"
+			IL_0323: ldloc.s 20
+			IL_0325: ldc.r8 1
+			IL_032e: neg
+			IL_032f: box [System.Runtime]System.Double
+			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0339: pop
+			IL_033a: leave IL_03dd
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0399: stloc.s 13
-			IL_039b: ldloc.s 13
-			IL_039d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03a2: dup
-			IL_03a3: brtrue IL_03b9
+			IL_033f: stloc.s 13
+			IL_0341: ldloc.s 13
+			IL_0343: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0348: dup
+			IL_0349: brtrue IL_035f
 
-			IL_03a8: pop
-			IL_03a9: ldloc.s 13
-			IL_03ab: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03b0: dup
-			IL_03b1: brtrue IL_03c5
+			IL_034e: pop
+			IL_034f: ldloc.s 13
+			IL_0351: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0356: dup
+			IL_0357: brtrue IL_036b
 
-			IL_03b6: pop
-			IL_03b7: rethrow
+			IL_035c: pop
+			IL_035d: rethrow
 
-			IL_03b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03be: stloc.s 14
-			IL_03c0: br IL_03c7
+			IL_035f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0364: stloc.s 14
+			IL_0366: br IL_036d
 
-			IL_03c5: stloc.s 14
+			IL_036b: stloc.s 14
 
-			IL_03c7: ldloc.s 14
-			IL_03c9: stloc.s 19
-			IL_03cb: ldloc.s 19
-			IL_03cd: stloc.s 15
-			IL_03cf: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L24C12::.ctor()
-			IL_03d4: stloc.s 16
-			IL_03d6: ldstr "console"
-			IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03e0: stloc.s 19
-			IL_03e2: ldloc.s 19
-			IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03e9: stloc.s 19
-			IL_03eb: ldloc.s 19
-			IL_03ed: ldstr "log"
-			IL_03f2: ldloc.s 15
-			IL_03f4: ldstr "name"
-			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0403: pop
-			IL_0404: ldstr "console"
-			IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_040e: stloc.s 19
-			IL_0410: ldloc.s 19
-			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0417: stloc.s 19
-			IL_0419: ldloc.s 19
-			IL_041b: ldstr "log"
-			IL_0420: ldloc.s 15
-			IL_0422: ldstr "message"
-			IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0431: pop
-			IL_0432: leave IL_0437
+			IL_036d: ldloc.s 14
+			IL_036f: stloc.s 19
+			IL_0371: ldloc.s 19
+			IL_0373: stloc.s 15
+			IL_0375: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L24C12::.ctor()
+			IL_037a: stloc.s 16
+			IL_037c: ldstr "console"
+			IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0386: stloc.s 19
+			IL_0388: ldloc.s 19
+			IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_038f: stloc.s 19
+			IL_0391: ldloc.s 19
+			IL_0393: ldstr "log"
+			IL_0398: ldloc.s 15
+			IL_039a: ldstr "name"
+			IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03a9: pop
+			IL_03aa: ldstr "console"
+			IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03b4: stloc.s 19
+			IL_03b6: ldloc.s 19
+			IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03bd: stloc.s 19
+			IL_03bf: ldloc.s 19
+			IL_03c1: ldstr "log"
+			IL_03c6: ldloc.s 15
+			IL_03c8: ldstr "message"
+			IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03d7: pop
+			IL_03d8: leave IL_03dd
 		} // end handler
 
-		IL_0437: ldnull
-		IL_0438: stloc.s 17
-		IL_043a: ret
+		IL_03dd: ldnull
+		IL_03de: stloc.s 17
+		IL_03e0: ret
 	} // end of method Int32Array_Set_BoundsChecks::__js_module_init__
 
 } // end of class Modules.Int32Array_Set_BoundsChecks
@@ -584,7 +552,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2505
+		// Method begins at RVA 0x24ad
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_FromArray_WithOffset.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_FromArray_WithOffset.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x216f
+			// Method begins at RVA 0x2142
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -34,7 +34,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2178
+			// Method begins at RVA 0x214b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -60,18 +60,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 275 (0x113)
+		// Code size: 230 (0xe6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Set_FromArray_WithOffset/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[3] object,
+			[3] float64,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[5] object,
 			[6] object,
-			[7] float64,
-			[8] float64
+			[7] float64
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Set_FromArray_WithOffset/Scope::.ctor()
@@ -111,53 +110,38 @@
 		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0089: pop
 		IL_008a: ldc.r8 0.0
-		IL_0093: box [System.Runtime]System.Double
-		IL_0098: stloc.3
-		// loop start (head: IL_0099)
-			IL_0099: ldloc.3
-			IL_009a: stloc.s 5
-			IL_009c: ldloc.1
-			IL_009d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
-			IL_00a2: stloc.s 7
-			IL_00a4: ldloc.s 5
-			IL_00a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00ab: stloc.s 8
-			IL_00ad: ldloc.s 8
-			IL_00af: ldloc.s 7
-			IL_00b1: clt
-			IL_00b3: brfalse IL_0112
+		IL_0093: stloc.3
+		// loop start (head: IL_0094)
+			IL_0094: ldloc.3
+			IL_0095: stloc.s 7
+			IL_0097: ldloc.s 7
+			IL_0099: ldloc.1
+			IL_009a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
+			IL_009f: clt
+			IL_00a1: brfalse IL_00e5
 
-			IL_00b8: ldstr "console"
-			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00c2: stloc.s 6
-			IL_00c4: ldloc.s 6
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00cb: stloc.s 6
-			IL_00cd: ldloc.s 6
-			IL_00cf: ldstr "log"
-			IL_00d4: ldloc.1
-			IL_00d5: ldloc.3
-			IL_00d6: unbox.any [System.Runtime]System.Double
-			IL_00db: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_00e0: box [System.Runtime]System.Double
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ea: pop
-			IL_00eb: ldloc.3
-			IL_00ec: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00f1: stloc.s 7
-			IL_00f3: ldloc.s 7
-			IL_00f5: ldc.r8 1
-			IL_00fe: add
-			IL_00ff: stloc.s 7
-			IL_0101: ldloc.s 7
-			IL_0103: box [System.Runtime]System.Double
-			IL_0108: stloc.s 5
-			IL_010a: ldloc.s 5
-			IL_010c: stloc.3
-			IL_010d: br IL_0099
+			IL_00a6: ldstr "console"
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00b0: stloc.s 6
+			IL_00b2: ldloc.s 6
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b9: stloc.s 6
+			IL_00bb: ldloc.s 6
+			IL_00bd: ldstr "log"
+			IL_00c2: ldloc.1
+			IL_00c3: ldloc.3
+			IL_00c4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_00c9: box [System.Runtime]System.Double
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00d3: pop
+			IL_00d4: ldloc.3
+			IL_00d5: ldc.r8 1
+			IL_00de: add
+			IL_00df: stloc.3
+			IL_00e0: br IL_0094
 		// end loop
 
-		IL_0112: ret
+		IL_00e5: ret
 	} // end of method Int32Array_Set_FromArray_WithOffset::__js_module_init__
 
 } // end of class Modules.Int32Array_Set_FromArray_WithOffset
@@ -169,7 +153,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2181
+		// Method begins at RVA 0x2154
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_Basic.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_Basic.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2292
+			// Method begins at RVA 0x2265
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a4
+				// Method begins at RVA 0x2277
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x229b
+			// Method begins at RVA 0x226e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,19 +82,18 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 566 (0x236)
+		// Code size: 521 (0x209)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Slice_Basic/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[2] object,
-			[3] object,
+			[3] float64,
 			[4] class Modules.Int32Array_Slice_Basic/Scope_For_L7C5/Block_L7C40,
 			[5] object,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[7] object,
-			[8] object,
-			[9] float64
+			[8] float64
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Slice_Basic/Scope::.ctor()
@@ -152,110 +151,95 @@
 		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00db: pop
 		IL_00dc: ldc.r8 0.0
-		IL_00e5: box [System.Runtime]System.Double
-		IL_00ea: stloc.3
-		// loop start (head: IL_00eb)
-			IL_00eb: ldloc.3
-			IL_00ec: stloc.s 8
-			IL_00ee: ldloc.2
-			IL_00ef: ldstr "length"
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f9: stloc.s 7
-			IL_00fb: ldloc.s 8
-			IL_00fd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0102: stloc.s 9
-			IL_0104: ldloc.s 9
-			IL_0106: ldloc.s 7
-			IL_0108: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_010d: clt
-			IL_010f: brfalse IL_016b
+		IL_00e5: stloc.3
+		// loop start (head: IL_00e6)
+			IL_00e6: ldloc.3
+			IL_00e7: stloc.s 8
+			IL_00e9: ldloc.s 8
+			IL_00eb: ldloc.2
+			IL_00ec: ldstr "length"
+			IL_00f1: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_00f6: clt
+			IL_00f8: brfalse IL_013e
 
-			IL_0114: newobj instance void Modules.Int32Array_Slice_Basic/Scope_For_L7C5/Block_L7C40::.ctor()
-			IL_0119: stloc.s 4
-			IL_011b: ldstr "console"
-			IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0125: stloc.s 7
-			IL_0127: ldloc.s 7
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_012e: stloc.s 7
-			IL_0130: ldloc.s 7
-			IL_0132: ldstr "log"
-			IL_0137: ldloc.2
-			IL_0138: ldloc.3
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0143: pop
-			IL_0144: ldloc.3
-			IL_0145: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_014a: stloc.s 9
-			IL_014c: ldloc.s 9
-			IL_014e: ldc.r8 1
-			IL_0157: add
-			IL_0158: stloc.s 9
-			IL_015a: ldloc.s 9
-			IL_015c: box [System.Runtime]System.Double
-			IL_0161: stloc.s 8
-			IL_0163: ldloc.s 8
-			IL_0165: stloc.3
-			IL_0166: br IL_00eb
+			IL_00fd: newobj instance void Modules.Int32Array_Slice_Basic/Scope_For_L7C5/Block_L7C40::.ctor()
+			IL_0102: stloc.s 4
+			IL_0104: ldstr "console"
+			IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_010e: stloc.s 7
+			IL_0110: ldloc.s 7
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0117: stloc.s 7
+			IL_0119: ldloc.s 7
+			IL_011b: ldstr "log"
+			IL_0120: ldloc.2
+			IL_0121: ldloc.3
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_012c: pop
+			IL_012d: ldloc.3
+			IL_012e: ldc.r8 1
+			IL_0137: add
+			IL_0138: stloc.3
+			IL_0139: br IL_00e6
 		// end loop
 
-		IL_016b: ldloc.2
-		IL_016c: ldc.r8 0.0
-		IL_0175: ldc.r8 99
-		IL_017e: ldc.i4.1
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-		IL_0184: pop
-		IL_0185: ldstr "console"
-		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018f: stloc.s 7
-		IL_0191: ldloc.s 7
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0198: stloc.s 7
-		IL_019a: ldloc.s 7
-		IL_019c: ldstr "log"
-		IL_01a1: ldloc.1
-		IL_01a2: ldc.r8 1
-		IL_01ab: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_01b0: box [System.Runtime]System.Double
-		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01ba: pop
-		IL_01bb: ldloc.1
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c1: stloc.s 7
-		IL_01c3: ldloc.s 7
-		IL_01c5: ldstr "slice"
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_01cf: stloc.s 7
-		IL_01d1: ldloc.s 7
-		IL_01d3: stloc.s 5
-		IL_01d5: ldstr "console"
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01df: stloc.s 7
-		IL_01e1: ldloc.s 7
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e8: stloc.s 7
-		IL_01ea: ldloc.s 7
-		IL_01ec: ldstr "log"
-		IL_01f1: ldloc.s 5
-		IL_01f3: ldstr "length"
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0202: pop
-		IL_0203: ldstr "console"
-		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020d: stloc.s 7
-		IL_020f: ldloc.s 7
-		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0216: stloc.s 7
-		IL_0218: ldloc.s 7
-		IL_021a: ldstr "log"
-		IL_021f: ldloc.s 5
-		IL_0221: ldc.r8 4
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0234: pop
-		IL_0235: ret
+		IL_013e: ldloc.2
+		IL_013f: ldc.r8 0.0
+		IL_0148: ldc.r8 99
+		IL_0151: ldc.i4.1
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+		IL_0157: pop
+		IL_0158: ldstr "console"
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0162: stloc.s 7
+		IL_0164: ldloc.s 7
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016b: stloc.s 7
+		IL_016d: ldloc.s 7
+		IL_016f: ldstr "log"
+		IL_0174: ldloc.1
+		IL_0175: ldc.r8 1
+		IL_017e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_0183: box [System.Runtime]System.Double
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_018d: pop
+		IL_018e: ldloc.1
+		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0194: stloc.s 7
+		IL_0196: ldloc.s 7
+		IL_0198: ldstr "slice"
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_01a2: stloc.s 7
+		IL_01a4: ldloc.s 7
+		IL_01a6: stloc.s 5
+		IL_01a8: ldstr "console"
+		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01b2: stloc.s 7
+		IL_01b4: ldloc.s 7
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01bb: stloc.s 7
+		IL_01bd: ldloc.s 7
+		IL_01bf: ldstr "log"
+		IL_01c4: ldloc.s 5
+		IL_01c6: ldstr "length"
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01d5: pop
+		IL_01d6: ldstr "console"
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e0: stloc.s 7
+		IL_01e2: ldloc.s 7
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e9: stloc.s 7
+		IL_01eb: ldloc.s 7
+		IL_01ed: ldstr "log"
+		IL_01f2: ldloc.s 5
+		IL_01f4: ldc.r8 4
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0207: pop
+		IL_0208: ret
 	} // end of method Int32Array_Slice_Basic::__js_module_init__
 
 } // end of class Modules.Int32Array_Slice_Basic
@@ -267,7 +251,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22ad
+		// Method begins at RVA 0x2280
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_RelativeIndices.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_RelativeIndices.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2387
+			// Method begins at RVA 0x232d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2399
+				// Method begins at RVA 0x233f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2390
+			// Method begins at RVA 0x2336
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ab
+				// Method begins at RVA 0x2351
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23a2
+			// Method begins at RVA 0x2348
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -124,16 +124,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 811 (0x32b)
+		// Code size: 721 (0x2d1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Slice_RelativeIndices/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[2] object,
-			[3] object,
+			[3] float64,
 			[4] class Modules.Int32Array_Slice_RelativeIndices/Scope_For_L7C5/Block_L7C42,
 			[5] object,
-			[6] object,
+			[6] float64,
 			[7] class Modules.Int32Array_Slice_RelativeIndices/Scope_For_L13C5/Block_L13C41,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[9] object,
@@ -201,183 +201,153 @@
 		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00e1: pop
 		IL_00e2: ldc.r8 0.0
-		IL_00eb: box [System.Runtime]System.Double
-		IL_00f0: stloc.3
-		// loop start (head: IL_00f1)
-			IL_00f1: ldloc.3
-			IL_00f2: stloc.s 10
-			IL_00f4: ldloc.2
-			IL_00f5: ldstr "length"
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ff: stloc.s 9
-			IL_0101: ldloc.s 10
-			IL_0103: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0108: stloc.s 11
-			IL_010a: ldloc.s 11
-			IL_010c: ldloc.s 9
-			IL_010e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0113: clt
-			IL_0115: brfalse IL_0171
+		IL_00eb: stloc.3
+		// loop start (head: IL_00ec)
+			IL_00ec: ldloc.3
+			IL_00ed: stloc.s 11
+			IL_00ef: ldloc.s 11
+			IL_00f1: ldloc.2
+			IL_00f2: ldstr "length"
+			IL_00f7: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_00fc: clt
+			IL_00fe: brfalse IL_0144
 
-			IL_011a: newobj instance void Modules.Int32Array_Slice_RelativeIndices/Scope_For_L7C5/Block_L7C42::.ctor()
-			IL_011f: stloc.s 4
-			IL_0121: ldstr "console"
-			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_012b: stloc.s 9
-			IL_012d: ldloc.s 9
-			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0134: stloc.s 9
-			IL_0136: ldloc.s 9
-			IL_0138: ldstr "log"
-			IL_013d: ldloc.2
-			IL_013e: ldloc.3
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0149: pop
-			IL_014a: ldloc.3
-			IL_014b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0150: stloc.s 11
-			IL_0152: ldloc.s 11
-			IL_0154: ldc.r8 1
-			IL_015d: add
-			IL_015e: stloc.s 11
-			IL_0160: ldloc.s 11
-			IL_0162: box [System.Runtime]System.Double
-			IL_0167: stloc.s 10
-			IL_0169: ldloc.s 10
-			IL_016b: stloc.3
-			IL_016c: br IL_00f1
+			IL_0103: newobj instance void Modules.Int32Array_Slice_RelativeIndices/Scope_For_L7C5/Block_L7C42::.ctor()
+			IL_0108: stloc.s 4
+			IL_010a: ldstr "console"
+			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0114: stloc.s 9
+			IL_0116: ldloc.s 9
+			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_011d: stloc.s 9
+			IL_011f: ldloc.s 9
+			IL_0121: ldstr "log"
+			IL_0126: ldloc.2
+			IL_0127: ldloc.3
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0132: pop
+			IL_0133: ldloc.3
+			IL_0134: ldc.r8 1
+			IL_013d: add
+			IL_013e: stloc.3
+			IL_013f: br IL_00ec
 		// end loop
 
-		IL_0171: ldloc.1
-		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0177: stloc.s 9
-		IL_0179: ldc.r8 20
-		IL_0182: neg
-		IL_0183: box [System.Runtime]System.Double
-		IL_0188: stloc.s 10
-		IL_018a: ldloc.s 9
-		IL_018c: ldstr "slice"
-		IL_0191: ldloc.s 10
-		IL_0193: ldc.r8 2
-		IL_019c: box [System.Runtime]System.Double
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01a6: stloc.s 9
-		IL_01a8: ldloc.s 9
-		IL_01aa: stloc.s 5
-		IL_01ac: ldstr "console"
-		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b6: stloc.s 9
-		IL_01b8: ldloc.s 9
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bf: stloc.s 9
-		IL_01c1: ldloc.s 9
-		IL_01c3: ldstr "log"
-		IL_01c8: ldloc.s 5
-		IL_01ca: ldstr "length"
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01d9: pop
-		IL_01da: ldc.r8 0.0
-		IL_01e3: box [System.Runtime]System.Double
-		IL_01e8: stloc.s 6
-		// loop start (head: IL_01ea)
-			IL_01ea: ldloc.s 6
-			IL_01ec: stloc.s 10
-			IL_01ee: ldloc.s 5
-			IL_01f0: ldstr "length"
-			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01fa: stloc.s 9
-			IL_01fc: ldloc.s 10
-			IL_01fe: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0203: stloc.s 11
-			IL_0205: ldloc.s 11
-			IL_0207: ldloc.s 9
-			IL_0209: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_020e: clt
-			IL_0210: brfalse IL_0270
+		IL_0144: ldloc.1
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014a: stloc.s 9
+		IL_014c: ldc.r8 20
+		IL_0155: neg
+		IL_0156: box [System.Runtime]System.Double
+		IL_015b: stloc.s 10
+		IL_015d: ldloc.s 9
+		IL_015f: ldstr "slice"
+		IL_0164: ldloc.s 10
+		IL_0166: ldc.r8 2
+		IL_016f: box [System.Runtime]System.Double
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0179: stloc.s 9
+		IL_017b: ldloc.s 9
+		IL_017d: stloc.s 5
+		IL_017f: ldstr "console"
+		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0189: stloc.s 9
+		IL_018b: ldloc.s 9
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0192: stloc.s 9
+		IL_0194: ldloc.s 9
+		IL_0196: ldstr "log"
+		IL_019b: ldloc.s 5
+		IL_019d: ldstr "length"
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01ac: pop
+		IL_01ad: ldc.r8 0.0
+		IL_01b6: stloc.s 6
+		// loop start (head: IL_01b8)
+			IL_01b8: ldloc.s 6
+			IL_01ba: stloc.s 11
+			IL_01bc: ldloc.s 11
+			IL_01be: ldloc.s 5
+			IL_01c0: ldstr "length"
+			IL_01c5: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_01ca: clt
+			IL_01cc: brfalse IL_0216
 
-			IL_0215: newobj instance void Modules.Int32Array_Slice_RelativeIndices/Scope_For_L13C5/Block_L13C41::.ctor()
-			IL_021a: stloc.s 7
-			IL_021c: ldstr "console"
-			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0226: stloc.s 9
-			IL_0228: ldloc.s 9
-			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_022f: stloc.s 9
-			IL_0231: ldloc.s 9
-			IL_0233: ldstr "log"
-			IL_0238: ldloc.s 5
-			IL_023a: ldloc.s 6
-			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0246: pop
-			IL_0247: ldloc.s 6
-			IL_0249: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_024e: stloc.s 11
-			IL_0250: ldloc.s 11
-			IL_0252: ldc.r8 1
-			IL_025b: add
-			IL_025c: stloc.s 11
-			IL_025e: ldloc.s 11
-			IL_0260: box [System.Runtime]System.Double
-			IL_0265: stloc.s 10
-			IL_0267: ldloc.s 10
-			IL_0269: stloc.s 6
-			IL_026b: br IL_01ea
+			IL_01d1: newobj instance void Modules.Int32Array_Slice_RelativeIndices/Scope_For_L13C5/Block_L13C41::.ctor()
+			IL_01d6: stloc.s 7
+			IL_01d8: ldstr "console"
+			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01e2: stloc.s 9
+			IL_01e4: ldloc.s 9
+			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01eb: stloc.s 9
+			IL_01ed: ldloc.s 9
+			IL_01ef: ldstr "log"
+			IL_01f4: ldloc.s 5
+			IL_01f6: ldloc.s 6
+			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0202: pop
+			IL_0203: ldloc.s 6
+			IL_0205: ldc.r8 1
+			IL_020e: add
+			IL_020f: stloc.s 6
+			IL_0211: br IL_01b8
 		// end loop
 
-		IL_0270: ldstr "console"
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_027a: stloc.s 9
-		IL_027c: ldloc.s 9
-		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0283: stloc.s 9
-		IL_0285: ldloc.1
-		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028b: stloc.s 12
-		IL_028d: ldloc.s 12
-		IL_028f: ldstr "slice"
-		IL_0294: ldc.r8 3
-		IL_029d: box [System.Runtime]System.Double
-		IL_02a2: ldc.r8 1
-		IL_02ab: box [System.Runtime]System.Double
-		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_02b5: stloc.s 12
-		IL_02b7: ldloc.s 12
-		IL_02b9: ldstr "length"
-		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02c3: stloc.s 12
-		IL_02c5: ldloc.s 9
-		IL_02c7: ldstr "log"
-		IL_02cc: ldloc.s 12
-		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02d3: pop
-		IL_02d4: ldstr "console"
-		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02de: stloc.s 12
-		IL_02e0: ldloc.s 12
-		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e7: stloc.s 12
-		IL_02e9: ldloc.1
-		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ef: stloc.s 9
-		IL_02f1: ldloc.s 9
-		IL_02f3: ldstr "slice"
-		IL_02f8: ldc.r8 10
-		IL_0301: box [System.Runtime]System.Double
-		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_030b: stloc.s 9
-		IL_030d: ldloc.s 9
-		IL_030f: ldstr "length"
-		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0319: stloc.s 9
-		IL_031b: ldloc.s 12
-		IL_031d: ldstr "log"
-		IL_0322: ldloc.s 9
-		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0329: pop
-		IL_032a: ret
+		IL_0216: ldstr "console"
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0220: stloc.s 9
+		IL_0222: ldloc.s 9
+		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0229: stloc.s 9
+		IL_022b: ldloc.1
+		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0231: stloc.s 12
+		IL_0233: ldloc.s 12
+		IL_0235: ldstr "slice"
+		IL_023a: ldc.r8 3
+		IL_0243: box [System.Runtime]System.Double
+		IL_0248: ldc.r8 1
+		IL_0251: box [System.Runtime]System.Double
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_025b: stloc.s 12
+		IL_025d: ldloc.s 12
+		IL_025f: ldstr "length"
+		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0269: stloc.s 12
+		IL_026b: ldloc.s 9
+		IL_026d: ldstr "log"
+		IL_0272: ldloc.s 12
+		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0279: pop
+		IL_027a: ldstr "console"
+		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0284: stloc.s 12
+		IL_0286: ldloc.s 12
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028d: stloc.s 12
+		IL_028f: ldloc.1
+		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0295: stloc.s 9
+		IL_0297: ldloc.s 9
+		IL_0299: ldstr "slice"
+		IL_029e: ldc.r8 10
+		IL_02a7: box [System.Runtime]System.Double
+		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02b1: stloc.s 9
+		IL_02b3: ldloc.s 9
+		IL_02b5: ldstr "length"
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02bf: stloc.s 9
+		IL_02c1: ldloc.s 12
+		IL_02c3: ldstr "log"
+		IL_02c8: ldloc.s 9
+		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02cf: pop
+		IL_02d0: ret
 	} // end of method Int32Array_Slice_RelativeIndices::__js_module_init__
 
 } // end of class Modules.Int32Array_Slice_RelativeIndices
@@ -389,7 +359,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23b4
+		// Method begins at RVA 0x235a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b5a
+				// Method begins at RVA 0x2b32
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b63
+				// Method begins at RVA 0x2b3b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b75
+					// Method begins at RVA 0x2b4d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b6c
+				// Method begins at RVA 0x2b44
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b90
+						// Method begins at RVA 0x2b68
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -132,7 +132,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2ba2
+							// Method begins at RVA 0x2b7a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -150,7 +150,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b99
+						// Method begins at RVA 0x2b71
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -168,7 +168,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b87
+					// Method begins at RVA 0x2b5f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -196,7 +196,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2bbd
+							// Method begins at RVA 0x2b95
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -214,7 +214,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2bb4
+						// Method begins at RVA 0x2b8c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -232,7 +232,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bab
+					// Method begins at RVA 0x2b83
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b7e
+				// Method begins at RVA 0x2b56
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +274,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bcf
+					// Method begins at RVA 0x2ba7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -292,7 +292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bc6
+				// Method begins at RVA 0x2b9e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -312,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bd8
+				// Method begins at RVA 0x2bb0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -336,7 +336,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bea
+					// Method begins at RVA 0x2bc2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -354,7 +354,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2be1
+				// Method begins at RVA 0x2bb9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -382,7 +382,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27a8
+			// Method begins at RVA 0x2780
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -431,7 +431,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a50
+			// Method begins at RVA 0x2a28
 			// Header size: 12
 			// Code size: 201 (0xc9)
 			.maxstack 8
@@ -551,7 +551,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27f8
+			// Method begins at RVA 0x27d0
 			// Header size: 12
 			// Code size: 461 (0x1cd)
 			.maxstack 8
@@ -788,7 +788,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29d4
+			// Method begins at RVA 0x29ac
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -880,7 +880,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c0e
+				// Method begins at RVA 0x2be6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -905,7 +905,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b25
+			// Method begins at RVA 0x2afd
 			// Header size: 1
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -945,7 +945,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c05
+					// Method begins at RVA 0x2bdd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -963,7 +963,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bfc
+				// Method begins at RVA 0x2bd4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -981,7 +981,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2bf3
+			// Method begins at RVA 0x2bcb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1007,7 +1007,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1868 (0x74c)
+		// Code size: 1828 (0x724)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope,
@@ -1016,7 +1016,7 @@
 			[3] object,
 			[4] float64,
 			[5] object,
-			[6] object,
+			[6] float64,
 			[7] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope_For_L73C5/Block_L73C47,
 			[8] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope_For_L73C5/Block_L73C47/Block_L74C46,
 			[9] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope/Block_L81C18,
@@ -1028,9 +1028,9 @@
 			[15] object,
 			[16] object,
 			[17] object,
-			[18] object,
-			[19] float64,
-			[20] bool
+			[18] float64,
+			[19] bool,
+			[20] object
 		)
 
 		IL_0000: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::.ctor()
@@ -1417,244 +1417,230 @@
 		IL_0423: box [System.Runtime]System.Double
 		IL_0428: stloc.s 5
 		IL_042a: ldc.r8 0.0
-		IL_0433: box [System.Runtime]System.Double
-		IL_0438: stloc.s 6
-		// loop start (head: IL_043a)
-			IL_043a: ldloc.s 6
-			IL_043c: stloc.s 18
-			IL_043e: ldloc.2
-			IL_043f: ldstr "wordArray"
-			IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0449: ldstr "length"
-			IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0453: stloc.s 15
-			IL_0455: ldloc.s 18
-			IL_0457: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_045c: stloc.s 19
-			IL_045e: ldloc.s 19
-			IL_0460: ldloc.s 15
-			IL_0462: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0467: clt
-			IL_0469: brfalse IL_0514
+		IL_0433: stloc.s 6
+		// loop start (head: IL_0435)
+			IL_0435: ldloc.s 6
+			IL_0437: stloc.s 18
+			IL_0439: ldloc.s 18
+			IL_043b: ldloc.2
+			IL_043c: ldstr "wordArray"
+			IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0446: ldstr "length"
+			IL_044b: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_0450: clt
+			IL_0452: brfalse IL_04ec
 
-			IL_046e: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope_For_L73C5/Block_L73C47::.ctor()
-			IL_0473: stloc.s 7
-			IL_0475: ldloc.2
-			IL_0476: ldstr "wordArray"
-			IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0480: ldloc.s 6
-			IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0487: stloc.s 15
-			IL_0489: ldloc.s 15
-			IL_048b: ldloc.3
-			IL_048c: ldstr "wordArray"
-			IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0496: ldloc.s 6
-			IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_049d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_04a2: stloc.s 20
-			IL_04a4: ldloc.s 20
-			IL_04a6: brfalse IL_04eb
+			IL_0457: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope_For_L73C5/Block_L73C47::.ctor()
+			IL_045c: stloc.s 7
+			IL_045e: ldloc.2
+			IL_045f: ldstr "wordArray"
+			IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0469: ldloc.s 6
+			IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0470: stloc.s 15
+			IL_0472: ldloc.s 15
+			IL_0474: ldloc.3
+			IL_0475: ldstr "wordArray"
+			IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_047f: ldloc.s 6
+			IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0486: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_048b: stloc.s 19
+			IL_048d: ldloc.s 19
+			IL_048f: brfalse IL_04d9
 
-			IL_04ab: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope_For_L73C5/Block_L73C47/Block_L74C46::.ctor()
-			IL_04b0: stloc.s 8
-			IL_04b2: ldloc.s 4
-			IL_04b4: ldc.r8 1
-			IL_04bd: add
-			IL_04be: stloc.s 4
-			IL_04c0: ldloc.s 5
-			IL_04c2: stloc.s 18
-			IL_04c4: ldloc.s 18
-			IL_04c6: ldc.r8 1
-			IL_04cf: neg
-			IL_04d0: box [System.Runtime]System.Double
-			IL_04d5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_04da: stloc.s 20
-			IL_04dc: ldloc.s 20
-			IL_04de: brfalse IL_04eb
+			IL_0494: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope_For_L73C5/Block_L73C47/Block_L74C46::.ctor()
+			IL_0499: stloc.s 8
+			IL_049b: ldloc.s 4
+			IL_049d: ldc.r8 1
+			IL_04a6: add
+			IL_04a7: stloc.s 4
+			IL_04a9: ldloc.s 5
+			IL_04ab: stloc.s 20
+			IL_04ad: ldloc.s 20
+			IL_04af: ldc.r8 1
+			IL_04b8: neg
+			IL_04b9: box [System.Runtime]System.Double
+			IL_04be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_04c3: stloc.s 19
+			IL_04c5: ldloc.s 19
+			IL_04c7: brfalse IL_04d9
 
-			IL_04e3: ldloc.s 6
-			IL_04e5: stloc.s 18
-			IL_04e7: ldloc.s 18
-			IL_04e9: stloc.s 5
+			IL_04cc: ldloc.s 6
+			IL_04ce: box [System.Runtime]System.Double
+			IL_04d3: stloc.s 20
+			IL_04d5: ldloc.s 20
+			IL_04d7: stloc.s 5
 
-			IL_04eb: ldloc.s 6
-			IL_04ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_04f2: stloc.s 19
-			IL_04f4: ldloc.s 19
-			IL_04f6: ldc.r8 1
-			IL_04ff: add
-			IL_0500: stloc.s 19
-			IL_0502: ldloc.s 19
-			IL_0504: box [System.Runtime]System.Double
-			IL_0509: stloc.s 18
-			IL_050b: ldloc.s 18
-			IL_050d: stloc.s 6
-			IL_050f: br IL_043a
+			IL_04d9: ldloc.s 6
+			IL_04db: ldc.r8 1
+			IL_04e4: add
+			IL_04e5: stloc.s 6
+			IL_04e7: br IL_0435
 		// end loop
 
-		IL_0514: ldstr "console"
-		IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_051e: stloc.s 15
-		IL_0520: ldloc.s 15
-		IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0527: stloc.s 15
-		IL_0529: ldloc.s 4
-		IL_052b: box [System.Runtime]System.Double
-		IL_0530: stloc.s 18
-		IL_0532: ldloc.s 15
-		IL_0534: ldstr "log"
-		IL_0539: ldstr "diffs"
-		IL_053e: ldloc.s 18
-		IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0545: pop
-		IL_0546: ldloc.s 5
-		IL_0548: stloc.s 18
-		IL_054a: ldloc.s 18
-		IL_054c: ldc.r8 1
-		IL_0555: neg
-		IL_0556: box [System.Runtime]System.Double
-		IL_055b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0560: stloc.s 20
-		IL_0562: ldloc.s 20
-		IL_0564: brfalse IL_05d7
+		IL_04ec: ldstr "console"
+		IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04f6: stloc.s 15
+		IL_04f8: ldloc.s 15
+		IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04ff: stloc.s 15
+		IL_0501: ldloc.s 4
+		IL_0503: box [System.Runtime]System.Double
+		IL_0508: stloc.s 20
+		IL_050a: ldloc.s 15
+		IL_050c: ldstr "log"
+		IL_0511: ldstr "diffs"
+		IL_0516: ldloc.s 20
+		IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_051d: pop
+		IL_051e: ldloc.s 5
+		IL_0520: stloc.s 20
+		IL_0522: ldloc.s 20
+		IL_0524: ldc.r8 1
+		IL_052d: neg
+		IL_052e: box [System.Runtime]System.Double
+		IL_0533: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0538: stloc.s 19
+		IL_053a: ldloc.s 19
+		IL_053c: brfalse IL_05af
 
-		IL_0569: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope/Block_L81C18::.ctor()
-		IL_056e: stloc.s 9
-		IL_0570: ldstr "console"
-		IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_057a: stloc.s 15
-		IL_057c: ldloc.s 15
-		IL_057e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0583: stloc.s 15
-		IL_0585: ldloc.2
-		IL_0586: ldstr "wordArray"
-		IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0590: ldloc.s 5
-		IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_0597: stloc.s 12
-		IL_0599: ldc.i4.4
-		IL_059a: newarr [System.Runtime]System.Object
-		IL_059f: dup
-		IL_05a0: ldc.i4.0
-		IL_05a1: ldstr "first"
-		IL_05a6: stelem.ref
-		IL_05a7: dup
-		IL_05a8: ldc.i4.1
-		IL_05a9: ldloc.s 5
-		IL_05ab: stelem.ref
-		IL_05ac: dup
-		IL_05ad: ldc.i4.2
-		IL_05ae: ldloc.s 12
-		IL_05b0: stelem.ref
-		IL_05b1: dup
-		IL_05b2: ldc.i4.3
-		IL_05b3: ldloc.3
-		IL_05b4: ldstr "wordArray"
-		IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05be: ldloc.s 5
-		IL_05c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_05c5: stelem.ref
-		IL_05c6: stloc.s 11
-		IL_05c8: ldloc.s 15
-		IL_05ca: ldstr "log"
-		IL_05cf: ldloc.s 11
-		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_05d6: pop
+		IL_0541: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope/Block_L81C18::.ctor()
+		IL_0546: stloc.s 9
+		IL_0548: ldstr "console"
+		IL_054d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0552: stloc.s 15
+		IL_0554: ldloc.s 15
+		IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_055b: stloc.s 15
+		IL_055d: ldloc.2
+		IL_055e: ldstr "wordArray"
+		IL_0563: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0568: ldloc.s 5
+		IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_056f: stloc.s 12
+		IL_0571: ldc.i4.4
+		IL_0572: newarr [System.Runtime]System.Object
+		IL_0577: dup
+		IL_0578: ldc.i4.0
+		IL_0579: ldstr "first"
+		IL_057e: stelem.ref
+		IL_057f: dup
+		IL_0580: ldc.i4.1
+		IL_0581: ldloc.s 5
+		IL_0583: stelem.ref
+		IL_0584: dup
+		IL_0585: ldc.i4.2
+		IL_0586: ldloc.s 12
+		IL_0588: stelem.ref
+		IL_0589: dup
+		IL_058a: ldc.i4.3
+		IL_058b: ldloc.3
+		IL_058c: ldstr "wordArray"
+		IL_0591: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0596: ldloc.s 5
+		IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_059d: stelem.ref
+		IL_059e: stloc.s 11
+		IL_05a0: ldloc.s 15
+		IL_05a2: ldstr "log"
+		IL_05a7: ldloc.s 11
+		IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_05ae: pop
 
-		IL_05d7: ldstr "console"
-		IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05e1: stloc.s 15
-		IL_05e3: ldloc.s 15
-		IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05ea: stloc.s 15
-		IL_05ec: ldloc.2
-		IL_05ed: ldstr "wordArray"
-		IL_05f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05f7: ldc.r8 0.0
-		IL_0600: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0605: stloc.s 12
-		IL_0607: ldloc.s 15
-		IL_0609: ldstr "log"
-		IL_060e: ldstr "w0"
-		IL_0613: ldloc.s 12
-		IL_0615: ldloc.3
-		IL_0616: ldstr "wordArray"
-		IL_061b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0620: ldc.r8 0.0
-		IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_062e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0633: pop
-		IL_0634: ldstr "console"
-		IL_0639: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_063e: stloc.s 12
-		IL_0640: ldloc.s 12
-		IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0647: stloc.s 12
-		IL_0649: ldloc.2
-		IL_064a: ldstr "wordArray"
-		IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0654: ldc.r8 1
-		IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0662: stloc.s 15
-		IL_0664: ldloc.s 12
-		IL_0666: ldstr "log"
-		IL_066b: ldstr "w1"
-		IL_0670: ldloc.s 15
-		IL_0672: ldloc.3
-		IL_0673: ldstr "wordArray"
-		IL_0678: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_067d: ldc.r8 1
-		IL_0686: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_068b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0690: pop
-		IL_0691: ldstr "console"
-		IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_069b: stloc.s 15
-		IL_069d: ldloc.s 15
-		IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06a4: stloc.s 15
-		IL_06a6: ldloc.2
-		IL_06a7: ldstr "wordArray"
-		IL_06ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06b1: ldc.r8 2
-		IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_06bf: stloc.s 12
-		IL_06c1: ldloc.s 15
-		IL_06c3: ldstr "log"
-		IL_06c8: ldstr "w2"
-		IL_06cd: ldloc.s 12
-		IL_06cf: ldloc.3
-		IL_06d0: ldstr "wordArray"
-		IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06da: ldc.r8 2
-		IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_06ed: pop
-		IL_06ee: ldstr "console"
-		IL_06f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06f8: stloc.s 12
-		IL_06fa: ldloc.s 12
-		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0701: stloc.s 12
-		IL_0703: ldloc.2
-		IL_0704: ldstr "wordArray"
-		IL_0709: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_070e: ldc.r8 3
-		IL_0717: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_071c: stloc.s 15
-		IL_071e: ldloc.s 12
-		IL_0720: ldstr "log"
-		IL_0725: ldstr "w3"
-		IL_072a: ldloc.s 15
-		IL_072c: ldloc.3
-		IL_072d: ldstr "wordArray"
-		IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0737: ldc.r8 3
-		IL_0740: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0745: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_074a: pop
-		IL_074b: ret
+		IL_05af: ldstr "console"
+		IL_05b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05b9: stloc.s 15
+		IL_05bb: ldloc.s 15
+		IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05c2: stloc.s 15
+		IL_05c4: ldloc.2
+		IL_05c5: ldstr "wordArray"
+		IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05cf: ldc.r8 0.0
+		IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05dd: stloc.s 12
+		IL_05df: ldloc.s 15
+		IL_05e1: ldstr "log"
+		IL_05e6: ldstr "w0"
+		IL_05eb: ldloc.s 12
+		IL_05ed: ldloc.3
+		IL_05ee: ldstr "wordArray"
+		IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05f8: ldc.r8 0.0
+		IL_0601: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_060b: pop
+		IL_060c: ldstr "console"
+		IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0616: stloc.s 12
+		IL_0618: ldloc.s 12
+		IL_061a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_061f: stloc.s 12
+		IL_0621: ldloc.2
+		IL_0622: ldstr "wordArray"
+		IL_0627: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_062c: ldc.r8 1
+		IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_063a: stloc.s 15
+		IL_063c: ldloc.s 12
+		IL_063e: ldstr "log"
+		IL_0643: ldstr "w1"
+		IL_0648: ldloc.s 15
+		IL_064a: ldloc.3
+		IL_064b: ldstr "wordArray"
+		IL_0650: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0655: ldc.r8 1
+		IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0668: pop
+		IL_0669: ldstr "console"
+		IL_066e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0673: stloc.s 15
+		IL_0675: ldloc.s 15
+		IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_067c: stloc.s 15
+		IL_067e: ldloc.2
+		IL_067f: ldstr "wordArray"
+		IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0689: ldc.r8 2
+		IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0697: stloc.s 12
+		IL_0699: ldloc.s 15
+		IL_069b: ldstr "log"
+		IL_06a0: ldstr "w2"
+		IL_06a5: ldloc.s 12
+		IL_06a7: ldloc.3
+		IL_06a8: ldstr "wordArray"
+		IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06b2: ldc.r8 2
+		IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_06c5: pop
+		IL_06c6: ldstr "console"
+		IL_06cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06d0: stloc.s 12
+		IL_06d2: ldloc.s 12
+		IL_06d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06d9: stloc.s 12
+		IL_06db: ldloc.2
+		IL_06dc: ldstr "wordArray"
+		IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06e6: ldc.r8 3
+		IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_06f4: stloc.s 15
+		IL_06f6: ldloc.s 12
+		IL_06f8: ldstr "log"
+		IL_06fd: ldstr "w3"
+		IL_0702: ldloc.s 15
+		IL_0704: ldloc.3
+		IL_0705: ldstr "wordArray"
+		IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_070f: ldc.r8 3
+		IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_071d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0722: pop
+		IL_0723: ret
 	} // end of method Prime_SetBitsTrue_LargeStep_OptimizedVsNaive::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive
@@ -1666,7 +1652,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2c17
+		// Method begins at RVA 0x2bef
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Construct_ArrayLike_Buffer_Search.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Construct_ArrayLike_Buffer_Search.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23dc
+			// Method begins at RVA 0x23b4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ee
+				// Method begins at RVA 0x23c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23e5
+			// Method begins at RVA 0x23bd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,12 +82,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 896 (0x380)
+		// Code size: 856 (0x358)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
-			[2] object,
+			[2] float64,
 			[3] class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search/Scope_For_L5C5/Block_L5C43,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
@@ -96,11 +96,10 @@
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
 			[9] object,
 			[10] float64,
-			[11] float64,
-			[12] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
-			[13] bool,
-			[14] object,
-			[15] object
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
+			[12] bool,
+			[13] object,
+			[14] object
 		)
 
 		IL_0000: newobj instance void Modules.Uint8Array_Construct_ArrayLike_Buffer_Search/Scope::.ctor()
@@ -144,218 +143,204 @@
 		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0097: pop
 		IL_0098: ldc.r8 0.0
-		IL_00a1: box [System.Runtime]System.Double
-		IL_00a6: stloc.2
-		// loop start (head: IL_00a7)
-			IL_00a7: ldloc.2
-			IL_00a8: stloc.s 7
-			IL_00aa: ldloc.1
-			IL_00ab: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_00b0: stloc.s 10
-			IL_00b2: ldloc.s 7
-			IL_00b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00b9: stloc.s 11
-			IL_00bb: ldloc.s 11
-			IL_00bd: ldloc.s 10
-			IL_00bf: clt
-			IL_00c1: brfalse IL_011c
+		IL_00a1: stloc.2
+		// loop start (head: IL_00a2)
+			IL_00a2: ldloc.2
+			IL_00a3: stloc.s 10
+			IL_00a5: ldloc.s 10
+			IL_00a7: ldloc.1
+			IL_00a8: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+			IL_00ad: clt
+			IL_00af: brfalse IL_00f4
 
-			IL_00c6: newobj instance void Modules.Uint8Array_Construct_ArrayLike_Buffer_Search/Scope_For_L5C5/Block_L5C43::.ctor()
-			IL_00cb: stloc.3
-			IL_00cc: ldstr "console"
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00d6: stloc.s 9
-			IL_00d8: ldloc.s 9
-			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00df: stloc.s 9
-			IL_00e1: ldloc.s 9
-			IL_00e3: ldstr "log"
-			IL_00e8: ldloc.1
-			IL_00e9: ldloc.2
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00f4: pop
-			IL_00f5: ldloc.2
-			IL_00f6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00fb: stloc.s 10
-			IL_00fd: ldloc.s 10
-			IL_00ff: ldc.r8 1
-			IL_0108: add
-			IL_0109: stloc.s 10
-			IL_010b: ldloc.s 10
-			IL_010d: box [System.Runtime]System.Double
-			IL_0112: stloc.s 7
-			IL_0114: ldloc.s 7
-			IL_0116: stloc.2
-			IL_0117: br IL_00a7
+			IL_00b4: newobj instance void Modules.Uint8Array_Construct_ArrayLike_Buffer_Search/Scope_For_L5C5/Block_L5C43::.ctor()
+			IL_00b9: stloc.3
+			IL_00ba: ldstr "console"
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c4: stloc.s 9
+			IL_00c6: ldloc.s 9
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00cd: stloc.s 9
+			IL_00cf: ldloc.s 9
+			IL_00d1: ldstr "log"
+			IL_00d6: ldloc.1
+			IL_00d7: ldloc.2
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e2: pop
+			IL_00e3: ldloc.2
+			IL_00e4: ldc.r8 1
+			IL_00ed: add
+			IL_00ee: stloc.2
+			IL_00ef: br IL_00a2
 		// end loop
 
-		IL_011c: ldc.r8 4
-		IL_0125: box [System.Runtime]System.Double
-		IL_012a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer::.ctor(object)
-		IL_012f: stloc.s 12
-		IL_0131: ldloc.s 12
-		IL_0133: stloc.s 4
-		IL_0135: ldloc.s 4
-		IL_0137: ldc.r8 1
-		IL_0140: box [System.Runtime]System.Double
-		IL_0145: ldc.r8 2
-		IL_014e: box [System.Runtime]System.Double
-		IL_0153: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object, object, object)
-		IL_0158: stloc.s 8
-		IL_015a: ldloc.s 8
-		IL_015c: stloc.s 5
-		IL_015e: ldloc.s 5
-		IL_0160: ldc.r8 0.0
-		IL_0169: ldc.r8 42
-		IL_0172: ldc.i4.1
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-		IL_0178: pop
-		IL_0179: ldloc.s 5
-		IL_017b: ldc.r8 1
-		IL_0184: ldc.r8 43
-		IL_018d: ldc.i4.1
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-		IL_0193: pop
-		IL_0194: ldstr "console"
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_019e: stloc.s 9
-		IL_01a0: ldloc.s 9
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a7: stloc.s 9
-		IL_01a9: ldloc.s 9
-		IL_01ab: ldstr "log"
-		IL_01b0: ldloc.s 5
-		IL_01b2: ldstr "byteOffset"
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01c1: pop
-		IL_01c2: ldstr "console"
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01cc: stloc.s 9
-		IL_01ce: ldloc.s 9
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d5: stloc.s 9
-		IL_01d7: ldloc.s 9
-		IL_01d9: ldstr "log"
-		IL_01de: ldloc.s 5
-		IL_01e0: ldstr "byteLength"
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01ef: pop
-		IL_01f0: ldstr "console"
-		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01fa: stloc.s 9
-		IL_01fc: ldloc.s 9
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0203: stloc.s 9
-		IL_0205: ldloc.s 5
-		IL_0207: ldstr "buffer"
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0211: ldloc.s 4
-		IL_0213: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0218: stloc.s 13
-		IL_021a: ldloc.s 13
-		IL_021c: box [System.Runtime]System.Boolean
-		IL_0221: stloc.s 14
+		IL_00f4: ldc.r8 4
+		IL_00fd: box [System.Runtime]System.Double
+		IL_0102: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer::.ctor(object)
+		IL_0107: stloc.s 11
+		IL_0109: ldloc.s 11
+		IL_010b: stloc.s 4
+		IL_010d: ldloc.s 4
+		IL_010f: ldc.r8 1
+		IL_0118: box [System.Runtime]System.Double
+		IL_011d: ldc.r8 2
+		IL_0126: box [System.Runtime]System.Double
+		IL_012b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object, object, object)
+		IL_0130: stloc.s 8
+		IL_0132: ldloc.s 8
+		IL_0134: stloc.s 5
+		IL_0136: ldloc.s 5
+		IL_0138: ldc.r8 0.0
+		IL_0141: ldc.r8 42
+		IL_014a: ldc.i4.1
+		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+		IL_0150: pop
+		IL_0151: ldloc.s 5
+		IL_0153: ldc.r8 1
+		IL_015c: ldc.r8 43
+		IL_0165: ldc.i4.1
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+		IL_016b: pop
+		IL_016c: ldstr "console"
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0176: stloc.s 9
+		IL_0178: ldloc.s 9
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017f: stloc.s 9
+		IL_0181: ldloc.s 9
+		IL_0183: ldstr "log"
+		IL_0188: ldloc.s 5
+		IL_018a: ldstr "byteOffset"
+		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0199: pop
+		IL_019a: ldstr "console"
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a4: stloc.s 9
+		IL_01a6: ldloc.s 9
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ad: stloc.s 9
+		IL_01af: ldloc.s 9
+		IL_01b1: ldstr "log"
+		IL_01b6: ldloc.s 5
+		IL_01b8: ldstr "byteLength"
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01c7: pop
+		IL_01c8: ldstr "console"
+		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d2: stloc.s 9
+		IL_01d4: ldloc.s 9
+		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01db: stloc.s 9
+		IL_01dd: ldloc.s 5
+		IL_01df: ldstr "buffer"
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e9: ldloc.s 4
+		IL_01eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01f0: stloc.s 12
+		IL_01f2: ldloc.s 12
+		IL_01f4: box [System.Runtime]System.Boolean
+		IL_01f9: stloc.s 13
+		IL_01fb: ldloc.s 9
+		IL_01fd: ldstr "log"
+		IL_0202: ldloc.s 13
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0209: pop
+		IL_020a: ldloc.s 4
+		IL_020c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_0211: stloc.s 8
+		IL_0213: ldloc.s 8
+		IL_0215: stloc.s 6
+		IL_0217: ldstr "console"
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0221: stloc.s 9
 		IL_0223: ldloc.s 9
-		IL_0225: ldstr "log"
-		IL_022a: ldloc.s 14
-		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0231: pop
-		IL_0232: ldloc.s 4
-		IL_0234: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_0239: stloc.s 8
-		IL_023b: ldloc.s 8
-		IL_023d: stloc.s 6
-		IL_023f: ldstr "console"
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0249: stloc.s 9
-		IL_024b: ldloc.s 9
-		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0252: stloc.s 9
-		IL_0254: ldloc.s 9
-		IL_0256: ldstr "log"
-		IL_025b: ldloc.s 6
-		IL_025d: ldc.r8 1
-		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0270: pop
-		IL_0271: ldstr "console"
-		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_027b: stloc.s 9
-		IL_027d: ldloc.s 9
-		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0284: stloc.s 9
-		IL_0286: ldloc.s 9
-		IL_0288: ldstr "log"
-		IL_028d: ldloc.s 6
-		IL_028f: ldc.r8 2
-		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02a2: pop
-		IL_02a3: ldstr "console"
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ad: stloc.s 9
-		IL_02af: ldloc.s 9
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b6: stloc.s 9
-		IL_02b8: ldloc.s 5
-		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02bf: stloc.s 15
-		IL_02c1: ldloc.s 15
-		IL_02c3: ldstr "includes"
-		IL_02c8: ldc.r8 43
-		IL_02d1: box [System.Runtime]System.Double
-		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02db: stloc.s 15
-		IL_02dd: ldloc.s 9
-		IL_02df: ldstr "log"
-		IL_02e4: ldloc.s 15
-		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02eb: pop
-		IL_02ec: ldstr "console"
-		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02f6: stloc.s 15
-		IL_02f8: ldloc.s 15
-		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ff: stloc.s 15
-		IL_0301: ldloc.s 5
-		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0308: stloc.s 9
-		IL_030a: ldloc.s 9
-		IL_030c: ldstr "indexOf"
-		IL_0311: ldc.r8 42
-		IL_031a: box [System.Runtime]System.Double
-		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0324: stloc.s 9
-		IL_0326: ldloc.s 15
-		IL_0328: ldstr "log"
-		IL_032d: ldloc.s 9
-		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0334: pop
-		IL_0335: ldstr "console"
-		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_033f: stloc.s 9
-		IL_0341: ldloc.s 9
-		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0348: stloc.s 9
-		IL_034a: ldloc.s 5
-		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0351: stloc.s 15
-		IL_0353: ldloc.s 15
-		IL_0355: ldstr "at"
-		IL_035a: ldc.r8 1
-		IL_0363: neg
-		IL_0364: box [System.Runtime]System.Double
-		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_036e: stloc.s 15
-		IL_0370: ldloc.s 9
-		IL_0372: ldstr "log"
-		IL_0377: ldloc.s 15
-		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_037e: pop
-		IL_037f: ret
+		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_022a: stloc.s 9
+		IL_022c: ldloc.s 9
+		IL_022e: ldstr "log"
+		IL_0233: ldloc.s 6
+		IL_0235: ldc.r8 1
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0248: pop
+		IL_0249: ldstr "console"
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0253: stloc.s 9
+		IL_0255: ldloc.s 9
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025c: stloc.s 9
+		IL_025e: ldloc.s 9
+		IL_0260: ldstr "log"
+		IL_0265: ldloc.s 6
+		IL_0267: ldc.r8 2
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_027a: pop
+		IL_027b: ldstr "console"
+		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0285: stloc.s 9
+		IL_0287: ldloc.s 9
+		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028e: stloc.s 9
+		IL_0290: ldloc.s 5
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0297: stloc.s 14
+		IL_0299: ldloc.s 14
+		IL_029b: ldstr "includes"
+		IL_02a0: ldc.r8 43
+		IL_02a9: box [System.Runtime]System.Double
+		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02b3: stloc.s 14
+		IL_02b5: ldloc.s 9
+		IL_02b7: ldstr "log"
+		IL_02bc: ldloc.s 14
+		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02c3: pop
+		IL_02c4: ldstr "console"
+		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ce: stloc.s 14
+		IL_02d0: ldloc.s 14
+		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d7: stloc.s 14
+		IL_02d9: ldloc.s 5
+		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02e0: stloc.s 9
+		IL_02e2: ldloc.s 9
+		IL_02e4: ldstr "indexOf"
+		IL_02e9: ldc.r8 42
+		IL_02f2: box [System.Runtime]System.Double
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02fc: stloc.s 9
+		IL_02fe: ldloc.s 14
+		IL_0300: ldstr "log"
+		IL_0305: ldloc.s 9
+		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_030c: pop
+		IL_030d: ldstr "console"
+		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0317: stloc.s 9
+		IL_0319: ldloc.s 9
+		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0320: stloc.s 9
+		IL_0322: ldloc.s 5
+		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0329: stloc.s 14
+		IL_032b: ldloc.s 14
+		IL_032d: ldstr "at"
+		IL_0332: ldc.r8 1
+		IL_033b: neg
+		IL_033c: box [System.Runtime]System.Double
+		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0346: stloc.s 14
+		IL_0348: ldloc.s 9
+		IL_034a: ldstr "log"
+		IL_034f: ldloc.s 14
+		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0356: pop
+		IL_0357: ret
 	} // end of method Uint8Array_Construct_ArrayLike_Buffer_Search::__js_module_init__
 
 } // end of class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search
@@ -367,7 +352,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23f7
+		// Method begins at RVA 0x23cf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetBlockScope.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetBlockScope.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20da
+				// Method begins at RVA 0x20de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -36,7 +36,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20d1
+			// Method begins at RVA 0x20d5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -62,13 +62,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 117 (0x75)
+		// Code size: 121 (0x79)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_LetBlockScope/Scope,
 			[1] float64,
 			[2] class Modules.Variable_LetBlockScope/Scope/Block_L4C0,
-			[3] object,
+			[3] float64,
 			[4] object,
 			[5] object
 		)
@@ -80,34 +80,36 @@
 		IL_0010: newobj instance void Modules.Variable_LetBlockScope/Scope/Block_L4C0::.ctor()
 		IL_0015: stloc.2
 		IL_0016: ldc.r8 2
-		IL_001f: box [System.Runtime]System.Double
-		IL_0024: stloc.3
-		IL_0025: ldstr "console"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_002f: stloc.s 4
-		IL_0031: ldloc.s 4
-		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0038: stloc.s 4
-		IL_003a: ldloc.s 4
-		IL_003c: ldstr "log"
-		IL_0041: ldloc.3
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0047: pop
-		IL_0048: ldstr "console"
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0052: stloc.s 4
-		IL_0054: ldloc.s 4
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005b: stloc.s 4
-		IL_005d: ldloc.1
-		IL_005e: box [System.Runtime]System.Double
-		IL_0063: stloc.s 5
-		IL_0065: ldloc.s 4
-		IL_0067: ldstr "log"
-		IL_006c: ldloc.s 5
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0073: pop
-		IL_0074: ret
+		IL_001f: stloc.3
+		IL_0020: ldstr "console"
+		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002a: stloc.s 4
+		IL_002c: ldloc.s 4
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0033: stloc.s 4
+		IL_0035: ldloc.3
+		IL_0036: box [System.Runtime]System.Double
+		IL_003b: stloc.s 5
+		IL_003d: ldloc.s 4
+		IL_003f: ldstr "log"
+		IL_0044: ldloc.s 5
+		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_004b: pop
+		IL_004c: ldstr "console"
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0056: stloc.s 4
+		IL_0058: ldloc.s 4
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005f: stloc.s 4
+		IL_0061: ldloc.1
+		IL_0062: box [System.Runtime]System.Double
+		IL_0067: stloc.s 5
+		IL_0069: ldloc.s 4
+		IL_006b: ldstr "log"
+		IL_0070: ldloc.s 5
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0077: pop
+		IL_0078: ret
 	} // end of method Variable_LetBlockScope::__js_module_init__
 
 } // end of class Modules.Variable_LetBlockScope
@@ -119,7 +121,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20e3
+		// Method begins at RVA 0x20e7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetNestedShadowingChain.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetNestedShadowingChain.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21a9
+						// Method begins at RVA 0x21c7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21a0
+					// Method begins at RVA 0x21be
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2197
+				// Method begins at RVA 0x21b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -80,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x218e
+			// Method begins at RVA 0x21ac
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -106,17 +106,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 306 (0x132)
+		// Code size: 336 (0x150)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_LetNestedShadowingChain/Scope,
 			[1] float64,
 			[2] class Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0,
-			[3] object,
+			[3] float64,
 			[4] class Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0/Block_L7C2,
-			[5] object,
+			[5] float64,
 			[6] class Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0/Block_L7C2/Block_L10C4,
-			[7] object,
+			[7] float64,
 			[8] object,
 			[9] object
 		)
@@ -128,88 +128,100 @@
 		IL_0010: newobj instance void Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0::.ctor()
 		IL_0015: stloc.2
 		IL_0016: ldc.r8 1
-		IL_001f: box [System.Runtime]System.Double
-		IL_0024: stloc.3
-		IL_0025: ldstr "console"
-		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_002f: stloc.s 8
-		IL_0031: ldloc.s 8
-		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0038: stloc.s 8
-		IL_003a: ldloc.s 8
-		IL_003c: ldstr "log"
-		IL_0041: ldloc.3
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0047: pop
-		IL_0048: newobj instance void Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0/Block_L7C2::.ctor()
-		IL_004d: stloc.s 4
-		IL_004f: ldc.r8 2
-		IL_0058: box [System.Runtime]System.Double
-		IL_005d: stloc.s 5
-		IL_005f: ldstr "console"
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0069: stloc.s 8
-		IL_006b: ldloc.s 8
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0072: stloc.s 8
-		IL_0074: ldloc.s 8
-		IL_0076: ldstr "log"
-		IL_007b: ldloc.s 5
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0082: pop
-		IL_0083: newobj instance void Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0/Block_L7C2/Block_L10C4::.ctor()
-		IL_0088: stloc.s 6
-		IL_008a: ldc.r8 3
-		IL_0093: box [System.Runtime]System.Double
-		IL_0098: stloc.s 7
-		IL_009a: ldstr "console"
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a4: stloc.s 8
-		IL_00a6: ldloc.s 8
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ad: stloc.s 8
-		IL_00af: ldloc.s 8
-		IL_00b1: ldstr "log"
-		IL_00b6: ldloc.s 7
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00bd: pop
-		IL_00be: ldstr "console"
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c8: stloc.s 8
-		IL_00ca: ldloc.s 8
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d1: stloc.s 8
-		IL_00d3: ldloc.s 8
-		IL_00d5: ldstr "log"
-		IL_00da: ldloc.s 5
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00e1: pop
-		IL_00e2: ldstr "console"
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ec: stloc.s 8
-		IL_00ee: ldloc.s 8
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f5: stloc.s 8
-		IL_00f7: ldloc.s 8
-		IL_00f9: ldstr "log"
-		IL_00fe: ldloc.3
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0104: pop
-		IL_0105: ldstr "console"
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_010f: stloc.s 8
-		IL_0111: ldloc.s 8
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0118: stloc.s 8
-		IL_011a: ldloc.1
-		IL_011b: box [System.Runtime]System.Double
-		IL_0120: stloc.s 9
-		IL_0122: ldloc.s 8
-		IL_0124: ldstr "log"
-		IL_0129: ldloc.s 9
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0130: pop
-		IL_0131: ret
+		IL_001f: stloc.3
+		IL_0020: ldstr "console"
+		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_002a: stloc.s 8
+		IL_002c: ldloc.s 8
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0033: stloc.s 8
+		IL_0035: ldloc.3
+		IL_0036: box [System.Runtime]System.Double
+		IL_003b: stloc.s 9
+		IL_003d: ldloc.s 8
+		IL_003f: ldstr "log"
+		IL_0044: ldloc.s 9
+		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_004b: pop
+		IL_004c: newobj instance void Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0/Block_L7C2::.ctor()
+		IL_0051: stloc.s 4
+		IL_0053: ldc.r8 2
+		IL_005c: stloc.s 5
+		IL_005e: ldstr "console"
+		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0068: stloc.s 8
+		IL_006a: ldloc.s 8
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0071: stloc.s 8
+		IL_0073: ldloc.s 5
+		IL_0075: box [System.Runtime]System.Double
+		IL_007a: stloc.s 9
+		IL_007c: ldloc.s 8
+		IL_007e: ldstr "log"
+		IL_0083: ldloc.s 9
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_008a: pop
+		IL_008b: newobj instance void Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0/Block_L7C2/Block_L10C4::.ctor()
+		IL_0090: stloc.s 6
+		IL_0092: ldc.r8 3
+		IL_009b: stloc.s 7
+		IL_009d: ldstr "console"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a7: stloc.s 8
+		IL_00a9: ldloc.s 8
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b0: stloc.s 8
+		IL_00b2: ldloc.s 7
+		IL_00b4: box [System.Runtime]System.Double
+		IL_00b9: stloc.s 9
+		IL_00bb: ldloc.s 8
+		IL_00bd: ldstr "log"
+		IL_00c2: ldloc.s 9
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00c9: pop
+		IL_00ca: ldstr "console"
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d4: stloc.s 8
+		IL_00d6: ldloc.s 8
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00dd: stloc.s 8
+		IL_00df: ldloc.s 5
+		IL_00e1: box [System.Runtime]System.Double
+		IL_00e6: stloc.s 9
+		IL_00e8: ldloc.s 8
+		IL_00ea: ldstr "log"
+		IL_00ef: ldloc.s 9
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00f6: pop
+		IL_00f7: ldstr "console"
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0101: stloc.s 8
+		IL_0103: ldloc.s 8
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010a: stloc.s 8
+		IL_010c: ldloc.3
+		IL_010d: box [System.Runtime]System.Double
+		IL_0112: stloc.s 9
+		IL_0114: ldloc.s 8
+		IL_0116: ldstr "log"
+		IL_011b: ldloc.s 9
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0122: pop
+		IL_0123: ldstr "console"
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_012d: stloc.s 8
+		IL_012f: ldloc.s 8
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0136: stloc.s 8
+		IL_0138: ldloc.1
+		IL_0139: box [System.Runtime]System.Double
+		IL_013e: stloc.s 9
+		IL_0140: ldloc.s 8
+		IL_0142: ldstr "log"
+		IL_0147: ldloc.s 9
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_014e: pop
+		IL_014f: ret
 	} // end of method Variable_LetNestedShadowingChain::__js_module_init__
 
 } // end of class Modules.Variable_LetNestedShadowingChain
@@ -221,7 +233,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b2
+		// Method begins at RVA 0x21d0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneAccess.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneAccess.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x217d
+				// Method begins at RVA 0x2175
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2186
+				// Method begins at RVA 0x217e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2174
+			// Method begins at RVA 0x216c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,12 +82,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 261 (0x105)
+		// Code size: 256 (0x100)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneAccess/Scope,
 			[1] class Modules.Variable_TemporalDeadZoneAccess/Scope/Block_L3C4,
-			[2] object,
+			[2] float64,
 			[3] class [System.Runtime]System.Exception,
 			[4] object,
 			[5] object,
@@ -130,67 +130,66 @@
 			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_005f: pop
 			IL_0060: ldc.r8 3
-			IL_0069: box [System.Runtime]System.Double
-			IL_006e: stloc.2
-			IL_006f: ldstr "console"
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0079: stloc.s 8
-			IL_007b: ldloc.s 8
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0082: stloc.s 8
-			IL_0084: ldloc.s 8
-			IL_0086: ldstr "log"
-			IL_008b: ldstr "NO_TDZ"
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0095: pop
-			IL_0096: leave IL_0101
+			IL_0069: stloc.2
+			IL_006a: ldstr "console"
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0074: stloc.s 8
+			IL_0076: ldloc.s 8
+			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_007d: stloc.s 8
+			IL_007f: ldloc.s 8
+			IL_0081: ldstr "log"
+			IL_0086: ldstr "NO_TDZ"
+			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0090: pop
+			IL_0091: leave IL_00fc
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_009b: stloc.3
-			IL_009c: ldloc.3
-			IL_009d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00a2: dup
-			IL_00a3: brtrue IL_00b8
+			IL_0096: stloc.3
+			IL_0097: ldloc.3
+			IL_0098: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_009d: dup
+			IL_009e: brtrue IL_00b3
 
-			IL_00a8: pop
-			IL_00a9: ldloc.3
-			IL_00aa: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00af: dup
-			IL_00b0: brtrue IL_00c4
+			IL_00a3: pop
+			IL_00a4: ldloc.3
+			IL_00a5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00aa: dup
+			IL_00ab: brtrue IL_00bf
 
-			IL_00b5: pop
-			IL_00b6: rethrow
+			IL_00b0: pop
+			IL_00b1: rethrow
 
-			IL_00b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_00bd: stloc.s 4
-			IL_00bf: br IL_00c6
+			IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00b8: stloc.s 4
+			IL_00ba: br IL_00c1
 
-			IL_00c4: stloc.s 4
+			IL_00bf: stloc.s 4
 
-			IL_00c6: ldloc.s 4
-			IL_00c8: stloc.s 8
-			IL_00ca: ldloc.s 8
-			IL_00cc: stloc.s 5
-			IL_00ce: newobj instance void Modules.Variable_TemporalDeadZoneAccess/Scope/Block_L7C12::.ctor()
-			IL_00d3: stloc.s 6
-			IL_00d5: ldstr "console"
-			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00df: stloc.s 8
-			IL_00e1: ldloc.s 8
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e8: stloc.s 8
-			IL_00ea: ldloc.s 8
-			IL_00ec: ldstr "log"
-			IL_00f1: ldstr "TDZ_ERROR"
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00fb: pop
-			IL_00fc: leave IL_0101
+			IL_00c1: ldloc.s 4
+			IL_00c3: stloc.s 8
+			IL_00c5: ldloc.s 8
+			IL_00c7: stloc.s 5
+			IL_00c9: newobj instance void Modules.Variable_TemporalDeadZoneAccess/Scope/Block_L7C12::.ctor()
+			IL_00ce: stloc.s 6
+			IL_00d0: ldstr "console"
+			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00da: stloc.s 8
+			IL_00dc: ldloc.s 8
+			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e3: stloc.s 8
+			IL_00e5: ldloc.s 8
+			IL_00e7: ldstr "log"
+			IL_00ec: ldstr "TDZ_ERROR"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f6: pop
+			IL_00f7: leave IL_00fc
 		} // end handler
 
-		IL_0101: ldnull
-		IL_0102: stloc.s 7
-		IL_0104: ret
+		IL_00fc: ldnull
+		IL_00fd: stloc.s 7
+		IL_00ff: ret
 	} // end of method Variable_TemporalDeadZoneAccess::__js_module_init__
 
 } // end of class Modules.Variable_TemporalDeadZoneAccess
@@ -202,7 +201,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218f
+		// Method begins at RVA 0x2187
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary

Extends the stable CLR type-inference rollout gate in `SymbolTableBuilder.InferVariableClrTypesForScope` to cover **block scopes at module top level** — block scopes that reach the Global (module) scope only through other block scopes (for-loop head scopes, block statements).

Previously inference ran for the Global scope itself, functions/class methods, and blocks nested inside functions, but skipped `for (let x = ...)` scopes directly under the module top level. Those loop variables stayed boxed `object` with `TypeUtilities.ToNumber` round-trips on every iteration.

## Acceptance criteria

`x` and `y` in `tests/performance/Benchmarks/Scenarios/stopwatch-modern.js` now compile to unboxed float64 locals. Verified via ilspy decompilation:

- Before: `object obj3 = 0.0; ... double num = TypeUtilities.ToNumber(value); if (!(num < 1021.0))`
- After: `double num = 0.0; ... if (!(num < 1021.0)) ... num += 1.0;` — no boxing, no `ToNumber` calls (`z` also becomes an unboxed double)

This is a general change: any top-level `let`/`const` loop or block-scoped variable with a provably stable type benefits.

## Safety

The existing inference machinery is reused unchanged — captured bindings, type-widening reassignments, and uninitialized declarations all go through the same conservative analysis used for blocks inside functions. Sanity-verified behavior:

- per-iteration closure capture of top-level `let` loop vars (`0 1 2`)
- top-level `let` widened by string reassignment
- captured-and-mutated top-level counter
- uninitialized top-level block `let` assigned later

## Validation

- `Jroc.Tests` ControlFlow execution tests: 58/58 pass
- `Jroc.Tests` Loops/Closure/Variables/CompoundAssignment execution slices: 31/31 pass
- `Jroc.Test262.Tests` `statements/for*` + `statements/let` execution slices: 171 passed, 7 skipped, 0 failed
- Compiled `stopwatch-modern.js` runs cleanly (exit 0)

Generator snapshot drift (if any) will be handled via the `update-generator-snapshots.yml` workflow after CI runs.
