### PR TITLE
runtime: migrate Node I/O records to JsObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime: migrate process version/environment snapshots, synchronous child-process result records, and network address records from `ExpandoObject` to `JsObject` (issue #1455, parent #1426). Process environment snapshots use uncached shape transitions so host-controlled environment variable names are neither globally interned nor retained by shared shape caches; child-process and network option reads now use the shared property API, preserving accessor-backed options.
+
 - runtime: migrate lower-coupling Node.js path, query-string, util, timers/promises, and filesystem ordinary result/helper objects from `ExpandoObject` to `JsObject` (issue #1454, parent #1426). Path and query-string result ordering, `util.types` and synthesized inheritance prototypes, `fs.constants`, promise-based file-handle read/write records, and `fs`/timer option reads retain their existing Node-visible behavior through shared property APIs. Higher-risk process, child-process, network, stream, and IPC objects remain deferred.
 
 - runtime: migrate CommonJS default `module.exports` plus ESM dynamic-import namespace, primitive-namespace, and namespace-cache descriptor records from `ExpandoObject` to `JsObject` (issue #1453, parent #1426). CommonJS export aliasing/replacement and circular-require identity, ESM accessor-backed live bindings, namespace cache identity (including non-extensible exports), and hosted `JsEngine.LoadModule` export resolution remain preserved.

--- a/src/JavaScriptRuntime/Node/ChildProcess.cs
+++ b/src/JavaScriptRuntime/Node/ChildProcess.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -85,19 +84,19 @@ namespace JavaScriptRuntime.Node
 
                 var completion = WaitForProcessCompletionSync(p, stdio);
 
-                dynamic result = new ExpandoObject();
-                result.status = (double)completion.ExitCode;
-                result.stdout = stdio.StdoutMode == StdioMode.Pipe ? completion.Stdout : null;
-                result.stderr = stdio.StderrMode == StdioMode.Pipe ? completion.Stderr : null;
+                var result = new JsObject();
+                result["status"] = (double)completion.ExitCode;
+                result["stdout"] = stdio.StdoutMode == StdioMode.Pipe ? completion.Stdout : null;
+                result["stderr"] = stdio.StderrMode == StdioMode.Pipe ? completion.Stderr : null;
                 return result;
             }
             catch (Exception ex)
             {
-                dynamic result = new ExpandoObject();
-                result.status = (double)(-1);
-                result.stdout = null;
-                result.stderr = ex.Message;
-                result.error = ex;
+                var result = new JsObject();
+                result["status"] = -1d;
+                result["stdout"] = null;
+                result["stderr"] = ex.Message;
+                result["error"] = ex;
                 return result;
             }
         }
@@ -899,12 +898,6 @@ namespace JavaScriptRuntime.Node
 
             try
             {
-                if (options is ExpandoObject exp)
-                {
-                    var dict = (IDictionary<string, object?>)exp;
-                    if (dict.TryGetValue(name, out var val)) return val;
-                }
-
                 return ObjectRuntime.GetProperty(options, name);
             }
             catch
@@ -966,8 +959,10 @@ namespace JavaScriptRuntime.Node
                 return false;
             }
 
-            if (options is IDictionary<string, object?> dictionary && dictionary.TryGetValue(name, out value))
+            if (ObjectRuntime.HasOwnValue(options, name)
+                || PropertyDescriptorStore.TryGetOwn(options, name, out _))
             {
+                value = ObjectRuntime.GetProperty(options, name);
                 return true;
             }
 

--- a/src/JavaScriptRuntime/Node/Net.cs
+++ b/src/JavaScriptRuntime/Node/Net.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -69,20 +68,6 @@ namespace JavaScriptRuntime.Node
 
             try
             {
-                if (options is ExpandoObject expando)
-                {
-                    var expandoDict = (IDictionary<string, object?>)expando;
-                    if (expandoDict.TryGetValue(name, out var expandoValue))
-                    {
-                        return expandoValue;
-                    }
-                }
-
-                if (options is IDictionary<string, object?> dict && dict.TryGetValue(name, out var dictValue))
-                {
-                    return dictValue;
-                }
-
                 return ObjectRuntime.GetProperty(options, name);
             }
             catch
@@ -376,11 +361,10 @@ namespace JavaScriptRuntime.Node
 
         internal static object CreateAddressRecord(string host, int port)
         {
-            var result = new ExpandoObject();
-            var dict = (IDictionary<string, object?>)result;
-            dict["address"] = host;
-            dict["family"] = "IPv4";
-            dict["port"] = (double)port;
+            var result = new JsObject();
+            result["address"] = host;
+            result["family"] = "IPv4";
+            result["port"] = (double)port;
             return result;
         }
 

--- a/src/JavaScriptRuntime/Node/Process.cs
+++ b/src/JavaScriptRuntime/Node/Process.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Dynamic;
 using System.Runtime.InteropServices;
 
 namespace JavaScriptRuntime.Node
@@ -194,27 +192,25 @@ namespace JavaScriptRuntime.Node
 
         private static object CreateVersions()
         {
-            var result = new ExpandoObject();
-            var dict = (IDictionary<string, object?>)result;
-            dict["node"] = TargetNodeVersion;
+            var result = new JsObject();
+            result["node"] = TargetNodeVersion;
             
             // Add .NET runtime version info
             var frameworkDescription = RuntimeInformation.FrameworkDescription;
-            dict["v8"] = "12.4.254.21-node.22"; // V8 version from Node 22.x
-            dict["modules"] = "127"; // Node modules ABI version for Node 22.x
+            result["v8"] = "12.4.254.21-node.22"; // V8 version from Node 22.x
+            result["modules"] = "127"; // Node modules ABI version for Node 22.x
             
             // Add jroc-specific version info
             var jrocVersion = typeof(Process).Assembly.GetName().Version?.ToString() ?? "0.0.0";
-            dict["jroc"] = jrocVersion;
-            dict["dotnet"] = frameworkDescription;
+            result["jroc"] = jrocVersion;
+            result["dotnet"] = frameworkDescription;
             
             return result;
         }
 
         private static object CreateEnvSnapshot()
         {
-            var result = new ExpandoObject();
-            var dict = (IDictionary<string, object?>)result;
+            var result = new JsObject(cacheShapeTransitions: false);
 
             foreach (DictionaryEntry entry in System.Environment.GetEnvironmentVariables())
             {
@@ -224,7 +220,7 @@ namespace JavaScriptRuntime.Node
                     continue;
                 }
 
-                dict[key] = entry.Value?.ToString() ?? string.Empty;
+                result[key] = entry.Value?.ToString() ?? string.Empty;
             }
 
             return result;

--- a/src/JavaScriptRuntime/Node/Stream.cs
+++ b/src/JavaScriptRuntime/Node/Stream.cs
@@ -386,7 +386,6 @@ namespace JavaScriptRuntime.Node
             return value switch
             {
                 JsObject => "Object",
-                System.Dynamic.ExpandoObject => "Object",
                 System.Collections.Generic.IDictionary<string, object?> => "Object",
                 _ => value.GetType().Name,
             };

--- a/tests/Jroc.Tests/Node/Net/RuntimeTests.cs
+++ b/tests/Jroc.Tests/Node/Net/RuntimeTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Dynamic;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
@@ -27,10 +26,10 @@ namespace Jroc.Tests.Node.Net
         [Fact]
         public void NetSocket_OptionsConstructor_ParsesAllowHalfOpen()
         {
-            dynamic options = new ExpandoObject();
-            options.allowHalfOpen = true;
+            var options = new JsObject();
+            options["allowHalfOpen"] = true;
 
-            var socket = new NetSocket((object)options);
+            var socket = new NetSocket(options);
 
             Assert.True(socket.allowHalfOpen);
         }
@@ -76,10 +75,10 @@ namespace Jroc.Tests.Node.Net
                 var schedulerState = serviceProvider.Resolve<NodeSchedulerState>();
                 var eventLoop = new NodeEventLoopPump(schedulerState, tickSource, waitHandle);
 
-                dynamic options = new ExpandoObject();
-                options.allowHalfOpen = true;
+                var options = new JsObject();
+                options["allowHalfOpen"] = true;
 
-                var socket = new NetSocket((object)options);
+                var socket = new NetSocket(options);
                 var events = new System.Collections.Generic.List<string>();
                 socket.on("data", (Func<object[], object?[], object?>)((scopes, args) =>
                 {

--- a/tests/Jroc.Tests/Node/NodeIoObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/Node/NodeIoObjectRepresentationTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using JavaScriptRuntime;
+using JavaScriptRuntime.Node;
+using Xunit;
+using NodeChildProcess = JavaScriptRuntime.Node.ChildProcess;
+using NodeProcess = JavaScriptRuntime.Node.Process;
+using NodeUtil = JavaScriptRuntime.Node.Util;
+
+namespace Jroc.Tests.Node;
+
+public class NodeIoObjectRepresentationTests
+{
+    [Fact]
+    public void ProcessVersionsAndEnvironment_AreJsObjects_WithoutInterningEnvironmentKeys()
+    {
+        var environmentKey = $"JROC_TEST_{Guid.NewGuid():N}";
+        var previousValue = Environment.GetEnvironmentVariable(environmentKey);
+
+        Assert.Null(string.IsInterned(environmentKey));
+        Environment.SetEnvironmentVariable(environmentKey, "value");
+
+        try
+        {
+            var process = new NodeProcess(new NonTerminatingEnvironment());
+
+            Assert.IsType<JsObject>(process.versions);
+            var environment = Assert.IsType<JsObject>(process.env);
+            Assert.Equal("value", ObjectRuntime.GetProperty(environment, environmentKey));
+            environment[environmentKey] = "updated";
+            Assert.Equal("updated", ObjectRuntime.GetProperty(environment, environmentKey));
+            Assert.Contains(environmentKey, environment.GetOwnPropertyNames());
+            Assert.Null(string.IsInterned(environmentKey));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(environmentKey, previousValue);
+        }
+    }
+
+    [Fact]
+    public void ChildProcessSpawnSync_ReturnsJsObject()
+    {
+        var childProcess = new NodeChildProcess();
+        var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : "/bin/sh";
+        var args = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? new object[] { "/c", "echo jroc" }
+            : new object[] { "-c", "printf jroc" };
+
+        var result = Assert.IsType<JsObject>(childProcess.spawnSync(command, args));
+
+        Assert.Equal(0d, ObjectRuntime.GetProperty(result, "status"));
+        Assert.Contains("jroc", ObjectRuntime.GetProperty(result, "stdout")?.ToString());
+    }
+
+    [Fact]
+    public void ChildProcessSpawnSyncFailure_ReturnsJsObject()
+    {
+        var result = Assert.IsType<JsObject>(
+            new NodeChildProcess().spawnSync($"jroc-missing-command-{Guid.NewGuid():N}"));
+
+        Assert.Equal(-1d, ObjectRuntime.GetProperty(result, "status"));
+        Assert.NotNull(ObjectRuntime.GetProperty(result, "error"));
+    }
+
+    [Fact]
+    public void ChildProcessForkOptions_RecognizeNonEnumerableHostDictionaryProperties()
+    {
+        var options = new Dictionary<string, object?> { ["silent"] = true };
+        PropertyDescriptorStore.DefineOrUpdate(options, "silent", new JsPropertyDescriptor
+        {
+            Kind = JsPropertyDescriptorKind.Data,
+            Value = true,
+            Writable = true,
+            Enumerable = false,
+            Configurable = true,
+        });
+        var tryHasOwnOption = typeof(NodeChildProcess).GetMethod(
+            "TryHasOwnOption",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        var arguments = new object?[] { options, "silent", null };
+
+        var found = Assert.IsType<bool>(tryHasOwnOption.Invoke(null, arguments));
+
+        Assert.True(found);
+        Assert.True(Assert.IsType<bool>(arguments[2]));
+    }
+
+    [Fact]
+    public void NetAddressRecord_IsJsObject()
+    {
+        var result = Assert.IsType<JsObject>(NodeNetworkingCommon.CreateAddressRecord("127.0.0.1", 8123));
+
+        Assert.Equal("127.0.0.1", ObjectRuntime.GetProperty(result, "address"));
+        Assert.Equal("IPv4", ObjectRuntime.GetProperty(result, "family"));
+        Assert.Equal(8123d, ObjectRuntime.GetProperty(result, "port"));
+        Assert.Equal(
+            "{\"address\":\"127.0.0.1\",\"family\":\"IPv4\",\"port\":8123}",
+            JavaScriptRuntime.JSON.Stringify(result));
+        Assert.Contains("address", new NodeUtil().inspect(result));
+    }
+}


### PR DESCRIPTION
Closes #1455

## Summary

- Migrate `process.versions`, `process.env`, `spawnSync` result records, and net address records from `ExpandoObject` to `JsObject`.
- Use uncached `JsObject` transitions for host-controlled environment names and shared runtime property APIs for child-process/net options.
- Preserve descriptor-backed host dictionary options and add representation, serialization, formatting, and environment behavior coverage.

## Validation

- `dotnet test tests\Jroc.Tests\Jroc.Tests.csproj --no-restore --filter 'FullyQualifiedName~NodeIoObjectRepresentationTests|FullyQualifiedName~Jroc.Tests.Node.ChildProcess|FullyQualifiedName~Jroc.Tests.Node.Net|FullyQualifiedName~Jroc.Tests.Node.Stream|FullyQualifiedName~Jroc.Tests.Node.Process'`
- `dotnet build --no-restore`
