### PR TITLE
perf(runtime): fast property lookup dispatch for Object.GetProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf/runtime: add fast property lookup dispatch to `Object.GetProperty`; plain JS objects (`JsObject` literals and function-constructed `ExpandoObject` instances) now resolve own reads with a single unified descriptor-store probe (`PropertyDescriptorStore.GetOwnLookup` answering deleted/descriptor/none at once) before the full dispatch ladder, and `TryGetOwnPropertyValue`/`TryGetFastDictionaryOwnValue` use the same single probe instead of separate `IsDeleted` + `TryGetOwn` calls. Kraken `ai-astar` warmed execution drops ~23% (71.5s → 55.1s locally). (#1418)
 - perf/runtime: make `PropertyDescriptorStore` reads lock-free; descriptor and override slots now publish immutable copy-on-write snapshots that hot read paths (`TryGetOwn`, `HasAny`, `TryGetOverride`, own-key enumeration) access via a volatile read while writers serialize on a per-slot write lock, removing `Monitor.Enter_Slowpath` as the dominant remaining hotspot in the Kraken `ai-astar` execution trace. (#1417)
 
 ## v0.11.18 - 2026-07-09

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -2693,7 +2693,10 @@ namespace JavaScriptRuntime
                 return false;
             }
 
-            if (PropertyDescriptorStore.TryGetOwn(receiver, memberName, out _))
+            // Perf (#1418): single probe instead of the previous TryGetOwn call;
+            // only a live descriptor shadows the dictionary slot (a delete
+            // tombstone intentionally does not, preserving prior behavior).
+            if (PropertyDescriptorStore.GetOwnLookup(receiver, memberName, out _) == PropertyDescriptorLookup.Found)
             {
                 return false;
             }
@@ -4079,14 +4082,16 @@ namespace JavaScriptRuntime
                 return true;
             }
 
-            if (PropertyDescriptorStore.IsDeleted(target, propName))
+            // Perf (#1418): single-probe lookup answering deleted/descriptor/none at once.
+            var ownLookup = PropertyDescriptorStore.GetOwnLookup(target, propName, out var desc);
+            if (ownLookup == PropertyDescriptorLookup.Deleted)
             {
                 value = null;
                 return false;
             }
 
             // Descriptor-defined properties (data/accessor)
-            if (PropertyDescriptorStore.TryGetOwn(target, propName, out var desc))
+            if (ownLookup == PropertyDescriptorLookup.Found)
             {
                 if (desc.Kind == JsPropertyDescriptorKind.Accessor)
                 {
@@ -5475,6 +5480,43 @@ namespace JavaScriptRuntime
         {
             // Null/undefined -> undefined (modeled as null)
             if (obj is null) return null;
+
+            // Perf (#1418): fast dispatch for plain JS objects (object literals via
+            // JsObject, function-constructed instances via ExpandoObject). Own
+            // properties on these receivers are authoritatively descriptor-backed
+            // (literal/assignment writes mirror a data descriptor), so a single
+            // descriptor probe resolves the overwhelmingly common case without
+            // walking the full dispatch ladder below. Misses fall through so
+            // rarely-taken paths (lazy class methods, __proto__, inheritance)
+            // keep their existing semantics. Function.Prototype is excluded to
+            // preserve the restricted 'caller'/'arguments' check.
+            if ((obj is JsObject || obj is System.Dynamic.ExpandoObject)
+                && !ReferenceEquals(obj, JavaScriptRuntime.Function.Prototype))
+            {
+                var lookup = PropertyDescriptorStore.GetOwnLookup(obj, name, out var fastDesc);
+                if (lookup == PropertyDescriptorLookup.Found)
+                {
+                    if (fastDesc.Kind == JsPropertyDescriptorKind.Data)
+                    {
+                        return fastDesc.Value;
+                    }
+
+                    return fastDesc.Get is null || fastDesc.Get is JsNull
+                        ? null
+                        : InvokeCallable(fastDesc.Get, obj, System.Array.Empty<object>());
+                }
+
+                if (lookup == PropertyDescriptorLookup.None
+                    && ((IDictionary<string, object?>)obj).TryGetValue(name, out var fastDictValue))
+                {
+                    // Dictionary-only entries (no shadowing descriptor) mirror the
+                    // existing TryGetFastDictionaryOwnValue behavior.
+                    return fastDictValue;
+                }
+
+                // Own miss (or delete tombstone): fall through to the full ladder.
+            }
+
             if (ReferenceEquals(obj, JavaScriptRuntime.Function.Prototype)
                 && (string.Equals(name, "caller", StringComparison.Ordinal) || string.Equals(name, "arguments", StringComparison.Ordinal)))
             {

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -47,6 +47,18 @@ internal enum PropertyDescriptorOverrideKind
     Delete
 }
 
+/// <summary>
+/// Result of a single-probe own-descriptor lookup (perf #1418): answers
+/// "deleted / descriptor / none" in one descriptor-store probe so hot read
+/// paths don't pay for separate IsDeleted + TryGetOwn calls.
+/// </summary>
+internal enum PropertyDescriptorLookup
+{
+    None,
+    Deleted,
+    Found
+}
+
 internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
 {
     // Perf (#1417): descriptor reads vastly outnumber writes on hot property paths, so
@@ -281,6 +293,37 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
 
     public static bool TryGetOwn(object target, string key, out JsPropertyDescriptor descriptor)
         => CurrentStore.TryGetOwn(target, key, out descriptor);
+
+    /// <summary>
+    /// Unified single-probe own lookup (perf #1418). Combines the tombstone check
+    /// (<see cref="IsDeleted"/>) and descriptor fetch (<see cref="TryGetOwn(object, string, out JsPropertyDescriptor)"/>)
+    /// into one descriptor-store probe. Like <c>TryGetOwn</c>, the returned descriptor
+    /// is shared and must be cloned by callers that mutate it.
+    /// </summary>
+    internal static PropertyDescriptorLookup GetOwnLookup(object target, string key, out JsPropertyDescriptor descriptor)
+    {
+        ValidateTargetAndKey(target, key);
+
+        if (CurrentStore is PropertyDescriptorStore runtimeStore)
+        {
+            if (runtimeStore._overrideSlots.TryGetValue(target, out var slot)
+                && slot.Read().Overrides.TryGetValue(key, out var entry))
+            {
+                if (entry.Kind == PropertyDescriptorOverrideKind.Delete)
+                {
+                    descriptor = null!;
+                    return PropertyDescriptorLookup.Deleted;
+                }
+
+                descriptor = entry.Descriptor!;
+                return PropertyDescriptorLookup.Found;
+            }
+        }
+
+        return _intrinsicStore.TryGetOwn(target, key, out descriptor)
+            ? PropertyDescriptorLookup.Found
+            : PropertyDescriptorLookup.None;
+    }
 
     public static bool HasAny(object target)
         => CurrentStore.HasAny(target);


### PR DESCRIPTION
## Summary

Adds a faster property lookup dispatch path to `Object.GetProperty`, addressing the general-dispatch overhead identified in #1418 after #1416/#1417 (base for these measurements is master at 9f38b9468, which already includes the lock-free descriptor store from #1421).

Fixes #1418

## Design

**Unified single-probe own lookup** — new `PropertyDescriptorStore.GetOwnLookup(target, key, out descriptor)` answers *deleted / descriptor / none* in a single descriptor-store probe (one override-slot snapshot read, falling back to the intrinsic store). This is the "unified read API" secondary opportunity called out in #1417/#1418. Like `TryGetOwn`, the returned descriptor is shared and must be cloned before mutation.

**Fast dispatch in `GetProperty`** — plain JS objects (`JsObject` object literals, function-constructed `ExpandoObject` instances) are the overwhelmingly common hot receivers, and their own properties are authoritatively descriptor-backed (literal/assignment writes mirror a data descriptor). A new early path resolves them with one probe:

- descriptor found → return data value / invoke getter (same receiver semantics as before)
- no descriptor → dictionary-only entries return the dict value (mirrors existing `TryGetFastDictionaryOwnValue` behavior)
- miss or delete tombstone → fall through to the unchanged full ladder, so lazy class-method materialization, legacy `__proto__`, primitive wrappers, and inherited lookup keep their exact semantics

`Function.Prototype` is excluded from the fast path to preserve the restricted `caller`/`arguments` `TypeError`.

**Fewer redundant probes in the ladder** — `TryGetOwnPropertyValue` previously called `IsDeleted` then `TryGetOwn` (two probes, each with its own ThreadLocal + CWT lookups); it now makes one `GetOwnLookup` call. `TryGetFastDictionaryOwnValue`'s shadowing check also uses the single probe, explicitly preserving the prior behavior where a delete tombstone does not shadow the dictionary slot.

Before this change a single hot own-property read paid up to ~5 descriptor-store probes across `TryGetFastDictionaryOwnValue` → `TryGetOwnPropertyValue`; it now pays exactly one.

## Before/after measurements (Kraken `ai-astar`)

Same machine, same runner (in-memory compile via `JrocInMemoryCompiler` + `JsEngine.LoadModule`, timing `go()`), runs interleaved under quiet conditions, `before` built from master `9f38b9468` via a git worktree so both sides used identical conditions.

### Wall-clock execution of `go()`

| Run | Before (master) | After (this PR) |
|---|---:|---:|
| run 0 (cold, includes JIT warmup) | 88.5 s | 62.1 s |
| run 1 (warmed) | 71.5 s | 55.1 s |

**Warmed execution: 71.5 s → 55.1 s (~23% faster).**

### CPU trace (dotnet-trace, default profile, 1 iteration)

Top relevant frames, exclusive/inclusive % of total samples:

| Frame | Before | After |
|---|---|---|
| `Object.GetProperty` self / inclusive | 10.71% / 14.25% | 12.96% / 13.03% |
| `Object.TryGetOwnPropertyValue` self / inclusive | 3.28% / 3.43% | not in top 15 |
| `ObjectRuntime.GetItem(object, string)` inclusive | 14.58% | 13.66% |
| hot compiled fn `FunctionExpression_L50268C32` inclusive | 18.39% | 19.65% |

Reading the trace: `GetProperty`'s inclusive-vs-self gap collapsed (14.25/10.71 → 13.03/12.96) because callee work — the `IsDeleted` + `TryGetOwn` double probes and the `TryGetOwnPropertyValue` ladder — has been eliminated from the hot path; `TryGetOwnPropertyValue` dropped out of the top frames entirely. The remaining `GetProperty` self time is the single-probe dispatch itself, and percentages are of a ~23% smaller total. Script code (`FunctionExpression_...`) now takes a proportionally larger share, which is the desired shift.

## Acceptance criteria from #1418

1. ✅ `Object.GetProperty` inclusive time drops materially (14.25% → 13.03% of a ~23% smaller total; `TryGetOwnPropertyValue` no longer a top frame)
2. ✅ Correctness-sensitive cases preserved — Proxy, accessors, inherited properties, prototype mutation, array indices, primitive wrappers all still route through the unchanged ladder; fast path only handles descriptor-backed/dict own reads on plain objects
3. ✅ Common plain object/property reads observably cheaper (1 probe instead of up to ~5), no speculative assumptions — the descriptor store remains authoritative exactly as before

## Validation

- `Jroc.Tests` — Object/defineProperty/freeze/seal/delete/proto: 165 passed; Classes/Function/PrototypeChain/Getter/Accessor: 263 passed; Proxy/Symbol/ForIn/enumeration: 250 passed; Array/String/Literals: 146 passed
- `Jroc.Test262.Tests` — defineProperty/getOwnProperty/freeze/seal/delete/proto slices: 812 passed, 0 failed
