### PR TITLE
fix(runtime): pass RegExp capture args to String.prototype.replace callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- runtime/tests: pass RegExp capture arguments to `String.prototype.replace` callback replacers, fixing captured replacement callbacks such as Dromaeo's regexp benchmark `capture.toUpperCase()` path.
 
 ## v0.11.15 - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 ## Unreleased
 
 - runtime/tests: pass RegExp capture arguments to `String.prototype.replace` callback replacers, fixing captured replacement callbacks such as Dromaeo's regexp benchmark `capture.toUpperCase()` path.
+- perf/benchmarks: report benchmark failures with the underlying exception details (root-cause `TypeError` etc.) in the final stdout summary, emit GitHub Actions error annotations, and stop printing "Benchmark execution complete!" after failed runs, so CI failures like the dromaeo-object-regexp crash are diagnosable without scanning the full log.
 
 ## v0.11.15 - 2026-07-08
 

--- a/src/JavaScriptRuntime/String.cs
+++ b/src/JavaScriptRuntime/String.cs
@@ -1463,6 +1463,24 @@ namespace JavaScriptRuntime
             return DotNet2JSConversions.ToString(callbackResult) ?? string.Empty;
         }
 
+        private static string InvokeRegExpReplaceCallback(Delegate callback, Match match, string input)
+        {
+            var args = new object?[match.Groups.Count + 2];
+            args[0] = match.Value;
+
+            for (var i = 1; i < match.Groups.Count; i++)
+            {
+                var group = match.Groups[i];
+                args[i] = group.Success ? group.Value : null;
+            }
+
+            args[match.Groups.Count] = (double)match.Index;
+            args[match.Groups.Count + 1] = input;
+
+            var callbackResult = Closure.InvokeFunctionCallWithArgs(callback, System.Array.Empty<object>(), args);
+            return DotNet2JSConversions.ToString(callbackResult) ?? string.Empty;
+        }
+
         /// <summary>
         /// Implements a subset of String.prototype.endsWith(searchString[, length]).
         /// If length is provided, the string is treated as if it were truncated to that length.
@@ -1753,7 +1771,7 @@ namespace JavaScriptRuntime
             {
                 if (cb is Delegate callback)
                 {
-                    return InvokeStringReplaceCallback(callback, match.Value, (double)match.Index, input);
+                    return InvokeRegExpReplaceCallback(callback, match, input);
                 }
 
                 // Fallback: ToString on callback object (unlikely useful)
@@ -2017,7 +2035,7 @@ namespace JavaScriptRuntime
 
                 if (replacement is Delegate replacementCallback)
                 {
-                    var evaluator = new MatchEvaluator(m => InvokeStringReplaceCallback(replacementCallback, m.Value, (double)m.Index, input));
+                    var evaluator = new MatchEvaluator(m => InvokeRegExpReplaceCallback(replacementCallback, m, input));
                     if (regExp.Global)
                     {
                         return regExp.Regex.Replace(input, evaluator);

--- a/tests/Jroc.Tests/String/ExecutionTests.cs
+++ b/tests/Jroc.Tests/String/ExecutionTests.cs
@@ -46,6 +46,12 @@ namespace Jroc.Tests.String
         }
 
         [Fact]
+        public Task String_Replace_Regex_CaptureCallback()
+        {
+            return ExecutionTest(nameof(String_Replace_Regex_CaptureCallback));
+        }
+
+        [Fact]
         public Task String_Match_NonGlobal()
         {
             return ExecutionTest(nameof(String_Match_NonGlobal));

--- a/tests/Jroc.Tests/String/JavaScript/String_Replace_Regex_CaptureCallback.js
+++ b/tests/Jroc.Tests/String/JavaScript/String_Replace_Regex_CaptureCallback.js
@@ -1,0 +1,13 @@
+"use strict";
+
+console.log("xaaBAAy".replace(/aa(b)aa/i, function (all, capture, offset, input) {
+    console.log(all);
+    console.log(capture);
+    console.log(offset);
+    console.log(input);
+    return capture.toUpperCase();
+}));
+
+console.log("a-a".replace(/(a)|(b)/g, function (all, a, b) {
+    return typeof b;
+}));

--- a/tests/Jroc.Tests/String/Snapshots/ExecutionTests.String_Replace_Regex_CaptureCallback.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/ExecutionTests.String_Replace_Regex_CaptureCallback.verified.txt
@@ -1,0 +1,6 @@
+aaBAA
+B
+1
+xaaBAAy
+xBy
+undefined-undefined

--- a/tests/performance/Benchmarks/Program.cs
+++ b/tests/performance/Benchmarks/Program.cs
@@ -56,7 +56,14 @@ else
     }
 }
 
-Console.WriteLine("\nBenchmark execution complete!");
+if (Environment.ExitCode != 0)
+{
+    Console.WriteLine("\nBenchmark execution FAILED (see failure summary above).");
+}
+else
+{
+    Console.WriteLine("\nBenchmark execution complete!");
+}
 Console.WriteLine("Results are saved in BenchmarkDotNet.Artifacts/");
 Console.WriteLine("\nFor more options:");
 Console.WriteLine("  dotnet run -c Release          # Run cross-runtime comparison");
@@ -68,38 +75,122 @@ Console.WriteLine("  dotnet run -c Release --validate # Run validation tests");
 static void SetExitCodeFromSummaries(IEnumerable<Summary> summaries)
 {
     var summaryList = summaries.ToArray();
-    var failedBenchmarks = summaryList
-        .SelectMany(summary => summary.Reports
-            .Where(report => !report.Success)
-            .Select(report => report.BenchmarkCase.ToString()))
-        .Distinct(StringComparer.Ordinal)
+    var failedReports = summaryList
+        .SelectMany(summary => summary.Reports.Where(report => !report.Success))
         .ToArray();
 
     var hasValidationFailures = summaryList.Any(summary =>
         summary.HasCriticalValidationErrors || summary.ValidationErrors.Any());
 
-    if (!hasValidationFailures && failedBenchmarks.Length == 0)
+    if (!hasValidationFailures && failedReports.Length == 0)
     {
         return;
     }
 
-    if (failedBenchmarks.Length > 0)
+    // Write the failure summary to stdout (not stderr) so it appears in-order in CI logs
+    // instead of being interleaved after later stdout writes.
+    if (failedReports.Length > 0)
     {
-        Console.Error.WriteLine();
-        Console.Error.WriteLine("Benchmark run failed. Cases with issues:");
-        foreach (var failedBenchmark in failedBenchmarks)
+        Console.WriteLine();
+        Console.WriteLine($"Benchmark run failed. {failedReports.Length} case(s) with issues:");
+        foreach (var report in failedReports)
         {
-            Console.Error.WriteLine($"  {failedBenchmark}");
+            var caseName = report.BenchmarkCase.ToString();
+            Console.WriteLine();
+            Console.WriteLine($"  FAILED: {caseName}");
+
+            var details = DescribeFailure(report).ToArray();
+            foreach (var detail in details)
+            {
+                Console.WriteLine($"    {detail}");
+            }
+
+            var rootCause = details.FirstOrDefault(IsJsErrorLine)
+                ?? details.FirstOrDefault(d => d.Contains("Exception", StringComparison.Ordinal))
+                ?? details.FirstOrDefault();
+            EmitGitHubErrorAnnotation(caseName, rootCause);
         }
     }
 
     if (hasValidationFailures)
     {
-        Console.Error.WriteLine();
-        Console.Error.WriteLine("Benchmark run failed due to BenchmarkDotNet validation errors.");
+        Console.WriteLine();
+        Console.WriteLine("Benchmark run failed due to BenchmarkDotNet validation errors:");
+        foreach (var error in summaryList.SelectMany(summary => summary.ValidationErrors))
+        {
+            Console.WriteLine($"  {error.Message}");
+        }
+
+        EmitGitHubErrorAnnotation("BenchmarkDotNet validation", "One or more validation errors; see log for details.");
     }
 
     Environment.ExitCode = 1;
+}
+
+static IEnumerable<string> DescribeFailure(BenchmarkReport report)
+{
+    foreach (var executeResult in report.ExecuteResults)
+    {
+        if (executeResult.IsSuccess)
+        {
+            continue;
+        }
+
+        if (executeResult.ExitCode is int exitCode && exitCode != 0)
+        {
+            yield return $"benchmark process exited with code {exitCode}";
+        }
+
+        foreach (var error in executeResult.Errors)
+        {
+            yield return error;
+        }
+
+        // The exception text from a crashed benchmark process lands in the parsed
+        // process output (non-measurement lines go to Results; StandardOutput is
+        // toolchain-dependent). Surface exception/stack lines so the root cause is
+        // visible in the final summary without scanning the full log.
+        var outputLines = executeResult.Results
+            .Concat(executeResult.StandardOutput)
+            .Concat(executeResult.PrefixedLines);
+        foreach (var line in outputLines)
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Contains("Exception", StringComparison.Ordinal)
+                || trimmed.StartsWith("--->", StringComparison.Ordinal)
+                || trimmed.StartsWith("at ", StringComparison.Ordinal)
+                || IsJsErrorLine(trimmed))
+            {
+                yield return trimmed;
+            }
+        }
+    }
+}
+
+static bool IsJsErrorLine(string line)
+{
+    var value = line.StartsWith("---> ", StringComparison.Ordinal) ? line.Substring(5) : line;
+    return value.StartsWith("TypeError", StringComparison.Ordinal)
+        || value.StartsWith("RangeError", StringComparison.Ordinal)
+        || value.StartsWith("SyntaxError", StringComparison.Ordinal)
+        || value.StartsWith("ReferenceError", StringComparison.Ordinal);
+}
+
+static void EmitGitHubErrorAnnotation(string title, string? message)
+{
+    if (!string.Equals(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), "true", StringComparison.OrdinalIgnoreCase))
+    {
+        return;
+    }
+
+    // GitHub Actions workflow command; renders as an error annotation in the run UI.
+    var detail = string.IsNullOrWhiteSpace(message) ? "see benchmark log for details" : message;
+    Console.WriteLine($"::error title=Benchmark failed: {Sanitize(title)}::{Sanitize(detail)}");
+
+    static string Sanitize(string value) => value
+        .Replace("%", "%25", StringComparison.Ordinal)
+        .Replace("\r", "%0D", StringComparison.Ordinal)
+        .Replace("\n", "%0A", StringComparison.Ordinal);
 }
 
 static string? TakeOption(ref string[] args, string name)


### PR DESCRIPTION
## Summary

`String.prototype.replace(regexp, fn)` callbacks were not receiving capture group arguments. The callback signature per spec is `(match, p1, p2, ..., offset, input)` — one arg per capture group before `offset` and `input`. This caused the Dromaeo `dromaeo-object-regexp` benchmark to crash with `TypeError: toUpperCase is not a function` during the `jroc execute (pre-compiled)` BenchmarkDotNet run.

## Root cause

PR #1341 (`f3014cf90`) changed the callback dispatch from matching exact `Func<object[], object>` / `Func<object[], object, object>` shapes to `replacement is Delegate` (correct — catches any arity), and introduced `InvokeStringReplaceCallback`. However that helper only passed `(match, offset, input)` — no capture groups. Any callback with capture params received the numeric offset where it expected a string.

The crash was also intermittent by nature: the callback only fires when `/aa(b)aa/g` happens to match the randomly generated test strings, which made it look like a resource-exhaustion problem after N successful iterations.

## Fix

Added `InvokeRegExpReplaceCallback` that builds the full argument list from `match.Groups`:
```
args = [match.Value, group1, group2, ..., groupN, (double)match.Index, input]
```
Both call sites in `ReplaceWithRegExp` (non-literal path and the `Replace(string, string, object, bool, bool)` overload) now use this helper.

## Benchmark failure reporting improvements

The failure was hard to diagnose because the exception was buried ~29k lines mid-log, and the final failure summary went to stderr where it interleaved out-of-order with stdout (rendering an empty case list followed by "Benchmark execution complete!"). This PR also hardens `tests/performance/Benchmarks/Program.cs`:

- Failure summary now goes to **stdout, in order**, before the completion message
- Each failed case includes the **benchmark process exit code and the exception/stack lines** extracted from `ExecuteResult` output, so the root cause (e.g. `TypeError: toUpperCase is not a function`) appears directly in the summary
- Emits `::error` **GitHub Actions annotations** with the root-cause line so failures surface in the run UI
- Prints `Benchmark execution FAILED` instead of `complete!` on failed runs
- Validation failures list their messages instead of a generic notice

Verified locally with an intentionally-failing scenario (full `JsModuleLoadException → TypeError` chain + annotation reported) and a passing scenario (output unchanged).

## Tests

- `String_Replace_Regex_CaptureCallback` — new regression test covering: single non-global match with 1 capture group + `toUpperCase()`, and a global match with 2 capture groups where one may be `undefined`.
- All 12 existing `test262/built-ins/String/prototype/replace` tests pass.
- All existing `Jroc.Tests.String` replace execution + generator tests pass.
- Locally verified: the previously failing `JrocPhasedBenchmarks.'jroc execute (pre-compiled)'` for `dromaeo-object-regexp` now completes (~245 ms mean) instead of crashing with exit code 255.