### PR TITLE
fix(benchmarks): stabilize published regexp runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/benchmarks: drain pending collectible in-memory load-context unloads between `jroc (compile+execute)` BenchmarkDotNet iterations so the published-package regexp scenarios stop failing mid-run; benchmark adapter failures now also preserve the full exception text for diagnosis.
 
 ## v0.11.14 - 2026-07-07
 

--- a/tests/performance/Benchmarks/JavaScriptRuntimeBenchmarks.cs
+++ b/tests/performance/Benchmarks/JavaScriptRuntimeBenchmarks.cs
@@ -106,6 +106,12 @@ public class JavaScriptRuntimeBenchmarks
         }
     }
 
+    [IterationCleanup(Target = nameof(Jroc_Total))]
+    public void CleanupJrocIteration()
+    {
+        _jrocRuntime.DrainPendingUnloadContexts();
+    }
+
     private string ResolveScriptName(string scenarioKey)
     {
         return _scenarioKeyToScriptName.TryGetValue(scenarioKey, out var scriptName)

--- a/tests/performance/Benchmarks/Runtimes/JrocRuntime.cs
+++ b/tests/performance/Benchmarks/Runtimes/JrocRuntime.cs
@@ -10,6 +10,8 @@ namespace Benchmarks.Runtimes;
 /// </summary>
 public class JrocRuntime : IJavaScriptRuntime
 {
+    private readonly List<WeakReference> _pendingUnloadContexts = [];
+
     public string Name => "jroc";
 
     public RuntimeExecutionResult Execute(string scriptContent, string scriptName = "script.js")
@@ -45,6 +47,7 @@ public class JrocRuntime : IJavaScriptRuntime
 
         // Load the compiled assembly from memory and execute
         var loadedAssembly = JrocInMemoryAssemblyLoader.Load(artifact);
+        var loadContextWeakReference = loadedAssembly.LoadContextWeakReference;
         try
         {
             var moduleId = artifact.ModuleIds[0];
@@ -59,13 +62,42 @@ public class JrocRuntime : IJavaScriptRuntime
         }
         catch (Exception ex)
         {
-            result.Error = $"jroc execution failed: {ex.Message}";
+            result.Error = $"jroc execution failed: {ex}";
         }
         finally
         {
             loadedAssembly.Dispose();
+            TrackPendingUnload(loadContextWeakReference);
         }
 
         return result;
+    }
+
+    public void DrainPendingUnloadContexts()
+    {
+        lock (_pendingUnloadContexts)
+        {
+            if (_pendingUnloadContexts.Count == 0)
+            {
+                return;
+            }
+
+            for (var i = 0; i < 10 && _pendingUnloadContexts.Exists(reference => reference.IsAlive); i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            }
+
+            _pendingUnloadContexts.RemoveAll(reference => !reference.IsAlive);
+        }
+    }
+
+    private void TrackPendingUnload(WeakReference loadContextWeakReference)
+    {
+        lock (_pendingUnloadContexts)
+        {
+            _pendingUnloadContexts.Add(loadContextWeakReference);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- drain pending collectible in-memory load-context unloads between `jroc (compile+execute)` benchmark iterations
- preserve full exception text from benchmark adapter failures to make benchmark crashes diagnosable
- add an Unreleased changelog entry for the benchmark harness fix

## Context

This fixes the BenchmarkDotNet release failure path seen while benchmarking published `0.11.14` packages, where the regexp scenarios could fail mid-run.
