### PR TITLE
docs: correct Section 20.2 rollup status

### DIFF
--- a/docs/ECMA262/20/Section20.md
+++ b/docs/ECMA262/20/Section20.md
@@ -4,7 +4,7 @@ Covers fundamental built-ins (such as Object and Function) and shared foundation
 
 [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-06-24T17:01:02Z
+> Last generated (UTC): 2026-07-07T17:05:44Z
 
 _This section is split into subsection documents for readability._
 
@@ -12,14 +12,14 @@ _This section is split into subsection documents for readability._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 20 | Fundamental Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-fundamental-objects) |
+| 20 | Fundamental Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-fundamental-objects) |
 
 ## Subsections
 
 | Subsection | Title | Status | Spec | Document |
 |---:|---|---|---|---|
 | 20.1 | Object Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-object-objects) | [Section20_1.md](Section20_1.md) |
-| 20.2 | Function Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-function-objects) | [Section20_2.md](Section20_2.md) |
+| 20.2 | Function Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-function-objects) | [Section20_2.md](Section20_2.md) |
 | 20.3 | Boolean Objects | Supported | [tc39.es](https://tc39.es/ecma262/#sec-boolean-objects) | [Section20_3.md](Section20_3.md) |
 | 20.4 | Symbol Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-symbol-objects) | [Section20_4.md](Section20_4.md) |
 | 20.5 | Error Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-error-objects) | [Section20_5.md](Section20_5.md) |

--- a/docs/ECMA262/20/Section20_2.json
+++ b/docs/ECMA262/20/Section20_2.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "20.2",
   "title": "Function Objects",
-  "status": "Incomplete",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-function-objects",
   "parent": {
     "clause": "20"

--- a/docs/ECMA262/20/Section20_2.md
+++ b/docs/ECMA262/20/Section20_2.md
@@ -4,11 +4,11 @@
 
 [Back to Section20](Section20.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-24T04:58:25Z
+> Last generated (UTC): 2026-07-07T17:05:44Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 20.2 | Function Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-function-objects) |
+| 20.2 | Function Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-function-objects) |
 
 ## Subclauses
 

--- a/docs/ECMA262/Index.md
+++ b/docs/ECMA262/Index.md
@@ -19,12 +19,12 @@ Notes:
 - `Partially Supported` is deprecated legacy wording and is treated as `Supported with Limitations`.
 - Prototype-chain design/strategy: see [PrototypeChainSupport.md](../compiler/PrototypeChainSupport.md).
 
-> Last generated (UTC): 2026-07-07T16:50:30Z
+> Last generated (UTC): 2026-07-07T17:05:44Z
 
 ## Summary
 - Total top-level sections indexed: **29**
 - Top-level sections with tracked status: **28**
-- Status breakdown: Supported with Limitations: **8**, Incomplete: **13**, Not Yet Supported: **1**, N/A (informational): **6**, Untracked: **1**
+- Status breakdown: Supported with Limitations: **9**, Incomplete: **12**, Not Yet Supported: **1**, N/A (informational): **6**, Untracked: **1**
 - Untracked top-level sections: **1**
 
 ## Sections
@@ -50,7 +50,7 @@ Notes:
 | 17 | Error Handling and Language Extensions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-error-handling-and-language-extensions) | [Section17.md](17/Section17.md) |
 | 18 | ECMAScript Standard Built-in Objects | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects) | [Section18.md](18/Section18.md) |
 | 19 | The Global Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-global-object) | [Section19.md](19/Section19.md) |
-| 20 | Fundamental Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-fundamental-objects) | [Section20.md](20/Section20.md) |
+| 20 | Fundamental Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-fundamental-objects) | [Section20.md](20/Section20.md) |
 | 21 | Numbers and Dates | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-numbers-and-dates) | [Section21.md](21/Section21.md) |
 | 22 | Text Processing | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-text-processing) | [Section22.md](22/Section22.md) |
 | 23 | Indexed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-indexed-collections) | [Section23.md](23/Section23.md) |


### PR DESCRIPTION
## Summary

- correct `docs/ECMA262/20/Section20_2.json` so Section 20.2 Function Objects is `Supported with Limitations`
- regenerate `docs/ECMA262/20/Section20_2.md`
- roll the corrected status up through `docs/ECMA262/20/Section20.md` and `docs/ECMA262/Index.md`

## Notes

- docs-only status correction based on the existing Section 20.2 subclause/support matrix
