### PR TITLE
fix(hosting): evaluate ESM export getters when resolving hosted export members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime/hosting/tests: fix ES module named exports (e.g. `export function runTest() {}`) resolving to `null` through the hosting exports layer (`JsEngine.LoadModule` dynamic/typed proxies); `ExportMemberResolver` now reads exports through the runtime property path so ESM export getters are evaluated instead of returning the raw backing slot.
 - compiler/tests: fix `InvalidProgramException` when a deeply nested array/object literal is stored into a scope field (e.g. Kraken ai-astar's top-level `var g1 = [[{...}]]` data table); the maxstack estimator now accounts for the receiver slot(s) pushed by scope/parameter/user-class field stores before the inlined value is constructed.
 - runtime/tests: pass RegExp capture arguments to `String.prototype.replace` callback replacers, fixing captured replacement callbacks such as Dromaeo's regexp benchmark `capture.toUpperCase()` path.
 - perf/benchmarks: report benchmark failures with the underlying exception details (root-cause `TypeError` etc.) in the final stdout summary, emit GitHub Actions error annotations, and stop printing "Benchmark execution complete!" after failed runs, so CI failures like the dromaeo-object-regexp crash are diagnosable without scanning the full log.

--- a/src/JavaScriptRuntime/Hosting/ExportMemberResolver.cs
+++ b/src/JavaScriptRuntime/Hosting/ExportMemberResolver.cs
@@ -99,8 +99,13 @@ internal static class ExportMemberResolver
 
         foreach (var candidate in GetNameCandidates(contractName))
         {
-            if (exports is IDictionary<string, object?> dict && dict.TryGetValue(candidate, out value))
+            if (exports is IDictionary<string, object?> dict
+                && (dict.ContainsKey(candidate) || JavaScriptRuntime.PropertyDescriptorStore.TryGetOwn(exports, candidate, out _)))
             {
+                // Read through the runtime property path so accessor properties
+                // (e.g. ES module export getters) are evaluated instead of
+                // returning the raw backing slot.
+                value = JavaScriptRuntime.ObjectRuntime.GetProperty(exports, candidate);
                 return true;
             }
 
@@ -183,6 +188,11 @@ internal static class ExportMemberResolver
     private static bool HasExportMember(object exports, string candidate)
     {
         if (exports is IDictionary<string, object?> dict && dict.ContainsKey(candidate))
+        {
+            return true;
+        }
+
+        if (JavaScriptRuntime.PropertyDescriptorStore.TryGetOwn(exports, candidate, out _))
         {
             return true;
         }

--- a/tests/Jroc.Tests/Hosting/JavaScript/mathEsm.js
+++ b/tests/Jroc.Tests/Hosting/JavaScript/mathEsm.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const version = "2.0.0";
+
+export function add(x, y) {
+  return x + y;
+}
+
+export { version };

--- a/tests/Jroc.Tests/Hosting/ModuleLoadTests.cs
+++ b/tests/Jroc.Tests/Hosting/ModuleLoadTests.cs
@@ -70,6 +70,28 @@ public class ModuleLoadTests
     }
 
     [Fact]
+    public void JsEngine_LoadModule_Typed_AllowsCallingEsmExports()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource("mathEsm", "mathEsm.js");
+        using var exports = Jroc.Runtime.JsEngine.LoadModule<IMathExports>(module.Assembly, "mathEsm");
+
+        Assert.Equal("2.0.0", exports.Version);
+        Assert.Equal(3.0, exports.Add(1, 2));
+    }
+
+    [Fact]
+    public void JsEngine_LoadModule_Dynamic_AllowsCallingEsmExports()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource("mathEsm", "mathEsm.js");
+
+        using var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "mathEsm");
+        dynamic exports = exportsObj;
+
+        Assert.Equal("2.0.0", (string)exports.version);
+        Assert.Equal(3.0, (double)exports.add(1, 2));
+    }
+
+    [Fact]
     public void JsEngine_LoadModule_Dynamic_AllowsMutatingExportsObject()
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("hostingMutable", "Hosting_TypedExports.js");


### PR DESCRIPTION
## Problem

Running the WIP Kraken benchmark (`--kracken`) failed with an opaque error:

```
Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: Cannot perform runtime binding on a null reference
   at Benchmarks.KrackenBenchmarks.RunKrackenTest()
```

## Root cause

ES module named exports (e.g. `export function runTest() {}`) are compiled by `ModuleLoader` into **accessor (getter) properties** on the module exports object (`__jroc_esm_export(name, getter)` → `Object.defineProperty(exports, name, { get: ... })`).

However, the hosting layer's `ExportMemberResolver.TryGetExportMember` read exports via the raw `IDictionary<string, object?>.TryGetValue`, which returns the null backing slot and **never invokes the getter**. CommonJS `module.exports = { ... }` worked because those are plain data properties — which is why every existing hosting test passed while ESM exports silently resolved to `null`.

The null export then fell through `JsDynamicExports.TryInvokeMember` (which swallows `MissingMemberException`) into DLR fallback binding on a null value, producing the unhelpful `RuntimeBinderException`.

## Fix

`ExportMemberResolver` now resolves dictionary-backed export members through `ObjectRuntime.GetProperty`, which honors property descriptors (getters), and also consults `PropertyDescriptorStore` for own-key existence.

## Validation

- New regression tests: `JsEngine_LoadModule_Typed_AllowsCallingEsmExports` and `JsEngine_LoadModule_Dynamic_AllowsCallingEsmExports` (new `mathEsm.js` fixture) — fail before the fix, pass after.
- Full `Jroc.Tests.Hosting` slice: 41 passed, 0 failed.
- Verified end-to-end that the full Kraken ai-astar script (data + test + `export function runTest()`) now compiles, loads, and `runTest()` executes via the dynamic exports proxy.
