### PR TITLE
feat(compiler): object literal shape eligibility analysis (#1429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- compiler/analysis: add object literal shape eligibility analysis (issue #1429, parent #1428). `SymbolTableBuilder` now records an `ObjectLiteralShapeInfo` on bindings declared with object literal initializers, conservatively proving whether every use of the binding is safe for future early-bound, strongly-typed CLR member access (any escape, reassignment, `delete`, computed access, spread, enumeration, export, or unresolvable member operation disqualifies). Analysis only; no codegen consumes the result yet.
+- compiler/fix: `AstWalker` now traverses into `SpreadElement` arguments (previously identifiers inside `...expr` in object/array literals and call arguments were invisible to AST analyses).
 
 ## v0.11.20 - 2026-07-10
 

--- a/src/Compiler/SymbolTable/BindingInfo.cs
+++ b/src/Compiler/SymbolTable/BindingInfo.cs
@@ -102,6 +102,14 @@ public class BindingInfo
     /// </summary>
     public bool RequiresRuntimeTemporalDeadZoneChecks { get; set; }
 
+    /// <summary>
+    /// Shape analysis result when this binding is declared with an object literal initializer.
+    /// Populated by <c>SymbolTableBuilder.AnalyzeObjectLiteralShapes</c>; null when the binding
+    /// is not an object-literal declaration. Consumers must check
+    /// <see cref="ObjectLiteralShapeInfo.IsEligible"/> before early-binding member access.
+    /// </summary>
+    public ObjectLiteralShapeInfo? ObjectLiteralShape { get; set; }
+
     public BindingInfo(string name, BindingKind kind, Scope declaringScope, Node declarationNode)
     {
         Name = name;

--- a/src/Compiler/SymbolTable/ObjectLiteralShapeInfo.cs
+++ b/src/Compiler/SymbolTable/ObjectLiteralShapeInfo.cs
@@ -1,0 +1,100 @@
+using Acornima.Ast;
+using System;
+using System.Collections.Generic;
+
+namespace Jroc.SymbolTables;
+
+/// <summary>
+/// Describes a single member of an object literal that is a candidate for
+/// early-bound, strongly-typed CLR member access (see issue #1428/#1429).
+/// </summary>
+public sealed class ObjectLiteralMemberInfo
+{
+    public ObjectLiteralMemberInfo(string name, Node valueNode, Type? clrType, bool isFunction)
+    {
+        Name = name;
+        ValueNode = valueNode;
+        ClrType = clrType;
+        IsFunction = isFunction;
+    }
+
+    /// <summary>Member name in literal source order.</summary>
+    public string Name { get; }
+
+    /// <summary>The AST node of the member's initializer value.</summary>
+    public Node ValueNode { get; }
+
+    /// <summary>
+    /// Conservative stable CLR type for the member value
+    /// (typeof(double), typeof(bool) or typeof(string)); null means boxed object.
+    /// A member only keeps an unboxed type when every observed write agrees.
+    /// </summary>
+    public Type? ClrType { get; internal set; }
+
+    /// <summary>
+    /// True when the member value is a function expression / arrow function and the
+    /// member is never reassigned. Demoted to a plain data member on any write.
+    /// </summary>
+    public bool IsFunction { get; internal set; }
+}
+
+/// <summary>
+/// Result of the compile-time eligibility analysis for a single object literal bound
+/// to a local/module binding. When <see cref="IsEligible"/> is true, later phases may
+/// generate a specialized CLR type and early-bind member accesses; otherwise the
+/// literal must compile exactly as today (plain JsObject).
+/// </summary>
+public sealed class ObjectLiteralShapeInfo
+{
+    public ObjectLiteralShapeInfo(ObjectExpression literal, BindingInfo binding, IReadOnlyList<ObjectLiteralMemberInfo> members)
+    {
+        Literal = literal;
+        Binding = binding;
+        Members = members;
+        IsEligible = true;
+    }
+
+    /// <summary>The object literal expression this shape describes.</summary>
+    public ObjectExpression Literal { get; }
+
+    /// <summary>The binding the literal is assigned to at its declaration.</summary>
+    public BindingInfo Binding { get; }
+
+    /// <summary>Members in literal source order.</summary>
+    public IReadOnlyList<ObjectLiteralMemberInfo> Members { get; }
+
+    /// <summary>
+    /// True when every use of the binding is provably safe for early binding.
+    /// The analysis is strictly conservative: any use it cannot prove safe disqualifies.
+    /// </summary>
+    public bool IsEligible { get; private set; }
+
+    /// <summary>First reason the literal was disqualified; null while eligible.</summary>
+    public string? DisqualifyReason { get; private set; }
+
+    internal void Disqualify(string reason)
+    {
+        if (!IsEligible)
+        {
+            return;
+        }
+
+        IsEligible = false;
+        DisqualifyReason = reason;
+    }
+
+    internal bool TryGetMember(string name, out ObjectLiteralMemberInfo member)
+    {
+        foreach (var candidate in Members)
+        {
+            if (string.Equals(candidate.Name, name, StringComparison.Ordinal))
+            {
+                member = candidate;
+                return true;
+            }
+        }
+
+        member = null!;
+        return false;
+    }
+}

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.ObjectLiteralShapes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.ObjectLiteralShapes.cs
@@ -1,0 +1,484 @@
+using Acornima;
+using Acornima.Ast;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Jroc.SymbolTables;
+
+/// <summary>
+/// Object literal shape eligibility analysis (issue #1429, parent #1428).
+///
+/// Decides, per object literal bound to a local/module binding, whether every use of the
+/// binding is provably safe for early-bound, strongly-typed CLR member access. The analysis
+/// is strictly conservative: any construct it cannot prove safe disqualifies the literal and
+/// the literal compiles exactly as today (plain JsObject). This pass performs analysis only;
+/// no codegen consumes the result yet.
+/// </summary>
+public partial class SymbolTableBuilder
+{
+    /// <summary>
+    /// Analyzes all object literals assigned to bindings at their declaration and records an
+    /// <see cref="ObjectLiteralShapeInfo"/> on each binding describing eligibility for
+    /// early-bound member access.
+    /// </summary>
+    private void AnalyzeObjectLiteralShapes(Scope root)
+    {
+        var candidates = CollectObjectLiteralShapeCandidates(root);
+        if (candidates.Count == 0)
+        {
+            return;
+        }
+
+        var parentMap = BuildParentMap(root.AstNode);
+        var scopeMap = BuildNodeScopeMap(root);
+
+        foreach (var shape in candidates.Values)
+        {
+            ValidateObjectLiteralStructure(shape);
+            CheckDeclarationContext(shape, parentMap);
+        }
+
+        AnalyzeObjectLiteralBindingUses(root.AstNode, candidates, parentMap, scopeMap);
+
+        foreach (var shape in candidates.Values)
+        {
+            shape.Binding.ObjectLiteralShape = shape;
+        }
+    }
+
+    private Dictionary<BindingInfo, ObjectLiteralShapeInfo> CollectObjectLiteralShapeCandidates(Scope root)
+    {
+        var candidates = new Dictionary<BindingInfo, ObjectLiteralShapeInfo>();
+
+        foreach (var scope in EnumerateScopes(root))
+        {
+            foreach (var binding in scope.Bindings.Values)
+            {
+                if (binding.DeclarationNode is not VariableDeclarator declarator
+                    || declarator.Id is not Identifier id
+                    || !string.Equals(id.Name, binding.Name, StringComparison.Ordinal)
+                    || declarator.Init is not ObjectExpression literal)
+                {
+                    continue;
+                }
+
+                if (binding.Kind != BindingKind.Const
+                    && binding.Kind != BindingKind.Let
+                    && binding.Kind != BindingKind.Var)
+                {
+                    continue;
+                }
+
+                var members = new List<ObjectLiteralMemberInfo>();
+                foreach (var propertyNode in literal.Properties)
+                {
+                    if (propertyNode is Property { Kind: PropertyKind.Init, Computed: false } property
+                        && property.Key is Identifier keyIdentifier
+                        && property.Value is Node valueNode)
+                    {
+                        var isFunction = valueNode is FunctionExpression or ArrowFunctionExpression;
+                        members.Add(new ObjectLiteralMemberInfo(
+                            keyIdentifier.Name,
+                            valueNode,
+                            isFunction ? null : InferObjectLiteralMemberClrType(valueNode),
+                            isFunction));
+                    }
+                    else
+                    {
+                        // Structure violations are recorded during validation; keep a placeholder
+                        // member list so the shape still reports the disqualify reason.
+                        members.Clear();
+                        break;
+                    }
+                }
+
+                candidates[binding] = new ObjectLiteralShapeInfo(literal, binding, members);
+            }
+        }
+
+        return candidates;
+    }
+
+    private static void ValidateObjectLiteralStructure(ObjectLiteralShapeInfo shape)
+    {
+        var literal = shape.Literal;
+        if (literal.Properties.Count == 0)
+        {
+            shape.Disqualify("literal has no members");
+            return;
+        }
+
+        var seenNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var propertyNode in literal.Properties)
+        {
+            if (propertyNode is SpreadElement)
+            {
+                shape.Disqualify("spread element in literal");
+                return;
+            }
+
+            if (propertyNode is not Property property)
+            {
+                shape.Disqualify($"unsupported literal member node '{propertyNode.Type}'");
+                return;
+            }
+
+            if (property.Kind != PropertyKind.Init)
+            {
+                shape.Disqualify("getter/setter member in literal");
+                return;
+            }
+
+            if (property.Computed)
+            {
+                shape.Disqualify("computed key in literal");
+                return;
+            }
+
+            if (property.Key is not Identifier keyIdentifier)
+            {
+                shape.Disqualify("non-identifier key in literal");
+                return;
+            }
+
+            if (string.Equals(keyIdentifier.Name, "__proto__", StringComparison.Ordinal))
+            {
+                shape.Disqualify("__proto__ key in literal");
+                return;
+            }
+
+            if (!seenNames.Add(keyIdentifier.Name))
+            {
+                shape.Disqualify($"duplicate key '{keyIdentifier.Name}' in literal");
+                return;
+            }
+        }
+    }
+
+    private static void CheckDeclarationContext(ObjectLiteralShapeInfo shape, Dictionary<Node, Node> parentMap)
+    {
+        // export const a = { ... } — the binding escapes the module.
+        var node = shape.Binding.DeclarationNode;
+        while (node != null && parentMap.TryGetValue(node, out var parent))
+        {
+            if (parent is ExportNamedDeclaration or ExportDefaultDeclaration or ExportAllDeclaration)
+            {
+                shape.Disqualify("binding is exported from the module");
+                return;
+            }
+
+            if (parent is not VariableDeclaration)
+            {
+                return;
+            }
+
+            node = parent;
+        }
+    }
+
+    private void AnalyzeObjectLiteralBindingUses(
+        Node rootNode,
+        Dictionary<BindingInfo, ObjectLiteralShapeInfo> candidates,
+        Dictionary<Node, Node> parentMap,
+        Dictionary<Node, Scope> scopeMap)
+    {
+        var candidateNames = new HashSet<string>(candidates.Keys.Select(b => b.Name), StringComparer.Ordinal);
+        var walker = new Jroc.Utilities.AstWalker();
+
+        walker.Visit(rootNode, node =>
+        {
+            if (node is not Identifier identifier || !candidateNames.Contains(identifier.Name))
+            {
+                return;
+            }
+
+            if (!scopeMap.TryGetValue(identifier, out var scope))
+            {
+                return;
+            }
+
+            var binding = TryResolveBinding(scope, identifier.Name);
+            if (binding == null || !candidates.TryGetValue(binding, out var shape) || !shape.IsEligible)
+            {
+                return;
+            }
+
+            if (!IsBindingValueReference(identifier, parentMap))
+            {
+                return;
+            }
+
+            AnalyzeObjectLiteralUse(shape, identifier, parentMap);
+        });
+    }
+
+    /// <summary>
+    /// Filters out identifier nodes that are not value references to the binding
+    /// (declaration names, member property names, object literal keys, labels).
+    /// </summary>
+    private static bool IsBindingValueReference(Identifier identifier, Dictionary<Node, Node> parentMap)
+    {
+        if (!parentMap.TryGetValue(identifier, out var parent))
+        {
+            return false;
+        }
+
+        return parent switch
+        {
+            // The declaration itself (const a = ...) is not a use.
+            VariableDeclarator declarator when ReferenceEquals(declarator.Id, identifier) => false,
+            // obj.a — property-name position, not a reference to the binding.
+            MemberExpression member when !member.Computed && ReferenceEquals(member.Property, identifier) => false,
+            // { a: ... } — key position.
+            Property property when !property.Computed && ReferenceEquals(property.Key, identifier) => false,
+            FunctionDeclaration functionDeclaration when ReferenceEquals(functionDeclaration.Id, identifier) => false,
+            FunctionExpression functionExpression when ReferenceEquals(functionExpression.Id, identifier) => false,
+            ClassDeclaration classDeclaration when ReferenceEquals(classDeclaration.Id, identifier) => false,
+            LabeledStatement => false,
+            _ => true
+        };
+    }
+
+    /// <summary>
+    /// Evaluates one value reference to a candidate binding. Only a small whitelist of
+    /// contexts is considered safe; everything else disqualifies the shape.
+    /// </summary>
+    private void AnalyzeObjectLiteralUse(
+        ObjectLiteralShapeInfo shape,
+        Identifier identifier,
+        Dictionary<Node, Node> parentMap)
+    {
+        parentMap.TryGetValue(identifier, out var parent);
+
+        switch (parent)
+        {
+            // obj.p — static member access on the object; validated below.
+            case MemberExpression member when ReferenceEquals(member.Object, identifier):
+                AnalyzeObjectLiteralMemberAccess(shape, member, parentMap);
+                return;
+
+            // typeof obj — always "object"; observes nothing about the members.
+            case NonUpdateUnaryExpression { Operator: Operator.TypeOf }:
+                return;
+
+            // Reassignment of the binding itself invalidates everything.
+            case AssignmentExpression assignment when ReferenceEquals(assignment.Left, identifier):
+                shape.Disqualify("binding is reassigned");
+                return;
+
+            case UpdateExpression update when ReferenceEquals(update.Argument, identifier):
+                shape.Disqualify("binding is reassigned");
+                return;
+
+            case CallExpression:
+            case NewExpression:
+                shape.Disqualify("object passed to a call");
+                return;
+
+            case ReturnStatement:
+            case ArrowFunctionExpression: // concise-body arrow return
+                shape.Disqualify("object returned from a function");
+                return;
+
+            case Property:
+            case ArrayExpression:
+                shape.Disqualify("object stored into another object or array");
+                return;
+
+            case AssignmentExpression assignment when ReferenceEquals(assignment.Right, identifier):
+                shape.Disqualify("object stored through an assignment");
+                return;
+
+            case VariableDeclarator declarator when ReferenceEquals(declarator.Init, identifier):
+                shape.Disqualify("object aliased to another binding");
+                return;
+
+            case SpreadElement:
+                shape.Disqualify("object used in a spread");
+                return;
+
+            case ForInStatement:
+            case ForOfStatement:
+                shape.Disqualify("object enumerated by for-in/for-of");
+                return;
+
+            case NonUpdateUnaryExpression { Operator: Operator.Delete }:
+                shape.Disqualify("delete applied to the binding");
+                return;
+
+            case BinaryExpression { Operator: Operator.In } binary when ReferenceEquals(binary.Right, identifier):
+                shape.Disqualify("object used with the 'in' operator");
+                return;
+
+            case ExportNamedDeclaration:
+            case ExportDefaultDeclaration:
+            case ExportSpecifier:
+                shape.Disqualify("object exported from the module");
+                return;
+
+            default:
+                shape.Disqualify($"object used in unsupported context '{parent?.Type.ToString() ?? "unknown"}'");
+                return;
+        }
+    }
+
+    private void AnalyzeObjectLiteralMemberAccess(
+        ObjectLiteralShapeInfo shape,
+        MemberExpression member,
+        Dictionary<Node, Node> parentMap)
+    {
+        if (member.Computed)
+        {
+            shape.Disqualify("computed member access on the object");
+            return;
+        }
+
+        if (member.Property is not Identifier propertyIdentifier)
+        {
+            shape.Disqualify("non-identifier member access on the object");
+            return;
+        }
+
+        if (!shape.TryGetMember(propertyIdentifier.Name, out var memberInfo))
+        {
+            shape.Disqualify($"access to undeclared member '{propertyIdentifier.Name}'");
+            return;
+        }
+
+        parentMap.TryGetValue(member, out var accessParent);
+
+        switch (accessParent)
+        {
+            // delete obj.p — member disappears; early binding would be incorrect.
+            case NonUpdateUnaryExpression { Operator: Operator.Delete }:
+                shape.Disqualify($"delete of member '{memberInfo.Name}'");
+                return;
+
+            // obj.p = v (including compound assignments, which read then write).
+            case AssignmentExpression assignment when ReferenceEquals(assignment.Left, member):
+                RecordObjectLiteralMemberWrite(shape, memberInfo, assignment);
+                return;
+
+            // obj.p++ / --obj.p — numeric read-modify-write.
+            case UpdateExpression:
+                RecordObjectLiteralMemberWriteType(memberInfo, typeof(double));
+                return;
+
+            // obj.p(...) — method call; obj becomes `this` inside the callee.
+            case CallExpression call when ReferenceEquals(call.Callee, member):
+                AnalyzeObjectLiteralMethodCall(shape, memberInfo);
+                return;
+
+            default:
+                // Plain read in any expression context is safe: the member value (not the
+                // object) is what flows onward.
+                return;
+        }
+    }
+
+    private static void RecordObjectLiteralMemberWrite(
+        ObjectLiteralShapeInfo shape,
+        ObjectLiteralMemberInfo memberInfo,
+        AssignmentExpression assignment)
+    {
+        Type? writtenType = null;
+        if (assignment.Operator == Operator.Assignment)
+        {
+            writtenType = InferObjectLiteralMemberClrType(assignment.Right);
+        }
+        else
+        {
+            // Compound assignments other than string concatenation produce numbers; `+=` can
+            // produce strings. Treat only provably numeric operators as double.
+            writtenType = assignment.Operator switch
+            {
+                Operator.SubtractionAssignment
+                    or Operator.MultiplicationAssignment
+                    or Operator.DivisionAssignment
+                    or Operator.RemainderAssignment
+                    or Operator.ExponentiationAssignment
+                    or Operator.BitwiseAndAssignment
+                    or Operator.BitwiseOrAssignment
+                    or Operator.BitwiseXorAssignment
+                    or Operator.LeftShiftAssignment
+                    or Operator.RightShiftAssignment
+                    or Operator.UnsignedRightShiftAssignment => typeof(double),
+                _ => null
+            };
+        }
+
+        RecordObjectLiteralMemberWriteType(memberInfo, writtenType);
+    }
+
+    private static void RecordObjectLiteralMemberWriteType(ObjectLiteralMemberInfo memberInfo, Type? writtenType)
+    {
+        // Any write demotes a function member to a plain data member.
+        memberInfo.IsFunction = false;
+
+        if (memberInfo.ClrType != null && memberInfo.ClrType != writtenType)
+        {
+            memberInfo.ClrType = null;
+        }
+    }
+
+    private void AnalyzeObjectLiteralMethodCall(ObjectLiteralShapeInfo shape, ObjectLiteralMemberInfo memberInfo)
+    {
+        if (!memberInfo.IsFunction)
+        {
+            shape.Disqualify($"call of non-function member '{memberInfo.Name}'");
+            return;
+        }
+
+        // Calling obj.p() passes obj as `this` into the callee. That is only safe when the
+        // callee provably never observes `this` (arrows capture lexical `this` instead).
+        if (memberInfo.ValueNode is ArrowFunctionExpression)
+        {
+            return;
+        }
+
+        if (FunctionObservesThis(memberInfo.ValueNode))
+        {
+            shape.Disqualify($"member '{memberInfo.Name}' is called and its body uses 'this'");
+        }
+    }
+
+    private readonly Dictionary<Node, bool> _functionObservesThisCache = new(ReferenceEqualityComparer.Instance);
+
+    private bool FunctionObservesThis(Node functionNode)
+    {
+        if (_functionObservesThisCache.TryGetValue(functionNode, out var cached))
+        {
+            return cached;
+        }
+
+        // Conservative: any ThisExpression anywhere in the body disqualifies, including inside
+        // nested functions (they could still be invoked with the object as `this` through
+        // aliases this pass does not track).
+        var observes = false;
+        var walker = new Jroc.Utilities.AstWalker();
+        walker.Visit(functionNode, node =>
+        {
+            if (node is ThisExpression)
+            {
+                observes = true;
+            }
+        });
+
+        _functionObservesThisCache[functionNode] = observes;
+        return observes;
+    }
+
+    private static Type? InferObjectLiteralMemberClrType(Node valueNode)
+    {
+        return valueNode switch
+        {
+            NumericLiteral => typeof(double),
+            BooleanLiteral => typeof(bool),
+            StringLiteral => typeof(string),
+            NonUpdateUnaryExpression { Operator: Operator.UnaryNegation or Operator.UnaryPlus } unary
+                when unary.Argument is NumericLiteral => typeof(double),
+            _ => null
+        };
+    }
+}

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.cs
@@ -250,6 +250,11 @@ namespace Jroc.SymbolTables
             InferCallableParameterClrTypes(globalScope);
             InferVariableClrTypes(globalScope);
             InferCallableReturnClrTypes(globalScope);
+
+            // Object literal shape eligibility analysis (issue #1429). Runs last so member
+            // type inference can rely on final variable/parameter/return type conclusions.
+            AnalyzeObjectLiteralShapes(globalScope);
+
             module.SymbolTable = new SymbolTable(globalScope);
         }
 

--- a/src/Compiler/Utilities/AstWalker.cs
+++ b/src/Compiler/Utilities/AstWalker.cs
@@ -146,6 +146,10 @@ public class AstWalker
                 VisitNodes(objExpr.Properties, visitor);
                 break;
 
+            case SpreadElement spreadElement:
+                Visit(spreadElement.Argument, visitor);
+                break;
+
             case Property prop:
                 Visit(prop.Key, visitor);
                 Visit(prop.Value, visitor);
@@ -377,6 +381,10 @@ public class AstWalker
 
             case ObjectExpression objExpr:
                 VisitNodesWithContext(objExpr.Properties, enterNode, exitNode);
+                break;
+
+            case SpreadElement spreadElement:
+                VisitWithContext(spreadElement.Argument, enterNode, exitNode);
                 break;
 
             case Property prop:

--- a/tests/Jroc.Tests/SymbolTable/ObjectLiteralShapeAnalysisTests.cs
+++ b/tests/Jroc.Tests/SymbolTable/ObjectLiteralShapeAnalysisTests.cs
@@ -1,0 +1,368 @@
+using Acornima.Ast;
+using Jroc.SymbolTables;
+using Jroc.Services;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Jroc.Tests;
+
+/// <summary>
+/// Tests for the object literal shape eligibility analysis (issue #1429).
+/// The analysis must be strictly conservative: only provably-safe literals qualify.
+/// </summary>
+public class ObjectLiteralShapeAnalysisTests
+{
+    private readonly JavaScriptParser _parser = new();
+    private readonly SymbolTableBuilder _scopeBuilder = new();
+
+    private SymbolTable BuildSymbolTable(string code)
+    {
+        var ast = _parser.ParseJavaScript(code, "test.js");
+        var module = new ModuleDefinition
+        {
+            Ast = ast,
+            Path = "test.js",
+            Name = "test",
+            ModuleId = "test"
+        };
+        _scopeBuilder.Build(module);
+        return module.SymbolTable!;
+    }
+
+    private ObjectLiteralShapeInfo GetShape(string code, string bindingName)
+    {
+        var symbolTable = BuildSymbolTable(code);
+        var binding = symbolTable.GetBindingInfo(bindingName);
+        Assert.NotNull(binding);
+        Assert.NotNull(binding!.ObjectLiteralShape);
+        return binding.ObjectLiteralShape!;
+    }
+
+    // ---------------------------------------------------------------------
+    // Eligible cases
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Eligible_ConstLiteral_StaticReadsOnly()
+    {
+        var shape = GetShape(
+            @"const a = { b: 'hello', n: 42, f: true };
+              console.log(a.b);
+              console.log(a.n);
+              console.log(a.f);",
+            "a");
+
+        Assert.True(shape.IsEligible, shape.DisqualifyReason);
+        Assert.Equal(new[] { "b", "n", "f" }, shape.Members.Select(m => m.Name));
+        Assert.Equal(typeof(string), shape.Members[0].ClrType);
+        Assert.Equal(typeof(double), shape.Members[1].ClrType);
+        Assert.Equal(typeof(bool), shape.Members[2].ClrType);
+    }
+
+    [Fact]
+    public void Eligible_StaticMemberWrites_KeepStableType()
+    {
+        var shape = GetShape(
+            @"const a = { n: 1 };
+              a.n = 2;
+              a.n = 3;
+              console.log(a.n);",
+            "a");
+
+        Assert.True(shape.IsEligible, shape.DisqualifyReason);
+        Assert.Equal(typeof(double), shape.Members[0].ClrType);
+    }
+
+    [Fact]
+    public void Eligible_MixedTypeWrite_DemotesMemberToObject()
+    {
+        var shape = GetShape(
+            @"const a = { n: 1 };
+              a.n = 'now a string';
+              console.log(a.n);",
+            "a");
+
+        Assert.True(shape.IsEligible, shape.DisqualifyReason);
+        Assert.Null(shape.Members[0].ClrType);
+    }
+
+    [Fact]
+    public void Eligible_UpdateExpression_KeepsNumericType()
+    {
+        var shape = GetShape(
+            @"const a = { n: 1 };
+              a.n++;
+              console.log(a.n);",
+            "a");
+
+        Assert.True(shape.IsEligible, shape.DisqualifyReason);
+        Assert.Equal(typeof(double), shape.Members[0].ClrType);
+    }
+
+    [Fact]
+    public void Eligible_VarBinding_NeverReassigned()
+    {
+        var shape = GetShape(
+            @"var a = { b: 1 };
+              console.log(a.b);",
+            "a");
+
+        Assert.True(shape.IsEligible, shape.DisqualifyReason);
+    }
+
+    [Fact]
+    public void Eligible_FunctionMember_CalledWithoutThis()
+    {
+        var shape = GetShape(
+            @"const a = { go: function (x) { return x + 1; } };
+              console.log(a.go(1));",
+            "a");
+
+        Assert.True(shape.IsEligible, shape.DisqualifyReason);
+        Assert.True(shape.Members[0].IsFunction);
+    }
+
+    [Fact]
+    public void Eligible_ReadInsideClosure()
+    {
+        var shape = GetShape(
+            @"const a = { b: 1 };
+              function reader() { return a.b; }
+              console.log(reader());",
+            "a");
+
+        Assert.True(shape.IsEligible, shape.DisqualifyReason);
+    }
+
+    [Fact]
+    public void Eligible_TypeofUse()
+    {
+        var shape = GetShape(
+            @"const a = { b: 1 };
+              console.log(typeof a);",
+            "a");
+
+        Assert.True(shape.IsEligible, shape.DisqualifyReason);
+    }
+
+    [Fact]
+    public void Eligible_ShadowedNameDoesNotDisqualify()
+    {
+        // The inner `a` is a different binding; passing it to a call must not
+        // disqualify the outer literal.
+        var shape = GetShape(
+            @"const a = { b: 1 };
+              function inner(a) { console.log(a); }
+              inner(42);
+              console.log(a.b);",
+            "a");
+
+        Assert.True(shape.IsEligible, shape.DisqualifyReason);
+    }
+
+    // ---------------------------------------------------------------------
+    // Disqualified: unsafe uses of the binding
+    // ---------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("callUnknown(a);", "object passed to a call")]
+    [InlineData("new Holder(a);", "object passed to a call")]
+    [InlineData("function f() { return a; } f();", "object returned from a function")]
+    [InlineData("const other = { nested: a };", "object stored into another object or array")]
+    [InlineData("const arr = [a];", "object stored into another object or array")]
+    [InlineData("let alias = a;", "object aliased to another binding")]
+    [InlineData("target.prop = a;", "object stored through an assignment")]
+    [InlineData("const copy = { ...a };", "object used in a spread")]
+    [InlineData("for (const k in a) { console.log(k); }", "object enumerated by for-in/for-of")]
+    [InlineData("console.log('b' in a);", "object used with the 'in' operator")]
+    public void Disqualified_UnsafeBindingUse(string usage, string expectedReasonFragment)
+    {
+        var code = $@"const a = {{ b: 1 }};
+              function callUnknown(x) {{ console.log(x); }}
+              function Holder(x) {{ this.x = x; }}
+              const target = {{ prop: 0 }};
+              {usage}
+              console.log(a.b);";
+
+        var shape = GetShape(code, "a");
+        Assert.False(shape.IsEligible);
+        Assert.Contains(expectedReasonFragment, shape.DisqualifyReason);
+    }
+
+    [Fact]
+    public void Disqualified_BindingReassigned()
+    {
+        var shape = GetShape(
+            @"let a = { b: 1 };
+              a = { b: 2 };
+              console.log(a.b);",
+            "a");
+
+        Assert.False(shape.IsEligible);
+        Assert.Contains("reassigned", shape.DisqualifyReason);
+    }
+
+    // ---------------------------------------------------------------------
+    // Disqualified: unsafe member operations
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Disqualified_DeleteMember()
+    {
+        var shape = GetShape(
+            @"const a = { b: 1 };
+              delete a.b;
+              console.log(a.b);",
+            "a");
+
+        Assert.False(shape.IsEligible);
+        Assert.Contains("delete", shape.DisqualifyReason);
+    }
+
+    [Fact]
+    public void Disqualified_ComputedMemberAccess()
+    {
+        var shape = GetShape(
+            @"const a = { b: 1 };
+              const k = 'b';
+              console.log(a[k]);",
+            "a");
+
+        Assert.False(shape.IsEligible);
+        Assert.Contains("computed member access", shape.DisqualifyReason);
+    }
+
+    [Fact]
+    public void Disqualified_UndeclaredMemberAccess()
+    {
+        var shape = GetShape(
+            @"const a = { b: 1 };
+              a.c = 2;
+              console.log(a.b);",
+            "a");
+
+        Assert.False(shape.IsEligible);
+        Assert.Contains("undeclared member 'c'", shape.DisqualifyReason);
+    }
+
+    [Fact]
+    public void Disqualified_ObjectFreeze()
+    {
+        var shape = GetShape(
+            @"const a = { b: 1 };
+              Object.freeze(a);
+              console.log(a.b);",
+            "a");
+
+        Assert.False(shape.IsEligible);
+        Assert.Contains("object passed to a call", shape.DisqualifyReason);
+    }
+
+    [Fact]
+    public void Disqualified_ObjectDefineProperty()
+    {
+        var shape = GetShape(
+            @"const a = { b: 1 };
+              Object.defineProperty(a, 'b', { value: 2 });
+              console.log(a.b);",
+            "a");
+
+        Assert.False(shape.IsEligible);
+        Assert.Contains("object passed to a call", shape.DisqualifyReason);
+    }
+
+    [Fact]
+    public void Disqualified_MethodCallWhoseBodyUsesThis()
+    {
+        var shape = GetShape(
+            @"const a = { n: 1, go: function () { return this.n; } };
+              console.log(a.go());",
+            "a");
+
+        Assert.False(shape.IsEligible);
+        Assert.Contains("uses 'this'", shape.DisqualifyReason);
+    }
+
+    // ---------------------------------------------------------------------
+    // Disqualified: unsafe literal structure
+    // ---------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("{}", "no members")]
+    [InlineData("{ ...src }", "spread element")]
+    [InlineData("{ get b() { return 1; } }", "getter/setter")]
+    [InlineData("{ set b(v) { } }", "getter/setter")]
+    [InlineData("{ ['b']: 1 }", "computed key")]
+    [InlineData("{ 'b': 1 }", "non-identifier key")]
+    [InlineData("{ 1: 'one' }", "non-identifier key")]
+    [InlineData("{ __proto__: null }", "__proto__")]
+    [InlineData("{ b: 1, b: 2 }", "duplicate key 'b'")]
+    public void Disqualified_UnsafeLiteralStructure(string literal, string expectedReasonFragment)
+    {
+        var code = $@"const src = {{ x: 1 }};
+              const a = {literal};
+              console.log(a);";
+
+        var symbolTable = BuildSymbolTable(code);
+        var binding = symbolTable.GetBindingInfo("a");
+        Assert.NotNull(binding);
+        var shape = binding!.ObjectLiteralShape;
+        Assert.NotNull(shape);
+        Assert.False(shape!.IsEligible);
+        Assert.Contains(expectedReasonFragment, shape.DisqualifyReason);
+    }
+
+    // ---------------------------------------------------------------------
+    // Member metadata
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void FunctionMember_DemotedToDataOnWrite()
+    {
+        var shape = GetShape(
+            @"const a = { go: function () { return 1; } };
+              a.go = 5;
+              console.log(a.go);",
+            "a");
+
+        Assert.True(shape.IsEligible, shape.DisqualifyReason);
+        Assert.False(shape.Members[0].IsFunction);
+        Assert.Null(shape.Members[0].ClrType);
+    }
+
+    [Fact]
+    public void NegativeNumericLiteral_InfersDouble()
+    {
+        var shape = GetShape(
+            @"const a = { n: -5 };
+              console.log(a.n);",
+            "a");
+
+        Assert.True(shape.IsEligible, shape.DisqualifyReason);
+        Assert.Equal(typeof(double), shape.Members[0].ClrType);
+    }
+
+    [Fact]
+    public void NonLiteralInitializer_MemberIsObjectTyped()
+    {
+        var shape = GetShape(
+            @"const seed = 10;
+              const a = { n: seed };
+              console.log(a.n);",
+            "a");
+
+        Assert.True(shape.IsEligible, shape.DisqualifyReason);
+        Assert.Null(shape.Members[0].ClrType);
+    }
+
+    [Fact]
+    public void NonLiteralBinding_HasNoShape()
+    {
+        var symbolTable = BuildSymbolTable("const a = 42; console.log(a);");
+        var binding = symbolTable.GetBindingInfo("a");
+        Assert.NotNull(binding);
+        Assert.Null(binding!.ObjectLiteralShape);
+    }
+}


### PR DESCRIPTION
Implements #1429 (phase 1 of #1428): the compile-time gatekeeper analysis that decides whether an object literal is eligible for early-bound, strongly-typed CLR member access. **Analysis only — no codegen consumes the result yet.**

## What's included

### New: `ObjectLiteralShapeInfo` / `ObjectLiteralMemberInfo` (`src/Compiler/SymbolTable/ObjectLiteralShapeInfo.cs`)
Deterministic internal representation for later phases:
- members in literal source order, each with a conservative CLR type (`double` / `bool` / `string` / `object`) and an `IsFunction` flag
- `IsEligible` plus a human-readable `DisqualifyReason` for diagnostics/tuning

### New: `SymbolTableBuilder.AnalyzeObjectLiteralShapes` (`SymbolTableBuilder.ObjectLiteralShapes.cs`)
Runs at the end of `Build()` after all type inference. For every binding declared with an object literal initializer (`const`/`let`/`var`), walks **every value reference** to the binding and disqualifies on anything not provably safe:

- **escape**: passed to any call/`new`, returned, stored into another object/array, aliased to another binding, assigned anywhere, spread, exported
- **mutation hazards**: binding reassignment, `delete obj.p`, computed member access `obj[k]`, access to undeclared members (shape growth)
- **enumeration/reflection**: `for-in` / `for-of`, `'p' in obj` (v1-conservative)
- **method calls**: `obj.p()` allowed only when `p` is a declared function member whose body provably never observes `this` (arrows always qualify)
- **literal structure**: spread into literal, getters/setters, computed keys, non-identifier keys, `__proto__`, duplicate keys

Member writes merge conservatively: conflicting write types demote the member to `object`; any write demotes a function member to a data member. Shadowed same-name bindings are resolved through the scope chain and do not disqualify.

Whitelist philosophy per the parent issue: **anything not explicitly proven safe disqualifies** — the literal then compiles exactly as today (plain `JsObject`).

### Fix: `AstWalker` now traverses `SpreadElement` arguments
Identifiers inside `...expr` (object/array literals, call arguments) were invisible to all AST analyses using the walker — same class of bug as the earlier `NewExpression` fix. Found because the `{ ...a }` disqualification test could not see the reference.

## Validation

- New unit suite `ObjectLiteralShapeAnalysisTests`: **39 tests** covering eligible patterns (static reads/writes, closures, `typeof`, shadowing, function members without `this`) and every disqualifier — all passing
- All 162 SymbolTable tests pass
- Execution slices: Literals/Spread/Destructuring/ObjectMethods (46), Function/Classes (203) — all passing
- test262 object-related execution slice: 382 passed, 0 failed

## Next phases

#1430 (runtime/type-generation groundwork) → #1431 (construction) → #1432 (early-bound access) → #1433 (validation/benchmarks) → #1434 (cascading interprocedural inference)