### PR TITLE
perf(runtime): back function instances with JsObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/runtime: ordinary receivers allocated by `new Fn()` and the shared ordinary `Function.prototype` / restricted-function prototype objects now use shape-backed `JsObject` storage instead of `ExpandoObject`. Constructor assignments therefore use the descriptor-free own-read path while preserving prototype lookup, bound/dynamic constructors, constructor return overrides, restricted `caller` / `arguments` thrower identity, and mixed-runtime `ExpandoObject` compatibility. A constructed-object benchmark (1,000 instances, 100 repeated read passes) improved precompiled execution from 38.6 ms to 25.8 ms (~33%); current `JsObject` setup/storage increased allocations from 6.95 MB to 11.51 MB, leaving allocation reduction for the core-dispatch/storage follow-up (#1450). (#1449, parent #1426)
 
 ## v0.11.21 - 2026-07-11
 

--- a/src/JavaScriptRuntime/Function.cs
+++ b/src/JavaScriptRuntime/Function.cs
@@ -35,25 +35,27 @@ public static class Function
     private static readonly ConditionalWeakTable<Delegate, InvocationMetadataSlot> _invocationMetadata = new();
     private static readonly ConditionalWeakTable<Delegate, UndefinedPrototypeSlot> _undefinedPrototypeFunctions = new();
     private static readonly ConditionalWeakTable<Delegate, WithObjectSlot> _withObjectBindings = new();
+    private static readonly Func<object[], object?[], object?> _restrictedPropertyThrower =
+        static (_, _) => throw new TypeError("Cannot access restricted function property");
 
-    internal static readonly ExpandoObject Prototype = CreatePrototype();
-    internal static readonly ExpandoObject RestrictedPropertiesPrototype = CreateRestrictedPropertiesPrototype();
+    internal static readonly JsObject Prototype = CreatePrototype();
+    internal static readonly JsObject RestrictedPropertiesPrototype = CreateRestrictedPropertiesPrototype();
 
-    private static ExpandoObject CreatePrototype()
+    private static JsObject CreatePrototype()
     {
         using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-        var exp = new ExpandoObject();
-        DefinePrototypeMethod(exp, "apply", (Func<object[], object?[]?, object?>)PrototypeApply, 2);
-        DefinePrototypeMethod(exp, "call", (Func<object[], object?[]?, object?>)PrototypeCall, 1);
-        DefinePrototypeMethod(exp, "bind", (Func<object[], object?[]?, object?>)PrototypeBind, 1);
-        DefinePrototypeMethod(exp, "toString", (Func<object[], object?[]?, object?>)PrototypeToString, 0);
-        DefineRestrictedProperty(exp, "caller");
-        DefineRestrictedProperty(exp, "arguments");
-        return exp;
+        var prototype = new JsObject();
+        DefinePrototypeMethod(prototype, "apply", (Func<object[], object?[]?, object?>)PrototypeApply, 2);
+        DefinePrototypeMethod(prototype, "call", (Func<object[], object?[]?, object?>)PrototypeCall, 1);
+        DefinePrototypeMethod(prototype, "bind", (Func<object[], object?[]?, object?>)PrototypeBind, 1);
+        DefinePrototypeMethod(prototype, "toString", (Func<object[], object?[]?, object?>)PrototypeToString, 0);
+        DefineRestrictedProperty(prototype, "caller");
+        DefineRestrictedProperty(prototype, "arguments");
+        return prototype;
     }
 
-    private static void DefinePrototypeMethod(ExpandoObject prototype, string name, Func<object[], object?[]?, object?> method, double length)
+    private static void DefinePrototypeMethod(JsObject prototype, string name, Func<object[], object?[]?, object?> method, double length)
     {
         var value = CreateBuiltinPrototypeFunction(method, length);
         PrototypeChain.SetPrototype(value, prototype);
@@ -102,14 +104,14 @@ public static class Function
         return method;
     }
 
-    private static ExpandoObject CreateRestrictedPropertiesPrototype()
+    private static JsObject CreateRestrictedPropertiesPrototype()
     {
         using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-        var exp = new ExpandoObject();
-        DefineRestrictedProperty(exp, "caller");
-        DefineRestrictedProperty(exp, "arguments");
-        return exp;
+        var prototype = new JsObject();
+        DefineRestrictedProperty(prototype, "caller");
+        DefineRestrictedProperty(prototype, "arguments");
+        return prototype;
     }
 
     private static void DefineRestrictedProperty(object target, string propertyName)
@@ -119,8 +121,8 @@ public static class Function
             Kind = JsPropertyDescriptorKind.Accessor,
             Enumerable = false,
             Configurable = true,
-            Get = (Func<object[], object?[], object?>)((_, __) => throw new TypeError($"Cannot access restricted function property '{propertyName}'")),
-            Set = (Func<object[], object?[], object?>)((_, __) => throw new TypeError($"Cannot access restricted function property '{propertyName}'"))
+            Get = _restrictedPropertyThrower,
+            Set = _restrictedPropertyThrower
         });
     }
 
@@ -595,12 +597,12 @@ public static class Function
                 throw new TypeError("Value is not a constructor");
             }
 
-            var instance = new System.Dynamic.ExpandoObject();
+            var instance = JavaScriptRuntime.Object.CreateOrdinaryObject();
 
-            // Default proto: ctor.prototype when it is an object or null; otherwise undefined.
-            // If undefined/non-object, we intentionally skip prototype assignment (minimal behavior).
+            // Override the ordinary Object.prototype default only when ctor.prototype is an object.
+            // Null and primitive prototype values use Object.prototype per GetPrototypeFromConstructor.
             var proto = JavaScriptRuntime.ObjectRuntime.GetItem(constructor, "prototype");
-            if (proto is JsNull || TypeUtilities.IsConstructorReturnOverride(proto))
+            if (TypeUtilities.IsConstructorReturnOverride(proto))
             {
                 PrototypeChain.SetPrototype(instance, proto);
             }

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -5481,7 +5481,7 @@ namespace JavaScriptRuntime
             // Null/undefined -> undefined (modeled as null)
             if (obj is null) return null;
 
-            // Perf: plain JsObject fast path. While an object literal has only
+            // Perf: plain JsObject fast path. While an ordinary object has only
             // mirrored default data descriptors (no accessors, deletes, or
             // attribute-bearing descriptors), its property dictionary is fully
             // authoritative for own reads — answer directly from the shape/slot
@@ -5495,8 +5495,8 @@ namespace JavaScriptRuntime
                     return plainValue;
                 }
             }
-            // Perf (#1418): fast dispatch for plain JS objects (object literals via
-            // JsObject, function-constructed instances via ExpandoObject). Own
+            // Perf (#1418): fast dispatch for plain JS objects (JsObject plus retained
+            // mixed-runtime ExpandoObject surfaces). Own
             // properties on these receivers are authoritatively descriptor-backed
             // (literal/assignment writes mirror a data descriptor), so a single
             // descriptor probe resolves the overwhelmingly common case without

--- a/tests/Jroc.Tests/Function/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Function/ExecutionTests.cs
@@ -226,6 +226,9 @@ namespace Jroc.Tests.Function
         public Task Function_Constructor_New_ShadowedLocal_NoSyntaxError() { var testName = nameof(Function_Constructor_New_ShadowedLocal_NoSyntaxError); return ExecutionTest(testName); }
 
         [Fact]
+        public Task Function_ConstructedInstance_ObjectSemantics() { var testName = nameof(Function_ConstructedInstance_ObjectSemantics); return ExecutionTest(testName); }
+
+        [Fact]
         public Task Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous() { var testName = nameof(Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous); return ExecutionTest(testName); }
 
         [Fact]

--- a/tests/Jroc.Tests/Function/FunctionRuntimeTests.cs
+++ b/tests/Jroc.Tests/Function/FunctionRuntimeTests.cs
@@ -1,0 +1,52 @@
+using JavaScriptRuntime;
+
+namespace Jroc.Tests.Function;
+
+public sealed class FunctionRuntimeTests
+{
+    [Fact]
+    public void Construct_UsesDescriptorFreeJsObjectStorage()
+    {
+        var runtime = RuntimeServices.BuildServiceProvider();
+        try
+        {
+            GlobalThis.ServiceProvider = runtime;
+            Func<object[], object?[]?, object?> constructor = static (_, args) =>
+            {
+                ObjectRuntime.SetProperty(RuntimeServices.GetCurrentThis()!, "value", args![0]);
+                return 7d;
+            };
+            JavaScriptRuntime.Function.InitializeFunctionInstance(constructor, 1d, "Receiver", requiresInvocationContext: true);
+
+            var instance = Assert.IsType<JsObject>(JavaScriptRuntime.Function.Construct(constructor, new object?[] { 42d }));
+            Assert.Equal(42d, instance["value"]);
+            Assert.Equal(42d, ObjectRuntime.GetProperty(instance, "value"));
+            Assert.False(instance.HasNonDataDescriptors);
+
+            var prototype = Assert.IsType<JsObject>(ObjectRuntime.GetProperty(constructor, "prototype"));
+            Assert.Same(prototype, JavaScriptRuntime.Object.getPrototypeOf(instance));
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void OrdinaryFunctionPrototypes_AreJsObjects()
+    {
+        _ = GlobalThis.Function;
+
+        Assert.IsType<JsObject>(JavaScriptRuntime.Function.Prototype);
+        Assert.IsType<JsObject>(JavaScriptRuntime.Function.RestrictedPropertiesPrototype);
+        Assert.Same(
+            JavaScriptRuntime.Function.Prototype,
+            JavaScriptRuntime.Object.getPrototypeOf(JavaScriptRuntime.Function.RestrictedPropertiesPrototype));
+
+        Assert.True(PropertyDescriptorStore.TryGetOwn(JavaScriptRuntime.Function.Prototype, "caller", out var caller));
+        Assert.True(PropertyDescriptorStore.TryGetOwn(JavaScriptRuntime.Function.Prototype, "arguments", out var arguments));
+        Assert.Same(caller.Get, caller.Set);
+        Assert.Same(caller.Get, arguments.Get);
+        Assert.Same(arguments.Get, arguments.Set);
+    }
+}

--- a/tests/Jroc.Tests/Function/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Function/GeneratorTests.cs
@@ -194,6 +194,9 @@ namespace Jroc.Tests.Function
         public Task Function_Constructor_New_ShadowedLocal_NoSyntaxError() { var testName = nameof(Function_Constructor_New_ShadowedLocal_NoSyntaxError); return GenerateTest(testName); }
 
         [Fact]
+        public Task Function_ConstructedInstance_ObjectSemantics() { var testName = nameof(Function_ConstructedInstance_ObjectSemantics); return GenerateTest(testName); }
+
+        [Fact]
         public Task Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous() { var testName = nameof(Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous); return GenerateTest(testName); }
 
         [Fact]

--- a/tests/Jroc.Tests/Function/JavaScript/Function_ConstructedInstance_ObjectSemantics.js
+++ b/tests/Jroc.Tests/Function/JavaScript/Function_ConstructedInstance_ObjectSemantics.js
@@ -1,0 +1,80 @@
+"use strict";
+
+function Point(x, y) {
+    this.x = x;
+    this.y = y;
+}
+
+Point.prototype.sum = function () {
+    return this.x + this.y;
+};
+
+const point = new Point(2, 3);
+point.x = 5;
+point.z = 4;
+console.log(point.sum());
+console.log(point instanceof Point);
+
+const descriptor = Object.getOwnPropertyDescriptor(point, "x");
+console.log(descriptor.value, descriptor.writable, descriptor.enumerable, descriptor.configurable);
+console.log(Object.keys(point).join(","));
+console.log(delete point.y);
+console.log(Object.keys(point).join(","));
+console.log(point.y === undefined);
+point.y = 8;
+console.log(Object.keys(point).join(","));
+console.log(Object.getPrototypeOf(point) === Point.prototype);
+
+const bridge = Object.create(Point.prototype);
+bridge.kind = "bridge";
+Object.setPrototypeOf(point, bridge);
+console.log(point.kind);
+console.log(point instanceof Point);
+
+function ReturnObject() {
+    this.discarded = true;
+    return { override: "object" };
+}
+
+function ReturnPrimitive() {
+    this.kept = "receiver";
+    return 17;
+}
+
+console.log(new ReturnObject().override);
+console.log(new ReturnPrimitive().kept);
+
+function makeConstructor(offset) {
+    return function (value) {
+        this.value = value + offset;
+    };
+}
+
+const Closed = makeConstructor(10);
+console.log(new Closed(5).value);
+
+const BoundPoint = Point.bind(null, 10);
+const boundPoint = new BoundPoint(5);
+console.log(boundPoint.sum());
+console.log(boundPoint instanceof Point);
+
+const Dynamic = new Function("value", "this.value = value;");
+const dynamicInstance = new Dynamic(9);
+console.log(dynamicInstance.value);
+console.log(dynamicInstance instanceof Dynamic);
+
+function PrimitivePrototype() {}
+PrimitivePrototype.prototype = 3;
+console.log(Object.getPrototypeOf(new PrimitivePrototype()) === Object.prototype);
+
+function NullPrototype() {}
+NullPrototype.prototype = null;
+console.log(Object.getPrototypeOf(new NullPrototype()) === Object.prototype);
+
+class PointReader {
+    static read(value) {
+        return value.sum();
+    }
+}
+
+console.log(PointReader.read(new Point(6, 1)));

--- a/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -1,0 +1,21 @@
+﻿8
+true
+5 true true true
+x,y,z
+true
+x,z
+true
+x,z,y
+true
+bridge
+true
+object
+receiver
+15
+15
+true
+9
+true
+true
+true
+7

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -1,0 +1,1520 @@
+﻿// IL code: Function_ConstructedInstance_ObjectSemantics
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Function_ConstructedInstance_ObjectSemantics
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit Point
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b1a
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object x,
+				object y
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x29a9
+			// Header size: 1
+			// Code size: 38 (0x26)
+			.maxstack 8
+
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldstr "x"
+			IL_000a: ldarg.1
+			IL_000b: ldc.i4.1
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0011: pop
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0017: ldstr "y"
+			IL_001c: ldarg.2
+			IL_001d: ldc.i4.1
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0023: pop
+			IL_0024: ldnull
+			IL_0025: ret
+		} // end of method Point::__js_call__
+
+	} // end of class Point
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L8C22
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b23
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x29d0
+			// Header size: 12
+			// Code size: 40 (0x28)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object
+			)
+
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldstr "x"
+			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_000f: stloc.0
+			IL_0010: ldloc.0
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0016: ldstr "y"
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0025: stloc.1
+			IL_0026: ldloc.1
+			IL_0027: ret
+		} // end of method FunctionExpression_L8C22::__js_call__
+
+	} // end of class FunctionExpression_L8C22
+
+	.class nested public auto ansi abstract sealed beforefieldinit ReturnObject
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b2c
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Function_ConstructedInstance_ObjectSemantics/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0d 00 00 02
+			)
+			// Method begins at RVA 0x2a04
+			// Header size: 1
+			// Code size: 45 (0x2d)
+			.maxstack 8
+
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldstr "discarded"
+			IL_000a: ldc.i4.1
+			IL_000b: box [System.Runtime]System.Boolean
+			IL_0010: ldc.i4.1
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0016: pop
+			IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001c: dup
+			IL_001d: ldstr "override"
+			IL_0022: ldstr "object"
+			IL_0027: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_002c: ret
+		} // end of method ReturnObject::__js_call__
+
+	} // end of class ReturnObject
+
+	.class nested public auto ansi abstract sealed beforefieldinit ReturnPrimitive
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b35
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			float64 __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2a32
+			// Header size: 1
+			// Code size: 32 (0x20)
+			.maxstack 8
+
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldstr "kept"
+			IL_000a: ldstr "receiver"
+			IL_000f: ldc.i4.1
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0015: pop
+			IL_0016: ldc.r8 17
+			IL_001f: ret
+		} // end of method ReturnPrimitive::__js_call__
+
+	} // end of class ReturnPrimitive
+
+	.class nested public auto ansi abstract sealed beforefieldinit makeConstructor
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L48C11
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2b47
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget,
+					object 'value'
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x2ab4
+				// Header size: 12
+				// Code size: 40 (0x28)
+				.maxstack 8
+				.locals init (
+					[0] object
+				)
+
+				IL_0000: ldarg.2
+				IL_0001: ldarg.0
+				IL_0002: ldc.i4.1
+				IL_0003: ldelem.ref
+				IL_0004: castclass Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope
+				IL_0009: ldfld object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope::offset
+				IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0013: stloc.0
+				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_0019: ldstr "value"
+				IL_001e: ldloc.0
+				IL_001f: ldc.i4.1
+				IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0025: pop
+				IL_0026: ldnull
+				IL_0027: ret
+			} // end of method FunctionExpression_L48C11::__js_call__
+
+		} // end of class FunctionExpression_L48C11
+
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 15 53 63 6f 70 65 20 6f 66 66 73 65 74 3d
+				7b 6f 66 66 73 65 74 7d 00 00
+			)
+			// Fields
+			.field public object offset
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b3e
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Function_ConstructedInstance_ObjectSemantics/Scope scope,
+				object newTarget,
+				object offset
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0d 00 00 02
+			)
+			// Method begins at RVA 0x2a54
+			// Header size: 12
+			// Code size: 55 (0x37)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope,
+				[1] object
+			)
+
+			IL_0000: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldloc.0
+			IL_0007: ldarg.2
+			IL_0008: stfld object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope::offset
+			IL_000d: ldc.i4.2
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldarg.0
+			IL_0016: stelem.ref
+			IL_0017: dup
+			IL_0018: ldc.i4.1
+			IL_0019: ldloc.0
+			IL_001a: stelem.ref
+			IL_001b: ldftn object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11::__js_call__(object[], object, object)
+			IL_0021: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0026: ldc.i4.1
+			IL_0027: conv.r8
+			IL_0028: ldstr ""
+			IL_002d: ldc.i4.0
+			IL_002e: ldc.i4.1
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0034: stloc.1
+			IL_0035: ldloc.1
+			IL_0036: ret
+		} // end of method makeConstructor::__js_call__
+
+	} // end of class makeConstructor
+
+	.class nested public auto ansi abstract sealed beforefieldinit '<>DynamicFunction_L61C17'
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b50
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2a97
+			// Header size: 1
+			// Code size: 20 (0x14)
+			.maxstack 8
+
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldstr "value"
+			IL_000a: ldarg.1
+			IL_000b: ldc.i4.0
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0011: pop
+			IL_0012: ldnull
+			IL_0013: ret
+		} // end of method '<>DynamicFunction_L61C17'::__js_call__
+
+	} // end of class <>DynamicFunction_L61C17
+
+	.class nested public auto ansi abstract sealed beforefieldinit PrimitivePrototype
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b59
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2aac
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldnull
+			IL_0001: ret
+		} // end of method PrimitivePrototype::__js_call__
+
+	} // end of class PrimitivePrototype
+
+	.class nested public auto ansi abstract sealed beforefieldinit NullPrototype
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b62
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2aaf
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldnull
+			IL_0001: ret
+		} // end of method NullPrototype::__js_call__
+
+	} // end of class NullPrototype
+
+	.class nested public auto ansi beforefieldinit PointReader
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b6b
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_read
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b74
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_read::.ctor
+
+		} // end of class Scope_read
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2ae8
+			// Header size: 1
+			// Code size: 7 (0x7)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: ret
+		} // end of method PointReader::.ctor
+
+		.method public hidebysig static 
+			object read (
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2af0
+			// Header size: 12
+			// Code size: 21 (0x15)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "sum"
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0012: stloc.0
+			IL_0013: ldloc.0
+			IL_0014: ret
+		} // end of method PointReader::read
+
+	} // end of class PointReader
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 80 be 53 63 6f 70 65 20 50 6f 69 6e 74 3d
+			7b 50 6f 69 6e 74 7d 2c 20 52 65 74 75 72 6e 4f
+			62 6a 65 63 74 3d 7b 52 65 74 75 72 6e 4f 62 6a
+			65 63 74 7d 2c 20 52 65 74 75 72 6e 50 72 69 6d
+			69 74 69 76 65 3d 7b 52 65 74 75 72 6e 50 72 69
+			6d 69 74 69 76 65 7d 2c 20 6d 61 6b 65 43 6f 6e
+			73 74 72 75 63 74 6f 72 3d 7b 6d 61 6b 65 43 6f
+			6e 73 74 72 75 63 74 6f 72 7d 2c 20 50 72 69 6d
+			69 74 69 76 65 50 72 6f 74 6f 74 79 70 65 3d 7b
+			50 72 69 6d 69 74 69 76 65 50 72 6f 74 6f 74 79
+			70 65 7d 2c 20 4e 75 6c 6c 50 72 6f 74 6f 74 79
+			70 65 3d 7b 4e 75 6c 6c 50 72 6f 74 6f 74 79 70
+			65 7d 00 00
+		)
+		// Fields
+		.field public object Point
+		.field public object ReturnObject
+		.field public object ReturnPrimitive
+		.field public object makeConstructor
+		.field public object PrimitivePrototype
+		.field public object NullPrototype
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2b11
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 2381 (0x94d)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Function_ConstructedInstance_ObjectSemantics/Scope,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] object,
+			[5] object,
+			[6] object,
+			[7] object,
+			[8] object,
+			[9] object,
+			[10] object,
+			[11] object,
+			[12] object,
+			[13] object,
+			[14] object,
+			[15] object,
+			[16] object,
+			[17] object,
+			[18] bool,
+			[19] object,
+			[20] object,
+			[21] object,
+			[22] object[],
+			[23] class [System.Runtime]System.Type
+		)
+
+		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
+		IL_0005: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/Scope::.ctor()
+		IL_000a: stloc.0
+		IL_000b: ldnull
+		IL_000c: ldftn object Modules.Function_ConstructedInstance_ObjectSemantics/Point::__js_call__(object, object, object)
+		IL_0012: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0017: ldc.i4.2
+		IL_0018: conv.r8
+		IL_0019: ldstr "Point"
+		IL_001e: ldc.i4.0
+		IL_001f: ldc.i4.1
+		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0025: stloc.s 16
+		IL_0027: ldloc.s 16
+		IL_0029: stloc.1
+		IL_002a: ldc.i4.1
+		IL_002b: newarr [System.Runtime]System.Object
+		IL_0030: dup
+		IL_0031: ldc.i4.0
+		IL_0032: ldloc.0
+		IL_0033: stelem.ref
+		IL_0034: ldc.i4.0
+		IL_0035: ldelem.ref
+		IL_0036: castclass Modules.Function_ConstructedInstance_ObjectSemantics/Scope
+		IL_003b: ldftn object Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object)
+		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0046: ldc.i4.0
+		IL_0047: conv.r8
+		IL_0048: ldstr "ReturnObject"
+		IL_004d: ldc.i4.0
+		IL_004e: ldc.i4.1
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0054: stloc.s 16
+		IL_0056: ldloc.s 16
+		IL_0058: stloc.2
+		IL_0059: ldnull
+		IL_005a: ldftn float64 Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive::__js_call__(object)
+		IL_0060: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
+		IL_0065: ldc.i4.0
+		IL_0066: conv.r8
+		IL_0067: ldstr "ReturnPrimitive"
+		IL_006c: ldc.i4.0
+		IL_006d: ldc.i4.1
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0073: stloc.s 16
+		IL_0075: ldloc.s 16
+		IL_0077: stloc.3
+		IL_0078: ldc.i4.1
+		IL_0079: newarr [System.Runtime]System.Object
+		IL_007e: dup
+		IL_007f: ldc.i4.0
+		IL_0080: ldloc.0
+		IL_0081: stelem.ref
+		IL_0082: ldc.i4.0
+		IL_0083: ldelem.ref
+		IL_0084: castclass Modules.Function_ConstructedInstance_ObjectSemantics/Scope
+		IL_0089: ldftn object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object, object)
+		IL_008f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0094: ldc.i4.1
+		IL_0095: conv.r8
+		IL_0096: ldstr "makeConstructor"
+		IL_009b: ldc.i4.0
+		IL_009c: ldc.i4.1
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00a2: stloc.s 16
+		IL_00a4: ldloc.s 16
+		IL_00a6: stloc.s 4
+		IL_00a8: ldnull
+		IL_00a9: ldftn object Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype::__js_call__(object)
+		IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00b4: ldc.i4.0
+		IL_00b5: conv.r8
+		IL_00b6: ldstr "PrimitivePrototype"
+		IL_00bb: ldc.i4.0
+		IL_00bc: ldc.i4.1
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00c2: stloc.s 16
+		IL_00c4: ldloc.s 16
+		IL_00c6: stloc.s 5
+		IL_00c8: ldnull
+		IL_00c9: ldftn object Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype::__js_call__(object)
+		IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00d4: ldc.i4.0
+		IL_00d5: conv.r8
+		IL_00d6: ldstr "NullPrototype"
+		IL_00db: ldc.i4.0
+		IL_00dc: ldc.i4.1
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00e2: stloc.s 16
+		IL_00e4: ldloc.s 16
+		IL_00e6: stloc.s 6
+		IL_00e8: ldnull
+		IL_00e9: ldftn object Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22::__js_call__(object)
+		IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00f4: ldc.i4.0
+		IL_00f5: conv.r8
+		IL_00f6: ldstr ""
+		IL_00fb: ldc.i4.0
+		IL_00fc: ldc.i4.1
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0102: stloc.s 16
+		IL_0104: ldloc.1
+		IL_0105: ldstr "prototype"
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010f: ldstr "sum"
+		IL_0114: ldloc.s 16
+		IL_0116: ldc.i4.1
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_011c: pop
+		IL_011d: ldloc.1
+		IL_011e: ldc.i4.2
+		IL_011f: newarr [System.Runtime]System.Object
+		IL_0124: dup
+		IL_0125: ldc.i4.0
+		IL_0126: ldc.r8 2
+		IL_012f: box [System.Runtime]System.Double
+		IL_0134: stelem.ref
+		IL_0135: dup
+		IL_0136: ldc.i4.1
+		IL_0137: ldc.r8 3
+		IL_0140: box [System.Runtime]System.Double
+		IL_0145: stelem.ref
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_014b: stloc.s 16
+		IL_014d: ldloc.s 16
+		IL_014f: stloc.s 7
+		IL_0151: ldloc.s 7
+		IL_0153: ldstr "x"
+		IL_0158: ldc.r8 5
+		IL_0161: ldc.i4.1
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0167: pop
+		IL_0168: ldloc.s 7
+		IL_016a: ldstr "z"
+		IL_016f: ldc.r8 4
+		IL_0178: ldc.i4.1
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_017e: pop
+		IL_017f: ldstr "console"
+		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0189: stloc.s 16
+		IL_018b: ldloc.s 16
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0192: stloc.s 16
+		IL_0194: ldloc.s 7
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019b: stloc.s 17
+		IL_019d: ldloc.s 17
+		IL_019f: ldstr "sum"
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_01a9: stloc.s 17
+		IL_01ab: ldloc.s 16
+		IL_01ad: ldstr "log"
+		IL_01b2: ldloc.s 17
+		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01b9: pop
+		IL_01ba: ldstr "console"
+		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c4: stloc.s 17
+		IL_01c6: ldloc.s 17
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01cd: stloc.s 17
+		IL_01cf: ldloc.s 7
+		IL_01d1: stloc.s 16
+		IL_01d3: ldloc.s 16
+		IL_01d5: ldloc.1
+		IL_01d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_01db: stloc.s 18
+		IL_01dd: ldloc.s 18
+		IL_01df: box [System.Runtime]System.Boolean
+		IL_01e4: stloc.s 19
+		IL_01e6: ldloc.s 17
+		IL_01e8: ldstr "log"
+		IL_01ed: ldloc.s 19
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01f4: pop
+		IL_01f5: ldloc.s 7
+		IL_01f7: ldstr "x"
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0201: stloc.s 17
+		IL_0203: ldloc.s 17
+		IL_0205: stloc.s 8
+		IL_0207: ldstr "console"
+		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0211: stloc.s 17
+		IL_0213: ldloc.s 17
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021a: stloc.s 17
+		IL_021c: ldloc.s 8
+		IL_021e: ldstr "value"
+		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0228: stloc.s 16
+		IL_022a: ldloc.s 8
+		IL_022c: ldstr "writable"
+		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0236: stloc.s 20
+		IL_0238: ldloc.s 8
+		IL_023a: ldstr "enumerable"
+		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0244: stloc.s 21
+		IL_0246: ldloc.s 17
+		IL_0248: ldstr "log"
+		IL_024d: ldc.i4.4
+		IL_024e: newarr [System.Runtime]System.Object
+		IL_0253: dup
+		IL_0254: ldc.i4.0
+		IL_0255: ldloc.s 16
+		IL_0257: stelem.ref
+		IL_0258: dup
+		IL_0259: ldc.i4.1
+		IL_025a: ldloc.s 20
+		IL_025c: stelem.ref
+		IL_025d: dup
+		IL_025e: ldc.i4.2
+		IL_025f: ldloc.s 21
+		IL_0261: stelem.ref
+		IL_0262: dup
+		IL_0263: ldc.i4.3
+		IL_0264: ldloc.s 8
+		IL_0266: ldstr "configurable"
+		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0270: stelem.ref
+		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_0276: pop
+		IL_0277: ldstr "console"
+		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0281: stloc.s 17
+		IL_0283: ldloc.s 17
+		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028a: stloc.s 17
+		IL_028c: ldloc.s 7
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0293: stloc.s 21
+		IL_0295: ldloc.s 21
+		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_029c: stloc.s 21
+		IL_029e: ldloc.s 21
+		IL_02a0: ldstr "join"
+		IL_02a5: ldstr ","
+		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02af: stloc.s 21
+		IL_02b1: ldloc.s 17
+		IL_02b3: ldstr "log"
+		IL_02b8: ldloc.s 21
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02bf: pop
+		IL_02c0: ldstr "console"
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ca: stloc.s 21
+		IL_02cc: ldloc.s 21
+		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d3: stloc.s 21
+		IL_02d5: ldloc.s 7
+		IL_02d7: ldstr "y"
+		IL_02dc: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_02e1: stloc.s 18
+		IL_02e3: ldloc.s 18
+		IL_02e5: box [System.Runtime]System.Boolean
+		IL_02ea: stloc.s 19
+		IL_02ec: ldloc.s 21
+		IL_02ee: ldstr "log"
+		IL_02f3: ldloc.s 19
+		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02fa: pop
+		IL_02fb: ldstr "console"
+		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0305: stloc.s 21
+		IL_0307: ldloc.s 21
+		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_030e: stloc.s 21
+		IL_0310: ldloc.s 7
+		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0317: stloc.s 17
+		IL_0319: ldloc.s 17
+		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0320: stloc.s 17
+		IL_0322: ldloc.s 17
+		IL_0324: ldstr "join"
+		IL_0329: ldstr ","
+		IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0333: stloc.s 17
+		IL_0335: ldloc.s 21
+		IL_0337: ldstr "log"
+		IL_033c: ldloc.s 17
+		IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0343: pop
+		IL_0344: ldstr "console"
+		IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_034e: stloc.s 17
+		IL_0350: ldloc.s 17
+		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0357: stloc.s 17
+		IL_0359: ldloc.s 7
+		IL_035b: ldstr "y"
+		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0365: ldnull
+		IL_0366: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_036b: stloc.s 18
+		IL_036d: ldloc.s 18
+		IL_036f: box [System.Runtime]System.Boolean
+		IL_0374: stloc.s 19
+		IL_0376: ldloc.s 17
+		IL_0378: ldstr "log"
+		IL_037d: ldloc.s 19
+		IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0384: pop
+		IL_0385: ldloc.s 7
+		IL_0387: ldstr "y"
+		IL_038c: ldc.r8 8
+		IL_0395: ldc.i4.1
+		IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_039b: pop
+		IL_039c: ldstr "console"
+		IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03a6: stloc.s 17
+		IL_03a8: ldloc.s 17
+		IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03af: stloc.s 17
+		IL_03b1: ldloc.s 7
+		IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_03b8: stloc.s 21
+		IL_03ba: ldloc.s 21
+		IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03c1: stloc.s 21
+		IL_03c3: ldloc.s 21
+		IL_03c5: ldstr "join"
+		IL_03ca: ldstr ","
+		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03d4: stloc.s 21
+		IL_03d6: ldloc.s 17
+		IL_03d8: ldstr "log"
+		IL_03dd: ldloc.s 21
+		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03e4: pop
+		IL_03e5: ldstr "console"
+		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03ef: stloc.s 21
+		IL_03f1: ldloc.s 21
+		IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03f8: stloc.s 21
+		IL_03fa: ldloc.s 7
+		IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0401: stloc.s 17
+		IL_0403: ldloc.s 17
+		IL_0405: ldloc.1
+		IL_0406: ldstr "prototype"
+		IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0410: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0415: stloc.s 18
+		IL_0417: ldloc.s 18
+		IL_0419: box [System.Runtime]System.Boolean
+		IL_041e: stloc.s 19
+		IL_0420: ldloc.s 21
+		IL_0422: ldstr "log"
+		IL_0427: ldloc.s 19
+		IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_042e: pop
+		IL_042f: ldloc.1
+		IL_0430: ldstr "prototype"
+		IL_0435: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
+		IL_043f: stloc.s 21
+		IL_0441: ldloc.s 21
+		IL_0443: stloc.s 9
+		IL_0445: ldloc.s 9
+		IL_0447: ldstr "kind"
+		IL_044c: ldstr "bridge"
+		IL_0451: ldc.i4.1
+		IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0457: pop
+		IL_0458: ldloc.s 7
+		IL_045a: ldloc.s 9
+		IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_0461: pop
+		IL_0462: ldstr "console"
+		IL_0467: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_046c: stloc.s 21
+		IL_046e: ldloc.s 21
+		IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0475: stloc.s 21
+		IL_0477: ldloc.s 21
+		IL_0479: ldstr "log"
+		IL_047e: ldloc.s 7
+		IL_0480: ldstr "kind"
+		IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_048f: pop
+		IL_0490: ldstr "console"
+		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_049a: stloc.s 21
+		IL_049c: ldloc.s 21
+		IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04a3: stloc.s 21
+		IL_04a5: ldloc.s 7
+		IL_04a7: stloc.s 17
+		IL_04a9: ldloc.s 17
+		IL_04ab: ldloc.1
+		IL_04ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_04b1: stloc.s 18
+		IL_04b3: ldloc.s 18
+		IL_04b5: box [System.Runtime]System.Boolean
+		IL_04ba: stloc.s 19
+		IL_04bc: ldloc.s 21
+		IL_04be: ldstr "log"
+		IL_04c3: ldloc.s 19
+		IL_04c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_04ca: pop
+		IL_04cb: ldstr "console"
+		IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04d5: stloc.s 21
+		IL_04d7: ldloc.s 21
+		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04de: stloc.s 21
+		IL_04e0: ldloc.2
+		IL_04e1: ldc.i4.0
+		IL_04e2: newarr [System.Runtime]System.Object
+		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_04ec: stloc.s 17
+		IL_04ee: ldloc.s 17
+		IL_04f0: ldstr "override"
+		IL_04f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04fa: stloc.s 17
+		IL_04fc: ldloc.s 21
+		IL_04fe: ldstr "log"
+		IL_0503: ldloc.s 17
+		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_050a: pop
+		IL_050b: ldstr "console"
+		IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0515: stloc.s 17
+		IL_0517: ldloc.s 17
+		IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_051e: stloc.s 17
+		IL_0520: ldloc.3
+		IL_0521: ldc.i4.0
+		IL_0522: newarr [System.Runtime]System.Object
+		IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_052c: stloc.s 21
+		IL_052e: ldloc.s 21
+		IL_0530: ldstr "kept"
+		IL_0535: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_053a: stloc.s 21
+		IL_053c: ldloc.s 17
+		IL_053e: ldstr "log"
+		IL_0543: ldloc.s 21
+		IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_054a: pop
+		IL_054b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0550: stloc.s 22
+		IL_0552: ldloc.s 4
+		IL_0554: ldloc.s 22
+		IL_0556: ldc.r8 10
+		IL_055f: box [System.Runtime]System.Double
+		IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0569: stloc.s 21
+		IL_056b: ldloc.s 21
+		IL_056d: stloc.s 10
+		IL_056f: ldstr "console"
+		IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0579: stloc.s 21
+		IL_057b: ldloc.s 21
+		IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0582: stloc.s 21
+		IL_0584: ldloc.s 10
+		IL_0586: ldc.i4.1
+		IL_0587: newarr [System.Runtime]System.Object
+		IL_058c: dup
+		IL_058d: ldc.i4.0
+		IL_058e: ldc.r8 5
+		IL_0597: box [System.Runtime]System.Double
+		IL_059c: stelem.ref
+		IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_05a2: stloc.s 17
+		IL_05a4: ldloc.s 17
+		IL_05a6: ldstr "value"
+		IL_05ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05b0: stloc.s 17
+		IL_05b2: ldloc.s 21
+		IL_05b4: ldstr "log"
+		IL_05b9: ldloc.s 17
+		IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_05c0: pop
+		IL_05c1: ldloc.1
+		IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05c7: stloc.s 17
+		IL_05c9: ldloc.s 17
+		IL_05cb: ldstr "bind"
+		IL_05d0: ldc.i4.0
+		IL_05d1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_05d6: ldc.r8 10
+		IL_05df: box [System.Runtime]System.Double
+		IL_05e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_05e9: stloc.s 17
+		IL_05eb: ldloc.s 17
+		IL_05ed: stloc.s 11
+		IL_05ef: ldloc.s 11
+		IL_05f1: ldc.i4.1
+		IL_05f2: newarr [System.Runtime]System.Object
+		IL_05f7: dup
+		IL_05f8: ldc.i4.0
+		IL_05f9: ldc.r8 5
+		IL_0602: box [System.Runtime]System.Double
+		IL_0607: stelem.ref
+		IL_0608: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_060d: stloc.s 17
+		IL_060f: ldloc.s 17
+		IL_0611: stloc.s 12
+		IL_0613: ldstr "console"
+		IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_061d: stloc.s 17
+		IL_061f: ldloc.s 17
+		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0626: stloc.s 17
+		IL_0628: ldloc.s 12
+		IL_062a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_062f: stloc.s 21
+		IL_0631: ldloc.s 21
+		IL_0633: ldstr "sum"
+		IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_063d: stloc.s 21
+		IL_063f: ldloc.s 17
+		IL_0641: ldstr "log"
+		IL_0646: ldloc.s 21
+		IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_064d: pop
+		IL_064e: ldstr "console"
+		IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0658: stloc.s 21
+		IL_065a: ldloc.s 21
+		IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0661: stloc.s 21
+		IL_0663: ldloc.s 12
+		IL_0665: stloc.s 17
+		IL_0667: ldloc.s 17
+		IL_0669: ldloc.1
+		IL_066a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_066f: stloc.s 18
+		IL_0671: ldloc.s 18
+		IL_0673: box [System.Runtime]System.Boolean
+		IL_0678: stloc.s 19
+		IL_067a: ldloc.s 21
+		IL_067c: ldstr "log"
+		IL_0681: ldloc.s 19
+		IL_0683: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0688: pop
+		IL_0689: ldnull
+		IL_068a: ldftn object Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'::__js_call__(object, object)
+		IL_0690: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0695: ldc.i4.1
+		IL_0696: conv.r8
+		IL_0697: ldstr ""
+		IL_069c: ldc.i4.0
+		IL_069d: ldc.i4.0
+		IL_069e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_06a3: stloc.s 21
+		IL_06a5: ldloc.s 21
+		IL_06a7: stloc.s 13
+		IL_06a9: ldloc.s 13
+		IL_06ab: ldc.i4.1
+		IL_06ac: newarr [System.Runtime]System.Object
+		IL_06b1: dup
+		IL_06b2: ldc.i4.0
+		IL_06b3: ldc.r8 9
+		IL_06bc: box [System.Runtime]System.Double
+		IL_06c1: stelem.ref
+		IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_06c7: stloc.s 21
+		IL_06c9: ldloc.s 21
+		IL_06cb: stloc.s 14
+		IL_06cd: ldstr "console"
+		IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06d7: stloc.s 21
+		IL_06d9: ldloc.s 21
+		IL_06db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06e0: stloc.s 21
+		IL_06e2: ldloc.s 21
+		IL_06e4: ldstr "log"
+		IL_06e9: ldloc.s 14
+		IL_06eb: ldstr "value"
+		IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_06fa: pop
+		IL_06fb: ldstr "console"
+		IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0705: stloc.s 21
+		IL_0707: ldloc.s 21
+		IL_0709: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_070e: stloc.s 21
+		IL_0710: ldloc.s 14
+		IL_0712: stloc.s 17
+		IL_0714: ldloc.s 17
+		IL_0716: ldloc.s 13
+		IL_0718: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_071d: stloc.s 18
+		IL_071f: ldloc.s 18
+		IL_0721: box [System.Runtime]System.Boolean
+		IL_0726: stloc.s 19
+		IL_0728: ldloc.s 21
+		IL_072a: ldstr "log"
+		IL_072f: ldloc.s 19
+		IL_0731: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0736: pop
+		IL_0737: ldloc.s 5
+		IL_0739: ldstr "prototype"
+		IL_073e: ldc.r8 3
+		IL_0747: ldc.i4.1
+		IL_0748: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_074d: pop
+		IL_074e: ldstr "console"
+		IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0758: stloc.s 21
+		IL_075a: ldloc.s 21
+		IL_075c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0761: stloc.s 21
+		IL_0763: ldloc.s 5
+		IL_0765: ldc.i4.0
+		IL_0766: newarr [System.Runtime]System.Object
+		IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_0770: stloc.s 17
+		IL_0772: ldloc.s 17
+		IL_0774: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0779: stloc.s 17
+		IL_077b: ldstr "Object"
+		IL_0780: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0785: stloc.s 20
+		IL_0787: ldloc.s 20
+		IL_0789: ldstr "prototype"
+		IL_078e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0793: stloc.s 20
+		IL_0795: ldloc.s 17
+		IL_0797: ldloc.s 20
+		IL_0799: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_079e: stloc.s 18
+		IL_07a0: ldloc.s 18
+		IL_07a2: box [System.Runtime]System.Boolean
+		IL_07a7: stloc.s 19
+		IL_07a9: ldloc.s 21
+		IL_07ab: ldstr "log"
+		IL_07b0: ldloc.s 19
+		IL_07b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_07b7: pop
+		IL_07b8: ldloc.s 6
+		IL_07ba: ldstr "prototype"
+		IL_07bf: ldc.i4.0
+		IL_07c0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_07c5: ldc.i4.1
+		IL_07c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_07cb: pop
+		IL_07cc: ldstr "console"
+		IL_07d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07d6: stloc.s 21
+		IL_07d8: ldloc.s 21
+		IL_07da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07df: stloc.s 21
+		IL_07e1: ldloc.s 6
+		IL_07e3: ldc.i4.0
+		IL_07e4: newarr [System.Runtime]System.Object
+		IL_07e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_07ee: stloc.s 20
+		IL_07f0: ldloc.s 20
+		IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_07f7: stloc.s 20
+		IL_07f9: ldstr "Object"
+		IL_07fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0803: stloc.s 17
+		IL_0805: ldloc.s 17
+		IL_0807: ldstr "prototype"
+		IL_080c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0811: stloc.s 17
+		IL_0813: ldloc.s 20
+		IL_0815: ldloc.s 17
+		IL_0817: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_081c: stloc.s 18
+		IL_081e: ldloc.s 18
+		IL_0820: box [System.Runtime]System.Boolean
+		IL_0825: stloc.s 19
+		IL_0827: ldloc.s 21
+		IL_0829: ldstr "log"
+		IL_082e: ldloc.s 19
+		IL_0830: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0835: pop
+		IL_0836: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
+		IL_083b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0840: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
+		IL_0845: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_084a: stloc.s 23
+		IL_084c: ldc.i4.1
+		IL_084d: newarr [System.Runtime]System.Object
+		IL_0852: dup
+		IL_0853: ldc.i4.0
+		IL_0854: ldloc.0
+		IL_0855: stelem.ref
+		IL_0856: stloc.s 22
+		IL_0858: ldc.i4.s 10
+		IL_085a: newarr [System.Runtime]System.Object
+		IL_085f: dup
+		IL_0860: ldc.i4.0
+		IL_0861: ldloc.s 23
+		IL_0863: stelem.ref
+		IL_0864: dup
+		IL_0865: ldc.i4.1
+		IL_0866: ldstr "read"
+		IL_086b: stelem.ref
+		IL_086c: dup
+		IL_086d: ldc.i4.2
+		IL_086e: ldstr "read"
+		IL_0873: stelem.ref
+		IL_0874: dup
+		IL_0875: ldc.i4.3
+		IL_0876: ldc.r8 1
+		IL_087f: box [System.Runtime]System.Double
+		IL_0884: stelem.ref
+		IL_0885: dup
+		IL_0886: ldc.i4.4
+		IL_0887: ldstr "read"
+		IL_088c: stelem.ref
+		IL_088d: dup
+		IL_088e: ldc.i4.5
+		IL_088f: ldc.i4.1
+		IL_0890: box [System.Runtime]System.Boolean
+		IL_0895: stelem.ref
+		IL_0896: dup
+		IL_0897: ldc.i4.6
+		IL_0898: ldc.i4.0
+		IL_0899: box [System.Runtime]System.Boolean
+		IL_089e: stelem.ref
+		IL_089f: dup
+		IL_08a0: ldc.i4.7
+		IL_08a1: ldc.i4.0
+		IL_08a2: box [System.Runtime]System.Boolean
+		IL_08a7: stelem.ref
+		IL_08a8: dup
+		IL_08a9: ldc.i4.8
+		IL_08aa: ldc.i4.0
+		IL_08ab: box [System.Runtime]System.Boolean
+		IL_08b0: stelem.ref
+		IL_08b1: dup
+		IL_08b2: ldc.i4.s 9
+		IL_08b4: ldloc.s 22
+		IL_08b6: stelem.ref
+		IL_08b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_08bc: pop
+		IL_08bd: ldc.i4.1
+		IL_08be: newarr [System.Runtime]System.Object
+		IL_08c3: dup
+		IL_08c4: ldc.i4.0
+		IL_08c5: ldloc.0
+		IL_08c6: stelem.ref
+		IL_08c7: stloc.s 22
+		IL_08c9: ldloc.s 23
+		IL_08cb: ldloc.s 22
+		IL_08cd: ldc.r8 0.0
+		IL_08d6: box [System.Runtime]System.Double
+		IL_08db: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_08e0: stloc.s 21
+		IL_08e2: ldloc.s 21
+		IL_08e4: stloc.s 15
+		IL_08e6: ldstr "console"
+		IL_08eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08f0: stloc.s 21
+		IL_08f2: ldloc.s 21
+		IL_08f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08f9: stloc.s 21
+		IL_08fb: ldloc.1
+		IL_08fc: ldc.i4.2
+		IL_08fd: newarr [System.Runtime]System.Object
+		IL_0902: dup
+		IL_0903: ldc.i4.0
+		IL_0904: ldc.r8 6
+		IL_090d: box [System.Runtime]System.Double
+		IL_0912: stelem.ref
+		IL_0913: dup
+		IL_0914: ldc.i4.1
+		IL_0915: ldc.r8 1
+		IL_091e: box [System.Runtime]System.Double
+		IL_0923: stelem.ref
+		IL_0924: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_0929: stloc.s 17
+		IL_092b: ldloc.s 15
+		IL_092d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetCurrentThis(object)
+		IL_0932: stloc.s 20
+		IL_0934: ldloc.s 17
+		IL_0936: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
+		IL_093b: stloc.s 17
+		IL_093d: ldloc.s 21
+		IL_093f: ldstr "log"
+		IL_0944: ldloc.s 17
+		IL_0946: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_094b: pop
+		IL_094c: ret
+	} // end of method Function_ConstructedInstance_ObjectSemantics::__js_module_init__
+
+} // end of class Modules.Function_ConstructedInstance_ObjectSemantics
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2b7d
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Function_ConstructedInstance_ObjectSemantics::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/tests/performance/Benchmarks/Scenarios/constructed-object.js
+++ b/tests/performance/Benchmarks/Scenarios/constructed-object.js
@@ -1,0 +1,26 @@
+"use strict";
+
+function Point(x, y) {
+    this.x = x;
+    this.y = y;
+}
+
+let checksum = 0;
+const points = [];
+for (let i = 0; i < 1000; i++) {
+    const point = new Point(i, i + 1);
+    point.x += 1;
+    point.y += 2;
+    points.push(point);
+}
+
+for (let iteration = 0; iteration < 100; iteration++) {
+    for (let i = 0; i < points.length; i++) {
+        const point = points[i];
+        checksum += point.x + point.y;
+    }
+}
+
+if (checksum !== 100300000) {
+    throw new Error("Unexpected constructed-object checksum: " + checksum);
+}


### PR DESCRIPTION
## Summary

- allocate ordinary `new Fn()` receivers as shape-backed `JsObject` instances
- migrate `Function.prototype` and the restricted-function prototype to `JsObject`
- preserve bound/dynamic constructors, return overrides, prototype fallback, `instanceof`, and mixed `ExpandoObject` compatibility
- add focused runtime, execution, generator, test262, and benchmark coverage

Closes #1449

## Compatibility notes

- Constructor `prototype` values that are objects override the ordinary default.
- `null` and primitive constructor prototype values correctly fall back to `Object.prototype`.
- Restricted `caller` and `arguments` accessors share the required thrower identity.
- Compiler metadata references were unchanged because the remaining `ExpandoObject` constructor references serve unrelated object-literal paths outside this phase.

## Performance

Benchmark: 1,000 function-constructed objects, one initialization/update pass, then 100 repeated direct property-read passes.

| Revision | JROC execution | Allocated |
| --- | ---: | ---: |
| `master` | 38.6 ms | 6.95 MB |
| This PR | 25.8 ms | 11.51 MB |

Execution improves by approximately **33%**. Current `JsObject` setup/storage increases allocations; #1450 tracks the core dispatch/storage follow-up where that cost can be reduced.

## Validation

- `dotnet build Jroc.sln --no-restore --verbosity minimal`
- focused Function execution/runtime coverage: 93 passed
- targeted Function bind/call, Object.getPrototypeOf, and function-statement test262 slices: 77 passed, 15 skipped
- full `Jroc.Tests` review run: all tests pass except the intentionally pending new generator baseline
- `node scripts/runPhasedBenchmarkScenario.js constructed-object`

