### PR TITLE
perf: eliminate descriptor clone-on-read and O(N^2) LIR scans (ai-astar, #1415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/runtime: stop cloning property descriptors on every property read (`PropertyDescriptorStore.TryGetOwn` intrinsic + runtime-store paths); descriptors are still cloned on write and by the few callers that mutate a read descriptor (`Object.seal`, `Object.freeze`, `SetProperty` accessor/data update). Cuts Kraken `ai-astar` execution time roughly in half (136s → 69s locally). (#1415)
+- perf/compiler: replace repeated O(N) LIR instruction scans with cached def-instruction/use lookups in `LIRToILCompiler` (`TryFindDefInstruction`, `HasAnyUses`) and build the def map once per method in `TempLocalAllocator`; compiling the Kraken `ai-astar` scenario (50k-line data literal) drops from ~65s to ~9.5s locally. (#1415)
 
 ## v0.11.17 - 2026-07-09
 

--- a/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
+++ b/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
@@ -2405,19 +2405,49 @@ internal sealed partial class LIRToILCompiler
         return scopeLocalOffset + MethodBody.VariableNames.Count + slot;
     }
 
+    private Dictionary<int, LIRInstruction>? _tempDefInstructionCache;
+
     private LIRInstruction? TryFindDefInstruction(TempVariable temp)
     {
-        foreach (var instr in MethodBody.Instructions
-            .Where(i => TempLocalAllocator.TryGetDefinedTemp(i, out var defined) && defined == temp))
+        // Built once per method body: a linear scan per lookup makes compilation of
+        // large method bodies O(N^2) (see issue #1415).
+        var cache = _tempDefInstructionCache;
+        if (cache is null)
         {
-            return instr;
+            cache = new Dictionary<int, LIRInstruction>(MethodBody.Instructions.Count);
+            foreach (var instr in MethodBody.Instructions)
+            {
+                if (TempLocalAllocator.TryGetDefinedTemp(instr, out var defined))
+                {
+                    // Keep the first definition to preserve the previous first-match semantics.
+                    cache.TryAdd(defined.Index, instr);
+                }
+            }
+            _tempDefInstructionCache = cache;
         }
-        return null;
+
+        return cache.TryGetValue(temp.Index, out var def) ? def : null;
     }
+
+    private HashSet<int>? _usedTempIndexCache;
 
     private bool HasAnyUses(TempVariable temp)
     {
-        return MethodBody.Instructions.Any(i => TempLocalAllocator.EnumerateUsedTemps(i).Any(u => u == temp));
+        var cache = _usedTempIndexCache;
+        if (cache is null)
+        {
+            cache = new HashSet<int>();
+            foreach (var instr in MethodBody.Instructions)
+            {
+                foreach (var used in TempLocalAllocator.EnumerateUsedTemps(instr))
+                {
+                    cache.Add(used.Index);
+                }
+            }
+            _usedTempIndexCache = cache;
+        }
+
+        return cache.Contains(temp.Index);
     }
 
     /// <summary>

--- a/src/Compiler/IL/TempLocalAllocator.cs
+++ b/src/Compiler/IL/TempLocalAllocator.cs
@@ -63,6 +63,10 @@ internal static class TempLocalAllocator
         var tempToSlot = new int[tempCount];
         Array.Fill(tempToSlot, -1);
 
+        // Def-instruction lookup built once so CanEmitInline doesn't rescan the
+        // instruction list per query (O(N^2) on large method bodies, issue #1415).
+        var defInstructions = BuildDefInstructionMap(methodBody);
+
         var slotStorages = new List<ValueStorage>();
         var freeByKey = new Dictionary<StorageKey, Stack<int>>();
 
@@ -107,7 +111,7 @@ internal static class TempLocalAllocator
                 defined.Index < tempCount &&
                 lastUse[defined.Index] >= 0 &&
                 (shouldMaterializeTemp is null || shouldMaterializeTemp[defined.Index]) &&
-                !CanEmitInline(instruction, methodBody) &&
+                !CanEmitInline(instruction, methodBody, defInstructions) &&
                 !(defined.Index < methodBody.TempVariableSlots.Count && methodBody.TempVariableSlots[defined.Index] >= 0))
             {
                 var storage = GetTempStorage(methodBody, defined);
@@ -134,7 +138,7 @@ internal static class TempLocalAllocator
     /// Returns true if the instruction defines a constant that can be emitted inline
     /// without needing a local variable slot.
     /// </summary>
-    private static bool CanEmitInline(LIRInstruction instruction, MethodBodyIR methodBody)
+    private static bool CanEmitInline(LIRInstruction instruction, MethodBodyIR methodBody, Dictionary<int, LIRInstruction> defInstructions)
     {
         if (instruction is LIRConstNumber or LIRConstString or LIRConstBoolean or LIRConstUndefined or LIRConstNull or LIRLoadParameter or LIRLoadThis)
         {
@@ -160,26 +164,28 @@ internal static class TempLocalAllocator
             {
                 return false;
             }
-            var sourceDefinition = TryFindDefInstruction(methodBody, convertToObject.Source);
-            return sourceDefinition != null && CanEmitInline(sourceDefinition, methodBody);
+            var sourceDefinition = defInstructions.TryGetValue(convertToObject.Source.Index, out var def) ? def : null;
+            return sourceDefinition != null && CanEmitInline(sourceDefinition, methodBody, defInstructions);
         }
 
         return false;
     }
 
     /// <summary>
-    /// Finds the instruction that defines the given temp variable.
+    /// Builds a temp-index → defining-instruction map in a single pass.
+    /// Keeps the first definition per temp to match the previous first-match scan semantics.
     /// </summary>
-    private static LIRInstruction? TryFindDefInstruction(MethodBodyIR methodBody, TempVariable temp)
+    private static Dictionary<int, LIRInstruction> BuildDefInstructionMap(MethodBodyIR methodBody)
     {
+        var map = new Dictionary<int, LIRInstruction>(methodBody.Instructions.Count);
         foreach (var inst in methodBody.Instructions)
         {
-            if (TryGetDefinedTemp(inst, out var def) && def.Index == temp.Index)
+            if (TryGetDefinedTemp(inst, out var def))
             {
-                return inst;
+                map.TryAdd(def.Index, inst);
             }
         }
-        return null;
+        return map;
     }
 
     private static ValueStorage GetTempStorage(MethodBodyIR methodBody, TempVariable temp)

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -1682,6 +1682,7 @@ namespace JavaScriptRuntime
                     continue;
                 }
 
+                desc = PropertyDescriptorStore.CloneDescriptor(desc);
                 desc.Configurable = false;
                 PropertyDescriptorStore.DefineOrUpdate(obj, key, desc);
             }
@@ -1712,6 +1713,7 @@ namespace JavaScriptRuntime
                     continue;
                 }
 
+                desc = PropertyDescriptorStore.CloneDescriptor(desc);
                 desc.Configurable = false;
                 if (desc.Kind == JsPropertyDescriptorKind.Data)
                 {
@@ -5710,6 +5712,7 @@ namespace JavaScriptRuntime
                     throw new TypeError($"Cannot assign to read only property '{name}' of object");
                 }
 
+                desc = PropertyDescriptorStore.CloneDescriptor(desc);
                 desc.Value = value;
                 PropertyDescriptorStore.DefineOrUpdate(obj, name, desc);
                 if (obj is System.Dynamic.ExpandoObject expDesc && !PropertyDescriptorStore.HasIntrinsicProperties(obj))

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -83,7 +83,12 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
                 {
                     if (slot.Descriptors.TryGetValue(key, out var stored))
                     {
-                        descriptor = CloneDescriptor(stored);
+                        // Perf (#1415): return the stored descriptor without cloning.
+                        // Stored descriptors are never mutated in place (writes go through
+                        // DefineOrUpdate, which clones the incoming descriptor), so callers
+                        // that only read the descriptor can safely share the instance.
+                        // Callers that mutate the result must clone it first.
+                        descriptor = stored;
                         return true;
                     }
                 }
@@ -290,7 +295,8 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
                 return false;
             }
 
-            descriptor = CloneDescriptor(entry.Descriptor!);
+            // Perf (#1415): no clone on the read path; see IntrinsicPropertyDescriptorStore.TryGetOwn.
+            descriptor = entry.Descriptor!;
             return true;
         }
 

--- a/tests/Jroc.Tests/PropertyDescriptorStoreTests.cs
+++ b/tests/Jroc.Tests/PropertyDescriptorStoreTests.cs
@@ -171,7 +171,7 @@ public class PropertyDescriptorStoreTests
     }
 
     [Fact]
-    public void RuntimeStore_ReturnsClonedDescriptors()
+    public void RuntimeStore_WritesCloneIncomingDescriptors()
     {
         var target = new JsObject();
         using (PropertyDescriptorStore.BeginIntrinsicInitialization())
@@ -184,11 +184,14 @@ public class PropertyDescriptorStoreTests
         {
             GlobalThis.ServiceProvider = runtime;
 
-            Assert.True(PropertyDescriptorStore.TryGetOwn(target, "value", out var descriptor));
-            descriptor.Value = "mutated copy";
+            // Writes clone the incoming descriptor, so later caller-side mutation
+            // of the written descriptor must not leak into the store.
+            var written = DataDescriptor("updated");
+            PropertyDescriptorStore.DefineOrUpdate(target, "value", written);
+            written.Value = "mutated after write";
 
             Assert.True(PropertyDescriptorStore.TryGetOwn(target, "value", out var reread));
-            Assert.Equal("original", reread.Value);
+            Assert.Equal("updated", reread.Value);
         }
         finally
         {


### PR DESCRIPTION
Addresses the two highest-priority performance problems found while profiling the Kraken `ai-astar` benchmark in #1415.

## Changes

### 1. Runtime: stop cloning property descriptors on every read (`PropertyDescriptorStore`)

`CloneDescriptor` accounted for ~17% of self-time during `ai-astar` execution because **every** property read (`GetProperty` → `TryGetOwnPropertyValue` → `TryGetOwn`) allocated a defensive copy of the stored descriptor.

- Both `TryGetOwn` read paths (intrinsic store and runtime store) now return the stored descriptor instance directly.
- This is safe because the store already clones on **all writes** (`DefineOrUpdateCore`, `DefineOrUpdateOverride`), so stored descriptors are never aliased by caller-provided instances and are never mutated in place.
- The only three call sites that mutate a descriptor returned by `TryGetOwn` now clone explicitly before mutating: `Object.seal`, `Object.freeze`, and the `SetProperty` data-descriptor update path. (`GetOwnPropertyDescriptorInternal`'s Array-prototype special case already cloned.)
- Updated `RuntimeStore_ReturnsClonedDescriptors` to assert the new contract (writes clone; caller-side mutation after write does not leak into the store).

### 2. Compiler: remove O(N²) LIR instruction scans (`LIRToILCompiler`, `TempLocalAllocator`)

Compiling the combined `ai-astar` script (50k-line data literal → one huge method body) spent ~35% of compile time linearly re-scanning the LIR instruction list:

- `LIRToILCompiler.TryFindDefInstruction` (17.6% self) and `HasAnyUses` now use lazily-built per-method caches (def-instruction dictionary / used-temp set). Safe because each `LIRToILCompiler` instance compiles exactly one method and the instruction list is not mutated during IL emission.
- `TempLocalAllocator.Allocate` now builds the def-instruction map once and passes it to `CanEmitInline`, replacing the per-temp linear scan.
- First-def-wins semantics of the original scans are preserved (`TryAdd`).

## Measured impact (local, Release, single `go()` iteration)

| Phase | Before | After | Speedup |
|---|---|---|---|
| Compile (combined ai-astar script) | 65.1 s | 9.5 s | **6.8×** |
| Execution (`go()`) | 136.1 s | 68.7 s | **2.0×** |

## Not addressed here (still tracked in #1415)

- Lock contention in the property store (`Monitor.Enter` ~5.5%)
- Main-thread cross-thread blocking (~27%, architectural)

## Testing

- `Jroc.Tests` Object + Classes execution tests: 107 passed
- test262 defineProperty/freeze/seal/getOwnPropertyDescriptor slices: 58 passed
- Generator snapshot slices (Function, ControlFlow, Array, Literals): 192 passed — confirms IL output is unchanged
- Proxy/Getter/Property slices: 353 passed (1 pre-existing test updated for the new clone contract)
- `PropertyDescriptorStoreTests`: 8 passed
