### PR TITLE
perf(compiler): infer parameter types from constructor calls and unary arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf/compiler: infer stable parameter CLR types from statically-resolved constructor calls (`new Identifier(...)`) and from numeric/boolean/typeof unary arguments (e.g. `-CubeSize`), so constructors like `CreateP(X, Y, Z)` in dromaeo-3d-cube compile with typed float64 parameters; also fixed AST walker traversal to descend into `new` expression callees and arguments so escaped function references in constructor arguments are detected (fixes #1334).
 - perf/compiler: extend stable CLR type inference to block scopes at module top level (for-loop head scopes and block statements), so top-level `let`/`const` loop variables like `x`/`y` in `stopwatch-modern.js` compile to unboxed float64 locals instead of boxed objects.
 - tests/docs/test262: expand ECMA-262 Section 21.1 Number coverage with newly ported constructor, constructor-property, prototype, prototype-method, and instance-shape test262 cases; implement the covered Number prototype method surface and refresh the Section 21.1 support docs.
 

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
@@ -91,7 +91,19 @@ public partial class SymbolTableBuilder
             {
                 if (TryResolveParameterInferenceCallTarget(call, currentScope, candidatesByScope, out var target))
                 {
-                    target.RecordCall(call, currentScope, this);
+                    target.RecordCall(call.Arguments, currentScope, this);
+                }
+                return;
+            }
+
+            if (node is NewExpression newExpression)
+            {
+                // Statically-resolved `new Identifier(...)` constructor calls contribute the same
+                // parameter evidence as direct calls. Arity mismatches and conflicting argument
+                // types are handled conservatively inside RecordCall.
+                if (TryResolveParameterInferenceNewTarget(newExpression, currentScope, candidatesByScope, out var newCallTarget))
+                {
+                    newCallTarget.RecordCall(newExpression.Arguments, currentScope, this);
                 }
                 return;
             }
@@ -114,7 +126,8 @@ public partial class SymbolTableBuilder
                 var referencedScope = TryGetCallableScopeForBinding(root, binding);
                 if (referencedScope != null
                     && candidatesByScope.TryGetValue(referencedScope, out var referencedCandidate)
-                    && !IsDirectIdentifierCall(id, parent))
+                    && !IsDirectIdentifierCall(id, parent)
+                    && !IsNewExpressionCallee(id, parent))
                 {
                     referencedCandidate.IsCallableUnsafe = true;
                 }
@@ -200,9 +213,9 @@ public partial class SymbolTableBuilder
         public bool[] IsParameterUnsafe { get; }
         public bool IsCallableUnsafe { get; set; }
 
-        public void RecordCall(CallExpression call, Scope callScope, SymbolTableBuilder builder)
+        public void RecordCall(in NodeList<Expression> arguments, Scope callScope, SymbolTableBuilder builder)
         {
-            if (call.Arguments.Count < ParameterNames.Count)
+            if (arguments.Count < ParameterNames.Count)
             {
                 IsCallableUnsafe = true;
                 return;
@@ -215,13 +228,13 @@ public partial class SymbolTableBuilder
                     continue;
                 }
 
-                if (call.Arguments[i] is SpreadElement)
+                if (arguments[i] is SpreadElement)
                 {
                     IsCallableUnsafe = true;
                     return;
                 }
 
-                if (call.Arguments[i] is not Node arg)
+                if (arguments[i] is not Node arg)
                 {
                     MarkParameterUnsafe(i);
                     continue;
@@ -266,6 +279,7 @@ public partial class SymbolTableBuilder
             MemberExpression memberExpression => InferStableMemberArgumentClrType(memberExpression, callScope),
             NewExpression newExpression => InferStableNewArgumentClrType(newExpression, callScope),
             CallExpression callExpression => InferStableCallArgumentClrType(callExpression, callScope),
+            NonUpdateUnaryExpression unaryExpression => InferStableUnaryArgumentClrType(unaryExpression, callScope),
             _ => null
         };
 
@@ -359,6 +373,29 @@ public partial class SymbolTableBuilder
         }
 
         return null;
+    }
+
+    private Type? InferStableUnaryArgumentClrType(NonUpdateUnaryExpression unaryExpression, Scope callScope)
+    {
+        switch (unaryExpression.Operator)
+        {
+            case Operator.UnaryNegation:
+            case Operator.UnaryPlus:
+            case Operator.BitwiseNot:
+                // Numeric unary operators over a provably stable double operand (e.g. `-CubeSize`)
+                // produce a double. Other operand types (strings, BigInt, ...) stay conservative.
+                var operandType = InferStableParameterArgumentClrType(unaryExpression.Argument, callScope);
+                return operandType == typeof(double) ? typeof(double) : null;
+
+            case Operator.LogicalNot:
+                return typeof(bool);
+
+            case Operator.TypeOf:
+                return typeof(string);
+
+            default:
+                return null;
+        }
     }
 
     private bool TryCreateParameterInferenceCandidate(Scope scope, out ParameterInferenceCandidate candidate)
@@ -462,6 +499,26 @@ public partial class SymbolTableBuilder
             targetScope = TryGetClassMethodScopeForReceiver(callScope, member.Object, methodId.Name);
         }
 
+        return targetScope != null && candidatesByScope.TryGetValue(targetScope, out candidate!);
+    }
+
+    private bool TryResolveParameterInferenceNewTarget(
+        NewExpression newExpression,
+        Scope callScope,
+        IReadOnlyDictionary<Scope, ParameterInferenceCandidate> candidatesByScope,
+        out ParameterInferenceCandidate candidate)
+    {
+        candidate = null!;
+
+        // Only statically-known `new Identifier(...)` constructor targets contribute evidence.
+        // Dynamic or computed constructor targets stay conservative.
+        if (newExpression.Callee is not Identifier calleeId)
+        {
+            return false;
+        }
+
+        var binding = TryResolveBinding(callScope, calleeId.Name);
+        var targetScope = TryGetCallableScopeForBinding(FindRootScope(callScope) ?? callScope, binding);
         return targetScope != null && candidatesByScope.TryGetValue(targetScope, out candidate!);
     }
 

--- a/src/Compiler/Utilities/AstWalker.cs
+++ b/src/Compiler/Utilities/AstWalker.cs
@@ -65,6 +65,11 @@ public class AstWalker
                 VisitNodes(callExpr.Arguments, visitor);
                 break;
 
+            case NewExpression newExpr:
+                Visit(newExpr.Callee, visitor);
+                VisitNodes(newExpr.Arguments, visitor);
+                break;
+
             case MemberExpression memberExpr:
                 Visit(memberExpr.Object, visitor);
                 Visit(memberExpr.Property, visitor);
@@ -291,6 +296,11 @@ public class AstWalker
             case CallExpression callExpr:
                 VisitWithContext(callExpr.Callee, enterNode, exitNode);
                 VisitNodesWithContext(callExpr.Arguments, enterNode, exitNode);
+                break;
+
+            case NewExpression newExpr:
+                VisitWithContext(newExpr.Callee, enterNode, exitNode);
+                VisitNodesWithContext(newExpr.Arguments, enterNode, exitNode);
                 break;
 
             case MemberExpression memberExpr:

--- a/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.CoercionCSE_BoxedDoubleToNumber_NoCse.verified.txt
+++ b/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.CoercionCSE_BoxedDoubleToNumber_NoCse.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b0
+				// Method begins at RVA 0x21b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -36,7 +36,7 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object newTarget,
-				object n
+				float64 n
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -44,56 +44,60 @@
 			)
 			// Method begins at RVA 0x213c
 			// Header size: 12
-			// Code size: 95 (0x5f)
+			// Code size: 97 (0x61)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] float64,
 				[1] object,
 				[2] object,
-				[3] float64,
-				[4] object,
+				[3] object,
+				[4] float64,
 				[5] float64
 			)
 
 			IL_0000: ldarg.1
-			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0006: ldc.r8 0.0
-			IL_000f: sub
-			IL_0010: box [System.Runtime]System.Double
-			IL_0015: stloc.0
-			IL_0016: ldloc.0
-			IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_001c: stloc.3
-			IL_001d: ldloc.3
-			IL_001e: box [System.Runtime]System.Double
-			IL_0023: stloc.s 4
-			IL_0025: ldloc.s 4
-			IL_0027: stloc.1
-			IL_0028: ldloc.0
-			IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002e: stloc.3
-			IL_002f: ldloc.3
-			IL_0030: box [System.Runtime]System.Double
-			IL_0035: stloc.s 4
-			IL_0037: ldloc.s 4
-			IL_0039: stloc.2
-			IL_003a: ldloc.1
-			IL_003b: stloc.s 4
-			IL_003d: ldloc.s 4
-			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0044: stloc.3
-			IL_0045: ldloc.2
-			IL_0046: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_004b: stloc.s 5
-			IL_004d: ldloc.3
-			IL_004e: ldloc.s 5
-			IL_0050: add
-			IL_0051: stloc.s 5
-			IL_0053: ldloc.s 5
-			IL_0055: box [System.Runtime]System.Double
-			IL_005a: stloc.s 4
-			IL_005c: ldloc.s 4
-			IL_005e: ret
+			IL_0001: ldc.r8 0.0
+			IL_000a: sub
+			IL_000b: stloc.0
+			IL_000c: ldloc.0
+			IL_000d: box [System.Runtime]System.Double
+			IL_0012: stloc.3
+			IL_0013: ldloc.3
+			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0019: stloc.s 4
+			IL_001b: ldloc.s 4
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: stloc.3
+			IL_0023: ldloc.3
+			IL_0024: stloc.1
+			IL_0025: ldloc.0
+			IL_0026: box [System.Runtime]System.Double
+			IL_002b: stloc.3
+			IL_002c: ldloc.3
+			IL_002d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0032: stloc.s 4
+			IL_0034: ldloc.s 4
+			IL_0036: box [System.Runtime]System.Double
+			IL_003b: stloc.3
+			IL_003c: ldloc.3
+			IL_003d: stloc.2
+			IL_003e: ldloc.1
+			IL_003f: stloc.3
+			IL_0040: ldloc.3
+			IL_0041: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0046: stloc.s 4
+			IL_0048: ldloc.2
+			IL_0049: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_004e: stloc.s 5
+			IL_0050: ldloc.s 4
+			IL_0052: ldloc.s 5
+			IL_0054: add
+			IL_0055: stloc.s 5
+			IL_0057: ldloc.s 5
+			IL_0059: box [System.Runtime]System.Double
+			IL_005e: stloc.3
+			IL_005f: ldloc.3
+			IL_0060: ret
 		} // end of method compute::__js_call__
 
 	} // end of class compute
@@ -112,7 +116,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a7
+			// Method begins at RVA 0x21a9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -151,8 +155,8 @@
 		IL_0000: newobj instance void Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0007: ldftn object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, float64)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
 		IL_0012: ldc.i4.1
 		IL_0013: conv.r8
 		IL_0014: ldstr "compute"
@@ -232,7 +236,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b9
+		// Method begins at RVA 0x21bb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63e8
+				// Method begins at RVA 0x63f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63f1
+				// Method begins at RVA 0x6401
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6403
+					// Method begins at RVA 0x6413
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x63fa
+				// Method begins at RVA 0x640a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6415
+					// Method begins at RVA 0x6425
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x640c
+				// Method begins at RVA 0x641c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -279,7 +279,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6427
+					// Method begins at RVA 0x6437
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -299,7 +299,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6430
+					// Method begins at RVA 0x6440
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -319,7 +319,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6439
+					// Method begins at RVA 0x6449
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -339,7 +339,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6442
+					// Method begins at RVA 0x6452
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -359,7 +359,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x644b
+					// Method begins at RVA 0x645b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -379,7 +379,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6454
+					// Method begins at RVA 0x6464
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -403,7 +403,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6466
+						// Method begins at RVA 0x6476
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -421,7 +421,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x645d
+					// Method begins at RVA 0x646d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -439,7 +439,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x641e
+				// Method begins at RVA 0x642e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -908,7 +908,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x646f
+				// Method begins at RVA 0x647f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1087,7 +1087,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6481
+					// Method begins at RVA 0x6491
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1105,7 +1105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6478
+				// Method begins at RVA 0x6488
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1381,7 +1381,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x648a
+				// Method begins at RVA 0x649a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1399,9 +1399,9 @@
 		.method public hidebysig static 
 			object __js_call__ (
 				object newTarget,
-				object X,
-				object Y,
-				object Z
+				float64 X,
+				float64 Y,
+				float64 Z
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -1409,7 +1409,7 @@
 			)
 			// Method begins at RVA 0x2d88
 			// Header size: 12
-			// Code size: 68 (0x44)
+			// Code size: 83 (0x53)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
@@ -1419,26 +1419,29 @@
 			IL_0001: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_0006: dup
 			IL_0007: ldarg.1
-			IL_0008: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_000d: dup
-			IL_000e: ldarg.2
-			IL_000f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0014: dup
-			IL_0015: ldarg.3
-			IL_0016: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_001b: dup
-			IL_001c: ldc.r8 1
-			IL_0025: box [System.Runtime]System.Double
-			IL_002a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_002f: stloc.0
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0035: ldstr "V"
-			IL_003a: ldloc.0
-			IL_003b: ldc.i4.1
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0041: pop
-			IL_0042: ldnull
-			IL_0043: ret
+			IL_0008: box [System.Runtime]System.Double
+			IL_000d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0012: dup
+			IL_0013: ldarg.2
+			IL_0014: box [System.Runtime]System.Double
+			IL_0019: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_001e: dup
+			IL_001f: ldarg.3
+			IL_0020: box [System.Runtime]System.Double
+			IL_0025: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_002a: dup
+			IL_002b: ldc.r8 1
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_003e: stloc.0
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0044: ldstr "V"
+			IL_0049: ldloc.0
+			IL_004a: ldc.i4.1
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0050: pop
+			IL_0051: ldnull
+			IL_0052: ret
 		} // end of method CreateP::__js_call__
 
 	} // end of class CreateP
@@ -1458,7 +1461,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x649c
+					// Method begins at RVA 0x64ac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1476,7 +1479,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6493
+				// Method begins at RVA 0x64a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1501,7 +1504,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2dd8
+			// Method begins at RVA 0x2de8
 			// Header size: 12
 			// Code size: 557 (0x22d)
 			.maxstack 8
@@ -1720,7 +1723,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64a5
+				// Method begins at RVA 0x64b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1745,7 +1748,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3014
+			// Method begins at RVA 0x3024
 			// Header size: 12
 			// Code size: 358 (0x166)
 			.maxstack 8
@@ -1895,7 +1898,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64ae
+				// Method begins at RVA 0x64be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1920,7 +1923,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3188
+			// Method begins at RVA 0x3198
 			// Header size: 12
 			// Code size: 296 (0x128)
 			.maxstack 8
@@ -2054,7 +2057,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x64c0
+					// Method begins at RVA 0x64d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2072,7 +2075,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64b7
+				// Method begins at RVA 0x64c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2097,7 +2100,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x32bc
+			// Method begins at RVA 0x32cc
 			// Header size: 12
 			// Code size: 316 (0x13c)
 			.maxstack 8
@@ -2244,7 +2247,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64c9
+				// Method begins at RVA 0x64d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2274,7 +2277,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x3404
+			// Method begins at RVA 0x3414
 			// Header size: 12
 			// Code size: 379 (0x17b)
 			.maxstack 8
@@ -2405,7 +2408,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64d2
+				// Method begins at RVA 0x64e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2433,7 +2436,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x358c
+			// Method begins at RVA 0x359c
 			// Header size: 12
 			// Code size: 474 (0x1da)
 			.maxstack 8
@@ -2607,7 +2610,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64db
+				// Method begins at RVA 0x64eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2635,7 +2638,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x3774
+			// Method begins at RVA 0x3784
 			// Header size: 12
 			// Code size: 474 (0x1da)
 			.maxstack 8
@@ -2809,7 +2812,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64e4
+				// Method begins at RVA 0x64f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2837,7 +2840,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x395c
+			// Method begins at RVA 0x396c
 			// Header size: 12
 			// Code size: 474 (0x1da)
 			.maxstack 8
@@ -3019,7 +3022,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x64ff
+						// Method begins at RVA 0x650f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3039,7 +3042,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6508
+						// Method begins at RVA 0x6518
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3059,7 +3062,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6511
+						// Method begins at RVA 0x6521
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3079,7 +3082,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x651a
+						// Method begins at RVA 0x652a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3097,7 +3100,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x64f6
+					// Method begins at RVA 0x6506
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3121,7 +3124,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x652c
+						// Method begins at RVA 0x653c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3141,7 +3144,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6535
+						// Method begins at RVA 0x6545
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3161,7 +3164,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x653e
+						// Method begins at RVA 0x654e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3181,7 +3184,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6547
+						// Method begins at RVA 0x6557
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3199,7 +3202,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6523
+					// Method begins at RVA 0x6533
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3223,7 +3226,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6559
+						// Method begins at RVA 0x6569
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3243,7 +3246,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6562
+						// Method begins at RVA 0x6572
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3263,7 +3266,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x656b
+						// Method begins at RVA 0x657b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3283,7 +3286,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6574
+						// Method begins at RVA 0x6584
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3301,7 +3304,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6550
+					// Method begins at RVA 0x6560
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3325,7 +3328,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6586
+						// Method begins at RVA 0x6596
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3345,7 +3348,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x658f
+						// Method begins at RVA 0x659f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3365,7 +3368,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6598
+						// Method begins at RVA 0x65a8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3385,7 +3388,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65a1
+						// Method begins at RVA 0x65b1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3403,7 +3406,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x657d
+					// Method begins at RVA 0x658d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3427,7 +3430,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65b3
+						// Method begins at RVA 0x65c3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3447,7 +3450,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65bc
+						// Method begins at RVA 0x65cc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3467,7 +3470,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65c5
+						// Method begins at RVA 0x65d5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3487,7 +3490,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65ce
+						// Method begins at RVA 0x65de
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3505,7 +3508,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65aa
+					// Method begins at RVA 0x65ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3529,7 +3532,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65e0
+						// Method begins at RVA 0x65f0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3549,7 +3552,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65e9
+						// Method begins at RVA 0x65f9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3569,7 +3572,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65f2
+						// Method begins at RVA 0x6602
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3589,7 +3592,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65fb
+						// Method begins at RVA 0x660b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3607,7 +3610,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65d7
+					// Method begins at RVA 0x65e7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3625,7 +3628,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64ed
+				// Method begins at RVA 0x64fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3651,7 +3654,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x3b44
+			// Method begins at RVA 0x3b54
 			// Header size: 12
 			// Code size: 5096 (0x13e8)
 			.maxstack 8
@@ -5205,7 +5208,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x660d
+					// Method begins at RVA 0x661d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5223,7 +5226,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6604
+				// Method begins at RVA 0x6614
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5249,7 +5252,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x4f38
+			// Method begins at RVA 0x4f48
 			// Header size: 12
 			// Code size: 1124 (0x464)
 			.maxstack 8
@@ -5677,7 +5680,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x661f
+					// Method begins at RVA 0x662f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5695,7 +5698,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6616
+				// Method begins at RVA 0x6626
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5722,7 +5725,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x53a8
+			// Method begins at RVA 0x53b8
 			// Header size: 12
 			// Code size: 4037 (0xfc5)
 			.maxstack 8
@@ -6995,7 +6998,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6628
+				// Method begins at RVA 0x6638
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7021,7 +7024,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x637c
+			// Method begins at RVA 0x638c
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -7114,7 +7117,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x63df
+			// Method begins at RVA 0x63ef
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -7261,8 +7264,8 @@
 		IL_0108: ldloc.s 8
 		IL_010a: stfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcNormal
 		IL_010f: ldnull
-		IL_0110: ldftn object Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP::__js_call__(object, object, object, object)
-		IL_0116: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+		IL_0110: ldftn object Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP::__js_call__(object, float64, float64, float64)
+		IL_0116: newobj instance void class [System.Runtime]System.Func`5<object, float64, float64, float64, object>::.ctor(object, native int)
 		IL_011b: ldc.i4.3
 		IL_011c: conv.r8
 		IL_011d: ldstr "CreateP"
@@ -7599,7 +7602,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x6631
+		// Method begins at RVA 0x6641
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
Fixes #1334

## Summary

Extends stable callable parameter type inference so constructor calls contribute the same evidence as direct calls, and adds inference for unary argument expressions.

## Changes

- **Constructor call evidence** (`SymbolTableBuilder.InferTypes.cs`): the parameter-inference walk now handles `NewExpression`. Statically-resolved `new Identifier(...)` targets are resolved through the same binding → callable-scope path as direct calls, and `RecordCall` was generalized to take an argument list shared by both call forms. Arity mismatches, spreads, and conflicting argument types remain conservatively handled.
- **Constructor callee no longer "escapes"**: an identifier used only as a `new` callee is no longer marked as an unsafe escaped function reference (`IsNewExpressionCallee` guard).
- **Unary argument inference**: `-x` / `+x` / `~x` over a provably stable-double operand infer `double`; `!x` infers `bool`; `typeof x` infers `string`. Other operand types (e.g. strings, potential BigInt) stay conservative.
- **AstWalker completeness fix** (`AstWalker.cs`): the walker had no `NewExpression` case, so `new` callees and arguments were never traversed. This was required for soundness (escaped function references in constructor arguments like `new E(D)` must mark `D` unsafe) and benefits all other walker consumers.

## Acceptance (from #1334)

`CreateP` in `dromaeo-3d-cube.js` now compiles with typed parameters:

```csharp
public static object __js_call__(object newTarget, double X, double Y, double Z)
```

driven purely by `new CreateP(-CubeSize, CubeSize, 0)`-style call sites (including the `-CubeSize` unary evidence, with `CubeSize` itself inferred as double via `Init(20)` through the fixpoint iteration). Runtime output of the compiled benchmark is unchanged.

## Conservatism verified

| Case | Result |
| --- | --- |
| `new A(1); A('s')` (conflicting evidence) | `object` param |
| `var alias = B; new B(1)` (escaped reference) | `object` param |
| `new C(1)` for `C(x, y)` (arity mismatch) | `object` params |
| `new E(D)` (function escapes via ctor arg) | `D` stays `object` |
| `S(-'str')` (non-double unary operand) | `object` param |

## Testing

- `Jroc.Tests` ExecutionTests: Function + Integration (153 passed), Classes/ControlFlow/Operator (186 passed)
- `Jroc.Test262.Tests`: `expressions.new` + Function slices (390 passed, 18 skipped)
- Manual IL inspection (ilspycmd) + execution of dromaeo-3d-cube, minimal repros, and edge cases
