### PR TITLE
perf(benchmarks): add YantraJS comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/benchmarks: add YantraJS to the standard BenchmarkDotNet cross-runtime suite. YantraJS evaluates each scenario in a fresh `JSContext`, so its reported result covers the same cold runtime creation and source evaluation path as the existing Jint, Okojo, ClearScript, and `jroc (compile+execute)` comparisons.
 
 ## v0.11.24 - 2026-07-13
 

--- a/tests/performance/Benchmarks/Benchmarks.csproj
+++ b/tests/performance/Benchmarks/Benchmarks.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Jint" Version="4.2.0" />
     <PackageReference Include="Okojo" Version="0.1.2-preview.1" />
+    <PackageReference Include="YantraJS.Core" Version="1.2.206" />
     <PackageReference Include="Microsoft.ClearScript.V8" Version="7.5.1" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.5.1" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.5.1" />

--- a/tests/performance/Benchmarks/JavaScriptRuntimeBenchmarks.cs
+++ b/tests/performance/Benchmarks/JavaScriptRuntimeBenchmarks.cs
@@ -23,6 +23,7 @@ public class JavaScriptRuntimeBenchmarks
     private readonly Dictionary<string, string> _scenarioKeyToScriptName = new(StringComparer.Ordinal);
     private readonly JintRuntime _jintRuntime = new();
     private readonly OkojoRuntime _okojoRuntime = new();
+    private readonly YantraJsRuntime _yantraJsRuntime = new();
     private readonly ClearScriptRuntime _clearScriptRuntime = new();
     private readonly JrocRuntime _jrocRuntime = new();
 
@@ -91,6 +92,18 @@ public class JavaScriptRuntimeBenchmarks
         if (!result.Success)
         {
             throw new Exception($"Okojo execution failed: {result.Error}");
+        }
+    }
+
+    [Benchmark(Description = "YantraJS")]
+    public void YantraJs()
+    {
+        var script = _scripts[ScriptName];
+        var result = _yantraJsRuntime.Execute(script, $"{ResolveScriptName(ScriptName)}.js");
+
+        if (!result.Success)
+        {
+            throw new Exception($"YantraJS execution failed: {result.Error}");
         }
     }
 

--- a/tests/performance/Benchmarks/README.md
+++ b/tests/performance/Benchmarks/README.md
@@ -5,6 +5,7 @@ This directory contains a comprehensive BenchmarkDotNet-based performance benchm
 - **ClearScript** - .NET-hosted V8 runtime
 - **Jint** - .NET JavaScript interpreter
 - **Okojo** - fully managed .NET JavaScript runtime
+- **YantraJS** - .NET JavaScript runtime
 - **jroc** - JavaScript-to-IL AOT compiler
 
 ## Purpose
@@ -33,6 +34,7 @@ Benchmarks/
 │   ├── ClearScriptRuntime.cs
 │   ├── JintRuntime.cs
 │   ├── OkojoRuntime.cs
+│   ├── YantraJsRuntime.cs
 │   └── JrocRuntime.cs
 ├── Compliance/          # Licensing and provenance tracking
 │   └── PROVENANCE.md

--- a/tests/performance/Benchmarks/Runtimes/YantraJsRuntime.cs
+++ b/tests/performance/Benchmarks/Runtimes/YantraJsRuntime.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+using YantraJS.Core;
+
+namespace Benchmarks.Runtimes;
+
+/// <summary>
+/// YantraJS runtime adapter - evaluates JavaScript in a fresh YantraJS context.
+/// </summary>
+public sealed class YantraJsRuntime : IJavaScriptRuntime
+{
+    public string Name => "YantraJS";
+
+    public RuntimeExecutionResult Execute(string scriptContent, string scriptName = "script.js")
+    {
+        var result = new RuntimeExecutionResult { Success = false };
+
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var context = new JSContext();
+            context.Eval(scriptContent, scriptName);
+            stopwatch.Stop();
+
+            result.ExecutionTime = stopwatch.Elapsed;
+            result.Success = true;
+        }
+        catch (Exception ex)
+        {
+            result.Error = $"YantraJS execution failed: {ex.Message}";
+        }
+
+        return result;
+    }
+}

--- a/tests/performance/Benchmarks/ValidationTest.cs
+++ b/tests/performance/Benchmarks/ValidationTest.cs
@@ -106,6 +106,24 @@ public static class ValidationTest
             Console.WriteLine($"   Exception: {ex.Message}");
         }
 
+        // Test YantraJS
+        Console.WriteLine("\n5. Testing YantraJS...");
+        try
+        {
+            var yantraJsRuntime = new YantraJsRuntime();
+            var yantraJsResult = yantraJsRuntime.Execute(script, "minimal.js");
+            Console.WriteLine($"   Success: {yantraJsResult.Success}");
+            Console.WriteLine($"   Execution Time: {yantraJsResult.ExecutionTime.TotalMilliseconds}ms");
+            if (!yantraJsResult.Success)
+            {
+                Console.WriteLine($"   Error: {yantraJsResult.Error}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"   Exception: {ex.Message}");
+        }
+
         Console.WriteLine("\nAll runtime adapters tested!");
     }
 }


### PR DESCRIPTION
Adds YantraJS to the standard BenchmarkDotNet cross-runtime suite using a fresh JSContext per operation, matching the cold evaluation model used by the existing adapters. Also adds adapter validation coverage, benchmark documentation, and an Unreleased changelog entry.