### PR TITLE
docs(ecma262): reclassify section 7.3 coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- docs/ecma262: reclassify ECMA-262 Section 7.3 Operations on Objects to `Supported with Limitations`, documenting the current integrity-level, apply/construct argument normalization, species accessor, private method/accessor, grouping, and class-field own-property coverage against existing runtime behavior and targeted evidence.
 - docs/ecma262: reclassify ECMA-262 Section 7.2 Testing and Comparison Operations to `Supported with Limitations`, documenting the current `RequireObjectCoercible`, `IsExtensible`, `isWellFormed`, identity, and comparison coverage against existing runtime behavior and targeted evidence.
 - runtime/tests/docs/test262: reclassify ECMA-262 Section 7.1 Type Conversion to `Supported with Limitations`, add shared `ToInt8` / `ToInt16` / `ToUint8` / `ToUint16` / `ToUint8Clamp` runtime helpers, implement `Uint8ClampedArray`, port new `for..of` test262 coverage for `Uint8ClampedArray`, and refresh the Section 7.1 support notes.
 - docs/ecma262: reclassify Section 6.2 ECMAScript Specification Types so every clause/subclause is now tracked as `Supported with Limitations` or `N/A (informational)`, documenting environment records, abstract closures, data blocks, and class static block records against current implementation evidence and rolling Section 6 up to `Supported with Limitations`.

--- a/docs/ECMA262/7/Section7.md
+++ b/docs/ECMA262/7/Section7.md
@@ -4,7 +4,7 @@ Specifies abstract operations: the reusable algorithmic building blocks used thr
 
 [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-07T20:03:34Z
+> Last generated (UTC): 2026-07-07T20:14:26Z
 
 _This section is split into subsection documents for readability._
 
@@ -20,5 +20,5 @@ _This section is split into subsection documents for readability._
 |---:|---|---|---|---|
 | 7.1 | Type Conversion | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-type-conversion) | [Section7_1.md](Section7_1.md) |
 | 7.2 | Testing and Comparison Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-testing-and-comparison-operations) | [Section7_2.md](Section7_2.md) |
-| 7.3 | Operations on Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-objects) | [Section7_3.md](Section7_3.md) |
+| 7.3 | Operations on Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-objects) | [Section7_3.md](Section7_3.md) |
 | 7.4 | Operations on Iterator Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-iterator-objects) | [Section7_4.md](Section7_4.md) |

--- a/docs/ECMA262/7/Section7_3.json
+++ b/docs/ECMA262/7/Section7_3.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "7.3",
   "title": "Operations on Objects",
-  "status": "Incomplete",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-operations-on-objects",
   "parent": {
     "clause": "7"
@@ -12,7 +12,7 @@
     {
       "clause": "7.3.1",
       "title": "MakeBasicObject ( internalSlotsList )",
-      "status": "Not Yet Supported",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-makebasicobject"
     },
     {
@@ -96,13 +96,13 @@
     {
       "clause": "7.3.15",
       "title": "SetIntegrityLevel ( O , level )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-setintegritylevel"
     },
     {
       "clause": "7.3.16",
       "title": "TestIntegrityLevel ( O , level )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-testintegritylevel"
     },
     {
@@ -120,7 +120,7 @@
     {
       "clause": "7.3.19",
       "title": "CreateListFromArrayLike ( obj [ , validElementTypes ] )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-createlistfromarraylike"
     },
     {
@@ -138,7 +138,7 @@
     {
       "clause": "7.3.22",
       "title": "SpeciesConstructor ( O , defaultConstructor )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-speciesconstructor"
     },
     {
@@ -150,7 +150,7 @@
     {
       "clause": "7.3.24",
       "title": "GetFunctionRealm ( obj )",
-      "status": "Not Yet Supported",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-getfunctionrealm"
     },
     {
@@ -174,13 +174,13 @@
     {
       "clause": "7.3.28",
       "title": "PrivateMethodOrAccessorAdd ( O , method )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-privatemethodoraccessoradd"
     },
     {
       "clause": "7.3.29",
       "title": "HostEnsureCanAddPrivateElement ( O )",
-      "status": "Not Yet Supported",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-hostensurecanaddprivateelement"
     },
     {
@@ -210,30 +210,44 @@
     {
       "clause": "7.3.34",
       "title": "AddValueToKeyedGroup ( groups , key , value )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-add-value-to-keyed-group"
     },
     {
       "clause": "7.3.35",
       "title": "GroupBy ( items , callback , keyCoercion )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-groupby"
     },
     {
       "clause": "7.3.36",
       "title": "GetOptionsObject ( options )",
-      "status": "Not Yet Supported",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-getoptionsobject"
     },
     {
       "clause": "7.3.37",
       "title": "SetterThatIgnoresPrototypeProperties ( thisValue , home , p , v )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-SetterThatIgnoresPrototypeProperties"
     }
   ],
   "support": {
     "entries": [
+      {
+        "clause": "7.3",
+        "feature": "Object operations across integrity, argument-list normalization, private elements, species accessors, and grouping",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-operations-on-objects",
+        "testScripts": [
+          "tests/Jroc.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js",
+          "tests/Jroc.Tests/Function/JavaScript/Function_Apply_Basic.js",
+          "tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateMethodAndAccessor_Log.js",
+          "tests/Jroc.Tests/Object/JavaScript/Object_GroupBy_Basic.js",
+          "tests/Jroc.Tests/Promise/JavaScript/Promise_SymbolSpecies.js"
+        ],
+        "notes": "JROC covers the object-operation helpers most visible through today's runtime surface, including integrity-state transitions, current argument-list normalization paths, private elements, built-in species accessors, class field own-property definition, and Object.groupBy. Remaining limitations are concentrated in exotic object/proxy edge cases and in abstract helpers that are still modeled inline rather than as fully general standalone operations."
+      },
       {
         "clause": "7.3.2",
         "feature": "Property get on object literals and host objects",
@@ -349,6 +363,42 @@
         "notes": "Implemented for supported array-like runtime types with partial coercion behavior."
       },
       {
+        "clause": "7.3.15",
+        "feature": "SetIntegrityLevel through Object.preventExtensions, Object.seal, and Object.freeze",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-setintegritylevel",
+        "testScripts": [
+          "tests/Jroc.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js",
+          "tests/Jroc.Tests/Object/JavaScript/Object_Integrity_DefineProperty_And_StrictWrites.js"
+        ],
+        "notes": "Ordinary-object integrity state is tracked and enforced for the covered preventExtensions/seal/freeze paths, including strict-mode write failures after freezing. Full proxy invariants and every exotic-object integrity rule are still incomplete."
+      },
+      {
+        "clause": "7.3.16",
+        "feature": "TestIntegrityLevel through Object.isExtensible, Object.isSealed, and Object.isFrozen",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-testintegritylevel",
+        "testScripts": [
+          "tests/Jroc.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js",
+          "tests/Jroc.Tests/Object/JavaScript/Object_Integrity_DefineProperty_And_StrictWrites.js"
+        ],
+        "notes": "The runtime reports integrity state consistently for the covered ordinary-object transitions and descriptor combinations. Coverage is still strongest for ordinary objects rather than every proxy and host-object edge case."
+      },
+      {
+        "clause": "7.3.19",
+        "feature": "CreateListFromArrayLike in apply/construct-style argument normalization",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-createlistfromarraylike",
+        "testScripts": [
+          "tests/Jroc.Tests/Function/JavaScript/Function_Apply_Basic.js",
+          "tests/Jroc.Tests/Function/JavaScript/Function_Apply_NullArgArray_TreatedAsEmpty.js"
+        ],
+        "test262Paths": [
+          "test/language/rest-parameters/rest-parameters-apply.js"
+        ],
+        "notes": "Current apply/construct normalization accepts JavaScript arrays, CLR arrays, and enumerable argument sources for the covered call sites. Generic length-indexed array-like objects and validElementTypes filtering are not yet modeled as a complete standalone abstract operation."
+      },
+      {
         "clause": "7.3.21",
         "feature": "OrdinaryHasInstance (instanceof paths)",
         "status": "Supported with Limitations",
@@ -357,6 +407,20 @@
           "tests/Jroc.Tests/BinaryOperator/JavaScript/BinaryOperator_InstanceOf_Basic.js"
         ],
         "notes": "Implemented with prototype-chain checks for supported callable constructor values; full spec hooks are incomplete."
+      },
+      {
+        "clause": "7.3.22",
+        "feature": "SpeciesConstructor through built-in @@species accessors and Promise constructor-receiver helpers",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-speciesconstructor",
+        "testScripts": [
+          "tests/Jroc.Tests/Promise/JavaScript/Promise_SymbolSpecies.js"
+        ],
+        "test262Paths": [
+          "test/built-ins/Map/Symbol.species/return-value.js",
+          "test/built-ins/Set/Symbol.species/return-value.js"
+        ],
+        "notes": "Promise, Map, and Set expose the covered @@species accessor behavior, and Promise constructor-receiver helpers honor the active constructor in the supported resolve/try paths. General species-based derived construction across all spec consumers is still incomplete."
       },
       {
         "clause": "7.3.23",
@@ -394,6 +458,21 @@
         "notes": "Private field access works for supported class forms. Supported private methods participate in receiver brand checks, including static private methods rejecting proxy receivers; private accessors and complete validation coverage remain limited."
       },
       {
+        "clause": "7.3.28",
+        "feature": "PrivateMethodOrAccessorAdd for private methods and private accessors",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-privatemethodoraccessoradd",
+        "testScripts": [
+          "tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateMethodAndAccessor_Log.js",
+          "tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateAccessor_EdgeCases_Log.js",
+          "tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateAccessor_ClassExpression_Log.js"
+        ],
+        "test262Paths": [
+          "test/language/expressions/class/elements/fields-multiple-definitions-static-private-methods-proxy.js"
+        ],
+        "notes": "JROC initializes and brands the covered private methods and private accessors, including static private method receiver checks and accessor invocation. Broader spec parity for every duplicate-definition and exotic evaluation edge case is still incomplete."
+      },
+      {
         "clause": "7.3.33",
         "feature": "InitializeInstanceElements (class fields + private fields)",
         "status": "Supported with Limitations",
@@ -403,7 +482,39 @@
           "tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateField_HelperMethod_Log.js",
           "tests/Jroc.Test262.Tests/language/expressions/class/JavaScript/constructor-this-tdz-during-initializers.js"
         ],
-        "notes": "Supports instance field initializers and private instance fields, including derived-constructor initialization after super() for supported class bases. Static blocks and supported private methods are implemented; private accessors and some inheritance details remain incomplete."
+        "notes": "Supports instance field initializers and private instance fields, including derived-constructor initialization after super() for supported class bases. Static blocks, supported private methods, and current private accessor forms are implemented; some inheritance and exotic receiver details remain incomplete."
+      },
+      {
+        "clause": "7.3.34",
+        "feature": "AddValueToKeyedGroup through Object.groupBy accumulation",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-add-value-to-keyed-group",
+        "testScripts": [
+          "tests/Jroc.Tests/Object/JavaScript/Object_GroupBy_Basic.js"
+        ],
+        "notes": "The Object.groupBy implementation groups callback results under the covered property keys and appends values into the correct per-key buckets. Edge cases around the full spec key-coercion matrix and every exotic iterable input remain incomplete."
+      },
+      {
+        "clause": "7.3.35",
+        "feature": "GroupBy via Object.groupBy",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-groupby",
+        "testScripts": [
+          "tests/Jroc.Tests/Object/JavaScript/Object_GroupBy_Basic.js"
+        ],
+        "notes": "Object.groupBy provides the covered callback-driven grouping behavior over supported iterable inputs. The current implementation does not yet claim full parity for all abrupt-completion, coercion-order, and exotic iterator corner cases."
+      },
+      {
+        "clause": "7.3.37",
+        "feature": "SetterThatIgnoresPrototypeProperties behavior in class field definition and class member installation",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-SetterThatIgnoresPrototypeProperties",
+        "test262Paths": [
+          "test/language/statements/class/elements/class-field-is-observable-by-proxy.js",
+          "test/language/statements/class/subclass/superclass-prototype-setter-constructor.js",
+          "test/language/statements/class/subclass/superclass-prototype-setter-method-override.js"
+        ],
+        "notes": "The covered class-field and class-member definition paths create own properties without accidentally dispatching inherited prototype setters, while still remaining observable through defineProperty-style proxy interception where the spec requires it. This documentation does not yet claim full parity for every built-in accessor that reuses the helper."
       }
     ]
   }

--- a/docs/ECMA262/7/Section7_3.md
+++ b/docs/ECMA262/7/Section7_3.md
@@ -4,17 +4,17 @@
 
 [Back to Section7](Section7.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-18T20:54:15Z
+> Last generated (UTC): 2026-07-07T20:14:57Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 7.3 | Operations on Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-objects) |
+| 7.3 | Operations on Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-objects) |
 
 ## Subclauses
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 7.3.1 | MakeBasicObject ( internalSlotsList ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-makebasicobject) |
+| 7.3.1 | MakeBasicObject ( internalSlotsList ) | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-makebasicobject) |
 | 7.3.2 | Get ( O , P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-get-o-p) |
 | 7.3.3 | GetV ( V , P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getv) |
 | 7.3.4 | Set ( O , P , V , Throw ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-set-o-p-v-throw) |
@@ -28,33 +28,39 @@
 | 7.3.12 | HasOwnProperty ( O , P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-hasownproperty) |
 | 7.3.13 | Call ( F , V [ , argumentsList ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-call) |
 | 7.3.14 | Construct ( F [ , argumentsList [ , newTarget ] ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-construct) |
-| 7.3.15 | SetIntegrityLevel ( O , level ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-setintegritylevel) |
-| 7.3.16 | TestIntegrityLevel ( O , level ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-testintegritylevel) |
+| 7.3.15 | SetIntegrityLevel ( O , level ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-setintegritylevel) |
+| 7.3.16 | TestIntegrityLevel ( O , level ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-testintegritylevel) |
 | 7.3.17 | CreateArrayFromList ( elements ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-createarrayfromlist) |
 | 7.3.18 | LengthOfArrayLike ( obj ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-lengthofarraylike) |
-| 7.3.19 | CreateListFromArrayLike ( obj [ , validElementTypes ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-createlistfromarraylike) |
+| 7.3.19 | CreateListFromArrayLike ( obj [ , validElementTypes ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-createlistfromarraylike) |
 | 7.3.20 | Invoke ( V , P [ , argumentsList ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-invoke) |
 | 7.3.21 | OrdinaryHasInstance ( C , O ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ordinaryhasinstance) |
-| 7.3.22 | SpeciesConstructor ( O , defaultConstructor ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-speciesconstructor) |
+| 7.3.22 | SpeciesConstructor ( O , defaultConstructor ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-speciesconstructor) |
 | 7.3.23 | EnumerableOwnProperties ( O , kind ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-enumerableownproperties) |
-| 7.3.24 | GetFunctionRealm ( obj ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-getfunctionrealm) |
+| 7.3.24 | GetFunctionRealm ( obj ) | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-getfunctionrealm) |
 | 7.3.25 | CopyDataProperties ( target , source , excludedItems ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-copydataproperties) |
 | 7.3.26 | PrivateElementFind ( O , P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-privateelementfind) |
 | 7.3.27 | PrivateFieldAdd ( O , P , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-privatefieldadd) |
-| 7.3.28 | PrivateMethodOrAccessorAdd ( O , method ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-privatemethodoraccessoradd) |
-| 7.3.29 | HostEnsureCanAddPrivateElement ( O ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-hostensurecanaddprivateelement) |
+| 7.3.28 | PrivateMethodOrAccessorAdd ( O , method ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-privatemethodoraccessoradd) |
+| 7.3.29 | HostEnsureCanAddPrivateElement ( O ) | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-hostensurecanaddprivateelement) |
 | 7.3.30 | PrivateGet ( O , P ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-privateget) |
 | 7.3.31 | PrivateSet ( O , P , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-privateset) |
 | 7.3.32 | DefineField ( receiver , fieldRecord ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-definefield) |
 | 7.3.33 | InitializeInstanceElements ( O , constructor ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-initializeinstanceelements) |
-| 7.3.34 | AddValueToKeyedGroup ( groups , key , value ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-add-value-to-keyed-group) |
-| 7.3.35 | GroupBy ( items , callback , keyCoercion ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-groupby) |
-| 7.3.36 | GetOptionsObject ( options ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-getoptionsobject) |
-| 7.3.37 | SetterThatIgnoresPrototypeProperties ( thisValue , home , p , v ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-SetterThatIgnoresPrototypeProperties) |
+| 7.3.34 | AddValueToKeyedGroup ( groups , key , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-add-value-to-keyed-group) |
+| 7.3.35 | GroupBy ( items , callback , keyCoercion ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-groupby) |
+| 7.3.36 | GetOptionsObject ( options ) | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-getoptionsobject) |
+| 7.3.37 | SetterThatIgnoresPrototypeProperties ( thisValue , home , p , v ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-SetterThatIgnoresPrototypeProperties) |
 
 ## Support
 
 Feature-level support tracking with repo test references and optional test262 evidence.
+
+### 7.3 ([tc39.es](https://tc39.es/ecma262/#sec-operations-on-objects))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Object operations across integrity, argument-list normalization, private elements, species accessors, and grouping | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js)<br>[`Function_Apply_Basic.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_Apply_Basic.js)<br>[`Classes_ClassPrivateMethodAndAccessor_Log.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateMethodAndAccessor_Log.js)<br>[`Object_GroupBy_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_GroupBy_Basic.js)<br>[`Promise_SymbolSpecies.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_SymbolSpecies.js) |  | JROC covers the object-operation helpers most visible through today's runtime surface, including integrity-state transitions, current argument-list normalization paths, private elements, built-in species accessors, class field own-property definition, and Object.groupBy. Remaining limitations are concentrated in exotic object/proxy edge cases and in abstract helpers that are still modeled inline rather than as fully general standalone operations. |
 
 ### 7.3.2 ([tc39.es](https://tc39.es/ecma262/#sec-get-o-p))
 
@@ -110,17 +116,41 @@ Feature-level support tracking with repo test references and optional test262 ev
 |---|---|---|---|---|
 | Construction (new) including dynamic constructor values | Supported with Limitations | [`Classes_DeclareEmptyClass.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_DeclareEmptyClass.js)<br>[`CommonJS_Export_ClassWithConstructor.js`](../../../tests/Jroc.Tests/CommonJS/JavaScript/CommonJS_Export_ClassWithConstructor.js)<br>[`NewExpression_Number_Sugar.js`](../../../tests/Jroc.Tests/Literals/JavaScript/NewExpression_Number_Sugar.js)<br>[`ctorPadding.js`](../../../tests/Jroc.Tests/Hosting/JavaScript/ctorPadding.js) |  | Supports statically-known constructors and runtime fallback for dynamic constructor values; full newTarget and exotic constructor behavior is incomplete. |
 
+### 7.3.15 ([tc39.es](https://tc39.es/ecma262/#sec-setintegritylevel))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| SetIntegrityLevel through Object.preventExtensions, Object.seal, and Object.freeze | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js)<br>[`Object_Integrity_DefineProperty_And_StrictWrites.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_Integrity_DefineProperty_And_StrictWrites.js) |  | Ordinary-object integrity state is tracked and enforced for the covered preventExtensions/seal/freeze paths, including strict-mode write failures after freezing. Full proxy invariants and every exotic-object integrity rule are still incomplete. |
+
+### 7.3.16 ([tc39.es](https://tc39.es/ecma262/#sec-testintegritylevel))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| TestIntegrityLevel through Object.isExtensible, Object.isSealed, and Object.isFrozen | Supported with Limitations | [`Object_Integrity_FreezeSeal_PreventExtensions.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_Integrity_FreezeSeal_PreventExtensions.js)<br>[`Object_Integrity_DefineProperty_And_StrictWrites.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_Integrity_DefineProperty_And_StrictWrites.js) |  | The runtime reports integrity state consistently for the covered ordinary-object transitions and descriptor combinations. Coverage is still strongest for ordinary objects rather than every proxy and host-object edge case. |
+
 ### 7.3.18 ([tc39.es](https://tc39.es/ecma262/#sec-lengthofarraylike))
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | LengthOfArrayLike | Supported with Limitations | [`Array_LengthProperty_ReturnsCount.js`](../../../tests/Jroc.Tests/Array/JavaScript/Array_LengthProperty_ReturnsCount.js)<br>[`Int32Array_Construct_Length.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/Int32Array_Construct_Length.js)<br>[`String_Split_Basic.js`](../../../tests/Jroc.Tests/String/JavaScript/String_Split_Basic.js) |  | Implemented for supported array-like runtime types with partial coercion behavior. |
 
+### 7.3.19 ([tc39.es](https://tc39.es/ecma262/#sec-createlistfromarraylike))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| CreateListFromArrayLike in apply/construct-style argument normalization | Supported with Limitations | [`Function_Apply_Basic.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_Apply_Basic.js)<br>[`Function_Apply_NullArgArray_TreatedAsEmpty.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_Apply_NullArgArray_TreatedAsEmpty.js) | `test/language/rest-parameters/rest-parameters-apply.js` | Current apply/construct normalization accepts JavaScript arrays, CLR arrays, and enumerable argument sources for the covered call sites. Generic length-indexed array-like objects and validElementTypes filtering are not yet modeled as a complete standalone abstract operation. |
+
 ### 7.3.21 ([tc39.es](https://tc39.es/ecma262/#sec-ordinaryhasinstance))
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | OrdinaryHasInstance (instanceof paths) | Supported with Limitations | [`BinaryOperator_InstanceOf_Basic.js`](../../../tests/Jroc.Tests/BinaryOperator/JavaScript/BinaryOperator_InstanceOf_Basic.js) |  | Implemented with prototype-chain checks for supported callable constructor values; full spec hooks are incomplete. |
+
+### 7.3.22 ([tc39.es](https://tc39.es/ecma262/#sec-speciesconstructor))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| SpeciesConstructor through built-in @@species accessors and Promise constructor-receiver helpers | Supported with Limitations | [`Promise_SymbolSpecies.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_SymbolSpecies.js) | `test/built-ins/Map/Symbol.species/return-value.js`<br>`test/built-ins/Set/Symbol.species/return-value.js` | Promise, Map, and Set expose the covered @@species accessor behavior, and Promise constructor-receiver helpers honor the active constructor in the supported resolve/try paths. General species-based derived construction across all spec consumers is still incomplete. |
 
 ### 7.3.23 ([tc39.es](https://tc39.es/ecma262/#sec-enumerableownproperties))
 
@@ -140,9 +170,33 @@ Feature-level support tracking with repo test references and optional test262 ev
 |---|---|---|---|---|
 | PrivateElementFind for private fields | Supported with Limitations | [`Classes_ClassPrivateField_HelperMethod_Log.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateField_HelperMethod_Log.js)<br>[`Classes_ClassPrivateProperty_HelperMethod_Log.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateProperty_HelperMethod_Log.js)<br>[`fields-multiple-definitions-static-private-methods-proxy.js`](../../../tests/Jroc.Test262.Tests/language/expressions/class/elements/JavaScript/fields-multiple-definitions-static-private-methods-proxy.js) |  | Private field access works for supported class forms. Supported private methods participate in receiver brand checks, including static private methods rejecting proxy receivers; private accessors and complete validation coverage remain limited. |
 
+### 7.3.28 ([tc39.es](https://tc39.es/ecma262/#sec-privatemethodoraccessoradd))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| PrivateMethodOrAccessorAdd for private methods and private accessors | Supported with Limitations | [`Classes_ClassPrivateMethodAndAccessor_Log.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateMethodAndAccessor_Log.js)<br>[`Classes_ClassPrivateAccessor_EdgeCases_Log.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateAccessor_EdgeCases_Log.js)<br>[`Classes_ClassPrivateAccessor_ClassExpression_Log.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateAccessor_ClassExpression_Log.js) | `test/language/expressions/class/elements/fields-multiple-definitions-static-private-methods-proxy.js` | JROC initializes and brands the covered private methods and private accessors, including static private method receiver checks and accessor invocation. Broader spec parity for every duplicate-definition and exotic evaluation edge case is still incomplete. |
+
 ### 7.3.33 ([tc39.es](https://tc39.es/ecma262/#sec-initializeinstanceelements))
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| InitializeInstanceElements (class fields + private fields) | Supported with Limitations | [`Classes_ClassProperty_DefaultAndLog.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassProperty_DefaultAndLog.js)<br>[`Classes_ClassPrivateField_HelperMethod_Log.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateField_HelperMethod_Log.js)<br>[`constructor-this-tdz-during-initializers.js`](../../../tests/Jroc.Test262.Tests/language/expressions/class/JavaScript/constructor-this-tdz-during-initializers.js) |  | Supports instance field initializers and private instance fields, including derived-constructor initialization after super() for supported class bases. Static blocks and supported private methods are implemented; private accessors and some inheritance details remain incomplete. |
+| InitializeInstanceElements (class fields + private fields) | Supported with Limitations | [`Classes_ClassProperty_DefaultAndLog.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassProperty_DefaultAndLog.js)<br>[`Classes_ClassPrivateField_HelperMethod_Log.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassPrivateField_HelperMethod_Log.js)<br>[`constructor-this-tdz-during-initializers.js`](../../../tests/Jroc.Test262.Tests/language/expressions/class/JavaScript/constructor-this-tdz-during-initializers.js) |  | Supports instance field initializers and private instance fields, including derived-constructor initialization after super() for supported class bases. Static blocks, supported private methods, and current private accessor forms are implemented; some inheritance and exotic receiver details remain incomplete. |
+
+### 7.3.34 ([tc39.es](https://tc39.es/ecma262/#sec-add-value-to-keyed-group))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| AddValueToKeyedGroup through Object.groupBy accumulation | Supported with Limitations | [`Object_GroupBy_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_GroupBy_Basic.js) |  | The Object.groupBy implementation groups callback results under the covered property keys and appends values into the correct per-key buckets. Edge cases around the full spec key-coercion matrix and every exotic iterable input remain incomplete. |
+
+### 7.3.35 ([tc39.es](https://tc39.es/ecma262/#sec-groupby))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| GroupBy via Object.groupBy | Supported with Limitations | [`Object_GroupBy_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_GroupBy_Basic.js) |  | Object.groupBy provides the covered callback-driven grouping behavior over supported iterable inputs. The current implementation does not yet claim full parity for all abrupt-completion, coercion-order, and exotic iterator corner cases. |
+
+### 7.3.37 ([tc39.es](https://tc39.es/ecma262/#sec-SetterThatIgnoresPrototypeProperties))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| SetterThatIgnoresPrototypeProperties behavior in class field definition and class member installation | Supported with Limitations |  | `test/language/statements/class/elements/class-field-is-observable-by-proxy.js`<br>`test/language/statements/class/subclass/superclass-prototype-setter-constructor.js`<br>`test/language/statements/class/subclass/superclass-prototype-setter-method-override.js` | The covered class-field and class-member definition paths create own properties without accidentally dispatching inherited prototype setters, while still remaining observable through defineProperty-style proxy interception where the spec requires it. This documentation does not yet claim full parity for every built-in accessor that reuses the helper. |
 


### PR DESCRIPTION
## Summary
- reclassify ECMA-262 Section 7.3 Operations on Objects to Supported with Limitations
- document integrity-level, argument normalization, species accessor, private method/accessor, grouping, and class-field own-property evidence
- update the Section 7 hub and changelog to match the new Section 7.3 status

## Validation
- focused Jroc.Tests slice for integrity, Object.groupBy, private accessors, and Promise[Symbol.species]
- focused Jroc.Test262.Tests slice for proxy-observable class fields, private method branding, and subclass prototype-setter cases