### PR TITLE
ci(perf): support Kracken branch comparisons

### DIFF
--- a/.github/workflows/benchmark-branch-comparison.yml
+++ b/.github/workflows/benchmark-branch-comparison.yml
@@ -1,5 +1,5 @@
 name: Benchmark branch comparison
-run-name: Benchmark ${{ inputs.scenario_name }} - master vs ${{ inputs.private_branch }}
+run-name: ${{ inputs.benchmark_suite }} ${{ inputs.scenario_name }} - master vs ${{ inputs.private_branch }}
 
 on:
   workflow_dispatch:
@@ -9,9 +9,17 @@ on:
         required: true
         type: string
       scenario_name:
-        description: "Exact phased BenchmarkDotNet scenario name"
+        description: "Scenario or filter name for the selected benchmark suite"
         required: true
         type: string
+      benchmark_suite:
+        description: "Benchmark suite to run"
+        required: true
+        default: phased
+        type: choice
+        options:
+          - phased
+          - kracken
 
 env:
   DOTNET_NOLOGO: true
@@ -55,6 +63,7 @@ jobs:
         shell: bash
         env:
           SCENARIO_NAME: ${{ inputs.scenario_name }}
+          BENCHMARK_SUITE: ${{ inputs.benchmark_suite }}
         run: |
           set -euo pipefail
 
@@ -68,9 +77,22 @@ jobs:
           dotnet build-server shutdown
           rm -rf BenchmarkDotNet.Artifacts
 
-          echo "=== master: $SCENARIO_NAME ==="
+          case "$BENCHMARK_SUITE" in
+            phased)
+              benchmark_args=(--phased --filter "*JrocPhasedBenchmarks*" --scenario "$SCENARIO_NAME")
+              ;;
+            kracken)
+              benchmark_args=(--kracken --filter "*$SCENARIO_NAME*")
+              ;;
+            *)
+              echo "Unsupported benchmark suite: $BENCHMARK_SUITE" >&2
+              exit 2
+              ;;
+          esac
+
+          echo "=== master: $BENCHMARK_SUITE $SCENARIO_NAME ==="
           dotnet run --project Benchmarks.csproj -c Release --no-build -- \
-            --phased --filter "*JrocPhasedBenchmarks*" --scenario "$SCENARIO_NAME" --exporters json \
+            "${benchmark_args[@]}" --exporters json \
             | tee "$output_dir/console.txt"
 
           cp -R BenchmarkDotNet.Artifacts "$output_dir/artifacts"
@@ -81,6 +103,7 @@ jobs:
         shell: bash
         env:
           SCENARIO_NAME: ${{ inputs.scenario_name }}
+          BENCHMARK_SUITE: ${{ inputs.benchmark_suite }}
           PRIVATE_BRANCH: ${{ inputs.private_branch }}
         run: |
           set -euo pipefail
@@ -95,9 +118,22 @@ jobs:
           dotnet build-server shutdown
           rm -rf BenchmarkDotNet.Artifacts
 
-          echo "=== $PRIVATE_BRANCH: $SCENARIO_NAME ==="
+          case "$BENCHMARK_SUITE" in
+            phased)
+              benchmark_args=(--phased --filter "*JrocPhasedBenchmarks*" --scenario "$SCENARIO_NAME")
+              ;;
+            kracken)
+              benchmark_args=(--kracken --filter "*$SCENARIO_NAME*")
+              ;;
+            *)
+              echo "Unsupported benchmark suite: $BENCHMARK_SUITE" >&2
+              exit 2
+              ;;
+          esac
+
+          echo "=== $PRIVATE_BRANCH: $BENCHMARK_SUITE $SCENARIO_NAME ==="
           dotnet run --project Benchmarks.csproj -c Release --no-build -- \
-            --phased --filter "*JrocPhasedBenchmarks*" --scenario "$SCENARIO_NAME" --exporters json \
+            "${benchmark_args[@]}" --exporters json \
             | tee "$output_dir/console.txt"
 
           cp -R BenchmarkDotNet.Artifacts "$output_dir/artifacts"
@@ -108,6 +144,7 @@ jobs:
         shell: bash
         env:
           SCENARIO_NAME: ${{ inputs.scenario_name }}
+          BENCHMARK_SUITE: ${{ inputs.benchmark_suite }}
           PRIVATE_BRANCH: ${{ inputs.private_branch }}
         run: |
           set -euo pipefail
@@ -117,6 +154,7 @@ jobs:
           {
             echo "# Benchmark comparison"
             echo
+            echo "- Benchmark suite: \`$BENCHMARK_SUITE\`"
             echo "- Scenario: \`$SCENARIO_NAME\`"
             echo "- Baseline: \`master\`"
             echo "- Candidate: \`$PRIVATE_BRANCH\`"

--- a/scripts/dispatchBenchmarkBranchComparisonWorkflow.js
+++ b/scripts/dispatchBenchmarkBranchComparisonWorkflow.js
@@ -9,6 +9,7 @@ function parseArgs(argv) {
   const args = {
     branch: null,
     scenario: null,
+    benchmarkSuite: "phased",
     repo: null,
     ref: "master",
     watch: false,
@@ -24,9 +25,12 @@ function parseArgs(argv) {
         args.branch = argv[++i] ?? null;
         break;
       case "--scenario":
-      case "--benchmark":
       case "-s":
         args.scenario = argv[++i] ?? null;
+        break;
+      case "--benchmark":
+      case "--suite":
+        args.benchmarkSuite = argv[++i] ?? null;
         break;
       case "--repo":
         args.repo = argv[++i] ?? null;
@@ -62,13 +66,13 @@ function printHelp() {
   process.stdout.write(`Usage: node scripts/dispatchBenchmarkBranchComparisonWorkflow.js <private-branch> <scenario-name> [options]
 
 Dispatches the manual workflow that benchmarks master first, then a private branch,
-using the same phased BenchmarkDotNet scenario. The workflow uploads both raw result
-sets and console output as an artifact.
+using the selected BenchmarkDotNet suite. The workflow uploads both raw result sets
+and console output as an artifact.
 
 Options:
   --branch, -b <branch>       Private branch/ref to compare with master.
-  --scenario, --benchmark,
-    -s <scenario>             Exact phased BenchmarkDotNet scenario name.
+  --scenario, -s <scenario>  Scenario or filter name for the selected suite.
+  --benchmark, --suite <name> Benchmark suite: phased (default) or kracken.
   --repo <owner/name>         Explicit repository override (defaults to origin).
   --ref <branch>              Branch/ref containing the workflow file (default: master).
   --watch                     Wait for the dispatched run to finish.
@@ -78,6 +82,7 @@ Options:
 Examples:
   node scripts/dispatchBenchmarkBranchComparisonWorkflow.js perf/object-shapes dromaeo-3d-cube
   node scripts/dispatchBenchmarkBranchComparisonWorkflow.js --branch perf/object-shapes --scenario dromaeo-3d-cube --watch
+  node scripts/dispatchBenchmarkBranchComparisonWorkflow.js v0.11.21 ai-astar --benchmark kracken --watch
 `);
 }
 
@@ -143,6 +148,9 @@ function main() {
 
   if (!args.branch) throw new Error("A private branch/ref is required.");
   if (!args.scenario) throw new Error("A benchmark scenario name is required.");
+  if (!["phased", "kracken"].includes(args.benchmarkSuite)) {
+    throw new Error("--benchmark must be either 'phased' or 'kracken'.");
+  }
   if (!args.ref) throw new Error("--ref requires a value.");
 
   const repo = args.repo ?? inferRepoFromGitRemote();
@@ -156,6 +164,8 @@ function main() {
     `private_branch=${args.branch}`,
     "-f",
     `scenario_name=${args.scenario}`,
+    "-f",
+    `benchmark_suite=${args.benchmarkSuite}`,
   ];
   if (repo) workflowArgs.push("--repo", repo);
 

--- a/tests/performance/Benchmarks/README.md
+++ b/tests/performance/Benchmarks/README.md
@@ -109,10 +109,10 @@ If any benchmark case fails, the run now exits non-zero and prints the failing b
 
 #### Branch comparison workflow
 
-Run the manual `Benchmark branch comparison` workflow to compare an exact phased
-scenario on `master` and a private branch on the same GitHub-hosted runner. It
-runs `master` first, prints both BenchmarkDotNet reports in the workflow log,
-and uploads raw reports plus console output as the
+Run the manual `Benchmark branch comparison` workflow to compare a scenario from
+the `phased` (default) or `kracken` benchmark suite on `master` and a private
+branch on the same GitHub-hosted runner. It runs `master` first, prints both
+BenchmarkDotNet reports in the workflow log, and uploads raw reports plus console output as the
 `benchmark-branch-comparison-results` artifact.
 
 Dispatch it from a checkout with:
@@ -125,6 +125,12 @@ For example:
 
 ```powershell
 node scripts/dispatchBenchmarkBranchComparisonWorkflow.js perf/object-shapes dromaeo-3d-cube --watch
+```
+
+To compare the Kraken `ai-astar` scenario:
+
+```powershell
+node scripts/dispatchBenchmarkBranchComparisonWorkflow.js v0.11.21 ai-astar --benchmark kracken --watch
 ```
 
 #### Cube-focused guardrail workflow


### PR DESCRIPTION
Extends the manual benchmark comparison workflow and dispatcher with a benchmark-suite selector. The existing phased suite remains the default; the new kracken option supports comparisons such as ai-astar.\n\nThis branch was used to complete the master versus v0.11.21 ai-astar comparison run.