### PR TITLE
docs(ecma262): reclassify section 6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- docs/ecma262: reclassify Section 6.2 ECMAScript Specification Types so every clause/subclause is now tracked as `Supported with Limitations` or `N/A (informational)`, documenting environment records, abstract closures, data blocks, and class static block records against current implementation evidence and rolling Section 6 up to `Supported with Limitations`.
 - runtime/tests/docs/test262: raise the Section 6.1.7 object-model coverage floor by fixing strict `NaN` equality for boxed doubles, preserving NaN across repeated ordinary-property updates, and enforcing the newly ported Proxy `[[GetOwnProperty]]` forwarding/invariant cases; refresh the Section 6.1 docs and roll-ups.
 - runtime/tests/docs/test262: expand ECMA-262 Section 21.2 BigInt coverage with newly ported prototype, prototype-method, branding, and wrapper-object test262 cases; add the covered `BigInt.prototype` surface (`toString`, `toLocaleString`, `valueOf`, `@@toStringTag`, and wrapper integration) and refresh the Section 21.2 support docs.
 - runtime/tests/docs/test262: expand ECMA-262 Section 21.3 Math coverage with new test262 ports across the previously untracked Math intrinsics, add ES2025 `Math.f16round` / `Math.sumPrecise` callable surface, fix `Math.pow(..., NaN)`, preserve signed zero in `Math.expm1` / `Math.log1p`, correct `ToUint32`-driven `Math.clz32` behavior for large negative inputs, and refresh the Section 21.3 support docs.

--- a/docs/ECMA262/6/Section6.md
+++ b/docs/ECMA262/6/Section6.md
@@ -4,7 +4,7 @@ Defines ECMAScript data types and values (primitives, objects) and the core conc
 
 [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-07T17:43:09Z
+> Last generated (UTC): 2026-07-07T18:30:38Z
 
 _This section is split into subsection documents for readability._
 
@@ -12,11 +12,11 @@ _This section is split into subsection documents for readability._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 6 | ECMAScript Data Types and Values | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values) |
+| 6 | ECMAScript Data Types and Values | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values) |
 
 ## Subsections
 
 | Subsection | Title | Status | Spec | Document |
 |---:|---|---|---|---|
 | 6.1 | ECMAScript Language Types | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-types) | [Section6_1.md](Section6_1.md) |
-| 6.2 | ECMAScript Specification Types | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-specification-types) | [Section6_2.md](Section6_2.md) |
+| 6.2 | ECMAScript Specification Types | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-specification-types) | [Section6_2.md](Section6_2.md) |

--- a/docs/ECMA262/6/Section6_2.json
+++ b/docs/ECMA262/6/Section6_2.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "6.2",
   "title": "ECMAScript Specification Types",
-  "status": "Incomplete",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-ecmascript-specification-types",
   "parent": {
     "clause": "6"
@@ -12,19 +12,19 @@
     {
       "clause": "6.2.1",
       "title": "The Enum Specification Type",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-enum-specification-type"
     },
     {
       "clause": "6.2.2",
       "title": "The List and Record Specification Types",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-list-and-record-specification-type"
     },
     {
       "clause": "6.2.3",
       "title": "The Set and Relation Specification Types",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-set-and-relation-specification-type"
     },
     {
@@ -162,37 +162,37 @@
     {
       "clause": "6.2.7",
       "title": "The Environment Record Specification Type",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-lexical-environment-and-environment-record-specification-types"
     },
     {
       "clause": "6.2.8",
       "title": "The Abstract Closure Specification Type",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-abstract-closure"
     },
     {
       "clause": "6.2.9",
       "title": "Data Blocks",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-data-blocks"
     },
     {
       "clause": "6.2.9.1",
       "title": "CreateByteDataBlock ( size )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-createbytedatablock"
     },
     {
       "clause": "6.2.9.2",
       "title": "CreateSharedByteDataBlock ( size )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-createsharedbytedatablock"
     },
     {
       "clause": "6.2.9.3",
       "title": "CopyDataBlockBytes ( toBlock , toIndex , fromBlock , fromIndex , count )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-copydatablockbytes"
     },
     {
@@ -216,7 +216,7 @@
     {
       "clause": "6.2.13",
       "title": "The ClassStaticBlockDefinition Record Specification Type",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-classstaticblockdefinition-record-specification-type"
     }
   ],
@@ -225,9 +225,30 @@
       {
         "clause": "6.2",
         "feature": "ECMAScript Specification Types (overall)",
-        "status": "Incomplete",
+        "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-ecmascript-specification-types",
-        "notes": "This section is normative and implementation-relevant. JROC partially maps these spec types via runtime/compiler behavior, but Environment Records and several internal-spec types remain untracked."
+        "notes": "Most Section 6.2 entries are specification-only modeling constructs or are represented indirectly by the compiler/runtime rather than as first-class JS values. JROC now documents the internal-only constructs as informational where appropriate and tracks the implementation-backed areas such as environment records, closures, data blocks, private elements, and class static blocks as supported with limitations."
+      },
+      {
+        "clause": "6.2.1",
+        "feature": "The Enum Specification Type",
+        "status": "N/A (informational)",
+        "specUrl": "https://tc39.es/ecma262/#sec-enum-specification-type",
+        "notes": "This clause defines a specification meta-type used to describe finite sets of abstract values in the standard. It does not correspond to a distinct user-visible runtime object model in JROC."
+      },
+      {
+        "clause": "6.2.2",
+        "feature": "The List and Record Specification Types",
+        "status": "N/A (informational)",
+        "specUrl": "https://tc39.es/ecma262/#sec-list-and-record-specification-type",
+        "notes": "These are ECMA-262 specification modeling types, not JavaScript runtime values. JROC uses ordinary CLR and runtime data structures to realize the behaviors of algorithms that are described in the spec using Lists and Records."
+      },
+      {
+        "clause": "6.2.3",
+        "feature": "The Set and Relation Specification Types",
+        "status": "N/A (informational)",
+        "specUrl": "https://tc39.es/ecma262/#sec-set-and-relation-specification-type",
+        "notes": "This clause describes internal spec bookkeeping structures rather than a dedicated JS surface. JROC implements the affected algorithms with host/runtime data structures instead of exposing first-class spec Set/Relation values."
       },
       {
         "clause": "6.2.4",
@@ -267,11 +288,72 @@
         "notes": "Descriptor creation and usage are implemented for supported object/runtime paths via PropertyDescriptorStore; full spec parity is incomplete."
       },
       {
+        "clause": "6.2.7",
+        "feature": "Environment Record specification type",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-lexical-environment-and-environment-record-specification-types",
+        "testScripts": [
+          "tests/Jroc.Tests/Variable/JavaScript/Variable_TemporalDeadZoneAccess.js",
+          "tests/Jroc.Tests/Variable/JavaScript/Variable_TemporalDeadZoneCapturedRead.js",
+          "tests/Jroc.Tests/CommonJS/JavaScript/CommonJS_Export_ObjectWithClosure.js"
+        ],
+        "notes": "JROC realizes lexical/global/function bindings through its scope-as-class model, plus TDZ checks and captured-scope indirection. The behavior matches the covered lexical binding and closure scenarios, but the implementation is not a one-to-one reification of every ECMA-262 Environment Record variant."
+      },
+      {
+        "clause": "6.2.8",
+        "feature": "Abstract Closure specification type",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-abstract-closure",
+        "testScripts": [
+          "tests/Jroc.Tests/CommonJS/JavaScript/CommonJS_Export_ObjectWithClosure.js",
+          "tests/Jroc.Tests/ArrowFunction/JavaScript/ArrowFunction_LexicalThis_TopLevelCallback.js"
+        ],
+        "notes": "Functions, arrows, methods, and other callable bodies are lowered into CLR callables plus captured scope arrays, which gives JROC a practical implementation of the spec's abstract-closure behavior. The covered closure and lexical-this cases work, but the implementation remains an approximation of the spec's internal abstract type."
+      },
+      {
         "clause": "6.2.9",
         "feature": "Data Blocks",
-        "status": "Not Yet Supported",
+        "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-data-blocks",
-        "notes": "Spec-level byte data block operations depend on ArrayBuffer/SharedArrayBuffer machinery, which is not yet implemented."
+        "testScripts": [
+          "tests/Jroc.Tests/TypedArray/JavaScript/ArrayBuffer_Construct_ByteLength.js",
+          "tests/Jroc.Tests/TypedArray/JavaScript/DataView_SetGet_UintAndEndian.js",
+          "tests/Jroc.Tests/TypedArray/JavaScript/Int32Array_Construct_ArrayBuffer_ViewProperties.js",
+          "tests/Jroc.Tests/TypedArray/JavaScript/SharedArrayBuffer_Int32Array_AtomicsWait.js"
+        ],
+        "notes": "JROC implements fixed-length ArrayBuffer-backed byte storage, DataView/typed-array reads and writes, and a minimal SharedArrayBuffer-backed path sufficient for the covered Atomics.wait scenario. Resizable/detached/growable/shared-memory edge cases remain incomplete, so the clause stays supported with limitations."
+      },
+      {
+        "clause": "6.2.9.1",
+        "feature": "CreateByteDataBlock",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-createbytedatablock",
+        "testScripts": [
+          "tests/Jroc.Tests/TypedArray/JavaScript/ArrayBuffer_Construct_ByteLength.js",
+          "tests/Jroc.Tests/TypedArray/JavaScript/DataView_SetGet_UintAndEndian.js"
+        ],
+        "notes": "ArrayBuffer allocation creates the covered fixed-length byte storage used by DataView and typed-array operations. Resizable buffers and detach semantics are not fully modeled."
+      },
+      {
+        "clause": "6.2.9.2",
+        "feature": "CreateSharedByteDataBlock",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-createsharedbytedatablock",
+        "testScripts": [
+          "tests/Jroc.Tests/TypedArray/JavaScript/SharedArrayBuffer_Int32Array_AtomicsWait.js"
+        ],
+        "notes": "JROC exposes a minimal SharedArrayBuffer-backed byte store that is sufficient for constructing a shared Int32Array and exercising the covered Atomics.wait path. Full shared-memory, growable-buffer, and spec host-hook semantics remain limited."
+      },
+      {
+        "clause": "6.2.9.3",
+        "feature": "CopyDataBlockBytes",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-copydatablockbytes",
+        "testScripts": [
+          "tests/Jroc.Tests/TypedArray/JavaScript/Int32Array_Set_FromArray_WithOffset.js",
+          "tests/Jroc.Tests/TypedArray/JavaScript/Int32Array_Slice_Basic.js"
+        ],
+        "notes": "The covered typed-array copy and slice paths demonstrate byte copying across ArrayBuffer-backed views. The abstract operation is not exposed directly, and detached/shared/growable corner cases remain incomplete."
       },
       {
         "clause": "6.2.10",
@@ -309,9 +391,13 @@
       {
         "clause": "6.2.13",
         "feature": "ClassStaticBlockDefinition record",
-        "status": "Not Yet Supported",
+        "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-classstaticblockdefinition-record-specification-type",
-        "notes": "Class static blocks are rejected by validation."
+        "testScripts": [
+          "tests/Jroc.Tests/ValidatorTests.cs",
+          "tests/Jroc.Tests/Classes/JavaScript/Classes_ClassStaticBlock_DeclarationOrder.js"
+        ],
+        "notes": "Class static blocks are validated, represented during compilation, and emitted into the synthesized class static constructor in declaration order. The feature is implemented for the covered cases, but it is still tracked conservatively here because class element support in JROC remains broader than this record type alone."
       }
     ]
   }

--- a/docs/ECMA262/6/Section6_2.md
+++ b/docs/ECMA262/6/Section6_2.md
@@ -4,19 +4,19 @@
 
 [Back to Section6](Section6.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-24T04:56:25Z
+> Last generated (UTC): 2026-07-07T18:30:38Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 6.2 | ECMAScript Specification Types | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-specification-types) |
+| 6.2 | ECMAScript Specification Types | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-specification-types) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 6.2.1 | The Enum Specification Type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-enum-specification-type) |
-| 6.2.2 | The List and Record Specification Types | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-list-and-record-specification-type) |
-| 6.2.3 | The Set and Relation Specification Types | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-set-and-relation-specification-type) |
+| 6.2.1 | The Enum Specification Type | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-enum-specification-type) |
+| 6.2.2 | The List and Record Specification Types | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-list-and-record-specification-type) |
+| 6.2.3 | The Set and Relation Specification Types | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-set-and-relation-specification-type) |
 | 6.2.4 | The Completion Record Specification Type | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-completion-record-specification-type) |
 | 6.2.4.1 | NormalCompletion ( value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-normalcompletion) |
 | 6.2.4.2 | ThrowCompletion ( value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-throwcompletion) |
@@ -39,16 +39,16 @@
 | 6.2.6.4 | FromPropertyDescriptor ( Desc ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-frompropertydescriptor) |
 | 6.2.6.5 | ToPropertyDescriptor ( Obj ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-topropertydescriptor) |
 | 6.2.6.6 | CompletePropertyDescriptor ( Desc ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-completepropertydescriptor) |
-| 6.2.7 | The Environment Record Specification Type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-lexical-environment-and-environment-record-specification-types) |
-| 6.2.8 | The Abstract Closure Specification Type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-abstract-closure) |
-| 6.2.9 | Data Blocks | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-data-blocks) |
-| 6.2.9.1 | CreateByteDataBlock ( size ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-createbytedatablock) |
-| 6.2.9.2 | CreateSharedByteDataBlock ( size ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-createsharedbytedatablock) |
-| 6.2.9.3 | CopyDataBlockBytes ( toBlock , toIndex , fromBlock , fromIndex , count ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-copydatablockbytes) |
+| 6.2.7 | The Environment Record Specification Type | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-lexical-environment-and-environment-record-specification-types) |
+| 6.2.8 | The Abstract Closure Specification Type | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-abstract-closure) |
+| 6.2.9 | Data Blocks | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-data-blocks) |
+| 6.2.9.1 | CreateByteDataBlock ( size ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-createbytedatablock) |
+| 6.2.9.2 | CreateSharedByteDataBlock ( size ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-createsharedbytedatablock) |
+| 6.2.9.3 | CopyDataBlockBytes ( toBlock , toIndex , fromBlock , fromIndex , count ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-copydatablockbytes) |
 | 6.2.10 | The PrivateElement Specification Type | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-privateelement-specification-type) |
 | 6.2.11 | The ClassFieldDefinition Record Specification Type | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-classfielddefinition-record-specification-type) |
 | 6.2.12 | Private Names | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-private-names) |
-| 6.2.13 | The ClassStaticBlockDefinition Record Specification Type | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-classstaticblockdefinition-record-specification-type) |
+| 6.2.13 | The ClassStaticBlockDefinition Record Specification Type | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-classstaticblockdefinition-record-specification-type) |
 
 ## Support
 
@@ -58,7 +58,25 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| ECMAScript Specification Types (overall) | Incomplete |  |  | This section is normative and implementation-relevant. JROC partially maps these spec types via runtime/compiler behavior, but Environment Records and several internal-spec types remain untracked. |
+| ECMAScript Specification Types (overall) | Supported with Limitations |  |  | Most Section 6.2 entries are specification-only modeling constructs or are represented indirectly by the compiler/runtime rather than as first-class JS values. JROC now documents the internal-only constructs as informational where appropriate and tracks the implementation-backed areas such as environment records, closures, data blocks, private elements, and class static blocks as supported with limitations. |
+
+### 6.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-enum-specification-type))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| The Enum Specification Type | N/A (informational) |  |  | This clause defines a specification meta-type used to describe finite sets of abstract values in the standard. It does not correspond to a distinct user-visible runtime object model in JROC. |
+
+### 6.2.2 ([tc39.es](https://tc39.es/ecma262/#sec-list-and-record-specification-type))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| The List and Record Specification Types | N/A (informational) |  |  | These are ECMA-262 specification modeling types, not JavaScript runtime values. JROC uses ordinary CLR and runtime data structures to realize the behaviors of algorithms that are described in the spec using Lists and Records. |
+
+### 6.2.3 ([tc39.es](https://tc39.es/ecma262/#sec-set-and-relation-specification-type))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| The Set and Relation Specification Types | N/A (informational) |  |  | This clause describes internal spec bookkeeping structures rather than a dedicated JS surface. JROC implements the affected algorithms with host/runtime data structures instead of exposing first-class spec Set/Relation values. |
 
 ### 6.2.4 ([tc39.es](https://tc39.es/ecma262/#sec-completion-record-specification-type))
 
@@ -78,11 +96,41 @@ Feature-level support tracking with repo test references and optional test262 ev
 |---|---|---|---|---|
 | Property descriptor specification type | Supported with Limitations | [`ObjectDefineProperty_Accessor.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectDefineProperty_Accessor.js)<br>[`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js)<br>[`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js) |  | Descriptor creation and usage are implemented for supported object/runtime paths via PropertyDescriptorStore; full spec parity is incomplete. |
 
+### 6.2.7 ([tc39.es](https://tc39.es/ecma262/#sec-lexical-environment-and-environment-record-specification-types))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Environment Record specification type | Supported with Limitations | [`Variable_TemporalDeadZoneAccess.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_TemporalDeadZoneAccess.js)<br>[`Variable_TemporalDeadZoneCapturedRead.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_TemporalDeadZoneCapturedRead.js)<br>[`CommonJS_Export_ObjectWithClosure.js`](../../../tests/Jroc.Tests/CommonJS/JavaScript/CommonJS_Export_ObjectWithClosure.js) |  | JROC realizes lexical/global/function bindings through its scope-as-class model, plus TDZ checks and captured-scope indirection. The behavior matches the covered lexical binding and closure scenarios, but the implementation is not a one-to-one reification of every ECMA-262 Environment Record variant. |
+
+### 6.2.8 ([tc39.es](https://tc39.es/ecma262/#sec-abstract-closure))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Abstract Closure specification type | Supported with Limitations | [`CommonJS_Export_ObjectWithClosure.js`](../../../tests/Jroc.Tests/CommonJS/JavaScript/CommonJS_Export_ObjectWithClosure.js)<br>[`ArrowFunction_LexicalThis_TopLevelCallback.js`](../../../tests/Jroc.Tests/ArrowFunction/JavaScript/ArrowFunction_LexicalThis_TopLevelCallback.js) |  | Functions, arrows, methods, and other callable bodies are lowered into CLR callables plus captured scope arrays, which gives JROC a practical implementation of the spec's abstract-closure behavior. The covered closure and lexical-this cases work, but the implementation remains an approximation of the spec's internal abstract type. |
+
 ### 6.2.9 ([tc39.es](https://tc39.es/ecma262/#sec-data-blocks))
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| Data Blocks | Not Yet Supported |  |  | Spec-level byte data block operations depend on ArrayBuffer/SharedArrayBuffer machinery, which is not yet implemented. |
+| Data Blocks | Supported with Limitations | [`ArrayBuffer_Construct_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/ArrayBuffer_Construct_ByteLength.js)<br>[`DataView_SetGet_UintAndEndian.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_SetGet_UintAndEndian.js)<br>[`Int32Array_Construct_ArrayBuffer_ViewProperties.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/Int32Array_Construct_ArrayBuffer_ViewProperties.js)<br>[`SharedArrayBuffer_Int32Array_AtomicsWait.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/SharedArrayBuffer_Int32Array_AtomicsWait.js) |  | JROC implements fixed-length ArrayBuffer-backed byte storage, DataView/typed-array reads and writes, and a minimal SharedArrayBuffer-backed path sufficient for the covered Atomics.wait scenario. Resizable/detached/growable/shared-memory edge cases remain incomplete, so the clause stays supported with limitations. |
+
+### 6.2.9.1 ([tc39.es](https://tc39.es/ecma262/#sec-createbytedatablock))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| CreateByteDataBlock | Supported with Limitations | [`ArrayBuffer_Construct_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/ArrayBuffer_Construct_ByteLength.js)<br>[`DataView_SetGet_UintAndEndian.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_SetGet_UintAndEndian.js) |  | ArrayBuffer allocation creates the covered fixed-length byte storage used by DataView and typed-array operations. Resizable buffers and detach semantics are not fully modeled. |
+
+### 6.2.9.2 ([tc39.es](https://tc39.es/ecma262/#sec-createsharedbytedatablock))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| CreateSharedByteDataBlock | Supported with Limitations | [`SharedArrayBuffer_Int32Array_AtomicsWait.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/SharedArrayBuffer_Int32Array_AtomicsWait.js) |  | JROC exposes a minimal SharedArrayBuffer-backed byte store that is sufficient for constructing a shared Int32Array and exercising the covered Atomics.wait path. Full shared-memory, growable-buffer, and spec host-hook semantics remain limited. |
+
+### 6.2.9.3 ([tc39.es](https://tc39.es/ecma262/#sec-copydatablockbytes))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| CopyDataBlockBytes | Supported with Limitations | [`Int32Array_Set_FromArray_WithOffset.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/Int32Array_Set_FromArray_WithOffset.js)<br>[`Int32Array_Slice_Basic.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/Int32Array_Slice_Basic.js) |  | The covered typed-array copy and slice paths demonstrate byte copying across ArrayBuffer-backed views. The abstract operation is not exposed directly, and detached/shared/growable corner cases remain incomplete. |
 
 ### 6.2.10 ([tc39.es](https://tc39.es/ecma262/#sec-privateelement-specification-type))
 
@@ -106,5 +154,5 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| ClassStaticBlockDefinition record | Not Yet Supported |  |  | Class static blocks are rejected by validation. |
+| ClassStaticBlockDefinition record | Supported with Limitations | `tests/Jroc.Tests/ValidatorTests.cs`<br>[`Classes_ClassStaticBlock_DeclarationOrder.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassStaticBlock_DeclarationOrder.js) |  | Class static blocks are validated, represented during compilation, and emitted into the synthesized class static constructor in declaration order. The feature is implemented for the covered cases, but it is still tracked conservatively here because class element support in JROC remains broader than this record type alone. |
 

--- a/docs/ECMA262/Index.md
+++ b/docs/ECMA262/Index.md
@@ -19,12 +19,12 @@ Notes:
 - `Partially Supported` is deprecated legacy wording and is treated as `Supported with Limitations`.
 - Prototype-chain design/strategy: see [PrototypeChainSupport.md](../compiler/PrototypeChainSupport.md).
 
-> Last generated (UTC): 2026-07-07T17:05:44Z
+> Last generated (UTC): 2026-07-07T18:30:38Z
 
 ## Summary
 - Total top-level sections indexed: **29**
 - Top-level sections with tracked status: **28**
-- Status breakdown: Supported with Limitations: **9**, Incomplete: **12**, Not Yet Supported: **1**, N/A (informational): **6**, Untracked: **1**
+- Status breakdown: Supported with Limitations: **10**, Incomplete: **11**, Not Yet Supported: **1**, N/A (informational): **6**, Untracked: **1**
 - Untracked top-level sections: **1**
 
 ## Sections
@@ -36,7 +36,7 @@ Notes:
 | 3 | Normative References | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-normative-references) | [Section3.md](3/Section3.md) |
 | 4 | Overview | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-overview) | [Section4.md](4/Section4.md) |
 | 5 | Notational Conventions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-notational-conventions) | [Section5.md](5/Section5.md) |
-| 6 | ECMAScript Data Types and Values | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values) | [Section6.md](6/Section6.md) |
+| 6 | ECMAScript Data Types and Values | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values) | [Section6.md](6/Section6.md) |
 | 7 | Abstract Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations) | [Section7.md](7/Section7.md) |
 | 8 | Syntax-Directed Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations) | [Section8.md](8/Section8.md) |
 | 9 | Executable Code and Execution Contexts | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-executable-code-and-execution-contexts) | [Section9.md](9/Section9.md) |


### PR DESCRIPTION
## Summary
- reclassify ECMA-262 Section 6.2 so every clause and subclause is now tracked as `Supported with Limitations` or `N/A (informational)`
- document current implementation evidence for environment records, abstract closures, data blocks, and class static block records
- roll the Section 6.2 status change through Section 6 and `docs/ECMA262/Index.md`
- add the matching changelog entry

## Notes
- no new test262 ports or product fixes were needed for this pass; the existing implementation and targeted repo tests were already sufficient to justify the promoted statuses
- `eval` remains intentionally unsupported and is unchanged by this PR
