### PR TITLE
docs(ecma262): reclassify section 7.4 coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- docs/ecma262: reclassify ECMA-262 Section 7.4 Operations on Iterator Objects to `Supported with Limitations`, documenting the current sync/async iterator acquisition, step/value, close-on-abrupt-completion, helper cleanup, and iterator-to-list style materialization coverage against existing runtime behavior and focused evidence.
 - docs/ecma262: reclassify ECMA-262 Section 7.3 Operations on Objects to `Supported with Limitations`, documenting the current integrity-level, apply/construct argument normalization, species accessor, private method/accessor, grouping, and class-field own-property coverage against existing runtime behavior and targeted evidence.
 - docs/ecma262: reclassify ECMA-262 Section 7.2 Testing and Comparison Operations to `Supported with Limitations`, documenting the current `RequireObjectCoercible`, `IsExtensible`, `isWellFormed`, identity, and comparison coverage against existing runtime behavior and targeted evidence.
 - runtime/tests/docs/test262: reclassify ECMA-262 Section 7.1 Type Conversion to `Supported with Limitations`, add shared `ToInt8` / `ToInt16` / `ToUint8` / `ToUint16` / `ToUint8Clamp` runtime helpers, implement `Uint8ClampedArray`, port new `for..of` test262 coverage for `Uint8ClampedArray`, and refresh the Section 7.1 support notes.

--- a/docs/ECMA262/7/Section7.md
+++ b/docs/ECMA262/7/Section7.md
@@ -4,7 +4,7 @@ Specifies abstract operations: the reusable algorithmic building blocks used thr
 
 [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-07T20:14:26Z
+> Last generated (UTC): 2026-07-07T20:40:52Z
 
 _This section is split into subsection documents for readability._
 
@@ -12,7 +12,7 @@ _This section is split into subsection documents for readability._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 7 | Abstract Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations) |
+| 7 | Abstract Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations) |
 
 ## Subsections
 
@@ -21,4 +21,4 @@ _This section is split into subsection documents for readability._
 | 7.1 | Type Conversion | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-type-conversion) | [Section7_1.md](Section7_1.md) |
 | 7.2 | Testing and Comparison Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-testing-and-comparison-operations) | [Section7_2.md](Section7_2.md) |
 | 7.3 | Operations on Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-objects) | [Section7_3.md](Section7_3.md) |
-| 7.4 | Operations on Iterator Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-iterator-objects) | [Section7_4.md](Section7_4.md) |
+| 7.4 | Operations on Iterator Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-iterator-objects) | [Section7_4.md](Section7_4.md) |

--- a/docs/ECMA262/7/Section7_4.json
+++ b/docs/ECMA262/7/Section7_4.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "7.4",
   "title": "Operations on Iterator Objects",
-  "status": "Incomplete",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-operations-on-iterator-objects",
   "parent": {
     "clause": "7"
@@ -36,7 +36,7 @@
     {
       "clause": "7.4.5",
       "title": "GetIteratorFlattenable ( obj , primitiveHandling )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-getiteratorflattenable"
     },
     {
@@ -66,7 +66,7 @@
     {
       "clause": "7.4.10",
       "title": "IteratorStepValue ( iteratorRecord )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-iteratorstepvalue"
     },
     {
@@ -78,7 +78,7 @@
     {
       "clause": "7.4.12",
       "title": "IteratorCloseAll ( iters , completion )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-iteratorcloseall"
     },
     {
@@ -108,18 +108,68 @@
     {
       "clause": "7.4.17",
       "title": "CreateListIteratorRecord ( list )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-createlistiteratorRecord"
     },
     {
       "clause": "7.4.18",
       "title": "IteratorToList ( iteratorRecord )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-iteratortolist"
     }
   ],
   "support": {
     "entries": [
+      {
+        "clause": "7.4",
+        "feature": "Iterator operations across sync iteration, async iteration fallback, helper adapters, abrupt-close behavior, and list materialization",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-operations-on-iterator-objects",
+        "testScripts": [
+          "tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js",
+          "tests/Jroc.Tests/Async/JavaScript/Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js",
+          "tests/Jroc.Tests/Iterator/JavaScript/Iterator_Helper_Cleanup.js",
+          "tests/Jroc.Tests/Iterator/JavaScript/Iterator_From_HelperChain.js",
+          "tests/Jroc.Tests/Object/JavaScript/Object_FromEntries_Basic.js"
+        ],
+        "notes": "JROC implements the iterator abstract-operation surface used by current language features and shipped iterator helpers, including sync/async acquisition, step/value/done extraction, close-on-abrupt-completion paths, and iterator-to-list style materialization. Remaining gaps are mostly proposal-edge semantics and the fact that some helpers are modeled inline through concrete iterator adapters rather than as separately named general-purpose abstract-operation entry points."
+      },
+      {
+        "clause": "7.4.1",
+        "feature": "Iterator record tracking through sync and async iterator adapters",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-iterator-records",
+        "testScripts": [
+          "tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js",
+          "tests/Jroc.Tests/Async/JavaScript/Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js"
+        ],
+        "notes": "Iterator state is represented by concrete `IJavaScriptIterator` and `IJavaScriptAsyncIterator` adapters that preserve next/return capability and done/value flow for the covered sync and async lowering paths. The runtime does not expose a distinct public iterator-record data structure beyond those adapters."
+      },
+      {
+        "clause": "7.4.2",
+        "feature": "GetIteratorDirect for native iterator objects and iterator helpers",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-getiteratordirect",
+        "testScripts": [
+          "tests/Jroc.Tests/Iterator/JavaScript/Iterator_Helper_Next_Return.js",
+          "tests/Jroc.Tests/Iterator/JavaScript/Iterator_From_HelperChain.js"
+        ],
+        "notes": "Native iterator objects and iterator-helper receivers can be consumed directly without re-entering `@@iterator`, matching the runtime's direct `IJavaScriptIterator` fast path. General coverage is anchored to the shipped iterator-helper surface rather than a standalone public helper."
+      },
+      {
+        "clause": "7.4.3",
+        "feature": "GetIteratorFromMethod for Symbol.iterator-based sources",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-getiteratorfrommethod",
+        "testScripts": [
+          "tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js",
+          "tests/Jroc.Tests/Function/JavaScript/Function_Call_Spread_StringIterable.js"
+        ],
+        "test262Paths": [
+          "test/language/expressions/yield/star-iterable.js"
+        ],
+        "notes": "The runtime calls user-provided `@@iterator` methods with the correct receiver across for-of, spread, and `yield*` paths for the covered iterable shapes. Unsupported or still-partial exotic iterator method scenarios remain documented as general iterator limitations rather than as a missing core path."
+      },
       {
         "clause": "7.4.4",
         "feature": "GetIterator for for..of sources",
@@ -130,6 +180,17 @@
           "tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js"
         ],
         "notes": "Supports built-in iterables, user-defined Symbol.iterator sources, and IEnumerable fallback paths."
+      },
+      {
+        "clause": "7.4.5",
+        "feature": "GetIteratorFlattenable for Iterator.from and flatMap-style iterable normalization",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-getiteratorflattenable",
+        "testScripts": [
+          "tests/Jroc.Tests/Iterator/JavaScript/Iterator_From_HelperChain.js",
+          "tests/Jroc.Tests/Iterator/JavaScript/Iterator_Helper_Cleanup.js"
+        ],
+        "notes": "Iterator helpers normalize iterable and iterator-like mapper results through `Iterator.from(...)`, which covers the current flattenable acquisition behavior used by the shipped helper surface. The full `primitiveHandling` matrix and every proposal-edge flattening scenario are not yet modeled as a separate standalone helper."
       },
       {
         "clause": "7.4.6",
@@ -163,6 +224,30 @@
         "notes": "Value extraction is implemented through IteratorResultValue for native and dynamic iterator result shapes."
       },
       {
+        "clause": "7.4.9",
+        "feature": "IteratorStep across for-of, destructuring, and iterator helpers",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-iteratorstep",
+        "testScripts": [
+          "tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js",
+          "tests/Jroc.Tests/Iterator/JavaScript/Iterator_From_HelperChain.js"
+        ],
+        "test262Paths": [
+          "test/language/expressions/yield/star-iterable.js"
+        ],
+        "notes": "The runtime advances iterator records and interprets iterator result objects consistently for the covered for-of, helper, and `yield*` flows. Remaining gaps are in less common exotic iterator result edge cases rather than ordinary step semantics."
+      },
+      {
+        "clause": "7.4.10",
+        "feature": "IteratorStepValue in iterator destructuring and step/value extraction helpers",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-iteratorstepvalue",
+        "test262Paths": [
+          "test/language/expressions/assignment/destructuring/iterator-destructuring-property-reference-target-evaluation-order.js"
+        ],
+        "notes": "Destructuring lowering uses dedicated step/value helpers that mirror `IteratorStepValue` semantics, including skipping value access when `done` is already true. Coverage is strongest in destructuring-driven consumers rather than as a separately exposed public runtime helper."
+      },
+      {
         "clause": "7.4.11",
         "feature": "IteratorClose",
         "status": "Supported with Limitations",
@@ -170,7 +255,32 @@
         "testScripts": [
           "tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js"
         ],
-        "notes": "Break/throw paths invoke iterator return() for supported iterator forms."
+        "test262Paths": [
+          "test/built-ins/Map/iterator-items-are-not-object-close-iterator.js",
+          "test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-value-accessor.js"
+        ],
+        "notes": "Break/throw and abrupt-built-in paths invoke iterator return() for supported iterator forms while preserving the original completion behavior in the covered cases."
+      },
+      {
+        "clause": "7.4.12",
+        "feature": "IteratorCloseAll for helper pipelines with multiple active iterators",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-iteratorcloseall",
+        "testScripts": [
+          "tests/Jroc.Tests/Iterator/JavaScript/Iterator_Helper_Cleanup.js"
+        ],
+        "notes": "The shipped iterator-helper pipeline closes both outer and active inner iterators in the covered flatMap and abrupt-cleanup cases, which is the current runtime analogue of `IteratorCloseAll`. JROC does not currently expose a separate reusable `IteratorCloseAll` helper outside those concrete iterator-helper consumers."
+      },
+      {
+        "clause": "7.4.13",
+        "feature": "IfAbruptCloseIterator in destructuring and iterable-consuming built-ins",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-ifabruptcloseiterator",
+        "test262Paths": [
+          "test/built-ins/Map/iterator-items-are-not-object-close-iterator.js",
+          "test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-value-accessor.js"
+        ],
+        "notes": "Abrupt completions in the covered Map and Object.fromEntries iterable-consumption paths close the active iterator before propagating the original error. The behavior is implemented inline in consumers rather than through a named public helper."
       },
       {
         "clause": "7.4.14",
@@ -204,6 +314,33 @@
           "tests/Jroc.Tests/AsyncGenerator/JavaScript/AsyncGenerator_BasicNext.js"
         ],
         "notes": "Iterator result objects are produced via IteratorResult helpers for sync and async iterator implementations."
+      },
+      {
+        "clause": "7.4.17",
+        "feature": "CreateListIteratorRecord for list-backed built-in iterators",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-createlistiteratorRecord",
+        "testScripts": [
+          "tests/Jroc.Tests/Function/JavaScript/Function_Call_Spread_StringIterable.js",
+          "tests/Jroc.Tests/Iterator/JavaScript/Iterator_Helper_Next_Return.js"
+        ],
+        "test262Paths": [
+          "test/built-ins/Array/prototype/values/returns-iterator.js"
+        ],
+        "notes": "Arrays, strings, typed arrays, arguments objects, and iterator helpers expose concrete list-backed iterator objects that fill the practical role of list iterator records for the covered runtime features. The implementation uses those concrete iterator classes directly rather than a separate standalone `CreateListIteratorRecord` entry point."
+      },
+      {
+        "clause": "7.4.18",
+        "feature": "IteratorToList for helper materialization and TypedArray.from source capture",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-iteratortolist",
+        "testScripts": [
+          "tests/Jroc.Tests/Iterator/JavaScript/Iterator_From_HelperChain.js"
+        ],
+        "test262Paths": [
+          "test/built-ins/TypedArray/from/iterated-array-changed-by-tonumber.js"
+        ],
+        "notes": "Iterator results are materialized into concrete lists for the covered `Iterator.prototype.toArray()` and `%TypedArray%.from(...)` paths, including capture-before-mutation behavior for iterated sources. The runtime still models list materialization inside specific consumers instead of through a single shared public helper."
       }
     ]
   }

--- a/docs/ECMA262/7/Section7_4.md
+++ b/docs/ECMA262/7/Section7_4.md
@@ -4,11 +4,11 @@
 
 [Back to Section7](Section7.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-07-07T20:40:52Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 7.4 | Operations on Iterator Objects | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-iterator-objects) |
+| 7.4 | Operations on Iterator Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-operations-on-iterator-objects) |
 
 ## Subclauses
 
@@ -18,70 +18,136 @@
 | 7.4.2 | GetIteratorDirect ( obj ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getiteratordirect) |
 | 7.4.3 | GetIteratorFromMethod ( obj , method ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getiteratorfrommethod) |
 | 7.4.4 | GetIterator ( obj , kind ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getiterator) |
-| 7.4.5 | GetIteratorFlattenable ( obj , primitiveHandling ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-getiteratorflattenable) |
+| 7.4.5 | GetIteratorFlattenable ( obj , primitiveHandling ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getiteratorflattenable) |
 | 7.4.6 | IteratorNext ( iteratorRecord [ , value ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iteratornext) |
 | 7.4.7 | IteratorComplete ( iteratorResult ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iteratorcomplete) |
 | 7.4.8 | IteratorValue ( iteratorResult ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iteratorvalue) |
 | 7.4.9 | IteratorStep ( iteratorRecord ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iteratorstep) |
-| 7.4.10 | IteratorStepValue ( iteratorRecord ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iteratorstepvalue) |
+| 7.4.10 | IteratorStepValue ( iteratorRecord ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iteratorstepvalue) |
 | 7.4.11 | IteratorClose ( iteratorRecord , completion ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iteratorclose) |
-| 7.4.12 | IteratorCloseAll ( iters , completion ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iteratorcloseall) |
+| 7.4.12 | IteratorCloseAll ( iters , completion ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iteratorcloseall) |
 | 7.4.13 | IfAbruptCloseIterator ( value , iteratorRecord ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ifabruptcloseiterator) |
 | 7.4.14 | AsyncIteratorClose ( iteratorRecord , completion ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-asynciteratorclose) |
 | 7.4.15 | IfAbruptCloseAsyncIterator ( value , iteratorRecord ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ifabruptcloseasynciterator) |
 | 7.4.16 | CreateIteratorResultObject ( value , done ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-createiterresultobject) |
-| 7.4.17 | CreateListIteratorRecord ( list ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-createlistiteratorRecord) |
-| 7.4.18 | IteratorToList ( iteratorRecord ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-iteratortolist) |
+| 7.4.17 | CreateListIteratorRecord ( list ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-createlistiteratorRecord) |
+| 7.4.18 | IteratorToList ( iteratorRecord ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-iteratortolist) |
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
+
+### 7.4 ([tc39.es](https://tc39.es/ecma262/#sec-operations-on-iterator-objects))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Iterator operations across sync iteration, async iteration fallback, helper adapters, abrupt-close behavior, and list materialization | Supported with Limitations | [`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js)<br>[`Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js`](../../../tests/Jroc.Tests/Async/JavaScript/Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js)<br>[`Iterator_Helper_Cleanup.js`](../../../tests/Jroc.Tests/Iterator/JavaScript/Iterator_Helper_Cleanup.js)<br>[`Iterator_From_HelperChain.js`](../../../tests/Jroc.Tests/Iterator/JavaScript/Iterator_From_HelperChain.js)<br>[`Object_FromEntries_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_FromEntries_Basic.js) |  | JROC implements the iterator abstract-operation surface used by current language features and shipped iterator helpers, including sync/async acquisition, step/value/done extraction, close-on-abrupt-completion paths, and iterator-to-list style materialization. Remaining gaps are mostly proposal-edge semantics and the fact that some helpers are modeled inline through concrete iterator adapters rather than as separately named general-purpose abstract-operation entry points. |
+
+### 7.4.1 ([tc39.es](https://tc39.es/ecma262/#sec-iterator-records))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Iterator record tracking through sync and async iterator adapters | Supported with Limitations | [`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js)<br>[`Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js`](../../../tests/Jroc.Tests/Async/JavaScript/Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js) |  | Iterator state is represented by concrete `IJavaScriptIterator` and `IJavaScriptAsyncIterator` adapters that preserve next/return capability and done/value flow for the covered sync and async lowering paths. The runtime does not expose a distinct public iterator-record data structure beyond those adapters. |
+
+### 7.4.2 ([tc39.es](https://tc39.es/ecma262/#sec-getiteratordirect))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| GetIteratorDirect for native iterator objects and iterator helpers | Supported with Limitations | [`Iterator_Helper_Next_Return.js`](../../../tests/Jroc.Tests/Iterator/JavaScript/Iterator_Helper_Next_Return.js)<br>[`Iterator_From_HelperChain.js`](../../../tests/Jroc.Tests/Iterator/JavaScript/Iterator_From_HelperChain.js) |  | Native iterator objects and iterator-helper receivers can be consumed directly without re-entering `@@iterator`, matching the runtime's direct `IJavaScriptIterator` fast path. General coverage is anchored to the shipped iterator-helper surface rather than a standalone public helper. |
+
+### 7.4.3 ([tc39.es](https://tc39.es/ecma262/#sec-getiteratorfrommethod))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| GetIteratorFromMethod for Symbol.iterator-based sources | Supported with Limitations | [`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js)<br>[`Function_Call_Spread_StringIterable.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_Call_Spread_StringIterable.js) | `test/language/expressions/yield/star-iterable.js` | The runtime calls user-provided `@@iterator` methods with the correct receiver across for-of, spread, and `yield*` paths for the covered iterable shapes. Unsupported or still-partial exotic iterator method scenarios remain documented as general iterator limitations rather than as a missing core path. |
 
 ### 7.4.4 ([tc39.es](https://tc39.es/ecma262/#sec-getiterator))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| GetIterator for for..of sources | Supported with Limitations | [`ControlFlow_ForOf_Array_Basic.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Array_Basic.js)<br>[`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js) | Supports built-in iterables, user-defined Symbol.iterator sources, and IEnumerable fallback paths. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| GetIterator for for..of sources | Supported with Limitations | [`ControlFlow_ForOf_Array_Basic.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Array_Basic.js)<br>[`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js) |  | Supports built-in iterables, user-defined Symbol.iterator sources, and IEnumerable fallback paths. |
+
+### 7.4.5 ([tc39.es](https://tc39.es/ecma262/#sec-getiteratorflattenable))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| GetIteratorFlattenable for Iterator.from and flatMap-style iterable normalization | Supported with Limitations | [`Iterator_From_HelperChain.js`](../../../tests/Jroc.Tests/Iterator/JavaScript/Iterator_From_HelperChain.js)<br>[`Iterator_Helper_Cleanup.js`](../../../tests/Jroc.Tests/Iterator/JavaScript/Iterator_Helper_Cleanup.js) |  | Iterator helpers normalize iterable and iterator-like mapper results through `Iterator.from(...)`, which covers the current flattenable acquisition behavior used by the shipped helper surface. The full `primitiveHandling` matrix and every proposal-edge flattening scenario are not yet modeled as a separate standalone helper. |
 
 ### 7.4.6 ([tc39.es](https://tc39.es/ecma262/#sec-iteratornext))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| IteratorNext | Supported with Limitations | [`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js)<br>[`Generator_BasicNext.js`](../../../tests/Jroc.Tests/Generator/JavaScript/Generator_BasicNext.js) | Iterator advancement is implemented for native and dynamic iterator objects used by lowering/runtime helpers. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IteratorNext | Supported with Limitations | [`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js)<br>[`Generator_BasicNext.js`](../../../tests/Jroc.Tests/Generator/JavaScript/Generator_BasicNext.js) |  | Iterator advancement is implemented for native and dynamic iterator objects used by lowering/runtime helpers. |
 
 ### 7.4.7 ([tc39.es](https://tc39.es/ecma262/#sec-iteratorcomplete))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| IteratorComplete | Supported with Limitations | [`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js) | Done-state checks are implemented through IteratorResultDone in iteration paths. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IteratorComplete | Supported with Limitations | [`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js) |  | Done-state checks are implemented through IteratorResultDone in iteration paths. |
 
 ### 7.4.8 ([tc39.es](https://tc39.es/ecma262/#sec-iteratorvalue))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| IteratorValue | Supported with Limitations | [`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js) | Value extraction is implemented through IteratorResultValue for native and dynamic iterator result shapes. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IteratorValue | Supported with Limitations | [`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js) |  | Value extraction is implemented through IteratorResultValue for native and dynamic iterator result shapes. |
+
+### 7.4.9 ([tc39.es](https://tc39.es/ecma262/#sec-iteratorstep))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IteratorStep across for-of, destructuring, and iterator helpers | Supported with Limitations | [`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js)<br>[`Iterator_From_HelperChain.js`](../../../tests/Jroc.Tests/Iterator/JavaScript/Iterator_From_HelperChain.js) | `test/language/expressions/yield/star-iterable.js` | The runtime advances iterator records and interprets iterator result objects consistently for the covered for-of, helper, and `yield*` flows. Remaining gaps are in less common exotic iterator result edge cases rather than ordinary step semantics. |
+
+### 7.4.10 ([tc39.es](https://tc39.es/ecma262/#sec-iteratorstepvalue))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IteratorStepValue in iterator destructuring and step/value extraction helpers | Supported with Limitations |  | `test/language/expressions/assignment/destructuring/iterator-destructuring-property-reference-target-evaluation-order.js` | Destructuring lowering uses dedicated step/value helpers that mirror `IteratorStepValue` semantics, including skipping value access when `done` is already true. Coverage is strongest in destructuring-driven consumers rather than as a separately exposed public runtime helper. |
 
 ### 7.4.11 ([tc39.es](https://tc39.es/ecma262/#sec-iteratorclose))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| IteratorClose | Supported with Limitations | [`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js) | Break/throw paths invoke iterator return() for supported iterator forms. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IteratorClose | Supported with Limitations | [`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js) | `test/built-ins/Map/iterator-items-are-not-object-close-iterator.js`<br>`test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-value-accessor.js` | Break/throw and abrupt-built-in paths invoke iterator return() for supported iterator forms while preserving the original completion behavior in the covered cases. |
+
+### 7.4.12 ([tc39.es](https://tc39.es/ecma262/#sec-iteratorcloseall))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IteratorCloseAll for helper pipelines with multiple active iterators | Supported with Limitations | [`Iterator_Helper_Cleanup.js`](../../../tests/Jroc.Tests/Iterator/JavaScript/Iterator_Helper_Cleanup.js) |  | The shipped iterator-helper pipeline closes both outer and active inner iterators in the covered flatMap and abrupt-cleanup cases, which is the current runtime analogue of `IteratorCloseAll`. JROC does not currently expose a separate reusable `IteratorCloseAll` helper outside those concrete iterator-helper consumers. |
+
+### 7.4.13 ([tc39.es](https://tc39.es/ecma262/#sec-ifabruptcloseiterator))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IfAbruptCloseIterator in destructuring and iterable-consuming built-ins | Supported with Limitations |  | `test/built-ins/Map/iterator-items-are-not-object-close-iterator.js`<br>`test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-value-accessor.js` | Abrupt completions in the covered Map and Object.fromEntries iterable-consumption paths close the active iterator before propagating the original error. The behavior is implemented inline in consumers rather than through a named public helper. |
 
 ### 7.4.14 ([tc39.es](https://tc39.es/ecma262/#sec-asynciteratorclose))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| AsyncIteratorClose | Supported with Limitations | [`Async_ForAwaitOf_AsyncIterator_BreakCloses.js`](../../../tests/Jroc.Tests/Async/JavaScript/Async_ForAwaitOf_AsyncIterator_BreakCloses.js)<br>[`Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js`](../../../tests/Jroc.Tests/Async/JavaScript/Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js) | Async iterator close is implemented for both native async iterators and sync-iterator fallback wrappers. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| AsyncIteratorClose | Supported with Limitations | [`Async_ForAwaitOf_AsyncIterator_BreakCloses.js`](../../../tests/Jroc.Tests/Async/JavaScript/Async_ForAwaitOf_AsyncIterator_BreakCloses.js)<br>[`Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js`](../../../tests/Jroc.Tests/Async/JavaScript/Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js) |  | Async iterator close is implemented for both native async iterators and sync-iterator fallback wrappers. |
 
 ### 7.4.15 ([tc39.es](https://tc39.es/ecma262/#sec-ifabruptcloseasynciterator))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| IfAbruptCloseAsyncIterator behavior in for-await control flow | Supported with Limitations | [`Async_ForAwaitOf_AsyncIterator_BreakCloses.js`](../../../tests/Jroc.Tests/Async/JavaScript/Async_ForAwaitOf_AsyncIterator_BreakCloses.js)<br>[`Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js`](../../../tests/Jroc.Tests/Async/JavaScript/Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js) | Abrupt loop exits trigger async iterator close in supported lowered paths. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IfAbruptCloseAsyncIterator behavior in for-await control flow | Supported with Limitations | [`Async_ForAwaitOf_AsyncIterator_BreakCloses.js`](../../../tests/Jroc.Tests/Async/JavaScript/Async_ForAwaitOf_AsyncIterator_BreakCloses.js)<br>[`Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js`](../../../tests/Jroc.Tests/Async/JavaScript/Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.js) |  | Abrupt loop exits trigger async iterator close in supported lowered paths. |
 
 ### 7.4.16 ([tc39.es](https://tc39.es/ecma262/#sec-createiterresultobject))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| CreateIteratorResultObject | Supported with Limitations | [`Generator_BasicNext.js`](../../../tests/Jroc.Tests/Generator/JavaScript/Generator_BasicNext.js)<br>[`AsyncGenerator_BasicNext.js`](../../../tests/Jroc.Tests/AsyncGenerator/JavaScript/AsyncGenerator_BasicNext.js) | Iterator result objects are produced via IteratorResult helpers for sync and async iterator implementations. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| CreateIteratorResultObject | Supported with Limitations | [`Generator_BasicNext.js`](../../../tests/Jroc.Tests/Generator/JavaScript/Generator_BasicNext.js)<br>[`AsyncGenerator_BasicNext.js`](../../../tests/Jroc.Tests/AsyncGenerator/JavaScript/AsyncGenerator_BasicNext.js) |  | Iterator result objects are produced via IteratorResult helpers for sync and async iterator implementations. |
+
+### 7.4.17 ([tc39.es](https://tc39.es/ecma262/#sec-createlistiteratorRecord))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| CreateListIteratorRecord for list-backed built-in iterators | Supported with Limitations | [`Function_Call_Spread_StringIterable.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_Call_Spread_StringIterable.js)<br>[`Iterator_Helper_Next_Return.js`](../../../tests/Jroc.Tests/Iterator/JavaScript/Iterator_Helper_Next_Return.js) | `test/built-ins/Array/prototype/values/returns-iterator.js` | Arrays, strings, typed arrays, arguments objects, and iterator helpers expose concrete list-backed iterator objects that fill the practical role of list iterator records for the covered runtime features. The implementation uses those concrete iterator classes directly rather than a separate standalone `CreateListIteratorRecord` entry point. |
+
+### 7.4.18 ([tc39.es](https://tc39.es/ecma262/#sec-iteratortolist))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IteratorToList for helper materialization and TypedArray.from source capture | Supported with Limitations | [`Iterator_From_HelperChain.js`](../../../tests/Jroc.Tests/Iterator/JavaScript/Iterator_From_HelperChain.js) | `test/built-ins/TypedArray/from/iterated-array-changed-by-tonumber.js` | Iterator results are materialized into concrete lists for the covered `Iterator.prototype.toArray()` and `%TypedArray%.from(...)` paths, including capture-before-mutation behavior for iterated sources. The runtime still models list materialization inside specific consumers instead of through a single shared public helper. |
 

--- a/docs/ECMA262/Index.md
+++ b/docs/ECMA262/Index.md
@@ -19,12 +19,12 @@ Notes:
 - `Partially Supported` is deprecated legacy wording and is treated as `Supported with Limitations`.
 - Prototype-chain design/strategy: see [PrototypeChainSupport.md](../compiler/PrototypeChainSupport.md).
 
-> Last generated (UTC): 2026-07-07T18:30:38Z
+> Last generated (UTC): 2026-07-07T20:40:52Z
 
 ## Summary
 - Total top-level sections indexed: **29**
 - Top-level sections with tracked status: **28**
-- Status breakdown: Supported with Limitations: **10**, Incomplete: **11**, Not Yet Supported: **1**, N/A (informational): **6**, Untracked: **1**
+- Status breakdown: Supported with Limitations: **11**, Incomplete: **10**, Not Yet Supported: **1**, N/A (informational): **6**, Untracked: **1**
 - Untracked top-level sections: **1**
 
 ## Sections
@@ -37,7 +37,7 @@ Notes:
 | 4 | Overview | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-overview) | [Section4.md](4/Section4.md) |
 | 5 | Notational Conventions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-notational-conventions) | [Section5.md](5/Section5.md) |
 | 6 | ECMAScript Data Types and Values | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values) | [Section6.md](6/Section6.md) |
-| 7 | Abstract Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations) | [Section7.md](7/Section7.md) |
+| 7 | Abstract Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations) | [Section7.md](7/Section7.md) |
 | 8 | Syntax-Directed Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations) | [Section8.md](8/Section8.md) |
 | 9 | Executable Code and Execution Contexts | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-executable-code-and-execution-contexts) | [Section9.md](9/Section9.md) |
 | 10 | Ordinary and Exotic Objects Behaviours | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-and-exotic-objects-behaviours) | [Section10.md](10/Section10.md) |


### PR DESCRIPTION
## Summary
- reclassify ECMA-262 Section 7.4 Operations on Iterator Objects to Supported with Limitations
- document iterator acquisition, step/value, close-on-abrupt-completion, helper cleanup, and iterator-to-list style materialization evidence
- roll Section 7 itself up to Supported with Limitations now that 7.1 through 7.4 are all tracked at supported or supported-with-limitations

## Validation
- focused Jroc.Tests slice for iterator helpers, iterable consumers, spread, and Promise/Map/Set/Object iterator behavior
- focused Jroc.Test262.Tests slice for destructuring iterator step/value, iterator-close-on-error, TypedArray.from iterator materialization, and yield* iterable behavior