### PR TITLE
perf(compiler): eliminate temp-use iterator allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/compiler: replace allocating LIR temp-use iterator traversal with a struct-visitor API across local allocation, stackification, normalization, branch analysis, and IL emission. A warmed seven-sample `dromaeo-3d-cube` compiler measurement reduced median allocated bytes from 84.06 MB to 16.16 MB (-80.8%). (#1481)
 
 ## v0.11.25 - 2026-07-14
 

--- a/src/Compiler/IL/BranchConditionOptimizer.cs
+++ b/src/Compiler/IL/BranchConditionOptimizer.cs
@@ -52,15 +52,8 @@ internal static class BranchConditionOptimizer
         {
             bool isBranch = instruction is LIRBranchIfFalse or LIRBranchIfTrue;
             
-            foreach (var used in TempLocalAllocator.EnumerateUsedTemps(instruction)
-                .Where(u => u.Index >= 0 && u.Index < tempCount))
-            {
-                useCount[used.Index]++;
-                if (!isBranch)
-                {
-                    usedByBranchOnly[used.Index] = false;
-                }
-            }
+            var visitor = new BranchUseVisitor(useCount, usedByBranchOnly, tempCount, isBranch);
+            TempLocalAllocator.VisitUsedTemps(instruction, ref visitor);
         }
 
         // Mark branch-only condition temps that are only used once by a branch as non-materialized.
@@ -78,6 +71,36 @@ internal static class BranchConditionOptimizer
             {
                 // Mark this temp as not needing materialization (false = not used outside)
                 shouldMaterializeTemp[i] = false;
+            }
+        }
+    }
+
+    private struct BranchUseVisitor : ITempUseVisitor
+    {
+        private readonly int[] _useCount;
+        private readonly bool[] _usedByBranchOnly;
+        private readonly int _tempCount;
+        private readonly bool _isBranch;
+
+        public BranchUseVisitor(int[] useCount, bool[] usedByBranchOnly, int tempCount, bool isBranch)
+        {
+            _useCount = useCount;
+            _usedByBranchOnly = usedByBranchOnly;
+            _tempCount = tempCount;
+            _isBranch = isBranch;
+        }
+
+        public void Visit(TempVariable temp)
+        {
+            if (temp.Index < 0 || temp.Index >= _tempCount)
+            {
+                return;
+            }
+
+            _useCount[temp.Index]++;
+            if (!_isBranch)
+            {
+                _usedByBranchOnly[temp.Index] = false;
             }
         }
     }

--- a/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
+++ b/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
@@ -201,15 +201,23 @@ internal sealed partial class LIRToILCompiler
         {
             // Try to include a little more context: which instruction attempted to use this temp.
             // This typically indicates a lowering/SSA bug where a temp is referenced without being defined.
-            var firstUse = MethodBody.Instructions
-                .Select((instr, idx) => (instr, idx))
-                .FirstOrDefault(t => TempLocalAllocator.EnumerateUsedTemps(t.instr).Any(u => u == temp));
+            LIRInstruction? firstUseInstruction = null;
+            int firstUseIndex = -1;
+            for (int i = 0; i < MethodBody.Instructions.Count; i++)
+            {
+                if (TempLocalAllocator.UsesTemp(MethodBody.Instructions[i], temp))
+                {
+                    firstUseInstruction = MethodBody.Instructions[i];
+                    firstUseIndex = i;
+                    break;
+                }
+            }
 
-            if (firstUse.instr != null)
+            if (firstUseInstruction != null)
             {
                 throw new InvalidOperationException(
                     $"Cannot emit unmaterialized temp {temp.Index} - no definition found. " +
-                    $"First use at instruction #{firstUse.idx}: {firstUse.instr.GetType().Name}");
+                    $"First use at instruction #{firstUseIndex}: {firstUseInstruction.GetType().Name}");
             }
 
             throw new InvalidOperationException($"Cannot emit unmaterialized temp {temp.Index} - no definition found (and no uses found in method body?)");
@@ -2021,12 +2029,9 @@ internal sealed partial class LIRToILCompiler
                 continue;
             }
 
-            foreach (var used in TempLocalAllocator.EnumerateUsedTemps(instruction))
+            if (TempLocalAllocator.UsesTemp(instruction, temp))
             {
-                if (used.Index == temp.Index)
-                {
-                    return true;
-                }
+                return true;
             }
         }
 
@@ -2445,15 +2450,28 @@ internal sealed partial class LIRToILCompiler
             cache = new HashSet<int>();
             foreach (var instr in MethodBody.Instructions)
             {
-                foreach (var used in TempLocalAllocator.EnumerateUsedTemps(instr))
-                {
-                    cache.Add(used.Index);
-                }
+                var visitor = new UsedTempIndexCollector(cache);
+                TempLocalAllocator.VisitUsedTemps(instr, ref visitor);
             }
             _usedTempIndexCache = cache;
         }
 
         return cache.Contains(temp.Index);
+    }
+
+    private struct UsedTempIndexCollector : ITempUseVisitor
+    {
+        private readonly HashSet<int> _indices;
+
+        public UsedTempIndexCollector(HashSet<int> indices)
+        {
+            _indices = indices;
+        }
+
+        public void Visit(TempVariable temp)
+        {
+            _indices.Add(temp.Index);
+        }
     }
 
     /// <summary>

--- a/src/Compiler/IL/Stackify.cs
+++ b/src/Compiler/IL/Stackify.cs
@@ -69,13 +69,8 @@ internal static class Stackify
                 defInstruction[def.Index] = instruction;
             }
 
-            foreach (var used in TempLocalAllocator.EnumerateUsedTemps(instruction))
-            {
-                if (used.Index >= 0 && used.Index < tempCount)
-                {
-                    useIndices[used.Index].Add(i);
-                }
-            }
+            var visitor = new UseIndexVisitor(useIndices, tempCount, i);
+            TempLocalAllocator.VisitUsedTemps(instruction, ref visitor);
         }
 
         // Second pass: check if temps meet stackify criteria
@@ -146,13 +141,8 @@ internal static class Stackify
         {
             // But only if target temp is the first operand consumed
             var useInstr = methodBody.Instructions[useIndex];
-            var operands = TempLocalAllocator.EnumerateUsedTemps(useInstr).ToList();
-            if (operands.Count > 0 && operands[0].Index == targetTemp.Index)
-            {
-                return true;
-            }
-            // If it's the only operand, also stackable
-            if (operands.Count == 1 && operands[0].Index == targetTemp.Index)
+            var operands = TempLocalAllocator.GetTempUseSummary(useInstr, targetTemp);
+            if (operands.Count > 0 && operands.First.Index == targetTemp.Index)
             {
                 return true;
             }
@@ -251,18 +241,8 @@ internal static class Stackify
 
         // At use site, verify target is consumed correctly
         var useInstr2 = methodBody.Instructions[useIndex];
-        var operands2 = TempLocalAllocator.EnumerateUsedTemps(useInstr2).ToList();
-
-        // Find which operand position our target is at
-        int targetOperandIndex = -1;
-        for (int j = 0; j < operands2.Count; j++)
-        {
-            if (operands2[j].Index == targetTemp.Index)
-            {
-                targetOperandIndex = j;
-                break;
-            }
-        }
+        var operands2 = TempLocalAllocator.GetTempUseSummary(useInstr2, targetTemp);
+        int targetOperandIndex = operands2.TargetIndex;
 
         if (targetOperandIndex < 0)
         {
@@ -287,6 +267,28 @@ internal static class Stackify
         }
 
         return true;
+    }
+
+    private struct UseIndexVisitor : ITempUseVisitor
+    {
+        private readonly List<int>[] _useIndices;
+        private readonly int _tempCount;
+        private readonly int _instructionIndex;
+
+        public UseIndexVisitor(List<int>[] useIndices, int tempCount, int instructionIndex)
+        {
+            _useIndices = useIndices;
+            _tempCount = tempCount;
+            _instructionIndex = instructionIndex;
+        }
+
+        public void Visit(TempVariable temp)
+        {
+            if (temp.Index >= 0 && temp.Index < _tempCount)
+            {
+                _useIndices[temp.Index].Add(_instructionIndex);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Compiler/IL/TempLocalAllocator.cs
+++ b/src/Compiler/IL/TempLocalAllocator.cs
@@ -4,6 +4,11 @@ using Jroc.IR;
 
 namespace Jroc.IL;
 
+internal interface ITempUseVisitor
+{
+    void Visit(TempVariable temp);
+}
+
 /// <summary>
 /// Result of temp local allocation - maps SSA temps to IL local slots.
 /// </summary>
@@ -51,12 +56,8 @@ internal static class TempLocalAllocator
         // First pass: determine last use for each temp.
         for (int i = 0; i < methodBody.Instructions.Count; i++)
         {
-            foreach (var used in EnumerateUsedTemps(methodBody.Instructions[i])
-                .Where(u => u.Index >= 0 && u.Index < tempCount &&
-                    (shouldMaterializeTemp is null || shouldMaterializeTemp[u.Index])))
-            {
-                lastUse[used.Index] = i;
-            }
+            var visitor = new LastUseVisitor(lastUse, tempCount, shouldMaterializeTemp, i);
+            VisitUsedTemps(methodBody.Instructions[i], ref visitor);
         }
 
         // Second pass: linear-scan allocation with reuse after last use.
@@ -75,33 +76,14 @@ internal static class TempLocalAllocator
             var instruction = methodBody.Instructions[i];
 
             // Free dead operands before allocating the result so we can reuse within the same instruction.
-            foreach (var used in EnumerateUsedTemps(instruction))
-            {
-                if (used.Index < 0 || used.Index >= tempCount)
-                {
-                    continue;
-                }
-
-                if (lastUse[used.Index] != i)
-                {
-                    continue;
-                }
-
-                var usedSlot = tempToSlot[used.Index];
-                if (usedSlot < 0)
-                {
-                    continue;
-                }
-
-                var usedStorage = GetTempStorage(methodBody, used);
-                var key = new StorageKey(usedStorage.Kind, usedStorage.ClrType, usedStorage.TypeHandle, usedStorage.ScopeName);
-                if (!freeByKey.TryGetValue(key, out var stack))
-                {
-                    stack = new Stack<int>();
-                    freeByKey[key] = stack;
-                }
-                stack.Push(usedSlot);
-            }
+            var releaseVisitor = new ReleaseDeadTempsVisitor(
+                methodBody,
+                lastUse,
+                tempToSlot,
+                tempCount,
+                i,
+                freeByKey);
+            VisitUsedTemps(instruction, ref releaseVisitor);
 
             // Allocate a slot for result if it will be used later.
             // Skip allocation for constant temps that can be emitted inline.
@@ -207,592 +189,459 @@ internal static class TempLocalAllocator
         return new ValueStorage(ValueStorageKind.Unknown);
     }
 
+    private struct LastUseVisitor : ITempUseVisitor
+    {
+        private readonly int[] _lastUse;
+        private readonly int _tempCount;
+        private readonly bool[]? _shouldMaterializeTemp;
+        private readonly int _instructionIndex;
+
+        public LastUseVisitor(int[] lastUse, int tempCount, bool[]? shouldMaterializeTemp, int instructionIndex)
+        {
+            _lastUse = lastUse;
+            _tempCount = tempCount;
+            _shouldMaterializeTemp = shouldMaterializeTemp;
+            _instructionIndex = instructionIndex;
+        }
+
+        public void Visit(TempVariable temp)
+        {
+            if (temp.Index >= 0
+                && temp.Index < _tempCount
+                && (_shouldMaterializeTemp is null || _shouldMaterializeTemp[temp.Index]))
+            {
+                _lastUse[temp.Index] = _instructionIndex;
+            }
+        }
+    }
+
+    private struct ReleaseDeadTempsVisitor : ITempUseVisitor
+    {
+        private readonly MethodBodyIR _methodBody;
+        private readonly int[] _lastUse;
+        private readonly int[] _tempToSlot;
+        private readonly int _tempCount;
+        private readonly int _instructionIndex;
+        private readonly Dictionary<StorageKey, Stack<int>> _freeByKey;
+
+        public ReleaseDeadTempsVisitor(
+            MethodBodyIR methodBody,
+            int[] lastUse,
+            int[] tempToSlot,
+            int tempCount,
+            int instructionIndex,
+            Dictionary<StorageKey, Stack<int>> freeByKey)
+        {
+            _methodBody = methodBody;
+            _lastUse = lastUse;
+            _tempToSlot = tempToSlot;
+            _tempCount = tempCount;
+            _instructionIndex = instructionIndex;
+            _freeByKey = freeByKey;
+        }
+
+        public void Visit(TempVariable temp)
+        {
+            if (temp.Index < 0
+                || temp.Index >= _tempCount
+                || _lastUse[temp.Index] != _instructionIndex)
+            {
+                return;
+            }
+
+            var usedSlot = _tempToSlot[temp.Index];
+            if (usedSlot < 0)
+            {
+                return;
+            }
+
+            var usedStorage = GetTempStorage(_methodBody, temp);
+            var key = new StorageKey(usedStorage.Kind, usedStorage.ClrType, usedStorage.TypeHandle, usedStorage.ScopeName);
+            if (!_freeByKey.TryGetValue(key, out var stack))
+            {
+                stack = new Stack<int>();
+                _freeByKey[key] = stack;
+            }
+
+            stack.Push(usedSlot);
+        }
+    }
+
     /// <summary>
-    /// Enumerates all temps used (read) by an instruction.
+    /// Visits all temps read by an instruction without allocating an iterator object.
     /// </summary>
-    internal static IEnumerable<TempVariable> EnumerateUsedTemps(LIRInstruction instruction)
+    internal static void VisitUsedTemps<TVisitor>(LIRInstruction instruction, ref TVisitor visitor)
+        where TVisitor : struct, ITempUseVisitor
     {
         switch (instruction)
         {
-            case LIRAddNumber add:
-                yield return add.Left;
-                yield return add.Right;
-                break;
-            case LIRConcatStrings concat:
-                yield return concat.Left;
-                yield return concat.Right;
-                break;
-            case LIRAddDynamic addDyn:
-                yield return addDyn.Left;
-                yield return addDyn.Right;
-                break;
-            case LIRAddDynamicDoubleObject addDynDoubleObject:
-                yield return addDynDoubleObject.LeftDouble;
-                yield return addDynDoubleObject.RightObject;
-                break;
-            case LIRAddDynamicObjectDouble addDynObjectDouble:
-                yield return addDynObjectDouble.LeftObject;
-                yield return addDynObjectDouble.RightDouble;
-                break;
-            case LIRAddAndToNumber addAndToNumber:
-                yield return addAndToNumber.Left;
-                yield return addAndToNumber.Right;
-                break;
-            case LIRSubNumber sub:
-                yield return sub.Left;
-                yield return sub.Right;
-                break;
-            case LIRMulNumber mul:
-                yield return mul.Left;
-                yield return mul.Right;
-                break;
-            case LIRMulDynamic mulDyn:
-                yield return mulDyn.Left;
-                yield return mulDyn.Right;
-                break;
-            case LIRCallIntrinsic call:
-                yield return call.IntrinsicObject;
-                yield return call.ArgumentsArray;
-                break;
-
-            case LIRCallIntrinsicGlobalFunction callGlobal:
-                foreach (var arg in callGlobal.Arguments)
+            case LIRAddNumber value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRConcatStrings value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRAddDynamic value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRAddDynamicDoubleObject value:
+                visitor.Visit(value.LeftDouble); visitor.Visit(value.RightObject); break;
+            case LIRAddDynamicObjectDouble value:
+                visitor.Visit(value.LeftObject); visitor.Visit(value.RightDouble); break;
+            case LIRAddAndToNumber value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRSubNumber value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRMulNumber value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRMulDynamic value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRCallIntrinsic value:
+                visitor.Visit(value.IntrinsicObject); visitor.Visit(value.ArgumentsArray); break;
+            case LIRCallIntrinsicGlobalFunction value:
+                VisitList(value.Arguments, ref visitor); break;
+            case LIRCallInstanceMethod value:
+                visitor.Visit(value.Receiver); VisitList(value.Arguments, ref visitor); break;
+            case LIRCallIntrinsicStatic value:
+                VisitList(value.Arguments, ref visitor); break;
+            case LIRCallIntrinsicStaticVoid value:
+                VisitList(value.Arguments, ref visitor); break;
+            case LIRCallIntrinsicStaticWithArgsArray value:
+                visitor.Visit(value.ArgumentsArray); break;
+            case LIRCallIntrinsicStaticVoidWithArgsArray value:
+                visitor.Visit(value.ArgumentsArray); break;
+            case LIRCallRuntimeServicesStatic value:
+                VisitList(value.Arguments, ref visitor); break;
+            case LIRConvertToObject value:
+                visitor.Visit(value.Source); break;
+            case LIRConvertToNumber value:
+                visitor.Visit(value.Source); break;
+            case LIRConvertToNumberDiscard value:
+                visitor.Visit(value.Source); break;
+            case LIRConvertToBoolean value:
+                visitor.Visit(value.Source); break;
+            case LIRConvertToString value:
+                visitor.Visit(value.Source); break;
+            case LIRTypeof value:
+                visitor.Visit(value.Value); break;
+            case LIRNegateNumber value:
+                visitor.Visit(value.Value); break;
+            case LIRNegateNumberDynamic value:
+                visitor.Visit(value.Value); break;
+            case LIRBitwiseNotNumber value:
+                visitor.Visit(value.Value); break;
+            case LIRBitwiseNotDynamic value:
+                visitor.Visit(value.Value); break;
+            case LIRLogicalNot value:
+                visitor.Visit(value.Value); break;
+            case LIRIsInstanceOf value:
+                visitor.Visit(value.Value); break;
+            case LIRCompareNumberLessThan value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRCompareNumberGreaterThan value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRCompareNumberLessThanOrEqual value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRCompareNumberGreaterThanOrEqual value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRCompareNumberEqual value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRCompareNumberNotEqual value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRCompareBooleanEqual value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRCompareBooleanNotEqual value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRDivNumber value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRModNumber value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRExpNumber value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRBitwiseAnd value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRBitwiseOr value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRBitwiseXor value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRLeftShift value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRRightShift value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRUnsignedRightShift value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRCallIsTruthy value:
+                visitor.Visit(value.Value); break;
+            case LIRCallIsTruthyDouble value:
+                visitor.Visit(value.Value); break;
+            case LIRCallIsTruthyBool value:
+                visitor.Visit(value.Value); break;
+            case LIRCopyTemp value:
+                visitor.Visit(value.Source); break;
+            case LIRInOperator value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRInstanceOfOperator value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIREqualDynamic value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRNotEqualDynamic value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRStrictEqualDynamic value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRStrictNotEqualDynamic value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRBinaryDynamicOperator value:
+                visitor.Visit(value.Left); visitor.Visit(value.Right); break;
+            case LIRReturn value:
+                visitor.Visit(value.ReturnValue); break;
+            case LIRBranchIfFalse value:
+                visitor.Visit(value.Condition); break;
+            case LIRBranchIfTrue value:
+                visitor.Visit(value.Condition); break;
+            case LIRCallFunction value:
+                visitor.Visit(value.ScopesArray); VisitList(value.Arguments, ref visitor); break;
+            case LIRTailCallFunctionReturn value:
+                visitor.Visit(value.ScopesArray); VisitList(value.Arguments, ref visitor); break;
+            case LIRCallFunctionWithArgsArray value:
+                visitor.Visit(value.ScopesArray); visitor.Visit(value.ArgumentsArray); break;
+            case LIRCallFunctionValue value:
+                visitor.Visit(value.FunctionValue); visitor.Visit(value.ScopesArray); visitor.Visit(value.ArgumentsArray); break;
+            case LIRCallFunctionValue0 value:
+                visitor.Visit(value.FunctionValue); visitor.Visit(value.ScopesArray); break;
+            case LIRCallFunctionValue1 value:
+                visitor.Visit(value.FunctionValue); visitor.Visit(value.ScopesArray); visitor.Visit(value.A0); break;
+            case LIRCallFunctionValue2 value:
+                visitor.Visit(value.FunctionValue); visitor.Visit(value.ScopesArray); visitor.Visit(value.A0); visitor.Visit(value.A1); break;
+            case LIRCallFunctionValue3 value:
+                visitor.Visit(value.FunctionValue); visitor.Visit(value.ScopesArray); visitor.Visit(value.A0); visitor.Visit(value.A1); visitor.Visit(value.A2); break;
+            case LIRCallRequire value:
+                visitor.Visit(value.RequireValue); visitor.Visit(value.ModuleId); break;
+            case LIRCallImport value:
+                visitor.Visit(value.ModuleSpecifier); visitor.Visit(value.CurrentModuleId); break;
+            case LIRConstructValue value:
+                visitor.Visit(value.ConstructorValue); visitor.Visit(value.ArgumentsArray); break;
+            case LIRCallFunctionBaseConstructor value:
+                visitor.Visit(value.ConstructorValue); visitor.Visit(value.ArgumentsArray); break;
+            case LIRCallMember value:
+                visitor.Visit(value.Receiver); visitor.Visit(value.ArgumentsArray); break;
+            case LIRCallMember0 value:
+                visitor.Visit(value.Receiver); break;
+            case LIRCallMember1 value:
+                visitor.Visit(value.Receiver); visitor.Visit(value.A0); break;
+            case LIRCallMember2 value:
+                visitor.Visit(value.Receiver); visitor.Visit(value.A0); visitor.Visit(value.A1); break;
+            case LIRCallMember3 value:
+                visitor.Visit(value.Receiver); visitor.Visit(value.A0); visitor.Visit(value.A1); visitor.Visit(value.A2); break;
+            case LIRCallTypedMember value:
+                visitor.Visit(value.Receiver); VisitList(value.Arguments, ref visitor); break;
+            case LIRCallTypedMemberWithFallback value:
+                visitor.Visit(value.Receiver); VisitList(value.Arguments, ref visitor); break;
+            case LIRCallUserClassInstanceMethod value:
+                VisitList(value.Arguments, ref visitor); break;
+            case LIRCallUserClassBaseConstructor value:
+                VisitList(value.Arguments, ref visitor); VisitList(value.AllJsArguments, ref visitor); break;
+            case LIRCallIntrinsicBaseConstructor value:
+                VisitList(value.Arguments, ref visitor); break;
+            case LIRCallUserClassBaseInstanceMethod value:
+                VisitList(value.Arguments, ref visitor); break;
+            case LIRBuildScopesArray value:
+                VisitScopeSlots(value.Slots, ref visitor); break;
+            case LIRStoreParameter value:
+                visitor.Visit(value.Value); break;
+            case LIRStoreLeafScopeField value:
+                visitor.Visit(value.Value); break;
+            case LIRStoreParentScopeField value:
+                visitor.Visit(value.Value); break;
+            case LIRStoreScopeFieldByName value:
+                visitor.Visit(value.Value); break;
+            case LIRLoadScopeField value:
+                visitor.Visit(value.ScopeInstance); break;
+            case LIRStoreScopeField value:
+                visitor.Visit(value.ScopeInstance); visitor.Visit(value.Value); break;
+            case LIRAwait value:
+                visitor.Visit(value.AwaitedValue); break;
+            case LIRYield value:
+                visitor.Visit(value.YieldedValue); break;
+            case LIRAsyncCallMoveNext value:
+                visitor.Visit(value.ScopesArray); break;
+            case LIRAsyncResolve value:
+                visitor.Visit(value.Value); break;
+            case LIRAsyncReject value:
+                visitor.Visit(value.Reason); break;
+            case LIRAsyncStateSwitch value:
+                visitor.Visit(value.StateValue); break;
+            case LIRAsyncStoreAwaitedResult value:
+                visitor.Visit(value.Value); break;
+            case LIRBuildArray value:
+                VisitList(value.Elements, ref visitor); break;
+            case LIRNewJsArray value:
+                VisitList(value.Elements, ref visitor); break;
+            case LIRNewJsObject value:
+                VisitObjectPropertyValues(value.Properties, ref visitor); break;
+            case LIRNewInferredJsObject value:
+                VisitInferredObjectPropertyValues(value.Properties, ref visitor); break;
+            case LIRGetInferredMember value:
+                visitor.Visit(value.Receiver); break;
+            case LIRSetInferredMember value:
+                visitor.Visit(value.Receiver); visitor.Visit(value.Value); break;
+            case LIRGetLength value:
+                visitor.Visit(value.Object); break;
+            case LIRGetStringLength value:
+                visitor.Visit(value.Receiver); break;
+            case LIRGetJsArrayLength value:
+                visitor.Visit(value.Receiver); break;
+            case LIRGetInt32ArrayLength value:
+                visitor.Visit(value.Receiver); break;
+            case LIRGetItem value:
+                visitor.Visit(value.Object); visitor.Visit(value.Index); break;
+            case LIRGetItemAsNumber value:
+                visitor.Visit(value.Object); visitor.Visit(value.Index); break;
+            case LIRGetItemAsNumberString value:
+                visitor.Visit(value.Object); visitor.Visit(value.Index); break;
+            case LIRSetItem value:
+                visitor.Visit(value.Object); visitor.Visit(value.Index); visitor.Visit(value.Value); break;
+            case LIRSetJsArrayLength value:
+                visitor.Visit(value.Receiver); visitor.Visit(value.Value); break;
+            case LIRGetJsArrayElement value:
+                visitor.Visit(value.Receiver); visitor.Visit(value.Index); break;
+            case LIRSetJsArrayElement value:
+                visitor.Visit(value.Receiver); visitor.Visit(value.Index); visitor.Visit(value.Value); break;
+            case LIRGetInt32ArrayElement value:
+                visitor.Visit(value.Receiver); visitor.Visit(value.Index); break;
+            case LIRSetInt32ArrayElement value:
+                visitor.Visit(value.Receiver); visitor.Visit(value.Index); visitor.Visit(value.Value); break;
+            case LIRArrayPushRange value:
+                visitor.Visit(value.TargetArray); visitor.Visit(value.SourceArray); break;
+            case LIRArrayAdd value:
+                visitor.Visit(value.TargetArray); visitor.Visit(value.Element); break;
+            case LIRNewBuiltInError value when value.Message.HasValue:
+                visitor.Visit(value.Message.Value); break;
+            case LIRNewIntrinsicObject value:
+                VisitList(value.Arguments, ref visitor); break;
+            case LIRNewUserClass value:
+                if (value.NeedsScopes && value.ScopesArray.HasValue)
                 {
-                    yield return arg;
+                    visitor.Visit(value.ScopesArray.Value);
                 }
-                break;
-            case LIRCallInstanceMethod callInstance:
-                yield return callInstance.Receiver;
-                foreach (var arg in callInstance.Arguments)
-                {
-                    yield return arg;
-                }
-                break;
-            case LIRCallIntrinsicStatic callStatic:
-                foreach (var arg in callStatic.Arguments)
-                {
-                    yield return arg;
-                }
-                break;
-
-            case LIRCallIntrinsicStaticVoid callStaticVoid:
-                foreach (var arg in callStaticVoid.Arguments)
-                {
-                    yield return arg;
-                }
-                break;
-
-            case LIRCallIntrinsicStaticWithArgsArray callStaticWithArgsArray:
-                yield return callStaticWithArgsArray.ArgumentsArray;
-                break;
-
-            case LIRCallIntrinsicStaticVoidWithArgsArray callStaticVoidWithArgsArray:
-                yield return callStaticVoidWithArgsArray.ArgumentsArray;
-                break;
-            
-            case LIRCallRuntimeServicesStatic callRuntimeServices:
-                foreach (var arg in callRuntimeServices.Arguments)
-                {
-                    yield return arg;
-                }
-                break;
-            
-            case LIRConvertToObject conv:
-                yield return conv.Source;
-                break;
-            case LIRConvertToNumber convNum:
-                yield return convNum.Source;
-                break;
-            case LIRConvertToNumberDiscard convNumDiscard:
-                yield return convNumDiscard.Source;
-                break;
-            case LIRConvertToBoolean convBool:
-                yield return convBool.Source;
-                break;
-            case LIRConvertToString convString:
-                yield return convString.Source;
-                break;
-            case LIRTypeof t:
-                yield return t.Value;
-                break;
-            case LIRNegateNumber neg:
-                yield return neg.Value;
-                break;
-            case LIRNegateNumberDynamic negDyn:
-                yield return negDyn.Value;
-                break;
-            case LIRBitwiseNotNumber not:
-                yield return not.Value;
-                break;
-            case LIRBitwiseNotDynamic notDyn:
-                yield return notDyn.Value;
-                break;
-            case LIRLogicalNot logicalNot:
-                yield return logicalNot.Value;
-                break;
-
-            case LIRIsInstanceOf isInstanceOf:
-                yield return isInstanceOf.Value;
-                break;
-            case LIRCompareNumberLessThan cmp:
-                yield return cmp.Left;
-                yield return cmp.Right;
-                break;
-            case LIRCompareNumberGreaterThan cmp:
-                yield return cmp.Left;
-                yield return cmp.Right;
-                break;
-            case LIRCompareNumberLessThanOrEqual cmp:
-                yield return cmp.Left;
-                yield return cmp.Right;
-                break;
-            case LIRCompareNumberGreaterThanOrEqual cmp:
-                yield return cmp.Left;
-                yield return cmp.Right;
-                break;
-            case LIRCompareNumberEqual cmp:
-                yield return cmp.Left;
-                yield return cmp.Right;
-                break;
-            case LIRCompareNumberNotEqual cmp:
-                yield return cmp.Left;
-                yield return cmp.Right;
-                break;
-            case LIRCompareBooleanEqual cmp:
-                yield return cmp.Left;
-                yield return cmp.Right;
-                break;
-            case LIRCompareBooleanNotEqual cmp:
-                yield return cmp.Left;
-                yield return cmp.Right;
-                break;
-            case LIRDivNumber div:
-                yield return div.Left;
-                yield return div.Right;
-                break;
-            case LIRModNumber mod:
-                yield return mod.Left;
-                yield return mod.Right;
-                break;
-            case LIRExpNumber exp:
-                yield return exp.Left;
-                yield return exp.Right;
-                break;
-            case LIRBitwiseAnd bitwiseAnd:
-                yield return bitwiseAnd.Left;
-                yield return bitwiseAnd.Right;
-                break;
-            case LIRBitwiseOr bitwiseOr:
-                yield return bitwiseOr.Left;
-                yield return bitwiseOr.Right;
-                break;
-            case LIRBitwiseXor bitwiseXor:
-                yield return bitwiseXor.Left;
-                yield return bitwiseXor.Right;
-                break;
-            case LIRLeftShift leftShift:
-                yield return leftShift.Left;
-                yield return leftShift.Right;
-                break;
-            case LIRRightShift rightShift:
-                yield return rightShift.Left;
-                yield return rightShift.Right;
-                break;
-            case LIRUnsignedRightShift unsignedRightShift:
-                yield return unsignedRightShift.Left;
-                yield return unsignedRightShift.Right;
-                break;
-            case LIRCallIsTruthy callIsTruthy:
-                yield return callIsTruthy.Value;
-                break;
-            case LIRCallIsTruthyDouble callIsTruthyDouble:
-                yield return callIsTruthyDouble.Value;
-                break;
-            case LIRCallIsTruthyBool callIsTruthyBool:
-                yield return callIsTruthyBool.Value;
-                break;
-            case LIRCopyTemp copyTemp:
-                yield return copyTemp.Source;
-                break;
-            case LIRInOperator inOp:
-                yield return inOp.Left;
-                yield return inOp.Right;
-                break;
-            case LIRInstanceOfOperator instOf:
-                yield return instOf.Left;
-                yield return instOf.Right;
-                break;
-            case LIREqualDynamic equalDyn:
-                yield return equalDyn.Left;
-                yield return equalDyn.Right;
-                break;
-            case LIRNotEqualDynamic notEqualDyn:
-                yield return notEqualDyn.Left;
-                yield return notEqualDyn.Right;
-                break;
-            case LIRStrictEqualDynamic strictEqualDyn:
-                yield return strictEqualDyn.Left;
-                yield return strictEqualDyn.Right;
-                break;
-            case LIRStrictNotEqualDynamic strictNotEqualDyn:
-                yield return strictNotEqualDyn.Left;
-                yield return strictNotEqualDyn.Right;
-                break;
-            case LIRBinaryDynamicOperator binaryDynamic:
-                yield return binaryDynamic.Left;
-                yield return binaryDynamic.Right;
-                break;
-            case LIRReturn ret:
-                yield return ret.ReturnValue;
-                break;
-            case LIRBranchIfFalse branchFalse:
-                yield return branchFalse.Condition;
-                break;
-            case LIRBranchIfTrue branchTrue:
-                yield return branchTrue.Condition;
-                break;
-            case LIRCallFunction callFunc:
-                yield return callFunc.ScopesArray;
-                foreach (var arg in callFunc.Arguments)
-                {
-                    yield return arg;
-                }
-                break;
-            case LIRTailCallFunctionReturn tailCall:
-                yield return tailCall.ScopesArray;
-                foreach (var arg in tailCall.Arguments)
-                {
-                    yield return arg;
-                }
-                break;
-            case LIRCallFunctionWithArgsArray callWithArgsArray:
-                yield return callWithArgsArray.ScopesArray;
-                yield return callWithArgsArray.ArgumentsArray;
-                break;
-            case LIRCallFunctionValue callValue:
-                yield return callValue.FunctionValue;
-                yield return callValue.ScopesArray;
-                yield return callValue.ArgumentsArray;
-                break;
-            case LIRCallFunctionValue0 callValue0:
-                yield return callValue0.FunctionValue;
-                yield return callValue0.ScopesArray;
-                break;
-            case LIRCallFunctionValue1 callValue1:
-                yield return callValue1.FunctionValue;
-                yield return callValue1.ScopesArray;
-                yield return callValue1.A0;
-                break;
-            case LIRCallFunctionValue2 callValue2:
-                yield return callValue2.FunctionValue;
-                yield return callValue2.ScopesArray;
-                yield return callValue2.A0;
-                yield return callValue2.A1;
-                break;
-            case LIRCallFunctionValue3 callValue3:
-                yield return callValue3.FunctionValue;
-                yield return callValue3.ScopesArray;
-                yield return callValue3.A0;
-                yield return callValue3.A1;
-                yield return callValue3.A2;
-                break;
-
-            case LIRCallRequire callRequire:
-                yield return callRequire.RequireValue;
-                yield return callRequire.ModuleId;
-                break;
-
-            case LIRCallImport callImport:
-                yield return callImport.ModuleSpecifier;
-                yield return callImport.CurrentModuleId;
-                break;
-
-            case LIRConstructValue constructValue:
-                yield return constructValue.ConstructorValue;
-                yield return constructValue.ArgumentsArray;
-                break;
-            case LIRCallFunctionBaseConstructor callFunctionBase:
-                yield return callFunctionBase.ConstructorValue;
-                yield return callFunctionBase.ArgumentsArray;
-                break;
-            case LIRCallMember callMember:
-                yield return callMember.Receiver;
-                yield return callMember.ArgumentsArray;
-                break;
-            case LIRCallMember0 callMember0:
-                yield return callMember0.Receiver;
-                break;
-            case LIRCallMember1 callMember1:
-                yield return callMember1.Receiver;
-                yield return callMember1.A0;
-                break;
-            case LIRCallMember2 callMember2:
-                yield return callMember2.Receiver;
-                yield return callMember2.A0;
-                yield return callMember2.A1;
-                break;
-            case LIRCallMember3 callMember3:
-                yield return callMember3.Receiver;
-                yield return callMember3.A0;
-                yield return callMember3.A1;
-                yield return callMember3.A2;
-                break;
-
-            case LIRCallTypedMember callTyped:
-                yield return callTyped.Receiver;
-                foreach (var arg in callTyped.Arguments)
-                {
-                    yield return arg;
-                }
-                break;
-
-            case LIRCallTypedMemberWithFallback callTypedFallback:
-                yield return callTypedFallback.Receiver;
-                foreach (var arg in callTypedFallback.Arguments)
-                {
-                    yield return arg;
-                }
-                break;
-
-            case LIRCallUserClassInstanceMethod callUserClass:
-                foreach (var arg in callUserClass.Arguments)
-                {
-                    yield return arg;
-                }
-                break;
-
-            case LIRCallUserClassBaseConstructor callBaseCtor:
-                foreach (var a in callBaseCtor.Arguments)
-                {
-                    yield return a;
-                }
-                foreach (var a in callBaseCtor.AllJsArguments)
-                {
-                    yield return a;
-                }
-                break;
-
-            case LIRCallIntrinsicBaseConstructor callIntrinsicBaseCtor:
-                foreach (var a in callIntrinsicBaseCtor.Arguments)
-                {
-                    yield return a;
-                }
-                break;
-
-            case LIRCallUserClassBaseInstanceMethod callBaseMethod:
-                foreach (var a in callBaseMethod.Arguments)
-                {
-                    yield return a;
-                }
-                break;
-            case LIRBuildScopesArray:
-                // LIRBuildScopesArray may load scope instances from temps (ScopeInstanceSource.Temp).
-                if (instruction is LIRBuildScopesArray buildScopes)
-                {
-                    foreach (var temp in buildScopes.Slots
-                        .Where(slot => slot.Source == ScopeInstanceSource.Temp && slot.SourceIndex >= 0)
-                        .Select(slot => new TempVariable(slot.SourceIndex)))
-                    {
-                        yield return temp;
-                    }
-                }
-                break;
-            case LIRLoadThis:
-                // LIRLoadThis doesn't consume any temps (it loads from IL argument 0)
-                break;
-            case LIRLoadParameter:
-                // LIRLoadParameter doesn't consume any temps (it loads from IL argument)
-                break;
-            case LIRStoreParameter storeParameter:
-                yield return storeParameter.Value;
-                break;
-            case LIRStoreLeafScopeField storeLeaf:
-                yield return storeLeaf.Value;
-                break;
-            case LIRStoreParentScopeField storeParent:
-                yield return storeParent.Value;
-                break;
-            case LIRStoreScopeFieldByName storeByName:
-                yield return storeByName.Value;
-                break;
-
-            case LIRLoadScopeField loadScopeField:
-                yield return loadScopeField.ScopeInstance;
-                break;
-
-            case LIRStoreScopeField storeScopeField:
-                yield return storeScopeField.ScopeInstance;
-                yield return storeScopeField.Value;
-                break;
-            case LIRLoadLeafScopeField:
-            case LIRLoadParentScopeField:
-            case LIRLoadScopeFieldByName:
-                // Load instructions don't consume temps (they load from scope fields)
-                break;
-
-            // Async / await state machine instructions
-            case LIRAwait awaitInstr:
-                yield return awaitInstr.AwaitedValue;
-                break;
-            // Generator state machine instructions
-            case LIRYield yieldInstr:
-                yield return yieldInstr.YieldedValue;
-                break;
-            case LIRGeneratorStateSwitch:
-                // Switch does not consume temps.
-                break;
-            case LIRAsyncCallMoveNext callMoveNext:
-                yield return callMoveNext.ScopesArray;
-                break;
-            case LIRAsyncResolve asyncResolve:
-                yield return asyncResolve.Value;
-                break;
-            case LIRAsyncReject asyncReject:
-                yield return asyncReject.Reason;
-                break;
-            case LIRAsyncStateSwitch stateSwitch:
-                yield return stateSwitch.StateValue;
-                break;
-            case LIRAsyncStoreAwaitedResult storeAwaited:
-                yield return storeAwaited.Value;
-                break;
-            case LIRBuildArray buildArray:
-                foreach (var elem in buildArray.Elements)
-                {
-                    yield return elem;
-                }
-                break;
-            case LIRNewJsArray newJsArray:
-                foreach (var elem in newJsArray.Elements)
-                {
-                    yield return elem;
-                }
-                break;
-            case LIRNewJsObject newJsObject:
-                foreach (var prop in newJsObject.Properties)
-                {
-                    yield return prop.Value;
-                }
-                break;
-            case LIRNewInferredJsObject newInferredJsObject:
-                foreach (var prop in newInferredJsObject.Properties)
-                {
-                    yield return prop.Value;
-                }
-                break;
-            case LIRGetInferredMember getInferredMember:
-                yield return getInferredMember.Receiver;
-                break;
-            case LIRSetInferredMember setInferredMember:
-                yield return setInferredMember.Receiver;
-                yield return setInferredMember.Value;
-                break;
-            case LIRGetLength getLength:
-                yield return getLength.Object;
-                break;
-            case LIRGetStringLength getStringLength:
-                yield return getStringLength.Receiver;
-                break;
-            case LIRGetJsArrayLength getJsArrayLength:
-                yield return getJsArrayLength.Receiver;
-                break;
-            case LIRGetInt32ArrayLength getInt32ArrayLength:
-                yield return getInt32ArrayLength.Receiver;
-                break;
-            case LIRGetItem getItem:
-                yield return getItem.Object;
-                yield return getItem.Index;
-                break;
-            case LIRGetItemAsNumber getItemAsNumber:
-                yield return getItemAsNumber.Object;
-                yield return getItemAsNumber.Index;
-                break;
-            case LIRGetItemAsNumberString getItemAsNumberString:
-                yield return getItemAsNumberString.Object;
-                yield return getItemAsNumberString.Index;
-                break;
-            case LIRSetItem setItem:
-                yield return setItem.Object;
-                yield return setItem.Index;
-                yield return setItem.Value;
-                break;
-            case LIRSetJsArrayLength setJsArrayLength:
-                yield return setJsArrayLength.Receiver;
-                yield return setJsArrayLength.Value;
-                break;
-            case LIRGetJsArrayElement getJsArray:
-                yield return getJsArray.Receiver;
-                yield return getJsArray.Index;
-                break;
-            case LIRSetJsArrayElement setJsArray:
-                yield return setJsArray.Receiver;
-                yield return setJsArray.Index;
-                yield return setJsArray.Value;
-                break;
-            case LIRGetInt32ArrayElement getInt32Array:
-                yield return getInt32Array.Receiver;
-                yield return getInt32Array.Index;
-                break;
-            case LIRSetInt32ArrayElement setInt32Array:
-                yield return setInt32Array.Receiver;
-                yield return setInt32Array.Index;
-                yield return setInt32Array.Value;
-                break;
-            case LIRArrayPushRange pushRange:
-                yield return pushRange.TargetArray;
-                yield return pushRange.SourceArray;
-                break;
-            case LIRArrayAdd arrayAdd:
-                yield return arrayAdd.TargetArray;
-                yield return arrayAdd.Element;
-                break;
-            case LIRNewBuiltInError newError:
-                if (newError.Message.HasValue)
-                {
-                    yield return newError.Message.Value;
-                }
-                break;
-            case LIRNewIntrinsicObject newIntrinsic:
-                foreach (var arg in newIntrinsic.Arguments)
-                {
-                    yield return arg;
-                }
-                break;
-            case LIRNewUserClass newUserClass:
-                if (newUserClass.NeedsScopes && newUserClass.ScopesArray.HasValue)
-                {
-                    yield return newUserClass.ScopesArray.Value;
-                }
-                foreach (var arg in newUserClass.Arguments)
-                {
-                    yield return arg;
-                }
-                break;
-
-            case LIRCallDeclaredCallable callDeclared:
-                foreach (var arg in callDeclared.Arguments)
-                {
-                    yield return arg;
-                }
-                break;
-
-            case LIRCreateBoundArrowFunction createArrow:
-                yield return createArrow.ScopesArray;
-                break;
-
-            case LIRCreateBoundFunctionExpression createFunc:
-                yield return createFunc.ScopesArray;
-                break;
-            case LIRStoreUserClassInstanceField storeInstanceField:
-                yield return storeInstanceField.Value;
-                break;
-
-            case LIRStoreUserClassStaticField storeStaticField:
-                yield return storeStaticField.Value;
-                break;
-            // LIRLabel and LIRBranch don't use temps
+                VisitList(value.Arguments, ref visitor);
+                break;
+            case LIRCallDeclaredCallable value:
+                VisitList(value.Arguments, ref visitor); break;
+            case LIRCreateBoundArrowFunction value:
+                visitor.Visit(value.ScopesArray); break;
+            case LIRCreateBoundFunctionExpression value:
+                visitor.Visit(value.ScopesArray); break;
+            case LIRStoreUserClassInstanceField value:
+                visitor.Visit(value.Value); break;
+            case LIRStoreUserClassStaticField value:
+                visitor.Visit(value.Value); break;
         }
     }
+
+    private static void VisitList<TVisitor>(IReadOnlyList<TempVariable> temps, ref TVisitor visitor)
+        where TVisitor : struct, ITempUseVisitor
+    {
+        for (int i = 0; i < temps.Count; i++)
+        {
+            visitor.Visit(temps[i]);
+        }
+    }
+
+    private static void VisitScopeSlots<TVisitor>(IReadOnlyList<ScopeSlotSource> slots, ref TVisitor visitor)
+        where TVisitor : struct, ITempUseVisitor
+    {
+        for (int i = 0; i < slots.Count; i++)
+        {
+            var slot = slots[i];
+            if (slot.Source == ScopeInstanceSource.Temp && slot.SourceIndex >= 0)
+            {
+                visitor.Visit(new TempVariable(slot.SourceIndex));
+            }
+        }
+    }
+
+    private static void VisitObjectPropertyValues<TVisitor>(IReadOnlyList<ObjectProperty> properties, ref TVisitor visitor)
+        where TVisitor : struct, ITempUseVisitor
+    {
+        for (int i = 0; i < properties.Count; i++)
+        {
+            visitor.Visit(properties[i].Value);
+        }
+    }
+
+    private static void VisitInferredObjectPropertyValues<TVisitor>(IReadOnlyList<InferredObjectProperty> properties, ref TVisitor visitor)
+        where TVisitor : struct, ITempUseVisitor
+    {
+        for (int i = 0; i < properties.Count; i++)
+        {
+            visitor.Visit(properties[i].Value);
+        }
+    }
+
+    internal static bool UsesTemp(LIRInstruction instruction, TempVariable target)
+    {
+        var visitor = new TempMatchVisitor(target.Index);
+        VisitUsedTemps(instruction, ref visitor);
+        return visitor.Found;
+    }
+
+    internal static TempUseSummary GetTempUseSummary(LIRInstruction instruction, TempVariable target)
+    {
+        var visitor = new TempUseSummaryVisitor(target.Index);
+        VisitUsedTemps(instruction, ref visitor);
+        return visitor.ToSummary();
+    }
+
+    internal readonly record struct TempUseSummary(int Count, TempVariable First, int TargetIndex);
+
+    private struct TempMatchVisitor : ITempUseVisitor
+    {
+        private readonly int _targetIndex;
+
+        public TempMatchVisitor(int targetIndex)
+        {
+            _targetIndex = targetIndex;
+        }
+
+        public bool Found { get; private set; }
+
+        public void Visit(TempVariable temp)
+        {
+            Found |= temp.Index == _targetIndex;
+        }
+    }
+
+    private struct TempUseSummaryVisitor : ITempUseVisitor
+    {
+        private readonly int _targetIndex;
+        private TempVariable _first;
+
+        public TempUseSummaryVisitor(int targetIndex)
+        {
+            _targetIndex = targetIndex;
+            _first = default;
+            TargetIndex = -1;
+        }
+
+        public int Count { get; private set; }
+        public int TargetIndex { get; private set; }
+
+        public void Visit(TempVariable temp)
+        {
+            if (Count == 0)
+            {
+                _first = temp;
+            }
+
+            if (temp.Index == _targetIndex && TargetIndex < 0)
+            {
+                TargetIndex = Count;
+            }
+
+            Count++;
+        }
+
+        public TempUseSummary ToSummary()
+            => new(Count, _first, TargetIndex);
+    }
+
 
     /// <summary>
     /// Gets the temp defined (written) by an instruction, if any.

--- a/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
@@ -1275,12 +1275,9 @@ internal static class LIRIntrinsicNormalization
                 continue;
             }
 
-            foreach (var used in TempLocalAllocator.EnumerateUsedTemps(methodBody.Instructions[i]))
+            if (TempLocalAllocator.UsesTemp(methodBody.Instructions[i], temp))
             {
-                if (used.Index == temp.Index)
-                {
-                    return true;
-                }
+                return true;
             }
         }
 

--- a/src/Compiler/IR/LIR/LIRMemberCallNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRMemberCallNormalization.cs
@@ -539,12 +539,9 @@ internal static class LIRMemberCallNormalization
                 continue;
             }
 
-            foreach (var used in TempLocalAllocator.EnumerateUsedTemps(methodBody.Instructions[i]))
+            if (TempLocalAllocator.UsesTemp(methodBody.Instructions[i], temp))
             {
-                if (used.Index == temp.Index)
-                {
-                    return true;
-                }
+                return true;
             }
         }
 

--- a/src/Compiler/IR/LIR/LIRTypeNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRTypeNormalization.cs
@@ -491,12 +491,9 @@ internal static class LIRTypeNormalization
                 continue;
             }
 
-            foreach (var used in TempLocalAllocator.EnumerateUsedTemps(methodBody.Instructions[i]))
+            if (TempLocalAllocator.UsesTemp(methodBody.Instructions[i], temp))
             {
-                if (used.Index == temp.Index)
-                {
-                    return true;
-                }
+                return true;
             }
         }
 

--- a/src/Compiler/TypedTempOptimization.md
+++ b/src/Compiler/TypedTempOptimization.md
@@ -310,7 +310,7 @@ The pinned-slot guard is required because a temp can be both a temp and a write
 to a stable IL local. Removing such an instruction can break loop-carried state,
 try/finally state, generator state, or other compiler-created variables.
 
-The use scan relies on `TempLocalAllocator.EnumerateUsedTemps`, so this PR also
+The use scan relies on `TempLocalAllocator.VisitUsedTemps`, so this PR also
 adds missing tracking for `LIRGetItemAsNumberString`. Without that, a boxed temp
 used by string-key item access could be incorrectly deleted.
 
@@ -352,7 +352,7 @@ uses but still be read through the variable slot by later generated IL.
 
 This PR updates `TempLocalAllocator` in two related ways:
 
-1. `EnumerateUsedTemps` now reports the `Object` and `Index` operands for
+1. `VisitUsedTemps` reports the `Object` and `Index` operands for
    `LIRGetItemAsNumberString`.
 2. `TryGetDefinedTemp` now reports its `Result`.
 
@@ -385,7 +385,7 @@ Future typed-temp optimizations should preserve these invariants:
    slot write is proven redundant.
 3. Do not use `ValueStorageFacts.IsSameRuntimeRepresentation` as a general
    conversion test. It is intentionally stricter.
-4. Keep `TempLocalAllocator.EnumerateUsedTemps` and `TryGetDefinedTemp` in sync
+4. Keep `TempLocalAllocator.VisitUsedTemps` and `TryGetDefinedTemp` in sync
    with every instruction shape that IL emission reads or writes.
 5. Treat `object` call boundaries differently from typed boundaries. Avoiding a
    box for a typed parameter is good; moving a box to a runtime-dispatch fallback

--- a/tests/Jroc.Tests/IL/TempLocalAllocatorTests.cs
+++ b/tests/Jroc.Tests/IL/TempLocalAllocatorTests.cs
@@ -7,6 +7,56 @@ namespace Jroc.Tests;
 public sealed class TempLocalAllocatorTests
 {
     [Fact]
+    public void VisitUsedTemps_VisitsFixedOperandsInOrder()
+    {
+        var instruction = new LIRSetItem(
+            Object: new TempVariable(1),
+            Index: new TempVariable(2),
+            Value: new TempVariable(3),
+            Result: new TempVariable(4));
+        var visitor = new CollectingVisitor();
+
+        TempLocalAllocator.VisitUsedTemps(instruction, ref visitor);
+
+        Assert.Equal(new[] { 1, 2, 3 }, visitor.Indices);
+    }
+
+    [Fact]
+    public void VisitUsedTemps_VisitsVariableOperandsInOrder()
+    {
+        var instruction = new LIRNewJsArray(
+            new[] { new TempVariable(1), new TempVariable(2), new TempVariable(3) },
+            new TempVariable(4));
+        var visitor = new CollectingVisitor();
+
+        TempLocalAllocator.VisitUsedTemps(instruction, ref visitor);
+
+        Assert.Equal(new[] { 1, 2, 3 }, visitor.Indices);
+    }
+
+    [Fact]
+    public void VisitUsedTemps_DoesNotAllocateForFixedOperandInstruction()
+    {
+        var instruction = new LIRSetItem(
+            Object: new TempVariable(1),
+            Index: new TempVariable(2),
+            Value: new TempVariable(3),
+            Result: new TempVariable(4));
+        var visitor = new CountingVisitor();
+
+        TempLocalAllocator.VisitUsedTemps(instruction, ref visitor);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 10_000; i++)
+        {
+            TempLocalAllocator.VisitUsedTemps(instruction, ref visitor);
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(0, allocated);
+        Assert.Equal(30_003, visitor.Count);
+    }
+
+    [Fact]
     public void TryGetDefinedTemp_Recognizes_LIRSetItem_Result()
     {
         var instruction = new LIRSetItem(
@@ -55,5 +105,30 @@ public sealed class TempLocalAllocatorTests
 
         Assert.True(TempLocalAllocator.TryGetDefinedTemp(instruction, out var defined));
         Assert.Equal(2, defined.Index);
+    }
+
+    private struct CollectingVisitor : ITempUseVisitor
+    {
+        public CollectingVisitor()
+        {
+            Indices = new List<int>();
+        }
+
+        public List<int> Indices { get; }
+
+        public void Visit(TempVariable temp)
+        {
+            Indices.Add(temp.Index);
+        }
+    }
+
+    private struct CountingVisitor : ITempUseVisitor
+    {
+        public int Count { get; private set; }
+
+        public void Visit(TempVariable temp)
+        {
+            Count++;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Replaces `TempLocalAllocator.EnumerateUsedTemps`' allocating `yield` iterator with a struct-visitor traversal. The visitor is used by temp-local allocation, stackification, branch analysis, normalization passes, and IL-emission temp-use queries.

The change removes iterator and LINQ allocation from the repeated LIR walks while retaining operand order and all variable-arity instruction traversal. Focused coverage verifies fixed operands, variable operands, and zero allocations across 10,000 fixed-operand traversals.

Closes #1481.

## Compiler allocation measurement

Measured `JrocInMemoryCompiler.Compile` for `tests\performance\Benchmarks\Scenarios\dromaeo-3d-cube.js` using a dedicated Release runner:

- one unmeasured warm-up compile;
- seven samples per revision;
- forced full GC before each sample;
- `GC.GetTotalAllocatedBytes(precise: true)` delta around only the compile call.

| Revision | Median allocated bytes | Median allocated MB | Change |
| --- | ---: | ---: | ---: |
| `master` (`e17ec384a`) | 84,057,144 | 84.06 | baseline |
| this branch (`e9c096271`) | 16,156,528 | 16.16 | -67,900,616 bytes (-80.8%) |

The final branch samples ranged from 13,566,808 to 16,209,424 allocated bytes; the low final sample was retained in the median rather than discarded.

## Validation

- `dotnet build src\Jroc.Core\Jroc.Core.csproj --nologo -v:q`
- `dotnet test tests\Jroc.Tests\Jroc.Tests.csproj --nologo -v:q --filter 'FullyQualifiedName~Compile_Resources_Dromaeo_3d_Cube|FullyQualifiedName~TempLocalAllocatorTests'`
