### PR TITLE
docs(ecma262): reclassify sections 8.2 and 8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- docs/ecma262: reclassify ECMA-262 Sections 8.2 Scope Analysis and 8.4 Function Name Inference to `Supported with Limitations`, documenting the current scope-building, hoisting, lexical-environment, and observable SetFunctionName / NamedEvaluation coverage against existing compiler/runtime behavior and focused evidence.
 - docs/ecma262: reclassify ECMA-262 Section 8.1 Runtime Semantics: Evaluation to `Supported with Limitations`, documenting the current HIR/LIR/IL evaluation pipeline coverage across expressions, control flow, generators, async evaluation, and evaluation-order semantics while keeping general `eval` unsupported by design.
 - docs/ecma262: reclassify ECMA-262 Section 7.4 Operations on Iterator Objects to `Supported with Limitations`, documenting the current sync/async iterator acquisition, step/value, close-on-abrupt-completion, helper cleanup, and iterator-to-list style materialization coverage against existing runtime behavior and focused evidence.
 - docs/ecma262: reclassify ECMA-262 Section 7.3 Operations on Objects to `Supported with Limitations`, documenting the current integrity-level, apply/construct argument normalization, species accessor, private method/accessor, grouping, and class-field own-property coverage against existing runtime behavior and targeted evidence.

--- a/docs/ECMA262/8/Section8.md
+++ b/docs/ECMA262/8/Section8.md
@@ -4,7 +4,7 @@ Defines syntax-directed operations, linking grammar productions to static semant
 
 [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-07T20:48:13Z
+> Last generated (UTC): 2026-07-07T21:06:59Z
 
 _This section is split into subsection documents for readability._
 
@@ -19,8 +19,8 @@ _This section is split into subsection documents for readability._
 | Subsection | Title | Status | Spec | Document |
 |---:|---|---|---|---|
 | 8.1 | Runtime Semantics: Evaluation | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#Evaluation) | [Section8_1.md](Section8_1.md) |
-| 8.2 | Scope Analysis | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-scope-analysis) | [Section8_2.md](Section8_2.md) |
+| 8.2 | Scope Analysis | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-scope-analysis) | [Section8_2.md](Section8_2.md) |
 | 8.3 | Labels | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-labels) | [Section8_3.md](Section8_3.md) |
-| 8.4 | Function Name Inference | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-function-name-inference) | [Section8_4.md](Section8_4.md) |
+| 8.4 | Function Name Inference | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-function-name-inference) | [Section8_4.md](Section8_4.md) |
 | 8.5 | Contains | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-contains) | [Section8_5.md](Section8_5.md) |
 | 8.6 | Miscellaneous | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-miscellaneous) | [Section8_6.md](Section8_6.md) |

--- a/docs/ECMA262/8/Section8_2.json
+++ b/docs/ECMA262/8/Section8_2.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "8.2",
   "title": "Scope Analysis",
-  "status": "Incomplete",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-syntax-directed-operations-scope-analysis",
   "parent": {
     "clause": "8"
@@ -78,6 +78,23 @@
   ],
   "support": {
     "entries": [
+      {
+        "clause": "8.2",
+        "feature": "Scope analysis across binding discovery, lexical environments, hoisting, and top-level declaration tracking",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-syntax-directed-operations-scope-analysis",
+        "testScripts": [
+          "tests/Jroc.Tests/SymbolTableBuilderTests.cs",
+          "tests/Jroc.Tests/Variable/JavaScript/Variable_LetBlockScope.js",
+          "tests/Jroc.Tests/CommonJS/JavaScript/CommonJS_FunctionDeclaration_Hoisting_BeforeUse.js"
+        ],
+        "test262Suites": [
+          "language/expressions/arrow-function",
+          "language/expressions/class",
+          "language/expressions/function"
+        ],
+        "notes": "JROC's symbol-table and scope-building pipeline covers the declaration-collection and environment-boundary analysis needed by the currently supported language surface, including destructuring bindings, lexical block scopes, loop-head scopes, hoisted var/function declarations, and top-level CommonJS-style module scope tracking. Remaining limitations mainly follow unsupported grammar/runtime forms and the fact that ESM-specific top-level semantics are still outside current support."
+      },
       {
         "clause": "8.2.1",
         "feature": "BoundNames collection for declarations and binding patterns",

--- a/docs/ECMA262/8/Section8_2.md
+++ b/docs/ECMA262/8/Section8_2.md
@@ -4,11 +4,11 @@
 
 [Back to Section8](Section8.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-24T04:56:48Z
+> Last generated (UTC): 2026-07-07T21:06:59Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 8.2 | Scope Analysis | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-scope-analysis) |
+| 8.2 | Scope Analysis | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-scope-analysis) |
 
 ## Subclauses
 
@@ -29,6 +29,12 @@
 ## Support
 
 Feature-level support tracking with repo test references and optional test262 evidence.
+
+### 8.2 ([tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-scope-analysis))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Scope analysis across binding discovery, lexical environments, hoisting, and top-level declaration tracking | Supported with Limitations | `tests/Jroc.Tests/SymbolTableBuilderTests.cs`<br>[`Variable_LetBlockScope.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_LetBlockScope.js)<br>[`CommonJS_FunctionDeclaration_Hoisting_BeforeUse.js`](../../../tests/Jroc.Tests/CommonJS/JavaScript/CommonJS_FunctionDeclaration_Hoisting_BeforeUse.js) | suite `language/expressions/arrow-function`<br>suite `language/expressions/class`<br>suite `language/expressions/function` | JROC's symbol-table and scope-building pipeline covers the declaration-collection and environment-boundary analysis needed by the currently supported language surface, including destructuring bindings, lexical block scopes, loop-head scopes, hoisted var/function declarations, and top-level CommonJS-style module scope tracking. Remaining limitations mainly follow unsupported grammar/runtime forms and the fact that ESM-specific top-level semantics are still outside current support. |
 
 ### 8.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-static-semantics-boundnames))
 

--- a/docs/ECMA262/8/Section8_4.json
+++ b/docs/ECMA262/8/Section8_4.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "8.4",
   "title": "Function Name Inference",
-  "status": "Incomplete",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-syntax-directed-operations-function-name-inference",
   "parent": {
     "clause": "8"
@@ -36,12 +36,26 @@
     {
       "clause": "8.4.5",
       "title": "Runtime Semantics: NamedEvaluation",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-runtime-semantics-namedevaluation"
     }
   ],
   "support": {
     "entries": [
+      {
+        "clause": "8.4",
+        "feature": "Function name inference across declarations, anonymous initializers, object/class property definitions, and dynamic function creation",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-syntax-directed-operations-function-name-inference",
+        "test262Paths": [
+          "test/language/statements/const/fn-name-arrow.js",
+          "test/language/expressions/object/__proto__-fn-name.js",
+          "test/language/statements/function/name.js",
+          "test/built-ins/GeneratorFunction/instance-name.js",
+          "test/language/expressions/class/elements/class-name-static-initializer-expr.js"
+        ],
+        "notes": "JROC covers the observable name-inference behavior used by today's supported declarations, anonymous initializer bindings, object/class element definitions, and dynamic generator-function creation. Remaining limitations are in spec-edge name-prefix cases and unsupported runtime forms rather than in the common SetFunctionName / NamedEvaluation paths covered here."
+      },
       {
         "clause": "8.4.1",
         "feature": "Function-expression naming for internal scope/binding identity",
@@ -51,7 +65,24 @@
           "tests/Jroc.Tests/SymbolTableBuilderTests.cs",
           "tests/Jroc.Tests/Function/JavaScript/Function_IIFE_Recursive.js"
         ],
+        "test262Paths": [
+          "test/language/expressions/function/named-no-strict-reassign-fn-name-in-body.js",
+          "test/language/expressions/function/named-strict-error-reassign-fn-name-in-body.js"
+        ],
         "notes": "Named function expressions create internal bindings and anonymous function expressions receive deterministic internal scope names."
+      },
+      {
+        "clause": "8.4.2",
+        "feature": "IsFunctionDefinition classification for anonymous initializer name inference sites",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-isfunctiondefinition",
+        "test262Paths": [
+          "test/language/statements/const/fn-name-arrow.js",
+          "test/language/statements/const/fn-name-fn.js",
+          "test/language/statements/const/fn-name-gen.js",
+          "test/language/statements/const/fn-name-class.js"
+        ],
+        "notes": "The compiler/runtime correctly recognize the covered function, arrow, generator, and class initializer forms that participate in name inference for bindings and property definitions."
       },
       {
         "clause": "8.4.3",
@@ -61,14 +92,36 @@
         "testScripts": [
           "tests/Jroc.Tests/SymbolTableBuilderTests.cs"
         ],
-        "notes": "Anonymous function expressions are distinguished for compiler-internal naming, but observable Function.name semantics are not fully implemented."
+        "test262Paths": [
+          "test/language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-arrow.js",
+          "test/language/expressions/function/dstr/ary-ptrn-elem-id-init-fn-name-fn.js"
+        ],
+        "notes": "Anonymous function expressions are distinguished for compiler-internal naming and for the covered observable name-inference sites used by destructuring defaults and property initialization."
+      },
+      {
+        "clause": "8.4.4",
+        "feature": "IsIdentifierRef participation in binding and destructuring name inference",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-isidentifierref",
+        "test262Paths": [
+          "test/language/expressions/function/dstr/obj-ptrn-id-init-fn-name-gen.js",
+          "test/language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-cover.js"
+        ],
+        "notes": "The covered destructuring-default and binding-identifier paths infer names from identifier references correctly where current supported syntax depends on them."
       },
       {
         "clause": "8.4.5",
         "feature": "NamedEvaluation / SetFunctionName observable semantics",
-        "status": "Not Yet Supported",
+        "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-runtime-semantics-namedevaluation",
-        "notes": "JROC does not currently implement spec-complete runtime name inference/exposure (for example full Function.prototype.name behavior for anonymous function assignment targets)."
+        "test262Paths": [
+          "test/language/statements/const/fn-name-arrow.js",
+          "test/language/expressions/object/__proto__-fn-name.js",
+          "test/language/statements/function/name.js",
+          "test/built-ins/GeneratorFunction/instance-name.js",
+          "test/language/expressions/class/elements/class-name-static-initializer-anonymous.js"
+        ],
+        "notes": "JROC now implements the covered observable NamedEvaluation / SetFunctionName behavior for declarations, anonymous binding initializers, object/class property definitions, and dynamic generator-function creation. Some spec-edge prefixing and unsupported runtime forms still keep this below full spec-complete parity."
       }
     ]
   }

--- a/docs/ECMA262/8/Section8_4.md
+++ b/docs/ECMA262/8/Section8_4.md
@@ -4,11 +4,11 @@
 
 [Back to Section8](Section8.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-07-07T21:06:59Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 8.4 | Function Name Inference | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-function-name-inference) |
+| 8.4 | Function Name Inference | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-function-name-inference) |
 
 ## Subclauses
 
@@ -18,27 +18,45 @@
 | 8.4.2 | Static Semantics: IsFunctionDefinition | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-isfunctiondefinition) |
 | 8.4.3 | Static Semantics: IsAnonymousFunctionDefinition ( expr ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-isanonymousfunctiondefinition) |
 | 8.4.4 | Static Semantics: IsIdentifierRef | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-isidentifierref) |
-| 8.4.5 | Runtime Semantics: NamedEvaluation | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-namedevaluation) |
+| 8.4.5 | Runtime Semantics: NamedEvaluation | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-namedevaluation) |
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
+
+### 8.4 ([tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-function-name-inference))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Function name inference across declarations, anonymous initializers, object/class property definitions, and dynamic function creation | Supported with Limitations |  | `test/language/statements/const/fn-name-arrow.js`<br>`test/language/expressions/object/__proto__-fn-name.js`<br>`test/language/statements/function/name.js`<br>`test/built-ins/GeneratorFunction/instance-name.js`<br>`test/language/expressions/class/elements/class-name-static-initializer-expr.js` | JROC covers the observable name-inference behavior used by today's supported declarations, anonymous initializer bindings, object/class element definitions, and dynamic generator-function creation. Remaining limitations are in spec-edge name-prefix cases and unsupported runtime forms rather than in the common SetFunctionName / NamedEvaluation paths covered here. |
 
 ### 8.4.1 ([tc39.es](https://tc39.es/ecma262/#sec-static-semantics-hasname))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Function-expression naming for internal scope/binding identity | Supported with Limitations | `tests/Jroc.Tests/SymbolTableBuilderTests.cs`<br>[`Function_IIFE_Recursive.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_IIFE_Recursive.js) | Named function expressions create internal bindings and anonymous function expressions receive deterministic internal scope names. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Function-expression naming for internal scope/binding identity | Supported with Limitations | `tests/Jroc.Tests/SymbolTableBuilderTests.cs`<br>[`Function_IIFE_Recursive.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_IIFE_Recursive.js) | `test/language/expressions/function/named-no-strict-reassign-fn-name-in-body.js`<br>`test/language/expressions/function/named-strict-error-reassign-fn-name-in-body.js` | Named function expressions create internal bindings and anonymous function expressions receive deterministic internal scope names. |
+
+### 8.4.2 ([tc39.es](https://tc39.es/ecma262/#sec-static-semantics-isfunctiondefinition))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IsFunctionDefinition classification for anonymous initializer name inference sites | Supported with Limitations |  | `test/language/statements/const/fn-name-arrow.js`<br>`test/language/statements/const/fn-name-fn.js`<br>`test/language/statements/const/fn-name-gen.js`<br>`test/language/statements/const/fn-name-class.js` | The compiler/runtime correctly recognize the covered function, arrow, generator, and class initializer forms that participate in name inference for bindings and property definitions. |
 
 ### 8.4.3 ([tc39.es](https://tc39.es/ecma262/#sec-isanonymousfunctiondefinition))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Anonymous function-expression detection in scope construction | Supported with Limitations | `tests/Jroc.Tests/SymbolTableBuilderTests.cs` | Anonymous function expressions are distinguished for compiler-internal naming, but observable Function.name semantics are not fully implemented. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Anonymous function-expression detection in scope construction | Supported with Limitations | `tests/Jroc.Tests/SymbolTableBuilderTests.cs` | `test/language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-arrow.js`<br>`test/language/expressions/function/dstr/ary-ptrn-elem-id-init-fn-name-fn.js` | Anonymous function expressions are distinguished for compiler-internal naming and for the covered observable name-inference sites used by destructuring defaults and property initialization. |
+
+### 8.4.4 ([tc39.es](https://tc39.es/ecma262/#sec-static-semantics-isidentifierref))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IsIdentifierRef participation in binding and destructuring name inference | Supported with Limitations |  | `test/language/expressions/function/dstr/obj-ptrn-id-init-fn-name-gen.js`<br>`test/language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-cover.js` | The covered destructuring-default and binding-identifier paths infer names from identifier references correctly where current supported syntax depends on them. |
 
 ### 8.4.5 ([tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-namedevaluation))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| NamedEvaluation / SetFunctionName observable semantics | Not Yet Supported |  | JROC does not currently implement spec-complete runtime name inference/exposure (for example full Function.prototype.name behavior for anonymous function assignment targets). |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| NamedEvaluation / SetFunctionName observable semantics | Supported with Limitations |  | `test/language/statements/const/fn-name-arrow.js`<br>`test/language/expressions/object/__proto__-fn-name.js`<br>`test/language/statements/function/name.js`<br>`test/built-ins/GeneratorFunction/instance-name.js`<br>`test/language/expressions/class/elements/class-name-static-initializer-anonymous.js` | JROC now implements the covered observable NamedEvaluation / SetFunctionName behavior for declarations, anonymous binding initializers, object/class property definitions, and dynamic generator-function creation. Some spec-edge prefixing and unsupported runtime forms still keep this below full spec-complete parity. |
 


### PR DESCRIPTION
## Summary
- reclassify ECMA-262 Section 8.2 Scope Analysis to Supported with Limitations
- reclassify ECMA-262 Section 8.4 Function Name Inference, including NamedEvaluation, to Supported with Limitations
- update the Section 8 hub and changelog while correctly leaving Section 8 overall incomplete because 8.6 remains incomplete

## Validation
- focused Jroc.Tests slice for scope analysis and declaration-tracking behavior
- focused Jroc.Test262.Tests slice for existing function-name inference coverage across const bindings, object/class definitions, generator functions, and related destructuring/default-name cases