### PR TITLE
Migrate Node utility and filesystem objects to JsObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime: migrate lower-coupling Node.js path, query-string, util, timers/promises, and filesystem ordinary result/helper objects from `ExpandoObject` to `JsObject` (issue #1454, parent #1426). Path and query-string result ordering, `util.types` and synthesized inheritance prototypes, `fs.constants`, promise-based file-handle read/write records, and `fs`/timer option reads retain their existing Node-visible behavior through shared property APIs. Higher-risk process, child-process, network, stream, and IPC objects remain deferred.
+
 - runtime: migrate CommonJS default `module.exports` plus ESM dynamic-import namespace, primitive-namespace, and namespace-cache descriptor records from `ExpandoObject` to `JsObject` (issue #1453, parent #1426). CommonJS export aliasing/replacement and circular-require identity, ESM accessor-backed live bindings, namespace cache identity (including non-extensible exports), and hosted `JsEngine.LoadModule` export resolution remain preserved.
 
 - runtime: migrate the per-realm global object and the shared `String`, string-iterator, `RegExp`, `Map`, and `Set` intrinsic prototypes from `ExpandoObject` to `JsObject` (issue #1452, parent #1426). Constructor/prototype identity cycles, intrinsic descriptors, prototype hierarchies, symbol properties, and runtime-store mutation isolation are preserved. `JsObject` now supplies DynamicObject member access and complete dictionary collection copy/removal behavior so the global-object migration retains its existing hosted DLR and collection surface. Array prototype representation remains unchanged under #1443.

--- a/src/JavaScriptRuntime/JsObject.cs
+++ b/src/JavaScriptRuntime/JsObject.cs
@@ -7,6 +7,11 @@ namespace JavaScriptRuntime;
 
 internal sealed class JsShape
 {
+    private enum PropertyNameStorage
+    {
+        Interned,
+        Direct
+    }
 
     private static readonly ThreadLocal<JsShape> _empty = new (() => new JsShape());
 
@@ -39,10 +44,10 @@ internal sealed class JsShape
         }
     }
 
-    private JsShape(string newPropertyName, JsShape parent)
+    private JsShape(string newPropertyName, JsShape parent, PropertyNameStorage propertyNameStorage)
     {
         var newSlots = parent._slots.ToDictionary();
-        newSlots[string.Intern(newPropertyName)] = newSlots.Count;
+        newSlots[propertyNameStorage == PropertyNameStorage.Interned ? string.Intern(newPropertyName) : newPropertyName] = newSlots.Count;
         _slots = newSlots.ToFrozenDictionary();
     }
 
@@ -67,10 +72,18 @@ internal sealed class JsShape
         {
             return existingShape;
         }
-        var newShape = new JsShape(newPropertyName, this);
+        var newShape = new JsShape(newPropertyName, this, PropertyNameStorage.Interned);
         _transitions![newPropertyName] = new WeakReference<JsShape>(newShape);
         return newShape;
     }
+
+    /// <summary>
+    /// Adds a property name without publishing it to the shared shape-transition cache.
+    /// This is for objects populated from untrusted input where neither global string
+    /// interning nor long-lived transition-cache keys are appropriate.
+    /// </summary>
+    public JsShape TransitionToUncached(string newPropertyName)
+        => new JsShape(newPropertyName, this, PropertyNameStorage.Direct);
 
     public JsShape TransitionAway(string deadPropertyName)
     {
@@ -98,6 +111,8 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
 
     private JsShape _shape = JsShape.Empty;
 
+    private readonly bool _cacheShapeTransitions;
+
     // Perf (#1418 follow-up): sticky flag set when this object gains descriptor
     // state that the plain dictionary cannot answer (accessors, delete tombstones,
     // non-default attributes from defineProperty/seal/freeze, intrinsic descriptors).
@@ -114,6 +129,21 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
     internal bool HasNonDataDescriptors => _hasNonDataDescriptors;
 
     internal void MarkNonDataDescriptors() => _hasNonDataDescriptors = true;
+
+    /// <summary>Creates an ordinary object using the shared shape-transition cache.</summary>
+    public JsObject()
+    {
+        _cacheShapeTransitions = true;
+    }
+
+    /// <summary>
+    /// Creates an ordinary object whose property names are appended without using shared
+    /// shape transitions. Intended for records populated from untrusted property keys.
+    /// </summary>
+    internal JsObject(bool cacheShapeTransitions)
+    {
+        _cacheShapeTransitions = cacheShapeTransitions;
+    }
 
     // -------------------------------------------------------------------------
     // Typed initializer methods used from generated IL (no boxing at call site)
@@ -317,7 +347,9 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
         var slot = _shape.GetSlot(key);
         if (slot == -1)
         {
-            _shape = _shape.TransitionTo(key);
+            _shape = _cacheShapeTransitions
+                ? _shape.TransitionTo(key)
+                : _shape.TransitionToUncached(key);
             slot = _shape.GetSlot(key);
 
             var newProperties = new JsValue[_properties!.Length + 1];

--- a/src/JavaScriptRuntime/Node/FS.cs
+++ b/src/JavaScriptRuntime/Node/FS.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Dynamic;
 using System.IO;
 using System.Threading.Tasks;
 using JavaScriptRuntime;
@@ -26,10 +25,10 @@ namespace JavaScriptRuntime.Node
 
         private static object CreateConstants()
         {
-            dynamic c = new ExpandoObject();
+            var constants = new JsObject();
             // Node's fs.constants.F_OK (value 0) - used as the existence-check mode.
-            c.F_OK = 0.0;
-            return c;
+            constants.SetNumber("F_OK", 0.0);
+            return constants;
         }
 
         // Dynamic-friendly overloads first so Object.CallInstanceMethod prefers them
@@ -945,29 +944,7 @@ namespace JavaScriptRuntime.Node
                 catch { return new JavaScriptRuntime.Array(); }
             }
 
-            bool withFileTypes = false;
-            try
-            {
-                if (options is System.Dynamic.ExpandoObject exp)
-                {
-                    var dict = (System.Collections.Generic.IDictionary<string, object?>)exp;
-                    if (dict.TryGetValue("withFileTypes", out var val))
-                    {
-                        withFileTypes = JavaScriptRuntime.TypeUtilities.ToBoolean(val);
-                    }
-                }
-                else if (options != null)
-                {
-                    // Fallback: use runtime dynamic property access for object literals
-                    try
-                    {
-                        var val = JavaScriptRuntime.ObjectRuntime.GetProperty(options, "withFileTypes");
-                        withFileTypes = JavaScriptRuntime.TypeUtilities.ToBoolean(val);
-                    }
-                    catch { }
-                }
-            }
-            catch { }
+            var withFileTypes = FsCommon.GetBooleanOption(options, "withFileTypes");
 
             if (!withFileTypes)
             {
@@ -1036,19 +1013,7 @@ namespace JavaScriptRuntime.Node
         public object rmSync(object file, object? options)
         {
             var path = file?.ToString() ?? string.Empty;
-            bool force = false;
-            try
-            {
-                if (options is System.Dynamic.ExpandoObject exp)
-                {
-                    var dict = (System.Collections.Generic.IDictionary<string, object?>)exp;
-                    if (dict.TryGetValue("force", out var val))
-                    {
-                        force = JavaScriptRuntime.TypeUtilities.ToBoolean(val);
-                    }
-                }
-            }
-            catch { }
+            var force = FsCommon.GetBooleanOption(options, "force");
 
             try
             {

--- a/src/JavaScriptRuntime/Node/FsCommon.cs
+++ b/src/JavaScriptRuntime/Node/FsCommon.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Dynamic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,17 +27,6 @@ namespace JavaScriptRuntime.Node
 
             try
             {
-                if (options is ExpandoObject exp)
-                {
-                    var dict = (System.Collections.Generic.IDictionary<string, object?>)exp;
-                    if (dict.TryGetValue(propertyName, out var val))
-                    {
-                        return TypeUtilities.ToBoolean(val);
-                    }
-
-                    return false;
-                }
-
                 var value = ObjectRuntime.GetProperty(options, propertyName);
                 return TypeUtilities.ToBoolean(value);
             }
@@ -57,15 +45,6 @@ namespace JavaScriptRuntime.Node
 
             try
             {
-                if (options is ExpandoObject exp)
-                {
-                    var dict = (System.Collections.Generic.IDictionary<string, object?>)exp;
-                    if (dict.TryGetValue(propertyName, out var value))
-                    {
-                        return value;
-                    }
-                }
-
                 return ObjectRuntime.GetProperty(options, propertyName);
             }
             catch

--- a/src/JavaScriptRuntime/Node/FsFileHandle.cs
+++ b/src/JavaScriptRuntime/Node/FsFileHandle.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Dynamic;
 using System.IO;
 using System.Threading.Tasks;
 using JavaScriptRuntime;
@@ -126,9 +125,9 @@ namespace JavaScriptRuntime.Node
                     temp.AsSpan(0, bytesRead).CopyTo(buffer.AsWritableSpan().Slice(offset, bytesRead));
                 }
 
-                dynamic result = new ExpandoObject();
-                result.bytesRead = (double)bytesRead;
-                result.buffer = buffer;
+                var result = new JsObject();
+                result.SetNumber("bytesRead", bytesRead);
+                result.SetObject("buffer", buffer);
                 _ioScheduler.EndIo(promiseWithResolvers, result, isError: false);
             }
             catch (Exception ex)
@@ -177,9 +176,9 @@ namespace JavaScriptRuntime.Node
 
                 await stream.FlushAsync().ConfigureAwait(false);
 
-                dynamic result = new ExpandoObject();
-                result.bytesWritten = (double)bytes.Length;
-                result.buffer = resultBuffer;
+                var result = new JsObject();
+                result.SetNumber("bytesWritten", bytes.Length);
+                result.SetObject("buffer", resultBuffer);
                 _ioScheduler.EndIo(promiseWithResolvers, result, isError: false);
             }
             catch (Exception ex)

--- a/src/JavaScriptRuntime/Node/Path.cs
+++ b/src/JavaScriptRuntime/Node/Path.cs
@@ -214,7 +214,7 @@ namespace JavaScriptRuntime.Node
                 name = baseName.Substring(0, baseName.Length - ext.Length);
             }
 
-            var result = new System.Dynamic.ExpandoObject();
+            var result = new JsObject();
             var dict = (IDictionary<string, object?>)result;
             dict["root"] = root;
             dict["dir"] = dir;
@@ -551,7 +551,7 @@ namespace JavaScriptRuntime.Node
                     name = baseName.Substring(0, baseName.Length - ext.Length);
                 }
 
-                var result = new System.Dynamic.ExpandoObject();
+                var result = new JsObject();
                 var dict = (IDictionary<string, object?>)result;
                 dict["root"] = root;
                 dict["dir"] = dir;

--- a/src/JavaScriptRuntime/Node/QueryString.cs
+++ b/src/JavaScriptRuntime/Node/QueryString.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
 
 using JsArray = JavaScriptRuntime.Array;
 
@@ -26,7 +25,7 @@ namespace JavaScriptRuntime.Node
             var assignmentText = NormalizeToken(assignment, "=");
             var entries = UrlQueryHelpers.ParseEntries(value, separatorText, assignmentText, plusAsSpace: true);
 
-            dynamic result = new ExpandoObject();
+            var result = new JsObject(cacheShapeTransitions: false);
             var dict = (IDictionary<string, object?>)result;
 
             foreach (var entry in entries)

--- a/src/JavaScriptRuntime/Node/TimersPromises.cs
+++ b/src/JavaScriptRuntime/Node/TimersPromises.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using JavaScriptRuntime.EngineCore;
 
 namespace JavaScriptRuntime.Node
@@ -225,15 +224,6 @@ namespace JavaScriptRuntime.Node
             if (options == null || options is JsNull)
             {
                 return null;
-            }
-
-            if (options is ExpandoObject expando)
-            {
-                var dict = (System.Collections.Generic.IDictionary<string, object?>)expando;
-                if (dict.TryGetValue(name, out var value))
-                {
-                    return value;
-                }
             }
 
             return ObjectRuntime.GetProperty(options, name);

--- a/src/JavaScriptRuntime/Node/Util.cs
+++ b/src/JavaScriptRuntime/Node/Util.cs
@@ -119,7 +119,7 @@ namespace JavaScriptRuntime.Node
             var ctorProto = Object.GetProperty(constructor, "prototype");
             if (ctorProto == null || ctorProto is JsNull)
             {
-                ctorProto = new System.Dynamic.ExpandoObject();
+                ctorProto = new JsObject();
                 Object.SetProperty(constructor, "prototype", ctorProto);
             }
 
@@ -406,7 +406,7 @@ namespace JavaScriptRuntime.Node
 
         private static object CreateTypesObject()
         {
-            var typesObj = new System.Dynamic.ExpandoObject();
+            var typesObj = new JsObject();
             var dict = (IDictionary<string, object?>)typesObj;
 
             dict["isArray"] = new Func<object?, bool>(v => v is JavaScriptRuntime.Array);

--- a/tests/Jroc.Tests/Node/NodeUtilityObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/Node/NodeUtilityObjectRepresentationTests.cs
@@ -1,0 +1,73 @@
+using JavaScriptRuntime;
+using NodeFs = JavaScriptRuntime.Node.FS;
+using NodePath = JavaScriptRuntime.Node.Path;
+using NodeQueryString = JavaScriptRuntime.Node.QueryString;
+using NodeUtil = JavaScriptRuntime.Node.Util;
+using Xunit;
+
+namespace Jroc.Tests.Node;
+
+public class NodeUtilityObjectRepresentationTests
+{
+    [Fact]
+    public void PathParse_ReturnsJsObject()
+    {
+        var path = new NodePath();
+
+        var result = Assert.IsType<JsObject>(path.parse("directory/file.txt"));
+
+        Assert.Equal("file.txt", ObjectRuntime.GetProperty(result, "base"));
+        Assert.Equal(".txt", ObjectRuntime.GetProperty(result, "ext"));
+        Assert.Equal("file", ObjectRuntime.GetProperty(result, "name"));
+    }
+
+    [Fact]
+    public void QueryStringParse_ReturnsJsObject_WithOrderedRepeatedValues()
+    {
+        var queryString = new NodeQueryString();
+
+        var result = Assert.IsType<JsObject>(queryString.parse("first=1&second=2&first=3"));
+        var repeatedValues = Assert.IsType<JavaScriptRuntime.Array>(ObjectRuntime.GetProperty(result, "first"));
+
+        Assert.Equal(new[] { "first", "second" }, result.GetOwnPropertyNames());
+        Assert.Equal(2d, repeatedValues.length);
+        Assert.Equal("1", repeatedValues[0d]);
+        Assert.Equal("3", repeatedValues[1d]);
+    }
+
+    [Fact]
+    public void QueryStringParse_DoesNotInternUntrustedKeys()
+    {
+        var queryString = new NodeQueryString();
+        var key = $"query-key-{Guid.NewGuid():N}";
+
+        Assert.Null(string.IsInterned(key));
+
+        _ = queryString.parse($"{key}=value");
+
+        Assert.Null(string.IsInterned(key));
+    }
+
+    [Fact]
+    public void UtilTypesAndSynthesizedPrototype_AreJsObjects()
+    {
+        var util = new NodeUtil();
+        Action child = static () => { };
+        Action parent = static () => { };
+
+        util.inherits(child, parent);
+
+        Assert.IsType<JsObject>(util.types);
+        Assert.IsType<JsObject>(ObjectRuntime.GetProperty(child, "prototype"));
+    }
+
+    [Fact]
+    public void FsConstants_AreJsObjects()
+    {
+        var fs = new NodeFs();
+
+        var constants = Assert.IsType<JsObject>(fs.constants);
+
+        Assert.Equal(0d, ObjectRuntime.GetProperty(constants, "F_OK"));
+    }
+}

--- a/tests/Jroc.Tests/Node/TimersPromises/RuntimeTests.cs
+++ b/tests/Jroc.Tests/Node/TimersPromises/RuntimeTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Dynamic;
 using JavaScriptRuntime;
 using JavaScriptRuntime.EngineCore;
 
@@ -109,10 +108,10 @@ namespace Jroc.Tests.Node.TimersPromises
             }
         }
 
-        private static ExpandoObject CreateOptions(object signal)
+        private static JsObject CreateOptions(object signal)
         {
-            dynamic options = new ExpandoObject();
-            options.signal = signal;
+            var options = new JsObject();
+            options.SetObject("signal", signal);
             return options;
         }
 


### PR DESCRIPTION
## Summary

Closes #1454.
Part of #1426.

Migrates lower-coupling Node utility and filesystem ordinary objects from `ExpandoObject` to `JsObject`.

## Changed representations

- `path.parse()` result records, including `path.posix.parse()` and `path.win32.parse()`
- `querystring.parse()` result records
- `util.types`
- `util.inherits()` synthesized constructor prototypes
- `fs.constants`
- `FileHandle.read()` and `FileHandle.write()` promise result records
- Timer and filesystem test option records

## Behavior preserved

- Path and query-string field order and duplicate query-value arrays.
- `util.types` predicates, `util.inspect`, and `util.inherits` prototype setup.
- `fs` constants, `withFileTypes`, `force`, and existing filesystem option behavior.
- Promise file-handle result property names (`bytesRead`/`bytesWritten`, `buffer`) and typed numeric values.
- Timer promise AbortSignal option reads.

## Query-key retention safeguard

`querystring.parse()` accepts arbitrary external property names. Normal `JsObject` shared shape transitions intern and cache property names, which would retain unique query keys for the process lifetime. This PR adds an uncached, non-interning shape-transition mode and uses it for query-string parse results, with a regression test using a unique key.

## Scope

Process, child-process, network, stream, and IPC `ExpandoObject` objects remain intentionally deferred to the next #1426 phase.

## Validation

- Node path/query-string/util/timers/filesystem execution and runtime suites: 104 passed
- Node path/query-string/timer/filesystem generator suites: 41 passed
- Debug solution build
- Two independent code-review passes
