### PR TITLE
ci(perf): compare benchmark scenarios across branches

### DIFF
--- a/.github/workflows/benchmark-branch-comparison.yml
+++ b/.github/workflows/benchmark-branch-comparison.yml
@@ -1,0 +1,134 @@
+name: Benchmark branch comparison
+run-name: Benchmark ${{ inputs.scenario_name }} - master vs ${{ inputs.private_branch }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      private_branch:
+        description: "Private branch or ref to compare with master"
+        required: true
+        type: string
+      scenario_name:
+        description: "Exact phased BenchmarkDotNet scenario name"
+        required: true
+        type: string
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+jobs:
+  compare:
+    name: Compare master and private branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout master baseline
+        uses: actions/checkout@v5
+        with:
+          ref: master
+          path: master
+          fetch-depth: 1
+
+      - name: Checkout private branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.private_branch }}
+          path: private
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Run master benchmark
+        shell: bash
+        env:
+          SCENARIO_NAME: ${{ inputs.scenario_name }}
+        run: |
+          set -euo pipefail
+
+          output_dir="$GITHUB_WORKSPACE/benchmark-comparison-results/master"
+          benchmark_dir="$GITHUB_WORKSPACE/master/tests/performance/Benchmarks"
+          mkdir -p "$output_dir"
+
+          cd "$benchmark_dir"
+          dotnet restore Benchmarks.csproj
+          dotnet build Benchmarks.csproj -c Release --no-restore
+          dotnet build-server shutdown
+          rm -rf BenchmarkDotNet.Artifacts
+
+          echo "=== master: $SCENARIO_NAME ==="
+          dotnet run --project Benchmarks.csproj -c Release --no-build -- \
+            --phased --filter "*JrocPhasedBenchmarks*" --scenario "$SCENARIO_NAME" --exporters json \
+            | tee "$output_dir/console.txt"
+
+          cp -R BenchmarkDotNet.Artifacts "$output_dir/artifacts"
+          find "$output_dir/artifacts/results" -name '*-report.md' -type f -print -exec cat {} \;
+
+      - name: Run private branch benchmark
+        if: always()
+        shell: bash
+        env:
+          SCENARIO_NAME: ${{ inputs.scenario_name }}
+          PRIVATE_BRANCH: ${{ inputs.private_branch }}
+        run: |
+          set -euo pipefail
+
+          output_dir="$GITHUB_WORKSPACE/benchmark-comparison-results/private"
+          benchmark_dir="$GITHUB_WORKSPACE/private/tests/performance/Benchmarks"
+          mkdir -p "$output_dir"
+
+          cd "$benchmark_dir"
+          dotnet restore Benchmarks.csproj
+          dotnet build Benchmarks.csproj -c Release --no-restore
+          dotnet build-server shutdown
+          rm -rf BenchmarkDotNet.Artifacts
+
+          echo "=== $PRIVATE_BRANCH: $SCENARIO_NAME ==="
+          dotnet run --project Benchmarks.csproj -c Release --no-build -- \
+            --phased --filter "*JrocPhasedBenchmarks*" --scenario "$SCENARIO_NAME" --exporters json \
+            | tee "$output_dir/console.txt"
+
+          cp -R BenchmarkDotNet.Artifacts "$output_dir/artifacts"
+          find "$output_dir/artifacts/results" -name '*-report.md' -type f -print -exec cat {} \;
+
+      - name: Write comparison metadata
+        if: always()
+        shell: bash
+        env:
+          SCENARIO_NAME: ${{ inputs.scenario_name }}
+          PRIVATE_BRANCH: ${{ inputs.private_branch }}
+        run: |
+          set -euo pipefail
+
+          output_dir="$GITHUB_WORKSPACE/benchmark-comparison-results"
+          mkdir -p "$output_dir"
+          {
+            echo "# Benchmark comparison"
+            echo
+            echo "- Scenario: \`$SCENARIO_NAME\`"
+            echo "- Baseline: \`master\`"
+            echo "- Candidate: \`$PRIVATE_BRANCH\`"
+            echo
+            echo "Raw BenchmarkDotNet reports and console output are in the \`master\` and \`private\` directories."
+          } | tee "$output_dir/README.md"
+
+      - name: Upload benchmark comparison results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-branch-comparison-results
+          path: benchmark-comparison-results
+          if-no-files-found: warn
+          retention-days: 90

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "release:cut": "node scripts/release.js",
     "release:validate": "npm run diff:test:canary:packed && dotnet test ./tests/Jroc.Tests/Jroc.Tests.csproj -c Release --filter \"FullyQualifiedName~JrocSdkPackageTests\" --nologo",
     "perf:phased:cube": "node scripts/runCubePhasedGuardrails.js",
+    "perf:compare:dispatch": "node scripts/dispatchBenchmarkBranchComparisonWorkflow.js",
     "perf:profile": "node scripts/profileBenchmarkScenario.js",
     "perf:phased:cube:dry": "node scripts/runCubePhasedGuardrails.js --dry",
     "perf:phased:cube:dry:il-smells": "node scripts/runCubePhasedGuardrails.js --dry --il-smells",

--- a/scripts/dispatchBenchmarkBranchComparisonWorkflow.js
+++ b/scripts/dispatchBenchmarkBranchComparisonWorkflow.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+"use strict";
+
+const cp = require("node:child_process");
+
+const workflowFile = "benchmark-branch-comparison.yml";
+
+function parseArgs(argv) {
+  const args = {
+    branch: null,
+    scenario: null,
+    repo: null,
+    ref: "master",
+    watch: false,
+    dryRun: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const current = argv[i];
+    switch (current) {
+      case "--branch":
+      case "-b":
+        args.branch = argv[++i] ?? null;
+        break;
+      case "--scenario":
+      case "--benchmark":
+      case "-s":
+        args.scenario = argv[++i] ?? null;
+        break;
+      case "--repo":
+        args.repo = argv[++i] ?? null;
+        break;
+      case "--ref":
+        args.ref = argv[++i] ?? null;
+        break;
+      case "--watch":
+        args.watch = true;
+        break;
+      case "--dry-run":
+        args.dryRun = true;
+        break;
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+      default:
+        if (!current.startsWith("-") && !args.branch) {
+          args.branch = current;
+        } else if (!current.startsWith("-") && !args.scenario) {
+          args.scenario = current;
+        } else {
+          throw new Error(`Unknown argument: ${current}`);
+        }
+    }
+  }
+
+  return args;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node scripts/dispatchBenchmarkBranchComparisonWorkflow.js <private-branch> <scenario-name> [options]
+
+Dispatches the manual workflow that benchmarks master first, then a private branch,
+using the same phased BenchmarkDotNet scenario. The workflow uploads both raw result
+sets and console output as an artifact.
+
+Options:
+  --branch, -b <branch>       Private branch/ref to compare with master.
+  --scenario, --benchmark,
+    -s <scenario>             Exact phased BenchmarkDotNet scenario name.
+  --repo <owner/name>         Explicit repository override (defaults to origin).
+  --ref <branch>              Branch/ref containing the workflow file (default: master).
+  --watch                     Wait for the dispatched run to finish.
+  --dry-run                   Print the gh command without dispatching.
+  --help, -h                  Show this help.
+
+Examples:
+  node scripts/dispatchBenchmarkBranchComparisonWorkflow.js perf/object-shapes dromaeo-3d-cube
+  node scripts/dispatchBenchmarkBranchComparisonWorkflow.js --branch perf/object-shapes --scenario dromaeo-3d-cube --watch
+`);
+}
+
+function run(command, args, options = {}) {
+  try {
+    return cp.execFileSync(command, args, {
+      encoding: "utf8",
+      stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    const stdout = error?.stdout ? String(error.stdout).trim() : "";
+    const stderr = error?.stderr ? String(error.stderr).trim() : "";
+    if (stdout) process.stderr.write(`${stdout}\n`);
+    if (stderr) process.stderr.write(`${stderr}\n`);
+    throw new Error(`Failed to run: ${command} ${args.join(" ")}`);
+  }
+}
+
+function inferRepoFromGitRemote() {
+  try {
+    const remote = run("git", ["remote", "get-url", "origin"]).trim();
+    const httpsMatch = remote.match(/^https?:\/\/github\.com\/(.+?)\/(.+?)(?:\.git)?$/);
+    if (httpsMatch) return `${httpsMatch[1]}/${httpsMatch[2]}`;
+
+    const sshMatch = remote.match(/^git@github\.com:(.+?)\/(.+?)(?:\.git)?$/);
+    if (sshMatch) return `${sshMatch[1]}/${sshMatch[2]}`;
+  } catch {
+    // Let gh infer the repository if the origin remote is unavailable.
+  }
+
+  return null;
+}
+
+function shellQuote(args) {
+  return args
+    .map((arg) => (/^[A-Za-z0-9_./:=@-]+$/.test(arg) ? arg : `"${arg.replaceAll('"', '\\"')}"`))
+    .join(" ");
+}
+
+function getRecentRuns(repo) {
+  const args = [
+    "run",
+    "list",
+    "--workflow",
+    workflowFile,
+    "--limit",
+    "5",
+    "--json",
+    "databaseId,url,status,conclusion,createdAt",
+  ];
+  if (repo) args.push("--repo", repo);
+
+  const json = run("gh", args).trim();
+  return json ? JSON.parse(json) : [];
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  if (!args.branch) throw new Error("A private branch/ref is required.");
+  if (!args.scenario) throw new Error("A benchmark scenario name is required.");
+  if (!args.ref) throw new Error("--ref requires a value.");
+
+  const repo = args.repo ?? inferRepoFromGitRemote();
+  const workflowArgs = [
+    "workflow",
+    "run",
+    workflowFile,
+    "--ref",
+    args.ref,
+    "-f",
+    `private_branch=${args.branch}`,
+    "-f",
+    `scenario_name=${args.scenario}`,
+  ];
+  if (repo) workflowArgs.push("--repo", repo);
+
+  if (args.dryRun) {
+    process.stdout.write(`gh ${shellQuote(workflowArgs)}\n`);
+    return;
+  }
+
+  const latestBefore = getRecentRuns(repo)[0]?.databaseId ?? 0;
+  run("gh", workflowArgs, { stdio: "inherit" });
+
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 3000);
+  const latestRun = getRecentRuns(repo).find((run) => Number(run.databaseId) > Number(latestBefore)) ?? null;
+  if (latestRun?.url) {
+    process.stdout.write(`Dispatched ${workflowFile}: ${latestRun.url}\n`);
+  } else {
+    process.stdout.write(`Dispatched ${workflowFile}.\n`);
+  }
+
+  if (args.watch && latestRun?.databaseId) {
+    const watchArgs = ["run", "watch", String(latestRun.databaseId), "--exit-status"];
+    if (repo) watchArgs.push("--repo", repo);
+    run("gh", watchArgs, { stdio: "inherit" });
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+}

--- a/tests/performance/Benchmarks/README.md
+++ b/tests/performance/Benchmarks/README.md
@@ -107,6 +107,26 @@ dotnet run -c Release -- --phased --scenario dromaeo-3d-cube
 
 If any benchmark case fails, the run now exits non-zero and prints the failing benchmark cases instead of silently treating them as successful timings.
 
+#### Branch comparison workflow
+
+Run the manual `Benchmark branch comparison` workflow to compare an exact phased
+scenario on `master` and a private branch on the same GitHub-hosted runner. It
+runs `master` first, prints both BenchmarkDotNet reports in the workflow log,
+and uploads raw reports plus console output as the
+`benchmark-branch-comparison-results` artifact.
+
+Dispatch it from a checkout with:
+
+```powershell
+node scripts/dispatchBenchmarkBranchComparisonWorkflow.js <private-branch> <scenario-name> --watch
+```
+
+For example:
+
+```powershell
+node scripts/dispatchBenchmarkBranchComparisonWorkflow.js perf/object-shapes dromaeo-3d-cube --watch
+```
+
 #### Cube-focused guardrail workflow
 Runs only the Dromaeo cube phased scenarios and prints the execution counters we track for issue #1327:
 


### PR DESCRIPTION
Adds a manual benchmark comparison workflow that runs one exact phased scenario on master first and then a supplied private branch on the same GitHub-hosted runner. It prints BenchmarkDotNet Markdown reports in the workflow log and uploads both raw result sets plus console output as a 90-day artifact.\n\nAlso adds a gh-based dispatcher script, npm shortcut, and usage documentation.\n\nThe workflow is intentionally manual-dispatch-only and is not merged.