### PR TITLE
perf(runtime): plain JsObject reads skip descriptor store via HasNonDataDescriptors flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/runtime: skip the descriptor-store probe (`ConditionalWeakTable` lookup) entirely for plain object literal reads; `JsObject` now tracks a sticky `HasNonDataDescriptors` flag (set by accessors, `delete` tombstones, non-default `defineProperty` attributes, `seal`/`freeze`, intrinsic descriptors, and class-prototype mirror writes), and while it is clear `Object.GetProperty` answers own reads directly from the object's shape/slot dictionary. Object-literal property read loops run ~32% faster locally (10.9s → 7.4s microbenchmark). (#1418 follow-up)
 
 ## v0.11.19 - 2026-07-10
 

--- a/src/JavaScriptRuntime/JsObject.cs
+++ b/src/JavaScriptRuntime/JsObject.cs
@@ -97,6 +97,23 @@ public sealed class JsObject : IDictionary<string, object?>
 
     private JsShape _shape = JsShape.Empty;
 
+    // Perf (#1418 follow-up): sticky flag set when this object gains descriptor
+    // state that the plain dictionary cannot answer (accessors, delete tombstones,
+    // non-default attributes from defineProperty/seal/freeze, intrinsic descriptors).
+    // While the flag is clear, every own descriptor is a mirrored default data
+    // descriptor whose value matches the dictionary, so hot read paths can go
+    // straight to the dictionary and skip the descriptor store probe entirely.
+    private volatile bool _hasNonDataDescriptors;
+
+    /// <summary>
+    /// True when own reads can no longer be answered from the property dictionary
+    /// alone (the object has accessors, deleted tombstones, or attribute-bearing
+    /// descriptors). Sticky: once set it is never cleared.
+    /// </summary>
+    internal bool HasNonDataDescriptors => _hasNonDataDescriptors;
+
+    internal void MarkNonDataDescriptors() => _hasNonDataDescriptors = true;
+
     // -------------------------------------------------------------------------
     // Typed initializer methods used from generated IL (no boxing at call site)
     // -------------------------------------------------------------------------

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -5481,6 +5481,20 @@ namespace JavaScriptRuntime
             // Null/undefined -> undefined (modeled as null)
             if (obj is null) return null;
 
+            // Perf: plain JsObject fast path. While an object literal has only
+            // mirrored default data descriptors (no accessors, deletes, or
+            // attribute-bearing descriptors), its property dictionary is fully
+            // authoritative for own reads — answer directly from the shape/slot
+            // storage without probing the descriptor store (ConditionalWeakTable).
+            // Own misses fall through so prototype-chain and special-name
+            // semantics are preserved.
+            if (obj is JsObject plainJsObject && !plainJsObject.HasNonDataDescriptors)
+            {
+                if (plainJsObject.TryGetBoxedValue(name, out var plainValue))
+                {
+                    return plainValue;
+                }
+            }
             // Perf (#1418): fast dispatch for plain JS objects (object literals via
             // JsObject, function-constructed instances via ExpandoObject). Own
             // properties on these receivers are authoritatively descriptor-backed
@@ -5490,7 +5504,7 @@ namespace JavaScriptRuntime
             // rarely-taken paths (lazy class methods, __proto__, inheritance)
             // keep their existing semantics. Function.Prototype is excluded to
             // preserve the restricted 'caller'/'arguments' check.
-            if ((obj is JsObject || obj is System.Dynamic.ExpandoObject)
+            else if ((obj is JsObject || obj is System.Dynamic.ExpandoObject)
                 && !ReferenceEquals(obj, JavaScriptRuntime.Function.Prototype))
             {
                 var lookup = PropertyDescriptorStore.GetOwnLookup(obj, name, out var fastDesc);

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -166,6 +166,9 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
 
             if (TryGetMirroredRawClassPrototype(target, TryGetOwn, out var mirroredTarget))
             {
+                // Mirrored writes never sync the raw prototype's dictionary, so its
+                // plain-object read fast path must be disabled regardless of shape.
+                MarkJsObjectNonDataDescriptors(mirroredTarget);
                 DefineOrUpdateCore(mirroredTarget, key, descriptor);
             }
         }
@@ -207,6 +210,11 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
 
         private void DefineOrUpdateCore(object target, string key, JsPropertyDescriptor descriptor)
         {
+            // Intrinsic descriptors are defined during engine setup without a
+            // guaranteed dictionary sync, so any intrinsic entry disables the
+            // plain-object read fast path for JsObject targets.
+            MarkJsObjectNonDataDescriptors(target);
+
             if (target is Delegate del)
             {
                 Function.ClearDeletedMetadataProperty(del, key);
@@ -234,6 +242,8 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
 
         private bool DeleteCore(object target, string key)
         {
+            MarkJsObjectNonDataDescriptors(target);
+
             if (!_slots.TryGetValue(target, out var slot))
             {
                 return false;
@@ -261,6 +271,31 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
     private static readonly ThreadLocal<int> _intrinsicInitializationDepth = new(() => 0);
 
     private readonly ConditionalWeakTable<object, OverrideSlot> _overrideSlots = new();
+
+    /// <summary>
+    /// Marks a <see cref="JsObject"/> target whose descriptor state can no longer be
+    /// answered from its property dictionary alone, disabling the plain-object read
+    /// fast path for that instance. See <see cref="JsObject.HasNonDataDescriptors"/>.
+    /// </summary>
+    private static void MarkJsObjectNonDataDescriptors(object target)
+    {
+        if (target is JsObject jsObject)
+        {
+            jsObject.MarkNonDataDescriptors();
+        }
+    }
+
+    /// <summary>
+    /// True for the descriptor shape produced by plain assignment/literal mirror
+    /// writes (data, writable, enumerable, configurable). All writers of this shape
+    /// keep the target dictionary in sync, so such descriptors never invalidate the
+    /// plain-object read fast path.
+    /// </summary>
+    private static bool IsMirroredDefaultDataDescriptor(JsPropertyDescriptor descriptor)
+        => descriptor.Kind == JsPropertyDescriptorKind.Data
+            && descriptor.Writable
+            && descriptor.Enumerable
+            && descriptor.Configurable;
 
     public PropertyDescriptorStore()
     {
@@ -346,6 +381,10 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(target);
 
+        // Descriptor copies do not sync the target's property dictionary, so a
+        // JsObject target can no longer rely on the plain-object read fast path.
+        MarkJsObjectNonDataDescriptors(target);
+
         foreach (var key in GetOwnKeys(source))
         {
             if (TryGetOwn(source, key, out var descriptor))
@@ -428,6 +467,9 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
 
         if (TryGetMirroredRawClassPrototype(target, ((IPropertyDescriptorStore)this).TryGetOwn, out var mirroredTarget))
         {
+            // Mirrored writes never sync the raw prototype's dictionary, so its
+            // plain-object read fast path must be disabled regardless of shape.
+            MarkJsObjectNonDataDescriptors(mirroredTarget);
             DefineOrUpdateOverride(mirroredTarget, key, descriptor);
         }
     }
@@ -529,6 +571,13 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
 
     private void DefineOrUpdateOverride(object target, string key, JsPropertyDescriptor descriptor)
     {
+        // Non-default descriptors (accessors, restricted attributes) make the
+        // dictionary non-authoritative for reads on JsObject targets.
+        if (!IsMirroredDefaultDataDescriptor(descriptor))
+        {
+            MarkJsObjectNonDataDescriptors(target);
+        }
+
         if (target is Delegate del)
         {
             Function.ClearDeletedMetadataProperty(del, key);
@@ -569,6 +618,9 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
 
     private bool DeleteOverride(object target, string key)
     {
+        // Delete tombstones are only visible through the descriptor store.
+        MarkJsObjectNonDataDescriptors(target);
+
         var hasIntrinsic = _intrinsicStore.TryGetOwn(target, key, out _);
         var slot = _overrideSlots.GetOrCreateValue(target);
 


### PR DESCRIPTION
# perf(runtime): plain JsObject reads skip the descriptor store

Follow-up to #1418. Adds the optimization discussed while profiling the ai-astar trace: `ConditionalWeakTable` descriptor-store probes were the top remaining callee cost under `ObjectRuntime.GetItem` / `Object.GetProperty` (~3.3% CWT + 1.8% Dictionary in the trace), even though most objects never use descriptor features.

## Change

- `JsObject` gains a sticky `HasNonDataDescriptors` flag. While clear, every own descriptor is a mirrored default data descriptor whose value matches the property dictionary, so `Object.GetProperty` answers own reads **directly from the shape/slot dictionary** — no `ConditionalWeakTable` probe at all. Own misses fall through to the full ladder, preserving prototype-chain and special-name semantics.
- The flag is set (and never cleared) by anything that makes the dictionary non-authoritative:
  - accessor or attribute-bearing descriptors (`Object.defineProperty`, `seal`, `freeze`)
  - `delete` tombstones
  - intrinsic-store descriptors (defined during engine setup without dictionary sync)
  - `CopyOwnProperties` targets and class-prototype mirror writes (descriptor-only, no dict sync)
- Rationale: real-world hot code overwhelmingly uses plain data properties; `defineProperty`/`freeze`/accessors are rare and setup-time. Objects that use them simply keep today's descriptor-backed path.

## Measurements (local, warmed runs)

Object-literal property read microbenchmark (1000 literals × 20k iterations of `n.x + n.y + n.f + n.g` reads):

| | run 0 | run 1 | run 2 |
|---|---|---|---|
| master | 11.16 s | 10.83 s | 10.85 s |
| this PR | 6.80 s | 7.66 s | 7.60 s |

**~32% faster** on literal-heavy reads.

Kraken `ai-astar` is unchanged (47.4s → 47.3s): its hot `GraphNode` objects are function-constructed and therefore `ExpandoObject` receivers, which cannot carry an instance flag (sealed BCL type). Extending the same idea to constructed instances would require replacing `ExpandoObject` as the instance backing type — noted as possible follow-up work.

## Validation

- `Jroc.Tests` slices: Object/defineProperty/freeze/seal/delete/proto/getter/accessor/literals (329 passed), classes/function/for-in/enumeration/spread/destructuring/JSON (338 passed)
- `Jroc.Test262.Tests` slice: defineProperty/getOwnProperty/freeze/seal/delete/proto (812 passed, 2 skipped)
