### PR TITLE
docs(ecma262): reclassify section 8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- docs/ecma262: reclassify ECMA-262 Section 8.6 Miscellaneous to `Supported with Limitations`, documenting the current function-instantiation, binding-initialization, iterator-binding, assignment-target, and property-name evaluation coverage and rolling Section 8 up to `Supported with Limitations`.
 - docs/ecma262: reclassify ECMA-262 Sections 8.2 Scope Analysis and 8.4 Function Name Inference to `Supported with Limitations`, documenting the current scope-building, hoisting, lexical-environment, and observable SetFunctionName / NamedEvaluation coverage against existing compiler/runtime behavior and focused evidence.
 - docs/ecma262: reclassify ECMA-262 Section 8.1 Runtime Semantics: Evaluation to `Supported with Limitations`, documenting the current HIR/LIR/IL evaluation pipeline coverage across expressions, control flow, generators, async evaluation, and evaluation-order semantics while keeping general `eval` unsupported by design.
 - docs/ecma262: reclassify ECMA-262 Section 7.4 Operations on Iterator Objects to `Supported with Limitations`, documenting the current sync/async iterator acquisition, step/value, close-on-abrupt-completion, helper cleanup, and iterator-to-list style materialization coverage against existing runtime behavior and focused evidence.

--- a/docs/ECMA262/8/Section8.md
+++ b/docs/ECMA262/8/Section8.md
@@ -4,7 +4,7 @@ Defines syntax-directed operations, linking grammar productions to static semant
 
 [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-07T21:06:59Z
+> Last generated (UTC): 2026-07-07T21:13:28Z
 
 _This section is split into subsection documents for readability._
 
@@ -12,7 +12,7 @@ _This section is split into subsection documents for readability._
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 8 | Syntax-Directed Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations) |
+| 8 | Syntax-Directed Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations) |
 
 ## Subsections
 
@@ -23,4 +23,4 @@ _This section is split into subsection documents for readability._
 | 8.3 | Labels | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-labels) | [Section8_3.md](Section8_3.md) |
 | 8.4 | Function Name Inference | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-function-name-inference) | [Section8_4.md](Section8_4.md) |
 | 8.5 | Contains | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-contains) | [Section8_5.md](Section8_5.md) |
-| 8.6 | Miscellaneous | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-miscellaneous) | [Section8_6.md](Section8_6.md) |
+| 8.6 | Miscellaneous | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-miscellaneous) | [Section8_6.md](Section8_6.md) |

--- a/docs/ECMA262/8/Section8_6.json
+++ b/docs/ECMA262/8/Section8_6.json
@@ -2,7 +2,7 @@
   "$schema": "../SectionDoc.schema.json",
   "clause": "8.6",
   "title": "Miscellaneous",
-  "status": "Incomplete",
+  "status": "Supported with Limitations",
   "specUrl": "https://tc39.es/ecma262/#sec-syntax-directed-operations-miscellaneous",
   "parent": {
     "clause": "8"
@@ -48,6 +48,25 @@
   ],
   "support": {
     "entries": [
+      {
+        "clause": "8.6",
+        "feature": "Miscellaneous syntax-directed operations for function instantiation, binding initialization, assignment targets, and property-name evaluation",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-syntax-directed-operations-miscellaneous",
+        "testScripts": [
+          "tests/Jroc.Tests/Function/JavaScript/Function_HelloWorld.js",
+          "tests/Jroc.Tests/Variable/JavaScript/Variable_ArrayDestructuring_Basic.js",
+          "tests/Jroc.Tests/Object/JavaScript/ObjectLiteral_ComputedKey_EvaluationOrder.js"
+        ],
+        "test262Suites": [
+          "language/statements/variable",
+          "language/expressions/assignment/destructuring",
+          "language/statements/for-of",
+          "language/expressions/object",
+          "language/expressions/class/elements"
+        ],
+        "notes": "JROC already covers the observable Section 8.6 semantics exercised by today's supported function forms, declaration/destructuring bindings, iterator-driven loop bindings, assignment-target classification, and computed property-name evaluation. Remaining limitations follow intentionally unsupported forms such as eval and other unsupported syntax/runtime edge cases rather than a missing core miscellaneous-operations pipeline."
+      },
       {
         "clause": "8.6.1",
         "feature": "Instantiation of function/arrow/class callable objects",

--- a/docs/ECMA262/8/Section8_6.md
+++ b/docs/ECMA262/8/Section8_6.md
@@ -4,11 +4,11 @@
 
 [Back to Section8](Section8.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-07-07T21:13:38Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
-| 8.6 | Miscellaneous | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-miscellaneous) |
+| 8.6 | Miscellaneous | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-miscellaneous) |
 
 ## Subclauses
 
@@ -23,41 +23,47 @@
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
+
+### 8.6 ([tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations-miscellaneous))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Miscellaneous syntax-directed operations for function instantiation, binding initialization, assignment targets, and property-name evaluation | Supported with Limitations | [`Function_HelloWorld.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_HelloWorld.js)<br>[`Variable_ArrayDestructuring_Basic.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_ArrayDestructuring_Basic.js)<br>[`ObjectLiteral_ComputedKey_EvaluationOrder.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectLiteral_ComputedKey_EvaluationOrder.js) | suite `language/statements/variable`<br>suite `language/expressions/assignment/destructuring`<br>suite `language/statements/for-of`<br>suite `language/expressions/object`<br>suite `language/expressions/class/elements` | JROC already covers the observable Section 8.6 semantics exercised by today's supported function forms, declaration/destructuring bindings, iterator-driven loop bindings, assignment-target classification, and computed property-name evaluation. Remaining limitations follow intentionally unsupported forms such as eval and other unsupported syntax/runtime edge cases rather than a missing core miscellaneous-operations pipeline. |
 
 ### 8.6.1 ([tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-instantiatefunctionobject))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Instantiation of function/arrow/class callable objects | Supported with Limitations | [`Function_HelloWorld.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_HelloWorld.js)<br>[`Function_IIFE_Recursive.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_IIFE_Recursive.js)<br>[`Classes_DeclareEmptyClass.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_DeclareEmptyClass.js) | Function-like AST forms are lowered to delegate-backed callables and class types, but full spec object-internal-slot behavior for every callable form is not complete. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Instantiation of function/arrow/class callable objects | Supported with Limitations | [`Function_HelloWorld.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_HelloWorld.js)<br>[`Function_IIFE_Recursive.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_IIFE_Recursive.js)<br>[`Classes_DeclareEmptyClass.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_DeclareEmptyClass.js) |  | Function-like AST forms are lowered to delegate-backed callables and class types, but full spec object-internal-slot behavior for every callable form is not complete. |
 
 ### 8.6.2 ([tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-bindinginitialization))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| BindingInitialization for declarations and supported destructuring | Supported with Limitations | [`Variable_ArrayDestructuring_Basic.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_ArrayDestructuring_Basic.js)<br>[`Variable_ObjectDestructuring_Basic.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_ObjectDestructuring_Basic.js)<br>[`Classes_ClassConstructor_ParameterDestructuring.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassConstructor_ParameterDestructuring.js) | Identifier/object/array/rest/default binding paths are implemented for supported contexts, with unsupported binding-pattern forms rejected by validation/parsing. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| BindingInitialization for declarations and supported destructuring | Supported with Limitations | [`Variable_ArrayDestructuring_Basic.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_ArrayDestructuring_Basic.js)<br>[`Variable_ObjectDestructuring_Basic.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_ObjectDestructuring_Basic.js)<br>[`Classes_ClassConstructor_ParameterDestructuring.js`](../../../tests/Jroc.Tests/Classes/JavaScript/Classes_ClassConstructor_ParameterDestructuring.js) |  | Identifier/object/array/rest/default binding paths are implemented for supported contexts, with unsupported binding-pattern forms rejected by validation/parsing. |
 
 ### 8.6.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-initializeboundname))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| InitializeBoundName behavior (writes/const restrictions) | Supported with Limitations | [`Variable_ConstReassignmentError.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_ConstReassignmentError.js)<br>[`Variable_DestructuringAssignment_Basic.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_DestructuringAssignment_Basic.js) | Binding writes are lowered with scope-aware storage operations and enforce const write restrictions in supported assignment/destructuring paths. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| InitializeBoundName behavior (writes/const restrictions) | Supported with Limitations | [`Variable_ConstReassignmentError.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_ConstReassignmentError.js)<br>[`Variable_DestructuringAssignment_Basic.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_DestructuringAssignment_Basic.js) |  | Binding writes are lowered with scope-aware storage operations and enforce const write restrictions in supported assignment/destructuring paths. |
 
 ### 8.6.3 ([tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-iteratorbindinginitialization))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| IteratorBindingInitialization in for-of and destructuring flows | Supported with Limitations | [`ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.js)<br>[`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js) | Iterator-driven binding initialization is implemented in lowered for-of/for-await and destructuring paths, with subset-based coverage of exotic iterator semantics. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| IteratorBindingInitialization in for-of and destructuring flows | Supported with Limitations | [`ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.js)<br>[`ControlFlow_ForOf_CustomIterable_IteratorProtocol.js`](../../../tests/Jroc.Tests/ControlFlow/JavaScript/ControlFlow_ForOf_CustomIterable_IteratorProtocol.js) |  | Iterator-driven binding initialization is implemented in lowered for-of/for-await and destructuring paths, with subset-based coverage of exotic iterator semantics. |
 
 ### 8.6.4 ([tc39.es](https://tc39.es/ecma262/#sec-static-semantics-assignmenttargettype))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| AssignmentTargetType checks for supported assignment targets | Supported with Limitations | `tests/Jroc.Tests/ValidatorTests.cs`<br>[`Variable_AssignmentTargets_MemberAndIndex.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_AssignmentTargets_MemberAndIndex.js)<br>[`Variable_DestructuringAssignment_Basic.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_DestructuringAssignment_Basic.js) | Assignment lowering/validation supports identifier, member, index, and supported destructuring targets; unsupported target forms are rejected. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| AssignmentTargetType checks for supported assignment targets | Supported with Limitations | `tests/Jroc.Tests/ValidatorTests.cs`<br>[`Variable_AssignmentTargets_MemberAndIndex.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_AssignmentTargets_MemberAndIndex.js)<br>[`Variable_DestructuringAssignment_Basic.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_DestructuringAssignment_Basic.js) |  | Assignment lowering/validation supports identifier, member, index, and supported destructuring targets; unsupported target forms are rejected. |
 
 ### 8.6.5 ([tc39.es](https://tc39.es/ecma262/#sec-static-semantics-propname))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| PropName evaluation for object/class member keys | Supported with Limitations | [`ObjectLiteral_ComputedKey_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectLiteral_ComputedKey_Basic.js)<br>[`ObjectLiteral_ComputedKey_EvaluationOrder.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectLiteral_ComputedKey_EvaluationOrder.js) | Property-name extraction/evaluation is implemented for identifier/literal/computed object keys in supported forms; several class-specific computed/private key variants remain limited. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| PropName evaluation for object/class member keys | Supported with Limitations | [`ObjectLiteral_ComputedKey_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectLiteral_ComputedKey_Basic.js)<br>[`ObjectLiteral_ComputedKey_EvaluationOrder.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectLiteral_ComputedKey_EvaluationOrder.js) |  | Property-name extraction/evaluation is implemented for identifier/literal/computed object keys in supported forms; several class-specific computed/private key variants remain limited. |
 

--- a/docs/ECMA262/Index.md
+++ b/docs/ECMA262/Index.md
@@ -19,12 +19,12 @@ Notes:
 - `Partially Supported` is deprecated legacy wording and is treated as `Supported with Limitations`.
 - Prototype-chain design/strategy: see [PrototypeChainSupport.md](../compiler/PrototypeChainSupport.md).
 
-> Last generated (UTC): 2026-07-07T20:40:52Z
+> Last generated (UTC): 2026-07-07T21:13:28Z
 
 ## Summary
 - Total top-level sections indexed: **29**
 - Top-level sections with tracked status: **28**
-- Status breakdown: Supported with Limitations: **11**, Incomplete: **10**, Not Yet Supported: **1**, N/A (informational): **6**, Untracked: **1**
+- Status breakdown: Supported with Limitations: **12**, Incomplete: **9**, Not Yet Supported: **1**, N/A (informational): **6**, Untracked: **1**
 - Untracked top-level sections: **1**
 
 ## Sections
@@ -38,7 +38,7 @@ Notes:
 | 5 | Notational Conventions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-notational-conventions) | [Section5.md](5/Section5.md) |
 | 6 | ECMAScript Data Types and Values | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values) | [Section6.md](6/Section6.md) |
 | 7 | Abstract Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations) | [Section7.md](7/Section7.md) |
-| 8 | Syntax-Directed Operations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations) | [Section8.md](8/Section8.md) |
+| 8 | Syntax-Directed Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations) | [Section8.md](8/Section8.md) |
 | 9 | Executable Code and Execution Contexts | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-executable-code-and-execution-contexts) | [Section9.md](9/Section9.md) |
 | 10 | Ordinary and Exotic Objects Behaviours | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-and-exotic-objects-behaviours) | [Section10.md](10/Section10.md) |
 | 11 | ECMAScript Language: Source Text | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-source-code) | [Section11.md](11/Section11.md) |
@@ -60,5 +60,4 @@ Notes:
 | 27 | Control Abstraction Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-control-abstraction-objects) | [Section27.md](27/Section27.md) |
 | 28 | Reflection | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-reflection) | [Section28.md](28/Section28.md) |
 | 29 | Memory Model | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-memory-model) | [Section29.md](29/Section29.md) |
-
 


### PR DESCRIPTION
## Summary
- reclassify ECMA-262 Section 8.6 Miscellaneous to `Supported with Limitations`
- document the existing function-instantiation, binding-initialization, iterator-binding, assignment-target, and property-name evidence
- roll Section 8 up to `Supported with Limitations` in `docs/ECMA262/8/Section8.md` and `docs/ECMA262/Index.md`

## Validation
- dotnet test .\tests\Jroc.Tests\Jroc.Tests.csproj --no-restore --filter "FullyQualifiedName~Jroc.Tests.Function.ExecutionTests.Function_HelloWorld|FullyQualifiedName~Jroc.Tests.Variable.ExecutionTests.Variable_ArrayDestructuring_Basic|FullyQualifiedName~Jroc.Tests.Object.ExecutionTests.ObjectLiteral_ComputedKey_EvaluationOrder" --nologo
- dotnet test .\tests\Jroc.Test262.Tests\Jroc.Test262.Tests.csproj --no-restore --filter "FullyQualifiedName~Jroc.Test262.Tests.language.statements.variable.ExecutionTests.dstr_ary_init_iter_close|FullyQualifiedName~Jroc.Test262.Tests.language.expressions.assignment.destructuring.ExecutionTests.keyed_destructuring_property_reference_target_evaluation_order_with_bindings|FullyQualifiedName~Jroc.Test262.Tests.language.expressions.assignment.destructuring.ExecutionTests.obj_rest_symbol_val|FullyQualifiedName~Jroc.Test262.Tests.language.statements.for_of.ExecutionTests.dstr_array_elem_iter_nrml_close|FullyQualifiedName~Jroc.Test262.Tests.language.statements.for_of.ExecutionTests.head_let_destructuring|FullyQualifiedName~Jroc.Test262.Tests.language.expressions.object_.ExecutionTests.computed_proto|FullyQualifiedName~Jroc.Test262.Tests.language.expressions.object_.ExecutionTests.literal_property_name_bigint|FullyQualifiedName~Jroc.Test262.Tests.language.expressions.class_.elements.ExecutionTests.fields_computed_name_static_propname_prototype" --nologo