### PR TITLE
docs(ecma262): reclassify section 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- docs/ecma262: reclassify ECMA-262 Section 7.2 Testing and Comparison Operations to `Supported with Limitations`, documenting the current `RequireObjectCoercible`, `IsExtensible`, `isWellFormed`, identity, and comparison coverage against existing runtime behavior and targeted evidence.
 - runtime/tests/docs/test262: reclassify ECMA-262 Section 7.1 Type Conversion to `Supported with Limitations`, add shared `ToInt8` / `ToInt16` / `ToUint8` / `ToUint16` / `ToUint8Clamp` runtime helpers, implement `Uint8ClampedArray`, port new `for..of` test262 coverage for `Uint8ClampedArray`, and refresh the Section 7.1 support notes.
 - docs/ecma262: reclassify Section 6.2 ECMAScript Specification Types so every clause/subclause is now tracked as `Supported with Limitations` or `N/A (informational)`, documenting environment records, abstract closures, data blocks, and class static block records against current implementation evidence and rolling Section 6 up to `Supported with Limitations`.
 - runtime/tests/docs/test262: raise the Section 6.1.7 object-model coverage floor by fixing strict `NaN` equality for boxed doubles, preserving NaN across repeated ordinary-property updates, and enforcing the newly ported Proxy `[[GetOwnProperty]]` forwarding/invariant cases; refresh the Section 6.1 docs and roll-ups.

--- a/docs/ECMA262/7/Section7.md
+++ b/docs/ECMA262/7/Section7.md
@@ -4,7 +4,7 @@ Specifies abstract operations: the reusable algorithmic building blocks used thr
 
 [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-07T18:47:23Z
+> Last generated (UTC): 2026-07-07T20:03:34Z
 
 _This section is split into subsection documents for readability._
 
@@ -19,6 +19,6 @@ _This section is split into subsection documents for readability._
 | Subsection | Title | Status | Spec | Document |
 |---:|---|---|---|---|
 | 7.1 | Type Conversion | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-type-conversion) | [Section7_1.md](Section7_1.md) |
-| 7.2 | Testing and Comparison Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-testing-and-comparison-operations) | [Section7_2.md](Section7_2.md) |
+| 7.2 | Testing and Comparison Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-testing-and-comparison-operations) | [Section7_2.md](Section7_2.md) |
 | 7.3 | Operations on Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-objects) | [Section7_3.md](Section7_3.md) |
 | 7.4 | Operations on Iterator Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-iterator-objects) | [Section7_4.md](Section7_4.md) |

--- a/docs/ECMA262/7/Section7_2.json
+++ b/docs/ECMA262/7/Section7_2.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "7.2",
   "title": "Testing and Comparison Operations",
-  "status": "Incomplete",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-testing-and-comparison-operations",
   "parent": {
     "clause": "7"
@@ -36,7 +36,7 @@
     {
       "clause": "7.2.5",
       "title": "IsExtensible ( O )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-isextensible-o"
     },
     {
@@ -48,7 +48,7 @@
     {
       "clause": "7.2.7",
       "title": "Static Semantics: IsStringWellFormedUnicode ( string )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-isstringwellformedunicode"
     },
     {
@@ -97,6 +97,30 @@
   "support": {
     "entries": [
       {
+        "clause": "7.2",
+        "feature": "Testing and comparison operations across coercion guards, identity, relational comparison, and integrity checks",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-testing-and-comparison-operations",
+        "testScripts": [
+          "tests/Jroc.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js",
+          "tests/Jroc.Tests/String/JavaScript/String_NewApis_Basic.js",
+          "tests/Jroc.Tests/BinaryOperator/JavaScript/BinaryOperator_Equal.js",
+          "tests/Jroc.Tests/BinaryOperator/JavaScript/BinaryOperator_StrictEqualCapturedVariable.js"
+        ],
+        "notes": "JROC covers the commonly exercised object-coercion, identity, extensibility, and comparison helpers that current language/runtime features depend on. Remaining gaps are mostly in rarely-used constructability/callability edge cases and in full abstract-operation parity for every host and proxy scenario."
+      },
+      {
+        "clause": "7.2.1",
+        "feature": "RequireObjectCoercible guards in object-destructuring and object built-ins",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-requireobjectcoercible",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/language/destructuring/binding/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/Object/setPrototypeOf/ExecutionTests.cs"
+        ],
+        "notes": "The runtime consistently throws when object-requiring operations receive nullish values in the covered destructuring and Object built-in paths. Coverage is still anchored to the current object-operation call sites rather than a separately documented standalone helper surface."
+      },
+      {
         "clause": "7.2.2",
         "feature": "IsArray",
         "status": "Supported",
@@ -131,6 +155,17 @@
         "notes": "Dynamic construction supports delegate/type/Construct-member shapes used by JROC; full constructability semantics are not complete."
       },
       {
+        "clause": "7.2.5",
+        "feature": "IsExtensible checks through Object.isExtensible and integrity operations",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-isextensible-o",
+        "testScripts": [
+          "tests/Jroc.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js",
+          "tests/Jroc.Test262.Tests/language/expressions/arrow-function/ExecutionTests.cs"
+        ],
+        "notes": "Object.isExtensible and the shared integrity-state tracking behave correctly for the covered ordinary-object and function-like cases. Proxy extensibility traps and some host-object edge cases are not fully modeled."
+      },
+      {
         "clause": "7.2.6",
         "feature": "IsRegExp classification in RegExp-aware operations",
         "status": "Supported with Limitations",
@@ -140,6 +175,27 @@
           "tests/Jroc.Tests/String/JavaScript/String_RegExp_Exec_LastIndex_Global.js"
         ],
         "notes": "RegExp-aware behavior is implemented for JavaScriptRuntime.RegExp call sites; Symbol.match override semantics are not fully modeled."
+      },
+      {
+        "clause": "7.2.7",
+        "feature": "IsStringWellFormedUnicode via String.prototype.isWellFormed and toWellFormed",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-isstringwellformedunicode",
+        "testScripts": [
+          "tests/Jroc.Tests/String/JavaScript/String_NewApis_Basic.js"
+        ],
+        "notes": "The runtime exposes well-formed Unicode detection and repair through the current String.prototype APIs, including lone-surrogate detection. Coverage is centered on the shipped string built-ins rather than the spec's internal static-semantics presentation."
+      },
+      {
+        "clause": "7.2.8",
+        "feature": "SameType discrimination across current runtime representations",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-sametype",
+        "testScripts": [
+          "tests/Jroc.Tests/Object/JavaScript/Object_Is_SameValue.js",
+          "tests/Jroc.Tests/BinaryOperator/JavaScript/BinaryOperator_StrictEqualCapturedVariable.js"
+        ],
+        "notes": "The runtime distinguishes current primitive, object, and BigInt shapes closely enough for the covered SameValue and strict-equality consumers. Some host-object and wrapper-object distinctions are still approximated through JROC's CLR-backed representation model."
       },
       {
         "clause": "7.2.9",
@@ -160,6 +216,17 @@
           "tests/Jroc.Tests/Array/JavaScript/Array_SearchOps_Basic.js"
         ],
         "notes": "Implemented in array includes/search paths and runtime helper comparisons."
+      },
+      {
+        "clause": "7.2.11",
+        "feature": "SameValueNonNumber behavior for non-numeric strict identity paths",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-samevaluenonnumber",
+        "testScripts": [
+          "tests/Jroc.Tests/Object/JavaScript/Object_Is_SameValue.js",
+          "tests/Jroc.Tests/BinaryOperator/JavaScript/BinaryOperator_StrictEqualCapturedVariable.js"
+        ],
+        "notes": "Non-number identity checks follow the covered object, string, boolean, nullish, and symbol-like paths used by Object.is and strict comparison. The remaining limitations come from JROC's partial wrapper-object and host-object fidelity rather than from the covered comparison logic itself."
       },
       {
         "clause": "7.2.12",

--- a/docs/ECMA262/7/Section7_2.md
+++ b/docs/ECMA262/7/Section7_2.md
@@ -4,11 +4,11 @@
 
 [Back to Section7](Section7.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-23T13:57:49Z
+> Last generated (UTC): 2026-07-07T20:03:34Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 7.2 | Testing and Comparison Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-testing-and-comparison-operations) |
+| 7.2 | Testing and Comparison Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-testing-and-comparison-operations) |
 
 ## Subclauses
 
@@ -18,9 +18,9 @@
 | 7.2.2 | IsArray ( argument ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-isarray) |
 | 7.2.3 | IsCallable ( argument ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iscallable) |
 | 7.2.4 | IsConstructor ( argument ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-isconstructor) |
-| 7.2.5 | IsExtensible ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-isextensible-o) |
+| 7.2.5 | IsExtensible ( O ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-isextensible-o) |
 | 7.2.6 | IsRegExp ( argument ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-isregexp) |
-| 7.2.7 | Static Semantics: IsStringWellFormedUnicode ( string ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-isstringwellformedunicode) |
+| 7.2.7 | Static Semantics: IsStringWellFormedUnicode ( string ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-isstringwellformedunicode) |
 | 7.2.8 | SameType ( x , y ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-sametype) |
 | 7.2.9 | SameValue ( x , y ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-samevalue) |
 | 7.2.10 | SameValueZero ( x , y ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-samevaluezero) |
@@ -32,6 +32,18 @@
 ## Support
 
 Feature-level support tracking with repo test references and optional test262 evidence.
+
+### 7.2 ([tc39.es](https://tc39.es/ecma262/#sec-testing-and-comparison-operations))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Testing and comparison operations across coercion guards, identity, relational comparison, and integrity checks | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js)<br>[`String_NewApis_Basic.js`](../../../tests/Jroc.Tests/String/JavaScript/String_NewApis_Basic.js)<br>[`BinaryOperator_Equal.js`](../../../tests/Jroc.Tests/BinaryOperator/JavaScript/BinaryOperator_Equal.js)<br>[`BinaryOperator_StrictEqualCapturedVariable.js`](../../../tests/Jroc.Tests/BinaryOperator/JavaScript/BinaryOperator_StrictEqualCapturedVariable.js) |  | JROC covers the commonly exercised object-coercion, identity, extensibility, and comparison helpers that current language/runtime features depend on. Remaining gaps are mostly in rarely-used constructability/callability edge cases and in full abstract-operation parity for every host and proxy scenario. |
+
+### 7.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-requireobjectcoercible))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| RequireObjectCoercible guards in object-destructuring and object built-ins | Supported with Limitations | `tests/Jroc.Test262.Tests/language/destructuring/binding/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/Object/setPrototypeOf/ExecutionTests.cs` |  | The runtime consistently throws when object-requiring operations receive nullish values in the covered destructuring and Object built-in paths. Coverage is still anchored to the current object-operation call sites rather than a separately documented standalone helper surface. |
 
 ### 7.2.2 ([tc39.es](https://tc39.es/ecma262/#sec-isarray))
 
@@ -51,11 +63,29 @@ Feature-level support tracking with repo test references and optional test262 ev
 |---|---|---|---|---|
 | IsConstructor checks for new-expression paths | Supported with Limitations | [`Classes_DeclareEmptyClass.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_DeclareEmptyClass.js)<br>[`BinaryOperator_InstanceOf_Basic.js`](../../../tests/Jroc.Tests/BinaryOperator/JavaScript/BinaryOperator_InstanceOf_Basic.js) |  | Dynamic construction supports delegate/type/Construct-member shapes used by JROC; full constructability semantics are not complete. |
 
+### 7.2.5 ([tc39.es](https://tc39.es/ecma262/#sec-isextensible-o))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IsExtensible checks through Object.isExtensible and integrity operations | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js)<br>`tests/Jroc.Test262.Tests/language/expressions/arrow-function/ExecutionTests.cs` |  | Object.isExtensible and the shared integrity-state tracking behave correctly for the covered ordinary-object and function-like cases. Proxy extensibility traps and some host-object edge cases are not fully modeled. |
+
 ### 7.2.6 ([tc39.es](https://tc39.es/ecma262/#sec-isregexp))
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | IsRegExp classification in RegExp-aware operations | Supported with Limitations | [`IntrinsicCallables_RegExp_Callable_CreatesRegex.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_RegExp_Callable_CreatesRegex.js)<br>[`String_RegExp_Exec_LastIndex_Global.js`](../../../tests/Jroc.Tests/String/JavaScript/String_RegExp_Exec_LastIndex_Global.js) |  | RegExp-aware behavior is implemented for JavaScriptRuntime.RegExp call sites; Symbol.match override semantics are not fully modeled. |
+
+### 7.2.7 ([tc39.es](https://tc39.es/ecma262/#sec-isstringwellformedunicode))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IsStringWellFormedUnicode via String.prototype.isWellFormed and toWellFormed | Supported with Limitations | [`String_NewApis_Basic.js`](../../../tests/Jroc.Tests/String/JavaScript/String_NewApis_Basic.js) |  | The runtime exposes well-formed Unicode detection and repair through the current String.prototype APIs, including lone-surrogate detection. Coverage is centered on the shipped string built-ins rather than the spec's internal static-semantics presentation. |
+
+### 7.2.8 ([tc39.es](https://tc39.es/ecma262/#sec-sametype))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| SameType discrimination across current runtime representations | Supported with Limitations | [`Object_Is_SameValue.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_Is_SameValue.js)<br>[`BinaryOperator_StrictEqualCapturedVariable.js`](../../../tests/Jroc.Tests/BinaryOperator/JavaScript/BinaryOperator_StrictEqualCapturedVariable.js) |  | The runtime distinguishes current primitive, object, and BigInt shapes closely enough for the covered SameValue and strict-equality consumers. Some host-object and wrapper-object distinctions are still approximated through JROC's CLR-backed representation model. |
 
 ### 7.2.9 ([tc39.es](https://tc39.es/ecma262/#sec-samevalue))
 
@@ -68,6 +98,12 @@ Feature-level support tracking with repo test references and optional test262 ev
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | SameValueZero | Supported | [`Array_SearchOps_Basic.js`](../../../tests/Jroc.Tests/Array/JavaScript/Array_SearchOps_Basic.js) |  | Implemented in array includes/search paths and runtime helper comparisons. |
+
+### 7.2.11 ([tc39.es](https://tc39.es/ecma262/#sec-samevaluenonnumber))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| SameValueNonNumber behavior for non-numeric strict identity paths | Supported with Limitations | [`Object_Is_SameValue.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_Is_SameValue.js)<br>[`BinaryOperator_StrictEqualCapturedVariable.js`](../../../tests/Jroc.Tests/BinaryOperator/JavaScript/BinaryOperator_StrictEqualCapturedVariable.js) |  | Non-number identity checks follow the covered object, string, boolean, nullish, and symbol-like paths used by Object.is and strict comparison. The remaining limitations come from JROC's partial wrapper-object and host-object fidelity rather than from the covered comparison logic itself. |
 
 ### 7.2.12 ([tc39.es](https://tc39.es/ecma262/#sec-islessthan))
 


### PR DESCRIPTION
## Summary
- reclassify ECMA-262 Section 7.2 to supported-with-limitations status using existing runtime behavior and targeted evidence
- document current coverage for RequireObjectCoercible, IsExtensible, isWellFormed, SameType, SameValueNonNumber, and the broader comparison helpers
- roll the Section 7.2 status through Section 7 and update the changelog

## Validation
- focused Jroc.Tests object/string/comparison slice
- focused Jroc.Test262 destructuring-binding and Object.setPrototypeOf slice