### PR TITLE
perf(compiler): specialize proven numeric var locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/compiler: specialize proven numeric function-local `var` bindings and loop induction variables into unboxed `double` locals after a flow-sensitive initialization/write proof. Hoisted reads, conditional and optional writes, mixed types, captures, shadowing, destructuring, and abrupt loop control retain object storage. Legacy `dromaeo-3d-cube` generated IL now has 44 fewer double boxes, 38 fewer `TypeUtilities.ToNumber` calls, and 4 fewer dynamic `Operators.*` calls; a same-runner comparison improved precompiled execution from 12.151 ms to 11.593 ms (-4.6%) and runtime allocation from 5,137.69 KB to 4,850.26 KB (-5.6%). Compile time changed from 79.525 ms to 75.792 ms (-4.7%) while compiler allocation increased from 12,596.37 KB to 13,060.09 KB (+3.7%). The modern lexical-declaration control remained allocation-neutral; its timing varied +3.7% in this run. (#1476, parent #1322)
 
 ## v0.11.26 - 2026-07-14
 

--- a/src/Compiler/IR/LIR/HIRToLIRLower.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLower.cs
@@ -10,6 +10,11 @@ namespace Jroc.IR;
 
 public sealed partial class HIRToLIRLowerer
 {
+    private static bool CanUseStablePrimitiveLocal(BindingInfo binding, Type clrType)
+        => binding.IsStableType
+           && binding.ClrType == clrType
+           && (binding.Kind != BindingKind.Var || binding.CanUseUnboxedLocal);
+
     private readonly MethodBodyIR _methodBodyIR = new MethodBodyIR();
     private readonly Scope? _scope;
     private readonly EnvironmentLayout? _environmentLayout;

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.MemberAccess.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.MemberAccess.cs
@@ -591,7 +591,8 @@ public sealed partial class HIRToLIRLowerer
         ValueStorage GetPreferredBindingReadStorage(BindingInfo b)
         {
             if (b.Kind == BindingKind.Var
-                && !b.DeclaringScope.Parameters.Contains(b.Name))
+                && !b.DeclaringScope.Parameters.Contains(b.Name)
+                && !b.CanUseUnboxedLocal)
             {
                 return new ValueStorage(ValueStorageKind.Reference, typeof(object));
             }

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.UpdateAndAssignment.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.UpdateAndAssignment.cs
@@ -1319,12 +1319,12 @@ public sealed partial class HIRToLIRLowerer
         // object-typed JS variable into an unboxed local slot.
         TempVariable slotValue;
         ValueStorage slotStorage;
-        if (binding.Kind != BindingKind.Var && binding.IsStableType && binding.ClrType == typeof(double))
+        if (CanUseStablePrimitiveLocal(binding, typeof(double)))
         {
             slotValue = EnsureNumber(valueToStore);
             slotStorage = new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double));
         }
-        else if (binding.Kind != BindingKind.Var && binding.IsStableType && binding.ClrType == typeof(bool))
+        else if (CanUseStablePrimitiveLocal(binding, typeof(bool)))
         {
             slotValue = EnsureBoolean(valueToStore);
             slotStorage = new ValueStorage(ValueStorageKind.UnboxedValue, typeof(bool));
@@ -1677,12 +1677,12 @@ public sealed partial class HIRToLIRLowerer
         // into an unboxed local slot.
         TempVariable slotValue;
         ValueStorage slotStorage;
-        if (binding.Kind != BindingKind.Var && binding.IsStableType && binding.ClrType == typeof(double))
+        if (CanUseStablePrimitiveLocal(binding, typeof(double)))
         {
             slotValue = EnsureNumber(valueToStore);
             slotStorage = new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double));
         }
-        else if (binding.Kind != BindingKind.Var && binding.IsStableType && binding.ClrType == typeof(bool))
+        else if (CanUseStablePrimitiveLocal(binding, typeof(bool)))
         {
             slotValue = EnsureBoolean(valueToStore);
             slotStorage = new ValueStorage(ValueStorageKind.UnboxedValue, typeof(bool));

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
@@ -474,7 +474,8 @@ public sealed partial class HIRToLIRLowerer
                     // var bindings can be observed as `undefined` before their initializer runs.
                     // Keep reads boxed to preserve that state shape across all control-flow paths.
                     if (b.Kind == BindingKind.Var
-                        && !b.DeclaringScope.Parameters.Contains(b.Name))
+                        && !b.DeclaringScope.Parameters.Contains(b.Name)
+                        && !b.CanUseUnboxedLocal)
                     {
                         return new ValueStorage(ValueStorageKind.Reference, typeof(object));
                     }

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementVariableDeclarations.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementVariableDeclarations.cs
@@ -94,6 +94,13 @@ public sealed partial class HIRToLIRLowerer
             return true;
         }
 
+        // A proven numeric var has no observable read on any path before its first
+        // numeric assignment, so its source-level `var x;` declaration is a runtime no-op.
+        if (exprStmt.Initializer == null && binding.CanUseUnboxedLocal)
+        {
+            return true;
+        }
+
         TempVariable value;
         TempVariable? withResolvedVarNameTemp = null;
         TempVariable? withResolvedVarShadowedTemp = null;
@@ -195,12 +202,12 @@ public sealed partial class HIRToLIRLowerer
         if (TryGetActiveScopeFieldStorage(binding, out var activeScopeTemp, out var activeScopeId, out var activeFieldId))
         {
             TempVariable fieldValue;
-            if ((binding.Kind != BindingKind.Var && binding.IsStableType && binding.ClrType == typeof(double))
+            if ((CanUseStablePrimitiveLocal(binding, typeof(double)))
                 || (binding.Kind == BindingKind.Const && initializerProvesUnboxedDouble))
             {
                 fieldValue = EnsureNumber(value);
             }
-            else if ((binding.Kind != BindingKind.Var && binding.IsStableType && binding.ClrType == typeof(bool))
+            else if ((CanUseStablePrimitiveLocal(binding, typeof(bool)))
                 || (binding.Kind == BindingKind.Const && initializerProvesUnboxedBool))
             {
                 fieldValue = EnsureBoolean(value);
@@ -257,12 +264,12 @@ public sealed partial class HIRToLIRLowerer
         // IMPORTANT: declared locals should never store raw unboxed JsNull into an object-typed IL local.
         // Use unboxed locals only for proven-stable primitives (double/bool); otherwise box to object.
         TempVariable slotValue;
-        if ((binding.Kind != BindingKind.Var && binding.IsStableType && binding.ClrType == typeof(double))
+        if (CanUseStablePrimitiveLocal(binding, typeof(double))
             || (binding.Kind == BindingKind.Const && initializerProvesUnboxedDouble))
         {
             slotValue = EnsureNumber(value);
         }
-        else if ((binding.Kind != BindingKind.Var && binding.IsStableType && binding.ClrType == typeof(bool))
+        else if (CanUseStablePrimitiveLocal(binding, typeof(bool))
             || (binding.Kind == BindingKind.Const && initializerProvesUnboxedBool))
         {
             slotValue = EnsureBoolean(value);

--- a/src/Compiler/SymbolTable/BindingInfo.cs
+++ b/src/Compiler/SymbolTable/BindingInfo.cs
@@ -86,6 +86,12 @@ public class BindingInfo
     public bool HasWrite { get; set; }
 
     /// <summary>
+    /// True when a non-captured <c>var</c> binding is proven numeric and definitely
+    /// initialized before every reachable read in its callable.
+    /// </summary>
+    public bool CanUseUnboxedLocal { get; set; }
+
+    /// <summary>
     /// True when accesses to this binding must respect the temporal dead zone.
     /// This applies to lexical declarations (<c>let</c>, <c>const</c>, and class bindings modeled as <c>let</c>)
     /// but not to parameters injected into the scope.

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
@@ -1367,8 +1367,6 @@ public partial class SymbolTableBuilder
             proposedClrTypes[uninitializedBindingName] = assignedType;
         }
 
-        InferDefinitelyInitializedNumericVarLocals(scope, proposedClrTypes);
-
         foreach (var kvp in proposedClrTypes)
         {
             var binding = scope.Bindings[kvp.Key];

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
@@ -991,6 +991,17 @@ public partial class SymbolTableBuilder
             return null;
         }
 
+        if (onlyReturn.Argument is Identifier returnedIdentifier)
+        {
+            var returnedBinding = TryResolveBinding(callableScope, returnedIdentifier.Name);
+            if (returnedBinding?.Kind == BindingKind.Var
+                && !returnedBinding.DeclaringScope.Parameters.Contains(returnedBinding.Name)
+                && returnedBinding.ClrType == null)
+            {
+                return null;
+            }
+        }
+
         var inferred = InferExpressionClrType(onlyReturn.Argument, callableScope);
 
         bool IsIdentifierForcedNumericBeforeReturn(string name)
@@ -1355,6 +1366,8 @@ public partial class SymbolTableBuilder
 
             proposedClrTypes[uninitializedBindingName] = assignedType;
         }
+
+        InferDefinitelyInitializedNumericVarLocals(scope, proposedClrTypes);
 
         foreach (var kvp in proposedClrTypes)
         {

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.NumericVarLocals.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.NumericVarLocals.cs
@@ -5,6 +5,33 @@ namespace Jroc.SymbolTables;
 
 public partial class SymbolTableBuilder
 {
+    private void InferDefinitelyInitializedNumericVarLocals(Scope root)
+    {
+        if (root.Kind == ScopeKind.Function)
+        {
+            var proposedClrTypes = root.Bindings.Values
+                .Where(binding => binding.IsStableType && binding.ClrType != null)
+                .ToDictionary(
+                    binding => binding.Name,
+                    binding => binding.ClrType!,
+                    StringComparer.Ordinal);
+
+            InferDefinitelyInitializedNumericVarLocals(root, proposedClrTypes);
+
+            foreach (var (name, clrType) in proposedClrTypes)
+            {
+                var binding = root.Bindings[name];
+                binding.ClrType = clrType;
+                binding.IsStableType = true;
+            }
+        }
+
+        foreach (var child in root.Children)
+        {
+            InferDefinitelyInitializedNumericVarLocals(child);
+        }
+    }
+
     private void InferDefinitelyInitializedNumericVarLocals(
         Scope scope,
         Dictionary<string, Type> proposedClrTypes)

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.NumericVarLocals.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.NumericVarLocals.cs
@@ -1,0 +1,688 @@
+using Acornima;
+using Acornima.Ast;
+
+namespace Jroc.SymbolTables;
+
+public partial class SymbolTableBuilder
+{
+    private void InferDefinitelyInitializedNumericVarLocals(
+        Scope scope,
+        Dictionary<string, Type> proposedClrTypes)
+    {
+        foreach (var binding in scope.Bindings.Values)
+        {
+            binding.CanUseUnboxedLocal = false;
+        }
+
+        if (scope.Kind != ScopeKind.Function || !TryGetCallableBody(scope, out var body))
+        {
+            return;
+        }
+
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (var binding in scope.Bindings.Values)
+            {
+                if (binding.Kind != BindingKind.Var
+                    || binding.IsCaptured
+                    || scope.Parameters.Contains(binding.Name)
+                    || binding.CanUseUnboxedLocal)
+                {
+                    continue;
+                }
+
+                var analyzer = new NumericVarDefiniteAssignmentAnalyzer(
+                    this,
+                    scope,
+                    binding,
+                    proposedClrTypes);
+                if (!analyzer.TryAnalyze(body))
+                {
+                    continue;
+                }
+
+                if (!proposedClrTypes.TryGetValue(binding.Name, out var existingType))
+                {
+                    proposedClrTypes[binding.Name] = typeof(double);
+                    changed = true;
+                }
+                else if (existingType != typeof(double))
+                {
+                    continue;
+                }
+
+                binding.CanUseUnboxedLocal = true;
+                changed = true;
+            }
+        }
+        while (changed);
+
+        // General stable-type inference can see a later numeric initializer and infer
+        // through an earlier hoisted read (for example, `var y = x; var x = 1`).
+        // Such an initializer evaluates to undefined and must not acquire a numeric
+        // local or callable-return fact.
+        foreach (var binding in scope.Bindings.Values)
+        {
+            if (binding.Kind != BindingKind.Var
+                || binding.CanUseUnboxedLocal
+                || binding.DeclarationNode is not VariableDeclarator { Init: Expression initializer })
+            {
+                continue;
+            }
+
+            var analyzer = new NumericVarDefiniteAssignmentAnalyzer(
+                this,
+                scope,
+                binding,
+                proposedClrTypes);
+            if (!analyzer.InitializerForwardsUnsafeNumericDependency(initializer))
+            {
+                continue;
+            }
+
+            proposedClrTypes.Remove(binding.Name);
+            binding.ClrType = null;
+            binding.IsStableType = false;
+        }
+    }
+
+    private static bool TryGetCallableBody(Scope scope, out BlockStatement body)
+    {
+        body = scope.AstNode switch
+        {
+            FunctionDeclaration declaration => declaration.Body,
+            FunctionExpression expression => expression.Body,
+            ArrowFunctionExpression { Body: BlockStatement block } => block,
+            _ => null!
+        };
+        return body != null;
+    }
+
+    private sealed class NumericVarDefiniteAssignmentAnalyzer
+    {
+        private readonly SymbolTableBuilder _builder;
+        private readonly Scope _functionScope;
+        private readonly BindingInfo _target;
+        private readonly Dictionary<string, Type> _proposedClrTypes;
+        private bool _sawNumericWrite;
+
+        public NumericVarDefiniteAssignmentAnalyzer(
+            SymbolTableBuilder builder,
+            Scope functionScope,
+            BindingInfo target,
+            Dictionary<string, Type> proposedClrTypes)
+        {
+            _builder = builder;
+            _functionScope = functionScope;
+            _target = target;
+            _proposedClrTypes = proposedClrTypes;
+        }
+
+        public bool TryAnalyze(BlockStatement body)
+        {
+            if (ContainsAbruptLoopControl(body))
+            {
+                return false;
+            }
+
+            var definitelyAssigned = false;
+            return AnalyzeStatementList(body.Body, _functionScope, ref definitelyAssigned)
+                && _sawNumericWrite;
+        }
+
+        public bool InitializerForwardsUnsafeNumericDependency(Expression expression)
+            => InitializerForwardsUnsafeNumericDependency(expression, _functionScope);
+
+        private bool InitializerForwardsUnsafeNumericDependency(
+            Expression expression,
+            Scope currentScope)
+        {
+            return expression switch
+            {
+                Identifier => HasUnsafeNumericVarDependency(expression, currentScope, parent: null),
+                ParenthesizedExpression parenthesized
+                    => InitializerForwardsUnsafeNumericDependency(parenthesized.Expression, currentScope),
+                SequenceExpression sequence when sequence.Expressions.Count > 0
+                    => InitializerForwardsUnsafeNumericDependency(sequence.Expressions[^1], currentScope),
+                ConditionalExpression conditional
+                    => InitializerForwardsUnsafeNumericDependency(conditional.Consequent, currentScope)
+                       || InitializerForwardsUnsafeNumericDependency(conditional.Alternate, currentScope),
+                LogicalExpression logical
+                    => InitializerForwardsUnsafeNumericDependency(logical.Left, currentScope)
+                       || InitializerForwardsUnsafeNumericDependency(logical.Right, currentScope),
+                AssignmentExpression assignment
+                    => InitializerForwardsUnsafeNumericDependency(assignment.Right, currentScope),
+                _ => false
+            };
+        }
+
+        private bool AnalyzeStatementList(
+            NodeList<Statement> statements,
+            Scope currentScope,
+            ref bool definitelyAssigned)
+        {
+            foreach (var statement in statements)
+            {
+                if (!AnalyzeStatement(statement, currentScope, ref definitelyAssigned))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool AnalyzeStatement(Node statement, Scope currentScope, ref bool definitelyAssigned)
+        {
+            currentScope = GetScopeForNode(currentScope, statement);
+
+            switch (statement)
+            {
+                case BlockStatement block:
+                    return AnalyzeStatementList(block.Body, currentScope, ref definitelyAssigned);
+
+                case VariableDeclaration declaration:
+                    foreach (var declarator in declaration.Declarations)
+                    {
+                        if (declarator.Id is Identifier id
+                            && ResolvesToTarget(currentScope, id.Name))
+                        {
+                            if (declarator.Init == null)
+                            {
+                                continue;
+                            }
+
+                            if (!AnalyzeExpression(declarator.Init, currentScope, ref definitelyAssigned)
+                                || InferNumericValueType(declarator.Init, currentScope) != typeof(double))
+                            {
+                                return false;
+                            }
+
+                            definitelyAssigned = true;
+                            _sawNumericWrite = true;
+                        }
+                        else
+                        {
+                            if (ContainsTargetReference(declarator.Id, currentScope))
+                            {
+                                return false;
+                            }
+
+                            if (declarator.Init != null
+                                && !AnalyzeExpression(declarator.Init, currentScope, ref definitelyAssigned))
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                    return true;
+
+                case ExpressionStatement expressionStatement:
+                    return AnalyzeExpression(expressionStatement.Expression, currentScope, ref definitelyAssigned);
+
+                case IfStatement ifStatement:
+                    if (!AnalyzeExpression(ifStatement.Test, currentScope, ref definitelyAssigned))
+                    {
+                        return false;
+                    }
+
+                    var thenAssigned = definitelyAssigned;
+                    if (!AnalyzeStatement(ifStatement.Consequent, currentScope, ref thenAssigned))
+                    {
+                        return false;
+                    }
+
+                    var elseAssigned = definitelyAssigned;
+                    if (ifStatement.Alternate != null
+                        && !AnalyzeStatement(ifStatement.Alternate, currentScope, ref elseAssigned))
+                    {
+                        return false;
+                    }
+
+                    definitelyAssigned = thenAssigned && elseAssigned;
+                    return true;
+
+                case ForStatement forStatement:
+                    if (forStatement.Init is Node init
+                        && !AnalyzeStatementOrExpression(init, currentScope, ref definitelyAssigned))
+                    {
+                        return false;
+                    }
+
+                    if (forStatement.Test != null
+                        && !AnalyzeExpression(forStatement.Test, currentScope, ref definitelyAssigned))
+                    {
+                        return false;
+                    }
+
+                    var loopAssigned = definitelyAssigned;
+                    if (!AnalyzeStatement(forStatement.Body, currentScope, ref loopAssigned)
+                        || (forStatement.Update != null
+                            && !AnalyzeExpression(forStatement.Update, currentScope, ref loopAssigned)))
+                    {
+                        return false;
+                    }
+
+                    return true;
+
+                case WhileStatement whileStatement:
+                    if (!AnalyzeExpression(whileStatement.Test, currentScope, ref definitelyAssigned))
+                    {
+                        return false;
+                    }
+
+                    var whileAssigned = definitelyAssigned;
+                    return AnalyzeStatement(whileStatement.Body, currentScope, ref whileAssigned);
+
+                case DoWhileStatement doWhileStatement:
+                    var doAssigned = definitelyAssigned;
+                    if (!AnalyzeStatement(doWhileStatement.Body, currentScope, ref doAssigned)
+                        || !AnalyzeExpression(doWhileStatement.Test, currentScope, ref doAssigned))
+                    {
+                        return false;
+                    }
+                    return true;
+
+                case ReturnStatement returnStatement:
+                    return returnStatement.Argument == null
+                        || AnalyzeExpression(returnStatement.Argument, currentScope, ref definitelyAssigned);
+
+                case ThrowStatement throwStatement:
+                    return AnalyzeExpression(throwStatement.Argument, currentScope, ref definitelyAssigned);
+
+                case LabeledStatement labeledStatement:
+                    return AnalyzeStatement(labeledStatement.Body, currentScope, ref definitelyAssigned);
+
+                case EmptyStatement:
+                case BreakStatement:
+                case ContinueStatement:
+                case DebuggerStatement:
+                    return true;
+
+                case FunctionDeclaration:
+                    return !ContainsTargetReference(statement, currentScope);
+
+                case ForInStatement:
+                case ForOfStatement:
+                case SwitchStatement:
+                case TryStatement:
+                case WithStatement:
+                    return !ContainsTargetReference(statement, currentScope);
+
+                default:
+                    return !ContainsTargetReference(statement, currentScope);
+            }
+        }
+
+        private bool AnalyzeStatementOrExpression(Node node, Scope currentScope, ref bool definitelyAssigned)
+            => node is Statement statement
+                ? AnalyzeStatement(statement, currentScope, ref definitelyAssigned)
+                : node is Expression expression
+                    && AnalyzeExpression(expression, currentScope, ref definitelyAssigned);
+
+        private bool AnalyzeExpression(Expression expression, Scope currentScope, ref bool definitelyAssigned)
+        {
+            currentScope = GetScopeForNode(currentScope, expression);
+
+            switch (expression)
+            {
+                case Identifier identifier:
+                    return !ResolvesToTarget(currentScope, identifier.Name) || definitelyAssigned;
+
+                case AssignmentExpression assignment
+                    when assignment.Left is Identifier id
+                         && ResolvesToTarget(currentScope, id.Name):
+                    if (assignment.Operator != Operator.Assignment && !definitelyAssigned)
+                    {
+                        return false;
+                    }
+
+                    if (!AnalyzeExpression(assignment.Right, currentScope, ref definitelyAssigned)
+                        || InferNumericValueType(assignment.Right, currentScope) != typeof(double))
+                    {
+                        return false;
+                    }
+
+                    definitelyAssigned = true;
+                    _sawNumericWrite = true;
+                    return true;
+
+                case AssignmentExpression assignment:
+                    if (assignment.Left is Expression leftExpression)
+                    {
+                        if (!AnalyzeExpression(leftExpression, currentScope, ref definitelyAssigned))
+                        {
+                            return false;
+                        }
+                    }
+                    else if (ContainsTargetReference(assignment.Left, currentScope))
+                    {
+                        return false;
+                    }
+
+                    return AnalyzeExpression(assignment.Right, currentScope, ref definitelyAssigned);
+
+                case UpdateExpression update
+                    when update.Argument is Identifier id
+                         && ResolvesToTarget(currentScope, id.Name):
+                    if (!definitelyAssigned)
+                    {
+                        return false;
+                    }
+                    _sawNumericWrite = true;
+                    return true;
+
+                case SequenceExpression sequence:
+                    foreach (var item in sequence.Expressions)
+                    {
+                        if (!AnalyzeExpression(item, currentScope, ref definitelyAssigned))
+                        {
+                            return false;
+                        }
+                    }
+                    return true;
+
+                case ConditionalExpression conditional:
+                    if (!AnalyzeExpression(conditional.Test, currentScope, ref definitelyAssigned))
+                    {
+                        return false;
+                    }
+
+                    var consequentAssigned = definitelyAssigned;
+                    var alternateAssigned = definitelyAssigned;
+                    if (!AnalyzeExpression(conditional.Consequent, currentScope, ref consequentAssigned)
+                        || !AnalyzeExpression(conditional.Alternate, currentScope, ref alternateAssigned))
+                    {
+                        return false;
+                    }
+
+                    definitelyAssigned = consequentAssigned && alternateAssigned;
+                    return true;
+
+                case LogicalExpression logical:
+                    if (!AnalyzeExpression(logical.Left, currentScope, ref definitelyAssigned))
+                    {
+                        return false;
+                    }
+
+                    var rightAssigned = definitelyAssigned;
+                    return AnalyzeExpression(logical.Right, currentScope, ref rightAssigned);
+
+                case CallExpression { Optional: true } optionalCall:
+                    if (!AnalyzeExpression(optionalCall.Callee, currentScope, ref definitelyAssigned))
+                    {
+                        return false;
+                    }
+
+                    var argumentAssigned = definitelyAssigned;
+                    foreach (var argument in optionalCall.Arguments)
+                    {
+                        if (!AnalyzeChildNode(argument, currentScope, ref argumentAssigned))
+                        {
+                            return false;
+                        }
+                    }
+                    return true;
+
+                case MemberExpression member:
+                    if (!AnalyzeExpression(member.Object, currentScope, ref definitelyAssigned))
+                    {
+                        return false;
+                    }
+
+                    if (!member.Computed)
+                    {
+                        return true;
+                    }
+
+                    if (!member.Optional)
+                    {
+                        return AnalyzeExpression(member.Property, currentScope, ref definitelyAssigned);
+                    }
+
+                    var propertyAssigned = definitelyAssigned;
+                    return AnalyzeExpression(member.Property, currentScope, ref propertyAssigned);
+
+                case FunctionExpression:
+                case ArrowFunctionExpression:
+                case ClassExpression:
+                    return !ContainsTargetReference(expression, currentScope);
+
+                default:
+                    return AnalyzeNodeChildren(expression, currentScope, ref definitelyAssigned);
+            }
+        }
+
+        private bool AnalyzeNodeChildren(Node node, Scope currentScope, ref bool definitelyAssigned)
+        {
+            foreach (var child in node.ChildNodes)
+            {
+                if (!AnalyzeChildNode(child, currentScope, ref definitelyAssigned))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool AnalyzeChildNode(Node node, Scope currentScope, ref bool definitelyAssigned)
+        {
+            if (node is Expression expression)
+            {
+                return AnalyzeExpression(expression, currentScope, ref definitelyAssigned);
+            }
+
+            if (node is Statement statement)
+            {
+                return AnalyzeStatement(statement, currentScope, ref definitelyAssigned);
+            }
+
+            currentScope = GetScopeForNode(currentScope, node);
+            if (node is Property property)
+            {
+                if (property.Computed
+                    && property.Key is Expression key
+                    && !AnalyzeExpression(key, currentScope, ref definitelyAssigned))
+                {
+                    return false;
+                }
+
+                return property.Value is not Node value
+                    || AnalyzeChildNode(value, currentScope, ref definitelyAssigned);
+            }
+
+            foreach (var child in node.ChildNodes)
+            {
+                if (!AnalyzeChildNode(child, currentScope, ref definitelyAssigned))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool ContainsTargetReference(Node node, Scope currentScope)
+        {
+            currentScope = GetScopeForNode(currentScope, node);
+            if (node is Identifier identifier && ResolvesToTarget(currentScope, identifier.Name))
+            {
+                return true;
+            }
+
+            foreach (var child in node.ChildNodes)
+            {
+                if (ContainsTargetReference(child, currentScope))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private Scope GetScopeForNode(Scope currentScope, INode node)
+            => currentScope.Children.FirstOrDefault(child => ReferenceEquals(child.AstNode, node))
+               ?? currentScope;
+
+        private bool ResolvesToTarget(Scope currentScope, string name)
+            => string.Equals(name, _target.Name, StringComparison.Ordinal)
+               && ReferenceEquals(TryResolveBinding(currentScope, name), _target);
+
+        private Type? InferExpressionType(Expression expression, Scope currentScope)
+        {
+            var shadowedProposalNames = new HashSet<string>(StringComparer.Ordinal);
+            CollectShadowedProposalNames(
+                expression,
+                currentScope,
+                parent: null,
+                shadowedProposalNames);
+
+            Dictionary<string, Type> scopeSafeProposals;
+            if (shadowedProposalNames.Count == 0)
+            {
+                scopeSafeProposals = _proposedClrTypes;
+            }
+            else
+            {
+                scopeSafeProposals = _proposedClrTypes
+                    .Where(entry => !shadowedProposalNames.Contains(entry.Key))
+                    .ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.Ordinal);
+            }
+
+            return _builder.InferExpressionClrType(
+                expression,
+                currentScope,
+                scopeSafeProposals,
+                _target,
+                _functionScope);
+        }
+
+        private Type? InferNumericValueType(Expression expression, Scope currentScope)
+        {
+            if (InitializerForwardsUnsafeNumericDependency(expression, currentScope))
+            {
+                return null;
+            }
+
+            var inferredType = InferExpressionType(expression, currentScope);
+            if (inferredType != null)
+            {
+                return inferredType;
+            }
+
+            return expression is NonUpdateUnaryExpression
+                   {
+                       Operator: Operator.UnaryNegation or Operator.UnaryPlus
+                   } unary
+                   && InferNumericValueType(unary.Argument, currentScope) == typeof(double)
+                ? typeof(double)
+                : null;
+        }
+
+        private bool HasUnsafeNumericVarDependency(Node node, Scope currentScope, Node? parent)
+        {
+            currentScope = GetScopeForNode(currentScope, node);
+            if (node is Identifier identifier)
+            {
+                if (parent is MemberExpression member
+                    && !member.Computed
+                    && ReferenceEquals(member.Property, identifier))
+                {
+                    return false;
+                }
+
+                if (parent is Property property
+                    && !property.Computed
+                    && !property.Shorthand
+                    && ReferenceEquals(property.Key, identifier))
+                {
+                    return false;
+                }
+
+                var dependency = TryResolveBinding(currentScope, identifier.Name);
+                return dependency != null
+                       && !ReferenceEquals(dependency, _target)
+                       && dependency.Kind == BindingKind.Var
+                       && !dependency.DeclaringScope.Parameters.Contains(dependency.Name)
+                       && !dependency.CanUseUnboxedLocal;
+            }
+
+            foreach (var child in node.ChildNodes)
+            {
+                if (HasUnsafeNumericVarDependency(child, currentScope, node))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void CollectShadowedProposalNames(
+            Node node,
+            Scope currentScope,
+            Node? parent,
+            HashSet<string> shadowedNames)
+        {
+            currentScope = GetScopeForNode(currentScope, node);
+            if (node is Identifier identifier)
+            {
+                if (parent is MemberExpression member
+                    && !member.Computed
+                    && ReferenceEquals(member.Property, identifier))
+                {
+                    return;
+                }
+
+                if (parent is Property property
+                    && !property.Computed
+                    && !property.Shorthand
+                    && ReferenceEquals(property.Key, identifier))
+                {
+                    return;
+                }
+
+                var binding = TryResolveBinding(currentScope, identifier.Name);
+                if (_proposedClrTypes.ContainsKey(identifier.Name)
+                    && binding != null
+                    && !ReferenceEquals(binding.DeclaringScope, _functionScope))
+                {
+                    shadowedNames.Add(identifier.Name);
+                }
+                return;
+            }
+
+            foreach (var child in node.ChildNodes)
+            {
+                CollectShadowedProposalNames(child, currentScope, node, shadowedNames);
+            }
+        }
+
+        private static bool ContainsAbruptLoopControl(Node node)
+        {
+            if (node is BreakStatement or ContinueStatement)
+            {
+                return true;
+            }
+
+            if (node is FunctionDeclaration or FunctionExpression or ArrowFunctionExpression)
+            {
+                return false;
+            }
+
+            foreach (var child in node.ChildNodes)
+            {
+                if (ContainsAbruptLoopControl(child))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.cs
@@ -249,6 +249,7 @@ namespace Jroc.SymbolTables
             // can use only proven-stable argument bindings, not initializer guesses.
             InferCallableParameterClrTypes(globalScope);
             InferVariableClrTypes(globalScope);
+            InferDefinitelyInitializedNumericVarLocals(globalScope);
             InferCallableReturnClrTypes(globalScope);
 
             // Object literal shape eligibility analysis (issue #1429). Runs last so member

--- a/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.NumericInference_ExponentiationLoop_NoBoxing.verified.txt
+++ b/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.NumericInference_ExponentiationLoop_NoBoxing.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2206
+					// Method begins at RVA 0x2166
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fd
+				// Method begins at RVA 0x215d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,131 +65,78 @@
 			)
 			// Method begins at RVA 0x20b0
 			// Header size: 12
-			// Code size: 312 (0x138)
+			// Code size: 152 (0x98)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] object,
-				[3] object,
-				[4] float64,
-				[5] object,
-				[6] float64
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] float64
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			IL_000f: ldc.r8 0.0
-			IL_0018: box [System.Runtime]System.Double
-			IL_001d: stloc.1
-			// loop start (head: IL_001e)
-				IL_001e: ldloc.1
-				IL_001f: stloc.3
-				IL_0020: ldloc.3
-				IL_0021: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0026: stloc.s 4
-				IL_0028: ldloc.s 4
-				IL_002a: ldc.r8 20
-				IL_0033: clt
-				IL_0035: brfalse IL_012d
+			IL_0009: stloc.0
+			IL_000a: ldc.r8 0.0
+			IL_0013: stloc.1
+			// loop start (head: IL_0014)
+				IL_0014: ldloc.1
+				IL_0015: stloc.3
+				IL_0016: ldloc.3
+				IL_0017: ldc.r8 20
+				IL_0020: clt
+				IL_0022: brfalse IL_0096
 
-				IL_003a: ldc.r8 0.0
-				IL_0043: box [System.Runtime]System.Double
-				IL_0048: stloc.2
-				IL_0049: ldloc.2
-				IL_004a: ldc.r8 1
-				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0058: stloc.s 5
-				IL_005a: ldloc.s 5
-				IL_005c: stloc.2
-				IL_005d: ldloc.2
-				IL_005e: stloc.s 5
-				IL_0060: ldloc.s 5
-				IL_0062: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0067: stloc.s 4
-				IL_0069: ldloc.s 4
-				IL_006b: ldc.r8 3
-				IL_0074: call float64 [System.Runtime]System.Math::Pow(float64, float64)
-				IL_0079: stloc.s 4
-				IL_007b: ldloc.s 4
-				IL_007d: box [System.Runtime]System.Double
+				IL_0027: ldc.r8 0.0
+				IL_0030: stloc.2
+				IL_0031: ldloc.2
+				IL_0032: ldc.r8 1
+				IL_003b: add
+				IL_003c: stloc.3
+				IL_003d: ldloc.3
+				IL_003e: stloc.2
+				IL_003f: ldloc.2
+				IL_0040: stloc.3
+				IL_0041: ldloc.3
+				IL_0042: ldc.r8 3
+				IL_004b: call float64 [System.Runtime]System.Math::Pow(float64, float64)
+				IL_0050: stloc.3
+				IL_0051: ldloc.3
+				IL_0052: stloc.2
+				IL_0053: ldloc.2
+				IL_0054: ldc.r8 7
+				IL_005d: mul
+				IL_005e: stloc.3
+				IL_005f: ldloc.3
+				IL_0060: stloc.2
+				IL_0061: ldloc.2
+				IL_0062: ldc.r8 11
+				IL_006b: sub
+				IL_006c: stloc.3
+				IL_006d: ldloc.3
+				IL_006e: stloc.2
+				IL_006f: ldloc.2
+				IL_0070: ldc.r8 2
+				IL_0079: div
+				IL_007a: stloc.3
+				IL_007b: ldloc.3
+				IL_007c: stloc.2
+				IL_007d: ldloc.0
+				IL_007e: stloc.3
+				IL_007f: ldloc.3
+				IL_0080: ldloc.2
+				IL_0081: add
 				IL_0082: stloc.3
 				IL_0083: ldloc.3
-				IL_0084: stloc.2
-				IL_0085: ldloc.2
-				IL_0086: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_008b: stloc.s 4
-				IL_008d: ldloc.s 4
-				IL_008f: ldc.r8 7
-				IL_0098: mul
-				IL_0099: stloc.s 4
-				IL_009b: ldloc.s 4
-				IL_009d: box [System.Runtime]System.Double
-				IL_00a2: stloc.3
-				IL_00a3: ldloc.3
-				IL_00a4: stloc.2
-				IL_00a5: ldloc.2
-				IL_00a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ab: stloc.s 4
-				IL_00ad: ldloc.s 4
-				IL_00af: ldc.r8 11
-				IL_00b8: sub
-				IL_00b9: stloc.s 4
-				IL_00bb: ldloc.s 4
-				IL_00bd: box [System.Runtime]System.Double
-				IL_00c2: stloc.3
-				IL_00c3: ldloc.3
-				IL_00c4: stloc.2
-				IL_00c5: ldloc.2
-				IL_00c6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00cb: stloc.s 4
-				IL_00cd: ldloc.s 4
-				IL_00cf: ldc.r8 2
-				IL_00d8: div
-				IL_00d9: stloc.s 4
-				IL_00db: ldloc.s 4
-				IL_00dd: box [System.Runtime]System.Double
-				IL_00e2: stloc.3
-				IL_00e3: ldloc.3
-				IL_00e4: stloc.2
-				IL_00e5: ldloc.0
-				IL_00e6: stloc.3
-				IL_00e7: ldloc.3
-				IL_00e8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ed: stloc.s 4
-				IL_00ef: ldloc.2
-				IL_00f0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00f5: stloc.s 6
-				IL_00f7: ldloc.s 4
-				IL_00f9: ldloc.s 6
-				IL_00fb: add
-				IL_00fc: stloc.s 6
-				IL_00fe: ldloc.s 6
-				IL_0100: box [System.Runtime]System.Double
-				IL_0105: stloc.3
-				IL_0106: ldloc.3
-				IL_0107: stloc.0
-				IL_0108: ldloc.1
-				IL_0109: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_010e: stloc.s 6
-				IL_0110: ldloc.s 6
-				IL_0112: ldc.r8 1
-				IL_011b: add
-				IL_011c: stloc.s 6
-				IL_011e: ldloc.s 6
-				IL_0120: box [System.Runtime]System.Double
-				IL_0125: stloc.3
-				IL_0126: ldloc.3
-				IL_0127: stloc.1
-				IL_0128: br IL_001e
+				IL_0084: stloc.0
+				IL_0085: ldloc.1
+				IL_0086: ldc.r8 1
+				IL_008f: add
+				IL_0090: stloc.1
+				IL_0091: br IL_0014
 			// end loop
 
-			IL_012d: ldloc.0
-			IL_012e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0133: stloc.s 6
-			IL_0135: ldloc.s 6
-			IL_0137: ret
+			IL_0096: ldloc.0
+			IL_0097: ret
 		} // end of method arith::__js_call__
 
 	} // end of class arith
@@ -208,7 +155,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21f4
+			// Method begins at RVA 0x2154
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -288,7 +235,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220f
+		// Method begins at RVA 0x216f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2213
+					// Method begins at RVA 0x2215
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -48,71 +48,74 @@
 				)
 				// Method begins at RVA 0x214c
 				// Header size: 12
-				// Code size: 169 (0xa9)
+				// Code size: 171 (0xab)
 				.maxstack 8
 				.locals init (
-					[0] object,
+					[0] float64,
 					[1] object,
-					[2] object
+					[2] object,
+					[3] object
 				)
 
 				IL_0000: ldc.r8 5
-				IL_0009: box [System.Runtime]System.Double
-				IL_000e: stloc.0
-				IL_000f: ldstr "console"
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0019: stloc.1
-				IL_001a: ldloc.1
-				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.1
-				IL_0021: ldloc.1
-				IL_0022: ldstr "log"
-				IL_0027: ldstr "Outer variable:"
-				IL_002c: ldarg.0
-				IL_002d: ldc.i4.0
-				IL_002e: ldelem.ref
-				IL_002f: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
-				IL_0034: ldfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope::outerVar
-				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_003e: pop
-				IL_003f: ldstr "console"
-				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0049: stloc.1
-				IL_004a: ldloc.1
-				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0050: stloc.1
-				IL_0051: ldloc.1
-				IL_0052: ldstr "log"
-				IL_0057: ldstr "Parameter:"
-				IL_005c: ldarg.0
-				IL_005d: ldc.i4.1
-				IL_005e: ldelem.ref
-				IL_005f: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope
-				IL_0064: ldfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope::param
-				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_006e: pop
-				IL_006f: ldstr "console"
-				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0079: stloc.1
-				IL_007a: ldloc.1
-				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0080: stloc.1
-				IL_0081: ldloc.1
-				IL_0082: ldstr "log"
-				IL_0087: ldstr "Inner variable:"
-				IL_008c: ldloc.0
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0092: pop
-				IL_0093: ldarg.0
-				IL_0094: ldc.i4.1
-				IL_0095: ldelem.ref
-				IL_0096: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope
-				IL_009b: ldfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope::param
-				IL_00a0: ldloc.0
-				IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00a6: stloc.2
-				IL_00a7: ldloc.2
-				IL_00a8: ret
+				IL_0009: stloc.0
+				IL_000a: ldstr "console"
+				IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0014: stloc.1
+				IL_0015: ldloc.1
+				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_001b: stloc.1
+				IL_001c: ldloc.1
+				IL_001d: ldstr "log"
+				IL_0022: ldstr "Outer variable:"
+				IL_0027: ldarg.0
+				IL_0028: ldc.i4.0
+				IL_0029: ldelem.ref
+				IL_002a: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
+				IL_002f: ldfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope::outerVar
+				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0039: pop
+				IL_003a: ldstr "console"
+				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0044: stloc.1
+				IL_0045: ldloc.1
+				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_004b: stloc.1
+				IL_004c: ldloc.1
+				IL_004d: ldstr "log"
+				IL_0052: ldstr "Parameter:"
+				IL_0057: ldarg.0
+				IL_0058: ldc.i4.1
+				IL_0059: ldelem.ref
+				IL_005a: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope
+				IL_005f: ldfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope::param
+				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0069: pop
+				IL_006a: ldstr "console"
+				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0074: stloc.1
+				IL_0075: ldloc.1
+				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_007b: stloc.1
+				IL_007c: ldloc.0
+				IL_007d: box [System.Runtime]System.Double
+				IL_0082: stloc.2
+				IL_0083: ldloc.1
+				IL_0084: ldstr "log"
+				IL_0089: ldstr "Inner variable:"
+				IL_008e: ldloc.2
+				IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0094: pop
+				IL_0095: ldarg.0
+				IL_0096: ldc.i4.1
+				IL_0097: ldelem.ref
+				IL_0098: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope
+				IL_009d: ldfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope::param
+				IL_00a2: ldloc.0
+				IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_00a8: stloc.3
+				IL_00a9: ldloc.3
+				IL_00aa: ret
 			} // end of method nestedFunction::__js_call__
 
 		} // end of class nestedFunction
@@ -134,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x220a
+				// Method begins at RVA 0x220c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -221,7 +224,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2201
+			// Method begins at RVA 0x2203
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -326,7 +329,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x221c
+		// Method begins at RVA 0x221e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21c8
+					// Method begins at RVA 0x21a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21bf
+				// Method begins at RVA 0x2199
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,66 +66,50 @@
 			)
 			// Method begins at RVA 0x212c
 			// Header size: 12
-			// Code size: 126 (0x7e)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object,
+				[1] float64,
 				[2] object,
-				[3] object,
-				[4] float64,
-				[5] float64
+				[3] float64
 			)
 
 			IL_0000: ldc.i4.0
 			IL_0001: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_0006: stloc.0
 			IL_0007: ldc.r8 0.0
-			IL_0010: box [System.Runtime]System.Double
-			IL_0015: stloc.1
-			// loop start (head: IL_0016)
-				IL_0016: ldloc.1
-				IL_0017: stloc.3
-				IL_0018: ldarg.1
-				IL_0019: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-				IL_001e: stloc.s 4
-				IL_0020: ldloc.3
-				IL_0021: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0026: stloc.s 5
-				IL_0028: ldloc.s 5
-				IL_002a: ldloc.s 4
-				IL_002c: clt
-				IL_002e: brfalse IL_007c
+			IL_0010: stloc.1
+			// loop start (head: IL_0011)
+				IL_0011: ldloc.1
+				IL_0012: stloc.3
+				IL_0013: ldloc.3
+				IL_0014: ldarg.1
+				IL_0015: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_001a: clt
+				IL_001c: brfalse IL_0056
 
-				IL_0033: ldarg.1
-				IL_0034: ldloc.1
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_003a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_003f: ldc.r8 2
-				IL_0048: mul
-				IL_0049: box [System.Runtime]System.Double
-				IL_004e: stloc.2
-				IL_004f: ldloc.0
-				IL_0050: ldloc.2
-				IL_0051: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0056: pop
-				IL_0057: ldloc.1
-				IL_0058: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005d: stloc.s 4
-				IL_005f: ldloc.s 4
-				IL_0061: ldc.r8 1
-				IL_006a: add
-				IL_006b: stloc.s 4
-				IL_006d: ldloc.s 4
-				IL_006f: box [System.Runtime]System.Double
-				IL_0074: stloc.3
-				IL_0075: ldloc.3
-				IL_0076: stloc.1
-				IL_0077: br IL_0016
+				IL_0021: ldarg.1
+				IL_0022: ldloc.1
+				IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0028: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_002d: ldc.r8 2
+				IL_0036: mul
+				IL_0037: box [System.Runtime]System.Double
+				IL_003c: stloc.2
+				IL_003d: ldloc.0
+				IL_003e: ldloc.2
+				IL_003f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0044: pop
+				IL_0045: ldloc.1
+				IL_0046: ldc.r8 1
+				IL_004f: add
+				IL_0050: stloc.1
+				IL_0051: br IL_0011
 			// end loop
 
-			IL_007c: ldloc.0
-			IL_007d: ret
+			IL_0056: ldloc.0
+			IL_0057: ret
 		} // end of method processArray::__js_call__
 
 	} // end of class processArray
@@ -145,7 +129,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b6
+			// Method begins at RVA 0x2190
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -255,7 +239,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d1
+		// Method begins at RVA 0x21ab
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Recursive.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Recursive.verified.txt
@@ -26,7 +26,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x226a
+					// Method begins at RVA 0x223d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2273
+					// Method begins at RVA 0x2246
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2261
+				// Method begins at RVA 0x2234
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -94,18 +94,17 @@
 			)
 			// Method begins at RVA 0x2158
 			// Header size: 12
-			// Code size: 244 (0xf4)
+			// Code size: 199 (0xc7)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
+				[1] float64,
 				[2] object,
 				[3] object,
 				[4] object,
-				[5] object,
-				[6] float64,
-				[7] object[],
-				[8] object
+				[5] float64,
+				[6] object[],
+				[7] object
 			)
 
 			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentCallee()
@@ -139,61 +138,46 @@
 			IL_0052: ret
 
 			IL_0053: ldc.r8 0.0
-			IL_005c: box [System.Runtime]System.Double
-			IL_0061: stloc.1
-			// loop start (head: IL_0062)
-				IL_0062: ldloc.1
-				IL_0063: stloc.s 5
-				IL_0065: ldarg.1
-				IL_0066: ldstr "children"
-				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0070: ldstr "length"
-				IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_007a: stloc.s 4
-				IL_007c: ldloc.s 5
-				IL_007e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0083: stloc.s 6
-				IL_0085: ldloc.s 6
-				IL_0087: ldloc.s 4
-				IL_0089: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_008e: clt
-				IL_0090: brfalse IL_00f2
+			IL_005c: stloc.1
+			// loop start (head: IL_005d)
+				IL_005d: ldloc.1
+				IL_005e: stloc.s 5
+				IL_0060: ldloc.s 5
+				IL_0062: ldarg.1
+				IL_0063: ldstr "children"
+				IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_006d: ldstr "length"
+				IL_0072: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0077: clt
+				IL_0079: brfalse IL_00c5
 
-				IL_0095: ldarg.1
-				IL_0096: ldstr "children"
-				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00a0: ldloc.1
-				IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00a6: stloc.2
-				IL_00a7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-				IL_00ac: stloc.s 7
-				IL_00ae: ldarg.2
-				IL_00af: ldc.r8 1
-				IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_00bd: stloc.s 8
-				IL_00bf: ldloc.0
-				IL_00c0: ldloc.s 7
-				IL_00c2: ldloc.2
-				IL_00c3: ldloc.s 8
-				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_00ca: pop
-				IL_00cb: ldloc.1
-				IL_00cc: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00d1: stloc.s 6
-				IL_00d3: ldloc.s 6
-				IL_00d5: ldc.r8 1
-				IL_00de: add
-				IL_00df: stloc.s 6
-				IL_00e1: ldloc.s 6
-				IL_00e3: box [System.Runtime]System.Double
-				IL_00e8: stloc.s 5
-				IL_00ea: ldloc.s 5
-				IL_00ec: stloc.1
-				IL_00ed: br IL_0062
+				IL_007e: ldarg.1
+				IL_007f: ldstr "children"
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0089: ldloc.1
+				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_008f: stloc.2
+				IL_0090: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+				IL_0095: stloc.s 6
+				IL_0097: ldarg.2
+				IL_0098: ldc.r8 1
+				IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_00a6: stloc.s 7
+				IL_00a8: ldloc.0
+				IL_00a9: ldloc.s 6
+				IL_00ab: ldloc.2
+				IL_00ac: ldloc.s 7
+				IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_00b3: pop
+				IL_00b4: ldloc.1
+				IL_00b5: ldc.r8 1
+				IL_00be: add
+				IL_00bf: stloc.1
+				IL_00c0: br IL_005d
 			// end loop
 
-			IL_00f2: ldnull
-			IL_00f3: ret
+			IL_00c5: ldnull
+			IL_00c6: ret
 		} // end of method walk::__js_call__
 
 	} // end of class walk
@@ -205,7 +189,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2258
+			// Method begins at RVA 0x222b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -331,7 +315,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x227c
+		// Method begins at RVA 0x224f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x542a
+				// Method begins at RVA 0x5112
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5433
+				// Method begins at RVA 0x511b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5445
+					// Method begins at RVA 0x512d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x543c
+				// Method begins at RVA 0x5124
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -191,7 +191,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5457
+					// Method begins at RVA 0x513f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -209,7 +209,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x544e
+				// Method begins at RVA 0x5136
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -265,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5460
+				// Method begins at RVA 0x5148
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -339,7 +339,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x547b
+						// Method begins at RVA 0x5163
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -359,7 +359,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5484
+						// Method begins at RVA 0x516c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -377,7 +377,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5472
+					// Method begins at RVA 0x515a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -395,7 +395,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5469
+				// Method begins at RVA 0x5151
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -424,260 +424,223 @@
 			)
 			// Method begins at RVA 0x344c
 			// Header size: 12
-			// Code size: 625 (0x271)
+			// Code size: 516 (0x204)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] object,
-				[3] object,
+				[1] float64,
+				[2] float64,
+				[3] float64,
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[6] object,
-				[7] float64,
+				[6] float64,
+				[7] object,
 				[8] object,
-				[9] float64,
-				[10] string
+				[9] string,
+				[10] object
 			)
 
 			IL_0000: ldnull
 			IL_0001: stloc.0
-			IL_0002: ldnull
-			IL_0003: stloc.1
-			IL_0004: ldarg.0
-			IL_0005: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-			IL_000a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_000f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0014: ldarg.2
-			IL_0015: clt
-			IL_0017: ldc.i4.0
-			IL_0018: ceq
-			IL_001a: brfalse IL_0051
+			IL_0002: ldarg.0
+			IL_0003: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_000d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0012: ldarg.2
+			IL_0013: clt
+			IL_0015: ldc.i4.0
+			IL_0016: ceq
+			IL_0018: brfalse IL_004f
 
-			IL_001f: ldarg.0
-			IL_0020: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002a: stloc.s 4
-			IL_002c: ldloc.s 4
-			IL_002e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0033: ldc.r8 0.0
-			IL_003c: box [System.Runtime]System.Double
-			IL_0041: ldarg.2
-			IL_0042: box [System.Runtime]System.Double
-			IL_0047: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice(object, object)
-			IL_004c: stloc.s 5
-			IL_004e: ldloc.s 5
-			IL_0050: ret
+			IL_001d: ldarg.0
+			IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0028: stloc.s 4
+			IL_002a: ldloc.s 4
+			IL_002c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0031: ldc.r8 0.0
+			IL_003a: box [System.Runtime]System.Double
+			IL_003f: ldarg.2
+			IL_0040: box [System.Runtime]System.Double
+			IL_0045: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice(object, object)
+			IL_004a: stloc.s 5
+			IL_004c: ldloc.s 5
+			IL_004e: ret
 
-			IL_0051: ldarg.0
-			IL_0052: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-			IL_0057: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_005c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0061: box [System.Runtime]System.Double
-			IL_0066: stloc.2
-			// loop start (head: IL_0067)
-				IL_0067: ldloc.2
-				IL_0068: stloc.s 6
-				IL_006a: ldloc.s 6
-				IL_006c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0071: stloc.s 7
-				IL_0073: ldloc.s 7
-				IL_0075: ldarg.2
-				IL_0076: clt
-				IL_0078: brfalse IL_0265
+			IL_004f: ldarg.0
+			IL_0050: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_0055: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_005a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_005f: stloc.1
+			// loop start (head: IL_0060)
+				IL_0060: ldloc.1
+				IL_0061: stloc.s 6
+				IL_0063: ldloc.s 6
+				IL_0065: ldarg.2
+				IL_0066: clt
+				IL_0068: brfalse IL_01f8
 
-				IL_007d: ldarg.0
-				IL_007e: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-				IL_0083: ldc.i4.1
-				IL_0084: newarr [System.Runtime]System.Object
-				IL_0089: dup
-				IL_008a: ldc.i4.0
-				IL_008b: ldarg.0
-				IL_008c: stelem.ref
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0092: stloc.s 4
-				IL_0094: ldloc.s 4
-				IL_0096: ldarg.0
-				IL_0097: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-				IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00a1: stloc.s 8
-				IL_00a3: ldarg.0
-				IL_00a4: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-				IL_00a9: ldc.i4.1
-				IL_00aa: newarr [System.Runtime]System.Object
-				IL_00af: dup
-				IL_00b0: ldc.i4.0
-				IL_00b1: ldarg.0
-				IL_00b2: stelem.ref
-				IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_00b8: stloc.s 4
-				IL_00ba: ldloc.s 8
-				IL_00bc: ldloc.s 4
-				IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00c3: stloc.s 8
-				IL_00c5: ldloc.s 8
-				IL_00c7: stloc.0
-				IL_00c8: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-				IL_00cd: stloc.s 7
-				IL_00cf: ldc.r8 4
-				IL_00d8: ldloc.s 7
-				IL_00da: mul
-				IL_00db: stloc.s 7
-				IL_00dd: ldloc.s 7
-				IL_00df: box [System.Runtime]System.Double
-				IL_00e4: stloc.s 6
-				IL_00e6: ldloc.s 6
-				IL_00e8: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-				IL_00ed: stloc.s 7
-				IL_00ef: ldloc.s 7
-				IL_00f1: box [System.Runtime]System.Double
-				IL_00f6: stloc.s 6
-				IL_00f8: ldloc.s 6
-				IL_00fa: stloc.1
-				IL_00fb: ldc.r8 0.0
-				IL_0104: box [System.Runtime]System.Double
-				IL_0109: stloc.3
-				// loop start (head: IL_010a)
-					IL_010a: ldloc.3
-					IL_010b: stloc.s 6
-					IL_010d: ldloc.s 6
-					IL_010f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0114: stloc.s 7
-					IL_0116: ldloc.1
-					IL_0117: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_011c: stloc.s 9
-					IL_011e: ldloc.s 7
-					IL_0120: ldloc.s 9
-					IL_0122: clt
-					IL_0124: brfalse IL_0196
+				IL_006d: ldarg.0
+				IL_006e: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+				IL_0073: ldc.i4.1
+				IL_0074: newarr [System.Runtime]System.Object
+				IL_0079: dup
+				IL_007a: ldc.i4.0
+				IL_007b: ldarg.0
+				IL_007c: stelem.ref
+				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0082: stloc.s 4
+				IL_0084: ldloc.s 4
+				IL_0086: ldarg.0
+				IL_0087: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0091: stloc.s 7
+				IL_0093: ldarg.0
+				IL_0094: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+				IL_0099: ldc.i4.1
+				IL_009a: newarr [System.Runtime]System.Object
+				IL_009f: dup
+				IL_00a0: ldc.i4.0
+				IL_00a1: ldarg.0
+				IL_00a2: stelem.ref
+				IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_00a8: stloc.s 4
+				IL_00aa: ldloc.s 7
+				IL_00ac: ldloc.s 4
+				IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00b3: stloc.s 7
+				IL_00b5: ldloc.s 7
+				IL_00b7: stloc.0
+				IL_00b8: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+				IL_00bd: stloc.s 6
+				IL_00bf: ldc.r8 4
+				IL_00c8: ldloc.s 6
+				IL_00ca: mul
+				IL_00cb: stloc.s 6
+				IL_00cd: ldloc.s 6
+				IL_00cf: box [System.Runtime]System.Double
+				IL_00d4: stloc.s 8
+				IL_00d6: ldloc.s 8
+				IL_00d8: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+				IL_00dd: stloc.s 6
+				IL_00df: ldloc.s 6
+				IL_00e1: stloc.2
+				IL_00e2: ldc.r8 0.0
+				IL_00eb: stloc.3
+				// loop start (head: IL_00ec)
+					IL_00ec: ldloc.3
+					IL_00ed: stloc.s 6
+					IL_00ef: ldloc.s 6
+					IL_00f1: ldloc.2
+					IL_00f2: clt
+					IL_00f4: brfalse IL_0150
 
-					IL_0129: ldarg.0
-					IL_012a: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-					IL_012f: ldc.i4.1
-					IL_0130: newarr [System.Runtime]System.Object
-					IL_0135: dup
-					IL_0136: ldc.i4.0
-					IL_0137: ldarg.0
-					IL_0138: stelem.ref
-					IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-					IL_013e: stloc.s 4
-					IL_0140: ldloc.s 4
-					IL_0142: ldloc.0
-					IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0148: stloc.s 8
-					IL_014a: ldarg.0
-					IL_014b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-					IL_0150: ldc.i4.1
-					IL_0151: newarr [System.Runtime]System.Object
-					IL_0156: dup
-					IL_0157: ldc.i4.0
-					IL_0158: ldarg.0
-					IL_0159: stelem.ref
-					IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-					IL_015f: stloc.s 4
-					IL_0161: ldloc.s 8
-					IL_0163: ldloc.s 4
-					IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_016a: stloc.s 8
-					IL_016c: ldloc.s 8
-					IL_016e: stloc.0
-					IL_016f: ldloc.3
-					IL_0170: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0175: stloc.s 9
-					IL_0177: ldloc.s 9
-					IL_0179: ldc.r8 1
-					IL_0182: add
-					IL_0183: stloc.s 9
-					IL_0185: ldloc.s 9
-					IL_0187: box [System.Runtime]System.Double
-					IL_018c: stloc.s 6
-					IL_018e: ldloc.s 6
-					IL_0190: stloc.3
-					IL_0191: br IL_010a
+					IL_00f9: ldarg.0
+					IL_00fa: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+					IL_00ff: ldc.i4.1
+					IL_0100: newarr [System.Runtime]System.Object
+					IL_0105: dup
+					IL_0106: ldc.i4.0
+					IL_0107: ldarg.0
+					IL_0108: stelem.ref
+					IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+					IL_010e: stloc.s 4
+					IL_0110: ldloc.s 4
+					IL_0112: ldloc.0
+					IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0118: stloc.s 7
+					IL_011a: ldarg.0
+					IL_011b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+					IL_0120: ldc.i4.1
+					IL_0121: newarr [System.Runtime]System.Object
+					IL_0126: dup
+					IL_0127: ldc.i4.0
+					IL_0128: ldarg.0
+					IL_0129: stelem.ref
+					IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+					IL_012f: stloc.s 4
+					IL_0131: ldloc.s 7
+					IL_0133: ldloc.s 4
+					IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_013a: stloc.s 7
+					IL_013c: ldloc.s 7
+					IL_013e: stloc.0
+					IL_013f: ldloc.3
+					IL_0140: ldc.r8 1
+					IL_0149: add
+					IL_014a: stloc.3
+					IL_014b: br IL_00ec
 				// end loop
 
-				IL_0196: ldc.r8 0.0
-				IL_019f: box [System.Runtime]System.Double
-				IL_01a4: stloc.3
-				// loop start (head: IL_01a5)
-					IL_01a5: ldloc.3
-					IL_01a6: stloc.s 6
-					IL_01a8: ldloc.0
-					IL_01a9: castclass [System.Runtime]System.String
-					IL_01ae: callvirt instance int32 [System.Runtime]System.String::get_Length()
-					IL_01b3: conv.r8
+				IL_0150: ldc.r8 0.0
+				IL_0159: stloc.3
+				// loop start (head: IL_015a)
+					IL_015a: ldloc.3
+					IL_015b: stloc.s 6
+					IL_015d: ldloc.s 6
+					IL_015f: ldloc.0
+					IL_0160: castclass [System.Runtime]System.String
+					IL_0165: callvirt instance int32 [System.Runtime]System.String::get_Length()
+					IL_016a: conv.r8
+					IL_016b: clt
+					IL_016d: brfalse IL_01d3
+
+					IL_0172: ldarg.0
+					IL_0173: ldloc.0
+					IL_0174: ldloc.3
+					IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_017a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+					IL_017f: ldloc.0
+					IL_0180: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0185: stloc.s 9
+					IL_0187: ldloc.3
+					IL_0188: box [System.Runtime]System.Double
+					IL_018d: stloc.s 8
+					IL_018f: ldloc.3
+					IL_0190: stloc.s 6
+					IL_0192: ldloc.s 6
+					IL_0194: ldc.r8 100
+					IL_019d: add
+					IL_019e: stloc.s 6
+					IL_01a0: ldloc.s 6
+					IL_01a2: box [System.Runtime]System.Double
+					IL_01a7: stloc.s 10
+					IL_01a9: ldloc.s 9
+					IL_01ab: ldloc.s 8
+					IL_01ad: ldloc.s 10
+					IL_01af: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
 					IL_01b4: stloc.s 9
-					IL_01b6: ldloc.s 6
-					IL_01b8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01bd: stloc.s 7
-					IL_01bf: ldloc.s 7
-					IL_01c1: ldloc.s 9
-					IL_01c3: clt
-					IL_01c5: brfalse IL_022f
-
-					IL_01ca: ldarg.0
-					IL_01cb: ldloc.0
-					IL_01cc: ldloc.3
-					IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_01d2: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-					IL_01d7: ldloc.0
-					IL_01d8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_01dd: stloc.s 10
-					IL_01df: ldloc.3
-					IL_01e0: stloc.s 6
-					IL_01e2: ldloc.s 6
-					IL_01e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01e9: stloc.s 9
-					IL_01eb: ldloc.s 9
-					IL_01ed: ldc.r8 100
-					IL_01f6: add
-					IL_01f7: stloc.s 9
-					IL_01f9: ldloc.s 9
-					IL_01fb: box [System.Runtime]System.Double
-					IL_0200: stloc.s 6
-					IL_0202: ldloc.s 10
-					IL_0204: ldloc.3
-					IL_0205: ldloc.s 6
-					IL_0207: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-					IL_020c: stloc.s 10
-					IL_020e: ldarg.0
-					IL_020f: ldloc.s 10
-					IL_0211: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-					IL_0216: ldloc.3
-					IL_0217: ldc.r8 100
-					IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-					IL_0225: stloc.s 8
-					IL_0227: ldloc.s 8
-					IL_0229: stloc.3
-					IL_022a: br IL_01a5
+					IL_01b6: ldarg.0
+					IL_01b7: ldloc.s 9
+					IL_01b9: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+					IL_01be: ldloc.3
+					IL_01bf: ldc.r8 100
+					IL_01c8: add
+					IL_01c9: stloc.s 6
+					IL_01cb: ldloc.s 6
+					IL_01cd: stloc.3
+					IL_01ce: br IL_015a
 				// end loop
 
-				IL_022f: ldarg.0
-				IL_0230: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-				IL_0235: ldloc.2
-				IL_0236: ldloc.0
-				IL_0237: ldc.i4.1
-				IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_023d: pop
-				IL_023e: ldloc.2
-				IL_023f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0244: stloc.s 9
-				IL_0246: ldloc.s 9
-				IL_0248: ldc.r8 1
-				IL_0251: add
-				IL_0252: stloc.s 9
-				IL_0254: ldloc.s 9
-				IL_0256: box [System.Runtime]System.Double
-				IL_025b: stloc.s 6
-				IL_025d: ldloc.s 6
-				IL_025f: stloc.2
-				IL_0260: br IL_0067
+				IL_01d3: ldarg.0
+				IL_01d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+				IL_01d9: ldloc.1
+				IL_01da: box [System.Runtime]System.Double
+				IL_01df: ldloc.0
+				IL_01e0: ldc.i4.1
+				IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_01e6: pop
+				IL_01e7: ldloc.1
+				IL_01e8: ldc.r8 1
+				IL_01f1: add
+				IL_01f2: stloc.1
+				IL_01f3: br IL_0060
 			// end loop
 
-			IL_0265: ldarg.0
-			IL_0266: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-			IL_026b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0270: ret
+			IL_01f8: ldarg.0
+			IL_01f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_01fe: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0203: ret
 		} // end of method generateTestStrings::__js_call__
 
 	} // end of class generateTestStrings
@@ -693,7 +656,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x548d
+				// Method begins at RVA 0x5175
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -719,7 +682,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x36cc
+			// Method begins at RVA 0x365c
 			// Header size: 12
 			// Code size: 77 (0x4d)
 			.maxstack 8
@@ -773,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5496
+				// Method begins at RVA 0x517e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -799,63 +762,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3728
+			// Method begins at RVA 0x36b8
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[0] float64,
+				[1] float64,
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 30
-				IL_0022: clt
-				IL_0024: brfalse IL_0075
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 30
+				IL_0016: clt
+				IL_0018: brfalse IL_0063
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.3
-				IL_003c: ldstr "split"
-				IL_0041: ldarg.0
-				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.2
-				IL_0067: ldloc.2
-				IL_0068: box [System.Runtime]System.Double
-				IL_006d: stloc.1
-				IL_006e: ldloc.1
-				IL_006f: stloc.0
-				IL_0070: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldloc.2
+				IL_003a: ldstr "split"
+				IL_003f: ldarg.0
+				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0052: ldloc.0
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.0
+				IL_005e: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method FunctionExpression_L56C36::__js_call__
 
 	} // end of class FunctionExpression_L56C36
@@ -871,7 +823,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x549f
+				// Method begins at RVA 0x5187
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -897,7 +849,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x37ac
+			// Method begins at RVA 0x372c
 			// Header size: 12
 			// Code size: 77 (0x4d)
 			.maxstack 8
@@ -951,7 +903,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54a8
+				// Method begins at RVA 0x5190
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -977,63 +929,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3808
+			// Method begins at RVA 0x3788
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[0] float64,
+				[1] float64,
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 30
-				IL_0022: clt
-				IL_0024: brfalse IL_0075
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 30
+				IL_0016: clt
+				IL_0018: brfalse IL_0063
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.3
-				IL_003c: ldstr "split"
-				IL_0041: ldarg.0
-				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.2
-				IL_0067: ldloc.2
-				IL_0068: box [System.Runtime]System.Double
-				IL_006d: stloc.1
-				IL_006e: ldloc.1
-				IL_006f: stloc.0
-				IL_0070: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldloc.2
+				IL_003a: ldstr "split"
+				IL_003f: ldarg.0
+				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0052: ldloc.0
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.0
+				IL_005e: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method FunctionExpression_L66C35::__js_call__
 
 	} // end of class FunctionExpression_L66C35
@@ -1049,7 +990,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54b1
+				// Method begins at RVA 0x5199
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1075,7 +1016,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x388c
+			// Method begins at RVA 0x37fc
 			// Header size: 12
 			// Code size: 77 (0x4d)
 			.maxstack 8
@@ -1129,7 +1070,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54ba
+				// Method begins at RVA 0x51a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1155,63 +1096,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x38e8
+			// Method begins at RVA 0x3858
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[0] float64,
+				[1] float64,
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0075
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_0063
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.3
-				IL_003c: ldstr "split"
-				IL_0041: ldarg.0
-				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.2
-				IL_0067: ldloc.2
-				IL_0068: box [System.Runtime]System.Double
-				IL_006d: stloc.1
-				IL_006e: ldloc.1
-				IL_006f: stloc.0
-				IL_0070: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldloc.2
+				IL_003a: ldstr "split"
+				IL_003f: ldarg.0
+				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0052: ldloc.0
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.0
+				IL_005e: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method FunctionExpression_L76C39::__js_call__
 
 	} // end of class FunctionExpression_L76C39
@@ -1227,7 +1157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54c3
+				// Method begins at RVA 0x51ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1253,7 +1183,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x396c
+			// Method begins at RVA 0x38cc
 			// Header size: 12
 			// Code size: 77 (0x4d)
 			.maxstack 8
@@ -1307,7 +1237,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54cc
+				// Method begins at RVA 0x51b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1333,63 +1263,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x39c8
+			// Method begins at RVA 0x3928
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[0] float64,
+				[1] float64,
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0075
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_0063
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.3
-				IL_003c: ldstr "match"
-				IL_0041: ldarg.0
-				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.2
-				IL_0067: ldloc.2
-				IL_0068: box [System.Runtime]System.Double
-				IL_006d: stloc.1
-				IL_006e: ldloc.1
-				IL_006f: stloc.0
-				IL_0070: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldloc.2
+				IL_003a: ldstr "match"
+				IL_003f: ldarg.0
+				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0052: ldloc.0
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.0
+				IL_005e: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method FunctionExpression_L88C23::__js_call__
 
 	} // end of class FunctionExpression_L88C23
@@ -1405,7 +1324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54d5
+				// Method begins at RVA 0x51bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1431,7 +1350,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3a4c
+			// Method begins at RVA 0x399c
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -1477,7 +1396,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54de
+				// Method begins at RVA 0x51c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1503,63 +1422,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3a90
+			// Method begins at RVA 0x39e0
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[0] float64,
+				[1] float64,
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0075
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_0063
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0034: stloc.3
-				IL_0035: ldloc.3
-				IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0041: ldloc.0
-				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.2
-				IL_0067: ldloc.2
-				IL_0068: box [System.Runtime]System.Double
-				IL_006d: stloc.1
-				IL_006e: ldloc.1
-				IL_006f: stloc.0
-				IL_0070: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0028: stloc.2
+				IL_0029: ldloc.2
+				IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				IL_002f: ldarg.0
+				IL_0030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0035: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_003a: ldloc.0
+				IL_003b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0040: castclass [System.Runtime]System.String
+				IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0052: ldloc.0
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.0
+				IL_005e: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method FunctionExpression_L97C22::__js_call__
 
 	} // end of class FunctionExpression_L97C22
@@ -1575,7 +1483,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54e7
+				// Method begins at RVA 0x51cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1601,7 +1509,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3b14
+			// Method begins at RVA 0x3a54
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -1647,7 +1555,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54f0
+				// Method begins at RVA 0x51d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1673,67 +1581,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3b58
+			// Method begins at RVA 0x3a98
 			// Header size: 12
-			// Code size: 130 (0x82)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0080
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_006a
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.3
-				IL_0044: ldstr "replace"
-				IL_0049: ldloc.s 4
-				IL_004b: ldstr ""
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0055: stloc.s 4
-				IL_0057: ldarg.0
-				IL_0058: ldloc.s 4
-				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005f: ldloc.0
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: stloc.2
-				IL_0066: ldloc.2
-				IL_0067: ldc.r8 1
-				IL_0070: add
-				IL_0071: stloc.2
-				IL_0072: ldloc.2
-				IL_0073: box [System.Runtime]System.Double
-				IL_0078: stloc.1
-				IL_0079: ldloc.1
-				IL_007a: stloc.0
-				IL_007b: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldarg.0
+				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_003f: stloc.3
+				IL_0040: ldloc.2
+				IL_0041: ldstr "replace"
+				IL_0046: ldloc.3
+				IL_0047: ldstr ""
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0051: stloc.3
+				IL_0052: ldarg.0
+				IL_0053: ldloc.3
+				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0059: ldloc.0
+				IL_005a: ldc.r8 1
+				IL_0063: add
+				IL_0064: stloc.0
+				IL_0065: br IL_000a
 			// end loop
 
-			IL_0080: ldnull
-			IL_0081: ret
+			IL_006a: ldnull
+			IL_006b: ret
 		} // end of method FunctionExpression_L106C31::__js_call__
 
 	} // end of class FunctionExpression_L106C31
@@ -1749,7 +1646,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54f9
+				// Method begins at RVA 0x51e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1775,7 +1672,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3be8
+			// Method begins at RVA 0x3b10
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -1821,7 +1718,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5502
+				// Method begins at RVA 0x51ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1847,67 +1744,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3c2c
+			// Method begins at RVA 0x3b54
 			// Header size: 12
-			// Code size: 130 (0x82)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0080
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_006a
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.3
-				IL_0044: ldstr "replace"
-				IL_0049: ldloc.s 4
-				IL_004b: ldstr "asdfasdfasdf"
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0055: stloc.s 4
-				IL_0057: ldarg.0
-				IL_0058: ldloc.s 4
-				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005f: ldloc.0
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: stloc.2
-				IL_0066: ldloc.2
-				IL_0067: ldc.r8 1
-				IL_0070: add
-				IL_0071: stloc.2
-				IL_0072: ldloc.2
-				IL_0073: box [System.Runtime]System.Double
-				IL_0078: stloc.1
-				IL_0079: ldloc.1
-				IL_007a: stloc.0
-				IL_007b: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldarg.0
+				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_003f: stloc.3
+				IL_0040: ldloc.2
+				IL_0041: ldstr "replace"
+				IL_0046: ldloc.3
+				IL_0047: ldstr "asdfasdfasdf"
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0051: stloc.3
+				IL_0052: ldarg.0
+				IL_0053: ldloc.3
+				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0059: ldloc.0
+				IL_005a: ldc.r8 1
+				IL_0063: add
+				IL_0064: stloc.0
+				IL_0065: br IL_000a
 			// end loop
 
-			IL_0080: ldnull
-			IL_0081: ret
+			IL_006a: ldnull
+			IL_006b: ret
 		} // end of method FunctionExpression_L115C33::__js_call__
 
 	} // end of class FunctionExpression_L115C33
@@ -1923,7 +1809,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x550b
+				// Method begins at RVA 0x51f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1949,7 +1835,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3cbc
+			// Method begins at RVA 0x3bcc
 			// Header size: 12
 			// Code size: 77 (0x4d)
 			.maxstack 8
@@ -2003,7 +1889,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5514
+				// Method begins at RVA 0x51fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2029,63 +1915,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3d18
+			// Method begins at RVA 0x3c28
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[0] float64,
+				[1] float64,
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0075
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_0063
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.3
-				IL_003c: ldstr "match"
-				IL_0041: ldarg.0
-				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.2
-				IL_0067: ldloc.2
-				IL_0068: box [System.Runtime]System.Double
-				IL_006d: stloc.1
-				IL_006e: ldloc.1
-				IL_006f: stloc.0
-				IL_0070: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldloc.2
+				IL_003a: ldstr "match"
+				IL_003f: ldarg.0
+				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0052: ldloc.0
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.0
+				IL_005e: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method FunctionExpression_L125C30::__js_call__
 
 	} // end of class FunctionExpression_L125C30
@@ -2101,7 +1976,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x551d
+				// Method begins at RVA 0x5205
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2127,7 +2002,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3d9c
+			// Method begins at RVA 0x3c9c
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -2173,7 +2048,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5526
+				// Method begins at RVA 0x520e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2199,63 +2074,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3de0
+			// Method begins at RVA 0x3ce0
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[0] float64,
+				[1] float64,
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0075
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_0063
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0034: stloc.3
-				IL_0035: ldloc.3
-				IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0041: ldloc.0
-				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.2
-				IL_0067: ldloc.2
-				IL_0068: box [System.Runtime]System.Double
-				IL_006d: stloc.1
-				IL_006e: ldloc.1
-				IL_006f: stloc.0
-				IL_0070: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0028: stloc.2
+				IL_0029: ldloc.2
+				IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				IL_002f: ldarg.0
+				IL_0030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0035: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_003a: ldloc.0
+				IL_003b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0040: castclass [System.Runtime]System.String
+				IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0052: ldloc.0
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.0
+				IL_005e: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method FunctionExpression_L134C29::__js_call__
 
 	} // end of class FunctionExpression_L134C29
@@ -2271,7 +2135,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x552f
+				// Method begins at RVA 0x5217
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2297,7 +2161,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3e64
+			// Method begins at RVA 0x3d54
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -2343,7 +2207,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5538
+				// Method begins at RVA 0x5220
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2369,67 +2233,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3ea8
+			// Method begins at RVA 0x3d98
 			// Header size: 12
-			// Code size: 130 (0x82)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0080
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_006a
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.3
-				IL_0044: ldstr "replace"
-				IL_0049: ldloc.s 4
-				IL_004b: ldstr ""
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0055: stloc.s 4
-				IL_0057: ldarg.0
-				IL_0058: ldloc.s 4
-				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005f: ldloc.0
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: stloc.2
-				IL_0066: ldloc.2
-				IL_0067: ldc.r8 1
-				IL_0070: add
-				IL_0071: stloc.2
-				IL_0072: ldloc.2
-				IL_0073: box [System.Runtime]System.Double
-				IL_0078: stloc.1
-				IL_0079: ldloc.1
-				IL_007a: stloc.0
-				IL_007b: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldarg.0
+				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_003f: stloc.3
+				IL_0040: ldloc.2
+				IL_0041: ldstr "replace"
+				IL_0046: ldloc.3
+				IL_0047: ldstr ""
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0051: stloc.3
+				IL_0052: ldarg.0
+				IL_0053: ldloc.3
+				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0059: ldloc.0
+				IL_005a: ldc.r8 1
+				IL_0063: add
+				IL_0064: stloc.0
+				IL_0065: br IL_000a
 			// end loop
 
-			IL_0080: ldnull
-			IL_0081: ret
+			IL_006a: ldnull
+			IL_006b: ret
 		} // end of method FunctionExpression_L143C38::__js_call__
 
 	} // end of class FunctionExpression_L143C38
@@ -2445,7 +2298,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5541
+				// Method begins at RVA 0x5229
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2471,7 +2324,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3f38
+			// Method begins at RVA 0x3e10
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -2517,7 +2370,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x554a
+				// Method begins at RVA 0x5232
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2543,67 +2396,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3f7c
+			// Method begins at RVA 0x3e54
 			// Header size: 12
-			// Code size: 130 (0x82)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0080
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_006a
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.3
-				IL_0044: ldstr "replace"
-				IL_0049: ldloc.s 4
-				IL_004b: ldstr "asdfasdfasdf"
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0055: stloc.s 4
-				IL_0057: ldarg.0
-				IL_0058: ldloc.s 4
-				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005f: ldloc.0
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: stloc.2
-				IL_0066: ldloc.2
-				IL_0067: ldc.r8 1
-				IL_0070: add
-				IL_0071: stloc.2
-				IL_0072: ldloc.2
-				IL_0073: box [System.Runtime]System.Double
-				IL_0078: stloc.1
-				IL_0079: ldloc.1
-				IL_007a: stloc.0
-				IL_007b: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldarg.0
+				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_003f: stloc.3
+				IL_0040: ldloc.2
+				IL_0041: ldstr "replace"
+				IL_0046: ldloc.3
+				IL_0047: ldstr "asdfasdfasdf"
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0051: stloc.3
+				IL_0052: ldarg.0
+				IL_0053: ldloc.3
+				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0059: ldloc.0
+				IL_005a: ldc.r8 1
+				IL_0063: add
+				IL_0064: stloc.0
+				IL_0065: br IL_000a
 			// end loop
 
-			IL_0080: ldnull
-			IL_0081: ret
+			IL_006a: ldnull
+			IL_006b: ret
 		} // end of method FunctionExpression_L152C40::__js_call__
 
 	} // end of class FunctionExpression_L152C40
@@ -2619,7 +2461,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5553
+				// Method begins at RVA 0x523b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2645,7 +2487,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x400c
+			// Method begins at RVA 0x3ecc
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -2695,7 +2537,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5565
+					// Method begins at RVA 0x524d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2719,7 +2561,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x53c9
+				// Method begins at RVA 0x50b1
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -2737,7 +2579,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x555c
+				// Method begins at RVA 0x5244
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2763,81 +2605,70 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4050
+			// Method begins at RVA 0x3f10
 			// Header size: 12
-			// Code size: 163 (0xa3)
+			// Code size: 143 (0x8f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/Scope,
-				[1] object,
-				[2] object,
-				[3] float64,
+				[1] float64,
+				[2] float64,
+				[3] object,
 				[4] object,
-				[5] object,
-				[6] object
+				[5] object
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldc.r8 0.0
-			IL_000f: box [System.Runtime]System.Double
-			IL_0014: stloc.1
-			// loop start (head: IL_0015)
-				IL_0015: ldloc.1
-				IL_0016: stloc.2
-				IL_0017: ldloc.2
-				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_001d: stloc.3
-				IL_001e: ldloc.3
-				IL_001f: ldc.r8 50
-				IL_0028: clt
-				IL_002a: brfalse IL_00a1
+			IL_000f: stloc.1
+			// loop start (head: IL_0010)
+				IL_0010: ldloc.1
+				IL_0011: stloc.2
+				IL_0012: ldloc.2
+				IL_0013: ldc.r8 50
+				IL_001c: clt
+				IL_001e: brfalse IL_008d
 
-				IL_002f: ldarg.0
-				IL_0030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0035: ldloc.1
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0040: stloc.s 4
-				IL_0042: ldarg.0
-				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0048: stloc.s 5
-				IL_004a: ldnull
-				IL_004b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
-				IL_0051: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-				IL_0056: ldc.i4.1
-				IL_0057: conv.r8
-				IL_0058: ldstr ""
-				IL_005d: ldc.i4.0
-				IL_005e: ldc.i4.1
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0064: stloc.s 6
-				IL_0066: ldloc.s 4
-				IL_0068: ldstr "replace"
-				IL_006d: ldloc.s 5
-				IL_006f: ldloc.s 6
-				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0076: stloc.s 6
-				IL_0078: ldarg.0
-				IL_0079: ldloc.s 6
-				IL_007b: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0080: ldloc.1
-				IL_0081: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0086: stloc.3
-				IL_0087: ldloc.3
-				IL_0088: ldc.r8 1
-				IL_0091: add
-				IL_0092: stloc.3
-				IL_0093: ldloc.3
-				IL_0094: box [System.Runtime]System.Double
-				IL_0099: stloc.2
-				IL_009a: ldloc.2
-				IL_009b: stloc.1
-				IL_009c: br IL_0015
+				IL_0023: ldarg.0
+				IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_002e: ldloc.1
+				IL_002f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0034: castclass [System.Runtime]System.String
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003e: stloc.3
+				IL_003f: ldarg.0
+				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0045: stloc.s 4
+				IL_0047: ldnull
+				IL_0048: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
+				IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+				IL_0053: ldc.i4.1
+				IL_0054: conv.r8
+				IL_0055: ldstr ""
+				IL_005a: ldc.i4.0
+				IL_005b: ldc.i4.1
+				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0061: stloc.s 5
+				IL_0063: ldloc.3
+				IL_0064: ldstr "replace"
+				IL_0069: ldloc.s 4
+				IL_006b: ldloc.s 5
+				IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0072: stloc.s 5
+				IL_0074: ldarg.0
+				IL_0075: ldloc.s 5
+				IL_0077: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007c: ldloc.1
+				IL_007d: ldc.r8 1
+				IL_0086: add
+				IL_0087: stloc.1
+				IL_0088: br IL_0010
 			// end loop
 
-			IL_00a1: ldnull
-			IL_00a2: ret
+			IL_008d: ldnull
+			IL_008e: ret
 		} // end of method FunctionExpression_L161C49::__js_call__
 
 	} // end of class FunctionExpression_L161C49
@@ -2853,7 +2684,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x556e
+				// Method begins at RVA 0x5256
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2879,7 +2710,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4100
+			// Method begins at RVA 0x3fac
 			// Header size: 12
 			// Code size: 77 (0x4d)
 			.maxstack 8
@@ -2933,7 +2764,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5577
+				// Method begins at RVA 0x525f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2959,63 +2790,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x415c
+			// Method begins at RVA 0x4008
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[0] float64,
+				[1] float64,
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0075
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_0063
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.3
-				IL_003c: ldstr "match"
-				IL_0041: ldarg.0
-				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.2
-				IL_0067: ldloc.2
-				IL_0068: box [System.Runtime]System.Double
-				IL_006d: stloc.1
-				IL_006e: ldloc.1
-				IL_006f: stloc.0
-				IL_0070: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldloc.2
+				IL_003a: ldstr "match"
+				IL_003f: ldarg.0
+				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0052: ldloc.0
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.0
+				IL_005e: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method FunctionExpression_L175C32::__js_call__
 
 	} // end of class FunctionExpression_L175C32
@@ -3031,7 +2851,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5580
+				// Method begins at RVA 0x5268
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3057,7 +2877,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x41e0
+			// Method begins at RVA 0x407c
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -3103,7 +2923,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5589
+				// Method begins at RVA 0x5271
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3129,63 +2949,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4224
+			// Method begins at RVA 0x40c0
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[0] float64,
+				[1] float64,
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0075
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_0063
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0034: stloc.3
-				IL_0035: ldloc.3
-				IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0041: ldloc.0
-				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.2
-				IL_0067: ldloc.2
-				IL_0068: box [System.Runtime]System.Double
-				IL_006d: stloc.1
-				IL_006e: ldloc.1
-				IL_006f: stloc.0
-				IL_0070: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0028: stloc.2
+				IL_0029: ldloc.2
+				IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				IL_002f: ldarg.0
+				IL_0030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0035: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_003a: ldloc.0
+				IL_003b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0040: castclass [System.Runtime]System.String
+				IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0052: ldloc.0
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.0
+				IL_005e: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method FunctionExpression_L184C31::__js_call__
 
 	} // end of class FunctionExpression_L184C31
@@ -3201,7 +3010,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5592
+				// Method begins at RVA 0x527a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3227,7 +3036,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x42a8
+			// Method begins at RVA 0x4134
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -3273,7 +3082,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x559b
+				// Method begins at RVA 0x5283
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3299,67 +3108,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x42ec
+			// Method begins at RVA 0x4178
 			// Header size: 12
-			// Code size: 130 (0x82)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0080
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_006a
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.3
-				IL_0044: ldstr "replace"
-				IL_0049: ldloc.s 4
-				IL_004b: ldstr ""
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0055: stloc.s 4
-				IL_0057: ldarg.0
-				IL_0058: ldloc.s 4
-				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005f: ldloc.0
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: stloc.2
-				IL_0066: ldloc.2
-				IL_0067: ldc.r8 1
-				IL_0070: add
-				IL_0071: stloc.2
-				IL_0072: ldloc.2
-				IL_0073: box [System.Runtime]System.Double
-				IL_0078: stloc.1
-				IL_0079: ldloc.1
-				IL_007a: stloc.0
-				IL_007b: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldarg.0
+				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_003f: stloc.3
+				IL_0040: ldloc.2
+				IL_0041: ldstr "replace"
+				IL_0046: ldloc.3
+				IL_0047: ldstr ""
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0051: stloc.3
+				IL_0052: ldarg.0
+				IL_0053: ldloc.3
+				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0059: ldloc.0
+				IL_005a: ldc.r8 1
+				IL_0063: add
+				IL_0064: stloc.0
+				IL_0065: br IL_000a
 			// end loop
 
-			IL_0080: ldnull
-			IL_0081: ret
+			IL_006a: ldnull
+			IL_006b: ret
 		} // end of method FunctionExpression_L193C40::__js_call__
 
 	} // end of class FunctionExpression_L193C40
@@ -3375,7 +3173,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x55a4
+				// Method begins at RVA 0x528c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3401,7 +3199,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x437c
+			// Method begins at RVA 0x41f0
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -3447,7 +3245,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x55ad
+				// Method begins at RVA 0x5295
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3473,67 +3271,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x43c0
+			// Method begins at RVA 0x4234
 			// Header size: 12
-			// Code size: 130 (0x82)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0080
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_006a
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.3
-				IL_0044: ldstr "replace"
-				IL_0049: ldloc.s 4
-				IL_004b: ldstr "asdfasdfasdf"
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0055: stloc.s 4
-				IL_0057: ldarg.0
-				IL_0058: ldloc.s 4
-				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005f: ldloc.0
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: stloc.2
-				IL_0066: ldloc.2
-				IL_0067: ldc.r8 1
-				IL_0070: add
-				IL_0071: stloc.2
-				IL_0072: ldloc.2
-				IL_0073: box [System.Runtime]System.Double
-				IL_0078: stloc.1
-				IL_0079: ldloc.1
-				IL_007a: stloc.0
-				IL_007b: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldarg.0
+				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_003f: stloc.3
+				IL_0040: ldloc.2
+				IL_0041: ldstr "replace"
+				IL_0046: ldloc.3
+				IL_0047: ldstr "asdfasdfasdf"
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0051: stloc.3
+				IL_0052: ldarg.0
+				IL_0053: ldloc.3
+				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0059: ldloc.0
+				IL_005a: ldc.r8 1
+				IL_0063: add
+				IL_0064: stloc.0
+				IL_0065: br IL_000a
 			// end loop
 
-			IL_0080: ldnull
-			IL_0081: ret
+			IL_006a: ldnull
+			IL_006b: ret
 		} // end of method FunctionExpression_L202C42::__js_call__
 
 	} // end of class FunctionExpression_L202C42
@@ -3549,7 +3336,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x55b6
+				// Method begins at RVA 0x529e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3575,7 +3362,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4450
+			// Method begins at RVA 0x42ac
 			// Header size: 12
 			// Code size: 77 (0x4d)
 			.maxstack 8
@@ -3629,7 +3416,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x55bf
+				// Method begins at RVA 0x52a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3655,63 +3442,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x44ac
+			// Method begins at RVA 0x4308
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[0] float64,
+				[1] float64,
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0075
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_0063
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.3
-				IL_003c: ldstr "match"
-				IL_0041: ldarg.0
-				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.2
-				IL_0067: ldloc.2
-				IL_0068: box [System.Runtime]System.Double
-				IL_006d: stloc.1
-				IL_006e: ldloc.1
-				IL_006f: stloc.0
-				IL_0070: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldloc.2
+				IL_003a: ldstr "match"
+				IL_003f: ldarg.0
+				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0052: ldloc.0
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.0
+				IL_005e: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method FunctionExpression_L212C39::__js_call__
 
 	} // end of class FunctionExpression_L212C39
@@ -3727,7 +3503,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x55c8
+				// Method begins at RVA 0x52b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3753,7 +3529,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4530
+			// Method begins at RVA 0x437c
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -3799,7 +3575,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x55d1
+				// Method begins at RVA 0x52b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3825,63 +3601,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4574
+			// Method begins at RVA 0x43c0
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[0] float64,
+				[1] float64,
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0075
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_0063
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0034: stloc.3
-				IL_0035: ldloc.3
-				IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0041: ldloc.0
-				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.2
-				IL_0067: ldloc.2
-				IL_0068: box [System.Runtime]System.Double
-				IL_006d: stloc.1
-				IL_006e: ldloc.1
-				IL_006f: stloc.0
-				IL_0070: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0028: stloc.2
+				IL_0029: ldloc.2
+				IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				IL_002f: ldarg.0
+				IL_0030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0035: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_003a: ldloc.0
+				IL_003b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0040: castclass [System.Runtime]System.String
+				IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0052: ldloc.0
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.0
+				IL_005e: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method FunctionExpression_L221C38::__js_call__
 
 	} // end of class FunctionExpression_L221C38
@@ -3897,7 +3662,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x55da
+				// Method begins at RVA 0x52c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3923,7 +3688,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x45f8
+			// Method begins at RVA 0x4434
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -3969,7 +3734,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x55e3
+				// Method begins at RVA 0x52cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3995,67 +3760,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x463c
+			// Method begins at RVA 0x4478
 			// Header size: 12
-			// Code size: 130 (0x82)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0080
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_006a
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.3
-				IL_0044: ldstr "replace"
-				IL_0049: ldloc.s 4
-				IL_004b: ldstr ""
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0055: stloc.s 4
-				IL_0057: ldarg.0
-				IL_0058: ldloc.s 4
-				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005f: ldloc.0
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: stloc.2
-				IL_0066: ldloc.2
-				IL_0067: ldc.r8 1
-				IL_0070: add
-				IL_0071: stloc.2
-				IL_0072: ldloc.2
-				IL_0073: box [System.Runtime]System.Double
-				IL_0078: stloc.1
-				IL_0079: ldloc.1
-				IL_007a: stloc.0
-				IL_007b: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldarg.0
+				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_003f: stloc.3
+				IL_0040: ldloc.2
+				IL_0041: ldstr "replace"
+				IL_0046: ldloc.3
+				IL_0047: ldstr ""
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0051: stloc.3
+				IL_0052: ldarg.0
+				IL_0053: ldloc.3
+				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0059: ldloc.0
+				IL_005a: ldc.r8 1
+				IL_0063: add
+				IL_0064: stloc.0
+				IL_0065: br IL_000a
 			// end loop
 
-			IL_0080: ldnull
-			IL_0081: ret
+			IL_006a: ldnull
+			IL_006b: ret
 		} // end of method FunctionExpression_L230C47::__js_call__
 
 	} // end of class FunctionExpression_L230C47
@@ -4071,7 +3825,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x55ec
+				// Method begins at RVA 0x52d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4097,7 +3851,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x46cc
+			// Method begins at RVA 0x44f0
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -4143,7 +3897,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x55f5
+				// Method begins at RVA 0x52dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4169,67 +3923,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4710
+			// Method begins at RVA 0x4534
 			// Header size: 12
-			// Code size: 130 (0x82)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0080
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_006a
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.3
-				IL_0044: ldstr "replace"
-				IL_0049: ldloc.s 4
-				IL_004b: ldstr "asdfasdfasdf"
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0055: stloc.s 4
-				IL_0057: ldarg.0
-				IL_0058: ldloc.s 4
-				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005f: ldloc.0
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: stloc.2
-				IL_0066: ldloc.2
-				IL_0067: ldc.r8 1
-				IL_0070: add
-				IL_0071: stloc.2
-				IL_0072: ldloc.2
-				IL_0073: box [System.Runtime]System.Double
-				IL_0078: stloc.1
-				IL_0079: ldloc.1
-				IL_007a: stloc.0
-				IL_007b: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldarg.0
+				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_003f: stloc.3
+				IL_0040: ldloc.2
+				IL_0041: ldstr "replace"
+				IL_0046: ldloc.3
+				IL_0047: ldstr "asdfasdfasdf"
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0051: stloc.3
+				IL_0052: ldarg.0
+				IL_0053: ldloc.3
+				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0059: ldloc.0
+				IL_005a: ldc.r8 1
+				IL_0063: add
+				IL_0064: stloc.0
+				IL_0065: br IL_000a
 			// end loop
 
-			IL_0080: ldnull
-			IL_0081: ret
+			IL_006a: ldnull
+			IL_006b: ret
 		} // end of method FunctionExpression_L239C49::__js_call__
 
 	} // end of class FunctionExpression_L239C49
@@ -4245,7 +3988,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x55fe
+				// Method begins at RVA 0x52e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4271,7 +4014,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x47a0
+			// Method begins at RVA 0x45ac
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -4321,7 +4064,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5610
+					// Method begins at RVA 0x52f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4345,7 +4088,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x53d0
+				// Method begins at RVA 0x50b8
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -4363,7 +4106,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5607
+				// Method begins at RVA 0x52ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4389,81 +4132,70 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x47e4
+			// Method begins at RVA 0x45f0
 			// Header size: 12
-			// Code size: 163 (0xa3)
+			// Code size: 143 (0x8f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/Scope,
-				[1] object,
-				[2] object,
-				[3] float64,
+				[1] float64,
+				[2] float64,
+				[3] object,
 				[4] object,
-				[5] object,
-				[6] object
+				[5] object
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldc.r8 0.0
-			IL_000f: box [System.Runtime]System.Double
-			IL_0014: stloc.1
-			// loop start (head: IL_0015)
-				IL_0015: ldloc.1
-				IL_0016: stloc.2
-				IL_0017: ldloc.2
-				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_001d: stloc.3
-				IL_001e: ldloc.3
-				IL_001f: ldc.r8 50
-				IL_0028: clt
-				IL_002a: brfalse IL_00a1
+			IL_000f: stloc.1
+			// loop start (head: IL_0010)
+				IL_0010: ldloc.1
+				IL_0011: stloc.2
+				IL_0012: ldloc.2
+				IL_0013: ldc.r8 50
+				IL_001c: clt
+				IL_001e: brfalse IL_008d
 
-				IL_002f: ldarg.0
-				IL_0030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0035: ldloc.1
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0040: stloc.s 4
-				IL_0042: ldarg.0
-				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0048: stloc.s 5
-				IL_004a: ldnull
-				IL_004b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
-				IL_0051: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-				IL_0056: ldc.i4.1
-				IL_0057: conv.r8
-				IL_0058: ldstr ""
-				IL_005d: ldc.i4.0
-				IL_005e: ldc.i4.1
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0064: stloc.s 6
-				IL_0066: ldloc.s 4
-				IL_0068: ldstr "replace"
-				IL_006d: ldloc.s 5
-				IL_006f: ldloc.s 6
-				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0076: stloc.s 6
-				IL_0078: ldarg.0
-				IL_0079: ldloc.s 6
-				IL_007b: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0080: ldloc.1
-				IL_0081: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0086: stloc.3
-				IL_0087: ldloc.3
-				IL_0088: ldc.r8 1
-				IL_0091: add
-				IL_0092: stloc.3
-				IL_0093: ldloc.3
-				IL_0094: box [System.Runtime]System.Double
-				IL_0099: stloc.2
-				IL_009a: ldloc.2
-				IL_009b: stloc.1
-				IL_009c: br IL_0015
+				IL_0023: ldarg.0
+				IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_002e: ldloc.1
+				IL_002f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0034: castclass [System.Runtime]System.String
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003e: stloc.3
+				IL_003f: ldarg.0
+				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0045: stloc.s 4
+				IL_0047: ldnull
+				IL_0048: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
+				IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+				IL_0053: ldc.i4.1
+				IL_0054: conv.r8
+				IL_0055: ldstr ""
+				IL_005a: ldc.i4.0
+				IL_005b: ldc.i4.1
+				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0061: stloc.s 5
+				IL_0063: ldloc.3
+				IL_0064: ldstr "replace"
+				IL_0069: ldloc.s 4
+				IL_006b: ldloc.s 5
+				IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0072: stloc.s 5
+				IL_0074: ldarg.0
+				IL_0075: ldloc.s 5
+				IL_0077: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007c: ldloc.1
+				IL_007d: ldc.r8 1
+				IL_0086: add
+				IL_0087: stloc.1
+				IL_0088: br IL_0010
 			// end loop
 
-			IL_00a1: ldnull
-			IL_00a2: ret
+			IL_008d: ldnull
+			IL_008e: ret
 		} // end of method FunctionExpression_L248C58::__js_call__
 
 	} // end of class FunctionExpression_L248C58
@@ -4479,7 +4211,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5619
+				// Method begins at RVA 0x5301
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4505,7 +4237,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4894
+			// Method begins at RVA 0x468c
 			// Header size: 12
 			// Code size: 77 (0x4d)
 			.maxstack 8
@@ -4559,7 +4291,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5622
+				// Method begins at RVA 0x530a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4585,63 +4317,52 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x48f0
+			// Method begins at RVA 0x46e8
 			// Header size: 12
-			// Code size: 119 (0x77)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object
+				[0] float64,
+				[1] float64,
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0075
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_0063
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldloc.3
-				IL_003c: ldstr "match"
-				IL_0041: ldarg.0
-				IL_0042: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_004c: stloc.3
-				IL_004d: ldarg.0
-				IL_004e: ldloc.3
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0054: ldloc.0
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: ldc.r8 1
-				IL_0065: add
-				IL_0066: stloc.2
-				IL_0067: ldloc.2
-				IL_0068: box [System.Runtime]System.Double
-				IL_006d: stloc.1
-				IL_006e: ldloc.1
-				IL_006f: stloc.0
-				IL_0070: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldloc.2
+				IL_003a: ldstr "match"
+				IL_003f: ldarg.0
+				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_004a: stloc.2
+				IL_004b: ldarg.0
+				IL_004c: ldloc.2
+				IL_004d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0052: ldloc.0
+				IL_0053: ldc.r8 1
+				IL_005c: add
+				IL_005d: stloc.0
+				IL_005e: br IL_000a
 			// end loop
 
-			IL_0075: ldnull
-			IL_0076: ret
+			IL_0063: ldnull
+			IL_0064: ret
 		} // end of method FunctionExpression_L262C31::__js_call__
 
 	} // end of class FunctionExpression_L262C31
@@ -4657,7 +4378,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x562b
+				// Method begins at RVA 0x5313
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4683,7 +4404,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4974
+			// Method begins at RVA 0x475c
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -4729,7 +4450,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5634
+				// Method begins at RVA 0x531c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4755,67 +4476,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x49b8
+			// Method begins at RVA 0x47a0
 			// Header size: 12
-			// Code size: 130 (0x82)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0080
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_006a
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.3
-				IL_0044: ldstr "replace"
-				IL_0049: ldloc.s 4
-				IL_004b: ldstr "asdfasdfasdf"
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0055: stloc.s 4
-				IL_0057: ldarg.0
-				IL_0058: ldloc.s 4
-				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005f: ldloc.0
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: stloc.2
-				IL_0066: ldloc.2
-				IL_0067: ldc.r8 1
-				IL_0070: add
-				IL_0071: stloc.2
-				IL_0072: ldloc.2
-				IL_0073: box [System.Runtime]System.Double
-				IL_0078: stloc.1
-				IL_0079: ldloc.1
-				IL_007a: stloc.0
-				IL_007b: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldarg.0
+				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_003f: stloc.3
+				IL_0040: ldloc.2
+				IL_0041: ldstr "replace"
+				IL_0046: ldloc.3
+				IL_0047: ldstr "asdfasdfasdf"
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0051: stloc.3
+				IL_0052: ldarg.0
+				IL_0053: ldloc.3
+				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0059: ldloc.0
+				IL_005a: ldc.r8 1
+				IL_0063: add
+				IL_0064: stloc.0
+				IL_0065: br IL_000a
 			// end loop
 
-			IL_0080: ldnull
-			IL_0081: ret
+			IL_006a: ldnull
+			IL_006b: ret
 		} // end of method FunctionExpression_L271C33::__js_call__
 
 	} // end of class FunctionExpression_L271C33
@@ -4831,7 +4541,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x563d
+				// Method begins at RVA 0x5325
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4857,7 +4567,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4a48
+			// Method begins at RVA 0x4818
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -4903,7 +4613,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5646
+				// Method begins at RVA 0x532e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4929,67 +4639,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4a8c
+			// Method begins at RVA 0x485c
 			// Header size: 12
-			// Code size: 130 (0x82)
+			// Code size: 108 (0x6c)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] object
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0080
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_006a
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldarg.0
-				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.3
-				IL_0044: ldstr "replace"
-				IL_0049: ldloc.s 4
-				IL_004b: ldstr "asdf\\1asdfasdf"
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0055: stloc.s 4
-				IL_0057: ldarg.0
-				IL_0058: ldloc.s 4
-				IL_005a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_005f: ldloc.0
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: stloc.2
-				IL_0066: ldloc.2
-				IL_0067: ldc.r8 1
-				IL_0070: add
-				IL_0071: stloc.2
-				IL_0072: ldloc.2
-				IL_0073: box [System.Runtime]System.Double
-				IL_0078: stloc.1
-				IL_0079: ldloc.1
-				IL_007a: stloc.0
-				IL_007b: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldarg.0
+				IL_003a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_003f: stloc.3
+				IL_0040: ldloc.2
+				IL_0041: ldstr "replace"
+				IL_0046: ldloc.3
+				IL_0047: ldstr "asdf\\1asdfasdf"
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0051: stloc.3
+				IL_0052: ldarg.0
+				IL_0053: ldloc.3
+				IL_0054: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0059: ldloc.0
+				IL_005a: ldc.r8 1
+				IL_0063: add
+				IL_0064: stloc.0
+				IL_0065: br IL_000a
 			// end loop
 
-			IL_0080: ldnull
-			IL_0081: ret
+			IL_006a: ldnull
+			IL_006b: ret
 		} // end of method FunctionExpression_L280C46::__js_call__
 
 	} // end of class FunctionExpression_L280C46
@@ -5005,7 +4704,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x564f
+				// Method begins at RVA 0x5337
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5031,7 +4730,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4b1c
+			// Method begins at RVA 0x48d4
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -5081,7 +4780,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5661
+					// Method begins at RVA 0x5349
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5106,7 +4805,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x53d8
+				// Method begins at RVA 0x50c0
 				// Header size: 12
 				// Code size: 26 (0x1a)
 				.maxstack 8
@@ -5135,7 +4834,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5658
+				// Method begins at RVA 0x5340
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5161,81 +4860,70 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4b60
+			// Method begins at RVA 0x4918
 			// Header size: 12
-			// Code size: 163 (0xa3)
+			// Code size: 143 (0x8f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/Scope,
-				[1] object,
-				[2] object,
-				[3] float64,
+				[1] float64,
+				[2] float64,
+				[3] object,
 				[4] object,
-				[5] object,
-				[6] object
+				[5] object
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldc.r8 0.0
-			IL_000f: box [System.Runtime]System.Double
-			IL_0014: stloc.1
-			// loop start (head: IL_0015)
-				IL_0015: ldloc.1
-				IL_0016: stloc.2
-				IL_0017: ldloc.2
-				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_001d: stloc.3
-				IL_001e: ldloc.3
-				IL_001f: ldc.r8 50
-				IL_0028: clt
-				IL_002a: brfalse IL_00a1
+			IL_000f: stloc.1
+			// loop start (head: IL_0010)
+				IL_0010: ldloc.1
+				IL_0011: stloc.2
+				IL_0012: ldloc.2
+				IL_0013: ldc.r8 50
+				IL_001c: clt
+				IL_001e: brfalse IL_008d
 
-				IL_002f: ldarg.0
-				IL_0030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0035: ldloc.1
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0040: stloc.s 4
-				IL_0042: ldarg.0
-				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0048: stloc.s 5
-				IL_004a: ldnull
-				IL_004b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
-				IL_0051: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-				IL_0056: ldc.i4.2
-				IL_0057: conv.r8
-				IL_0058: ldstr ""
-				IL_005d: ldc.i4.0
-				IL_005e: ldc.i4.1
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0064: stloc.s 6
-				IL_0066: ldloc.s 4
-				IL_0068: ldstr "replace"
-				IL_006d: ldloc.s 5
-				IL_006f: ldloc.s 6
-				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0076: stloc.s 6
-				IL_0078: ldarg.0
-				IL_0079: ldloc.s 6
-				IL_007b: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0080: ldloc.1
-				IL_0081: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0086: stloc.3
-				IL_0087: ldloc.3
-				IL_0088: ldc.r8 1
-				IL_0091: add
-				IL_0092: stloc.3
-				IL_0093: ldloc.3
-				IL_0094: box [System.Runtime]System.Double
-				IL_0099: stloc.2
-				IL_009a: ldloc.2
-				IL_009b: stloc.1
-				IL_009c: br IL_0015
+				IL_0023: ldarg.0
+				IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_002e: ldloc.1
+				IL_002f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0034: castclass [System.Runtime]System.String
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003e: stloc.3
+				IL_003f: ldarg.0
+				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0045: stloc.s 4
+				IL_0047: ldnull
+				IL_0048: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
+				IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+				IL_0053: ldc.i4.2
+				IL_0054: conv.r8
+				IL_0055: ldstr ""
+				IL_005a: ldc.i4.0
+				IL_005b: ldc.i4.1
+				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0061: stloc.s 5
+				IL_0063: ldloc.3
+				IL_0064: ldstr "replace"
+				IL_0069: ldloc.s 4
+				IL_006b: ldloc.s 5
+				IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0072: stloc.s 5
+				IL_0074: ldarg.0
+				IL_0075: ldloc.s 5
+				IL_0077: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007c: ldloc.1
+				IL_007d: ldc.r8 1
+				IL_0086: add
+				IL_0087: stloc.1
+				IL_0088: br IL_0010
 			// end loop
 
-			IL_00a1: ldnull
-			IL_00a2: ret
+			IL_008d: ldnull
+			IL_008e: ret
 		} // end of method FunctionExpression_L289C55::__js_call__
 
 	} // end of class FunctionExpression_L289C55
@@ -5251,7 +4939,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x566a
+				// Method begins at RVA 0x5352
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5277,7 +4965,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4c10
+			// Method begins at RVA 0x49b4
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -5327,7 +5015,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x567c
+					// Method begins at RVA 0x5364
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5352,7 +5040,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x5400
+				// Method begins at RVA 0x50e8
 				// Header size: 12
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -5380,7 +5068,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5673
+				// Method begins at RVA 0x535b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5406,81 +5094,70 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4c54
+			// Method begins at RVA 0x49f8
 			// Header size: 12
-			// Code size: 163 (0xa3)
+			// Code size: 143 (0x8f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/Scope,
-				[1] object,
-				[2] object,
-				[3] float64,
+				[1] float64,
+				[2] float64,
+				[3] object,
 				[4] object,
-				[5] object,
-				[6] object
+				[5] object
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldc.r8 0.0
-			IL_000f: box [System.Runtime]System.Double
-			IL_0014: stloc.1
-			// loop start (head: IL_0015)
-				IL_0015: ldloc.1
-				IL_0016: stloc.2
-				IL_0017: ldloc.2
-				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_001d: stloc.3
-				IL_001e: ldloc.3
-				IL_001f: ldc.r8 50
-				IL_0028: clt
-				IL_002a: brfalse IL_00a1
+			IL_000f: stloc.1
+			// loop start (head: IL_0010)
+				IL_0010: ldloc.1
+				IL_0011: stloc.2
+				IL_0012: ldloc.2
+				IL_0013: ldc.r8 50
+				IL_001c: clt
+				IL_001e: brfalse IL_008d
 
-				IL_002f: ldarg.0
-				IL_0030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_0035: ldloc.1
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0040: stloc.s 4
-				IL_0042: ldarg.0
-				IL_0043: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-				IL_0048: stloc.s 5
-				IL_004a: ldnull
-				IL_004b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
-				IL_0051: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-				IL_0056: ldc.i4.2
-				IL_0057: conv.r8
-				IL_0058: ldstr ""
-				IL_005d: ldc.i4.0
-				IL_005e: ldc.i4.1
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0064: stloc.s 6
-				IL_0066: ldloc.s 4
-				IL_0068: ldstr "replace"
-				IL_006d: ldloc.s 5
-				IL_006f: ldloc.s 6
-				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0076: stloc.s 6
-				IL_0078: ldarg.0
-				IL_0079: ldloc.s 6
-				IL_007b: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0080: ldloc.1
-				IL_0081: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0086: stloc.3
-				IL_0087: ldloc.3
-				IL_0088: ldc.r8 1
-				IL_0091: add
-				IL_0092: stloc.3
-				IL_0093: ldloc.3
-				IL_0094: box [System.Runtime]System.Double
-				IL_0099: stloc.2
-				IL_009a: ldloc.2
-				IL_009b: stloc.1
-				IL_009c: br IL_0015
+				IL_0023: ldarg.0
+				IL_0024: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_002e: ldloc.1
+				IL_002f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0034: castclass [System.Runtime]System.String
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003e: stloc.3
+				IL_003f: ldarg.0
+				IL_0040: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+				IL_0045: stloc.s 4
+				IL_0047: ldnull
+				IL_0048: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
+				IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+				IL_0053: ldc.i4.2
+				IL_0054: conv.r8
+				IL_0055: ldstr ""
+				IL_005a: ldc.i4.0
+				IL_005b: ldc.i4.1
+				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0061: stloc.s 5
+				IL_0063: ldloc.3
+				IL_0064: ldstr "replace"
+				IL_0069: ldloc.s 4
+				IL_006b: ldloc.s 5
+				IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0072: stloc.s 5
+				IL_0074: ldarg.0
+				IL_0075: ldloc.s 5
+				IL_0077: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007c: ldloc.1
+				IL_007d: ldc.r8 1
+				IL_0086: add
+				IL_0087: stloc.1
+				IL_0088: br IL_0010
 			// end loop
 
-			IL_00a1: ldnull
-			IL_00a2: ret
+			IL_008d: ldnull
+			IL_008e: ret
 		} // end of method FunctionExpression_L300C64::__js_call__
 
 	} // end of class FunctionExpression_L300C64
@@ -5496,7 +5173,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5685
+				// Method begins at RVA 0x536d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5522,7 +5199,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4d04
+			// Method begins at RVA 0x4a94
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -5568,7 +5245,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x568e
+				// Method begins at RVA 0x5376
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5594,67 +5271,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4d48
+			// Method begins at RVA 0x4ad8
 			// Header size: 12
-			// Code size: 132 (0x84)
+			// Code size: 112 (0x70)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0082
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_006e
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldstr "aaaaaaaaaa"
-				IL_0040: ldstr "g"
-				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_004a: stloc.s 4
-				IL_004c: ldloc.3
-				IL_004d: ldstr "match"
-				IL_0052: ldloc.s 4
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0059: stloc.3
-				IL_005a: ldarg.0
-				IL_005b: ldloc.3
-				IL_005c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0061: ldloc.0
-				IL_0062: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0067: stloc.2
-				IL_0068: ldloc.2
-				IL_0069: ldc.r8 1
-				IL_0072: add
-				IL_0073: stloc.2
-				IL_0074: ldloc.2
-				IL_0075: box [System.Runtime]System.Double
-				IL_007a: stloc.1
-				IL_007b: ldloc.1
-				IL_007c: stloc.0
-				IL_007d: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldstr "aaaaaaaaaa"
+				IL_003e: ldstr "g"
+				IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_0048: stloc.3
+				IL_0049: ldloc.2
+				IL_004a: ldstr "match"
+				IL_004f: ldloc.3
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0055: stloc.2
+				IL_0056: ldarg.0
+				IL_0057: ldloc.2
+				IL_0058: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005d: ldloc.0
+				IL_005e: ldc.r8 1
+				IL_0067: add
+				IL_0068: stloc.0
+				IL_0069: br IL_000a
 			// end loop
 
-			IL_0082: ldnull
-			IL_0083: ret
+			IL_006e: ldnull
+			IL_006f: ret
 		} // end of method FunctionExpression_L313C25::__js_call__
 
 	} // end of class FunctionExpression_L313C25
@@ -5670,7 +5336,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5697
+				// Method begins at RVA 0x537f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5696,7 +5362,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4dd8
+			// Method begins at RVA 0x4b54
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -5742,7 +5408,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56a0
+				// Method begins at RVA 0x5388
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5768,67 +5434,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4e1c
+			// Method begins at RVA 0x4b98
 			// Header size: 12
-			// Code size: 134 (0x86)
+			// Code size: 112 (0x70)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[4] object
+				[0] float64,
+				[1] float64,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0084
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_006e
 
-				IL_0029: ldstr "aaaaaaaaaa"
-				IL_002e: ldstr "g"
-				IL_0033: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0038: stloc.3
-				IL_0039: ldloc.3
-				IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003f: stloc.s 4
-				IL_0041: ldloc.s 4
-				IL_0043: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-				IL_0048: ldarg.0
-				IL_0049: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_004e: ldloc.0
-				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-				IL_0059: stloc.s 4
-				IL_005b: ldarg.0
-				IL_005c: ldloc.s 4
-				IL_005e: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0063: ldloc.0
-				IL_0064: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0069: stloc.2
-				IL_006a: ldloc.2
-				IL_006b: ldc.r8 1
-				IL_0074: add
-				IL_0075: stloc.2
-				IL_0076: ldloc.2
-				IL_0077: box [System.Runtime]System.Double
-				IL_007c: stloc.1
-				IL_007d: ldloc.1
-				IL_007e: stloc.0
-				IL_007f: br IL_000f
+				IL_001d: ldstr "aaaaaaaaaa"
+				IL_0022: ldstr "g"
+				IL_0027: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_002c: stloc.2
+				IL_002d: ldloc.2
+				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0033: stloc.3
+				IL_0034: ldloc.3
+				IL_0035: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				IL_003a: ldarg.0
+				IL_003b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0040: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0045: ldloc.0
+				IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_004b: castclass [System.Runtime]System.String
+				IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_0055: stloc.3
+				IL_0056: ldarg.0
+				IL_0057: ldloc.3
+				IL_0058: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005d: ldloc.0
+				IL_005e: ldc.r8 1
+				IL_0067: add
+				IL_0068: stloc.0
+				IL_0069: br IL_000a
 			// end loop
 
-			IL_0084: ldnull
-			IL_0085: ret
+			IL_006e: ldnull
+			IL_006f: ret
 		} // end of method FunctionExpression_L322C24::__js_call__
 
 	} // end of class FunctionExpression_L322C24
@@ -5844,7 +5499,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56a9
+				// Method begins at RVA 0x5391
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5870,7 +5525,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4eb0
+			// Method begins at RVA 0x4c14
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -5916,7 +5571,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56b2
+				// Method begins at RVA 0x539a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5942,68 +5597,57 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4ef4
+			// Method begins at RVA 0x4c58
 			// Header size: 12
-			// Code size: 137 (0x89)
+			// Code size: 117 (0x75)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0087
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_0073
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldstr "aaaaaaaaaa"
-				IL_0040: ldstr "g"
-				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_004a: stloc.s 4
-				IL_004c: ldloc.3
-				IL_004d: ldstr "replace"
-				IL_0052: ldloc.s 4
-				IL_0054: ldstr ""
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_005e: stloc.3
-				IL_005f: ldarg.0
-				IL_0060: ldloc.3
-				IL_0061: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0066: ldloc.0
-				IL_0067: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_006c: stloc.2
-				IL_006d: ldloc.2
-				IL_006e: ldc.r8 1
-				IL_0077: add
-				IL_0078: stloc.2
-				IL_0079: ldloc.2
-				IL_007a: box [System.Runtime]System.Double
-				IL_007f: stloc.1
-				IL_0080: ldloc.1
-				IL_0081: stloc.0
-				IL_0082: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldstr "aaaaaaaaaa"
+				IL_003e: ldstr "g"
+				IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_0048: stloc.3
+				IL_0049: ldloc.2
+				IL_004a: ldstr "replace"
+				IL_004f: ldloc.3
+				IL_0050: ldstr ""
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_005a: stloc.2
+				IL_005b: ldarg.0
+				IL_005c: ldloc.2
+				IL_005d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0062: ldloc.0
+				IL_0063: ldc.r8 1
+				IL_006c: add
+				IL_006d: stloc.0
+				IL_006e: br IL_000a
 			// end loop
 
-			IL_0087: ldnull
-			IL_0088: ret
+			IL_0073: ldnull
+			IL_0074: ret
 		} // end of method FunctionExpression_L331C33::__js_call__
 
 	} // end of class FunctionExpression_L331C33
@@ -6019,7 +5663,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56bb
+				// Method begins at RVA 0x53a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6045,7 +5689,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4f8c
+			// Method begins at RVA 0x4cdc
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -6091,7 +5735,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56c4
+				// Method begins at RVA 0x53ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6117,68 +5761,57 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4fd0
+			// Method begins at RVA 0x4d20
 			// Header size: 12
-			// Code size: 137 (0x89)
+			// Code size: 117 (0x75)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0087
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_0073
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldstr "aaaaaaaaaa"
-				IL_0040: ldstr "g"
-				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_004a: stloc.s 4
-				IL_004c: ldloc.3
-				IL_004d: ldstr "replace"
-				IL_0052: ldloc.s 4
-				IL_0054: ldstr "asdfasdfasdf"
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_005e: stloc.3
-				IL_005f: ldarg.0
-				IL_0060: ldloc.3
-				IL_0061: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0066: ldloc.0
-				IL_0067: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_006c: stloc.2
-				IL_006d: ldloc.2
-				IL_006e: ldc.r8 1
-				IL_0077: add
-				IL_0078: stloc.2
-				IL_0079: ldloc.2
-				IL_007a: box [System.Runtime]System.Double
-				IL_007f: stloc.1
-				IL_0080: ldloc.1
-				IL_0081: stloc.0
-				IL_0082: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldstr "aaaaaaaaaa"
+				IL_003e: ldstr "g"
+				IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_0048: stloc.3
+				IL_0049: ldloc.2
+				IL_004a: ldstr "replace"
+				IL_004f: ldloc.3
+				IL_0050: ldstr "asdfasdfasdf"
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_005a: stloc.2
+				IL_005b: ldarg.0
+				IL_005c: ldloc.2
+				IL_005d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0062: ldloc.0
+				IL_0063: ldc.r8 1
+				IL_006c: add
+				IL_006d: stloc.0
+				IL_006e: br IL_000a
 			// end loop
 
-			IL_0087: ldnull
-			IL_0088: ret
+			IL_0073: ldnull
+			IL_0074: ret
 		} // end of method FunctionExpression_L340C35::__js_call__
 
 	} // end of class FunctionExpression_L340C35
@@ -6194,7 +5827,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56cd
+				// Method begins at RVA 0x53b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6220,7 +5853,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5068
+			// Method begins at RVA 0x4da4
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -6266,7 +5899,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56d6
+				// Method begins at RVA 0x53be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6292,67 +5925,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x50ac
+			// Method begins at RVA 0x4de8
 			// Header size: 12
-			// Code size: 132 (0x84)
+			// Code size: 112 (0x70)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0082
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_006e
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldstr "aaaaaaaaaa"
-				IL_0040: ldstr "g"
-				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_004a: stloc.s 4
-				IL_004c: ldloc.3
-				IL_004d: ldstr "match"
-				IL_0052: ldloc.s 4
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0059: stloc.3
-				IL_005a: ldarg.0
-				IL_005b: ldloc.3
-				IL_005c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0061: ldloc.0
-				IL_0062: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0067: stloc.2
-				IL_0068: ldloc.2
-				IL_0069: ldc.r8 1
-				IL_0072: add
-				IL_0073: stloc.2
-				IL_0074: ldloc.2
-				IL_0075: box [System.Runtime]System.Double
-				IL_007a: stloc.1
-				IL_007b: ldloc.1
-				IL_007c: stloc.0
-				IL_007d: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldstr "aaaaaaaaaa"
+				IL_003e: ldstr "g"
+				IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_0048: stloc.3
+				IL_0049: ldloc.2
+				IL_004a: ldstr "match"
+				IL_004f: ldloc.3
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0055: stloc.2
+				IL_0056: ldarg.0
+				IL_0057: ldloc.2
+				IL_0058: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005d: ldloc.0
+				IL_005e: ldc.r8 1
+				IL_0067: add
+				IL_0068: stloc.0
+				IL_0069: br IL_000a
 			// end loop
 
-			IL_0082: ldnull
-			IL_0083: ret
+			IL_006e: ldnull
+			IL_006f: ret
 		} // end of method FunctionExpression_L349C32::__js_call__
 
 	} // end of class FunctionExpression_L349C32
@@ -6368,7 +5990,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56df
+				// Method begins at RVA 0x53c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6394,7 +6016,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x513c
+			// Method begins at RVA 0x4e64
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -6440,7 +6062,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56e8
+				// Method begins at RVA 0x53d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6466,67 +6088,56 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5180
+			// Method begins at RVA 0x4ea8
 			// Header size: 12
-			// Code size: 134 (0x86)
+			// Code size: 112 (0x70)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[4] object
+				[0] float64,
+				[1] float64,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[3] object
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 100
-				IL_0022: clt
-				IL_0024: brfalse IL_0084
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 100
+				IL_0016: clt
+				IL_0018: brfalse IL_006e
 
-				IL_0029: ldstr "aaaaaaaaaa"
-				IL_002e: ldstr "g"
-				IL_0033: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0038: stloc.3
-				IL_0039: ldloc.3
-				IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003f: stloc.s 4
-				IL_0041: ldloc.s 4
-				IL_0043: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-				IL_0048: ldarg.0
-				IL_0049: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_004e: ldloc.0
-				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-				IL_0059: stloc.s 4
-				IL_005b: ldarg.0
-				IL_005c: ldloc.s 4
-				IL_005e: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0063: ldloc.0
-				IL_0064: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0069: stloc.2
-				IL_006a: ldloc.2
-				IL_006b: ldc.r8 1
-				IL_0074: add
-				IL_0075: stloc.2
-				IL_0076: ldloc.2
-				IL_0077: box [System.Runtime]System.Double
-				IL_007c: stloc.1
-				IL_007d: ldloc.1
-				IL_007e: stloc.0
-				IL_007f: br IL_000f
+				IL_001d: ldstr "aaaaaaaaaa"
+				IL_0022: ldstr "g"
+				IL_0027: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_002c: stloc.2
+				IL_002d: ldloc.2
+				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0033: stloc.3
+				IL_0034: ldloc.3
+				IL_0035: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				IL_003a: ldarg.0
+				IL_003b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0040: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0045: ldloc.0
+				IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_004b: castclass [System.Runtime]System.String
+				IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+				IL_0055: stloc.3
+				IL_0056: ldarg.0
+				IL_0057: ldloc.3
+				IL_0058: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_005d: ldloc.0
+				IL_005e: ldc.r8 1
+				IL_0067: add
+				IL_0068: stloc.0
+				IL_0069: br IL_000a
 			// end loop
 
-			IL_0084: ldnull
-			IL_0085: ret
+			IL_006e: ldnull
+			IL_006f: ret
 		} // end of method FunctionExpression_L358C31::__js_call__
 
 	} // end of class FunctionExpression_L358C31
@@ -6542,7 +6153,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56f1
+				// Method begins at RVA 0x53d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6568,7 +6179,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5214
+			// Method begins at RVA 0x4f24
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -6614,7 +6225,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x56fa
+				// Method begins at RVA 0x53e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6640,68 +6251,57 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5258
+			// Method begins at RVA 0x4f68
 			// Header size: 12
-			// Code size: 137 (0x89)
+			// Code size: 117 (0x75)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0087
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_0073
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldstr "aaaaaaaaaa"
-				IL_0040: ldstr "g"
-				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_004a: stloc.s 4
-				IL_004c: ldloc.3
-				IL_004d: ldstr "replace"
-				IL_0052: ldloc.s 4
-				IL_0054: ldstr ""
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_005e: stloc.3
-				IL_005f: ldarg.0
-				IL_0060: ldloc.3
-				IL_0061: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0066: ldloc.0
-				IL_0067: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_006c: stloc.2
-				IL_006d: ldloc.2
-				IL_006e: ldc.r8 1
-				IL_0077: add
-				IL_0078: stloc.2
-				IL_0079: ldloc.2
-				IL_007a: box [System.Runtime]System.Double
-				IL_007f: stloc.1
-				IL_0080: ldloc.1
-				IL_0081: stloc.0
-				IL_0082: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldstr "aaaaaaaaaa"
+				IL_003e: ldstr "g"
+				IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_0048: stloc.3
+				IL_0049: ldloc.2
+				IL_004a: ldstr "replace"
+				IL_004f: ldloc.3
+				IL_0050: ldstr ""
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_005a: stloc.2
+				IL_005b: ldarg.0
+				IL_005c: ldloc.2
+				IL_005d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0062: ldloc.0
+				IL_0063: ldc.r8 1
+				IL_006c: add
+				IL_006d: stloc.0
+				IL_006e: br IL_000a
 			// end loop
 
-			IL_0087: ldnull
-			IL_0088: ret
+			IL_0073: ldnull
+			IL_0074: ret
 		} // end of method FunctionExpression_L367C40::__js_call__
 
 	} // end of class FunctionExpression_L367C40
@@ -6717,7 +6317,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5703
+				// Method begins at RVA 0x53eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6743,7 +6343,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x52f0
+			// Method begins at RVA 0x4fec
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -6789,7 +6389,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x570c
+				// Method begins at RVA 0x53f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6815,68 +6415,57 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x5334
+			// Method begins at RVA 0x5030
 			// Header size: 12
-			// Code size: 137 (0x89)
+			// Code size: 117 (0x75)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object,
-				[2] float64,
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[0] float64,
+				[1] float64,
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
 			IL_0000: ldc.r8 0.0
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: stloc.0
-			// loop start (head: IL_000f)
-				IL_000f: ldloc.0
-				IL_0010: stloc.1
-				IL_0011: ldloc.1
-				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0017: stloc.2
-				IL_0018: ldloc.2
-				IL_0019: ldc.r8 50
-				IL_0022: clt
-				IL_0024: brfalse IL_0087
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 50
+				IL_0016: clt
+				IL_0018: brfalse IL_0073
 
-				IL_0029: ldarg.0
-				IL_002a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-				IL_002f: ldloc.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.3
-				IL_003b: ldstr "aaaaaaaaaa"
-				IL_0040: ldstr "g"
-				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_004a: stloc.s 4
-				IL_004c: ldloc.3
-				IL_004d: ldstr "replace"
-				IL_0052: ldloc.s 4
-				IL_0054: ldstr "asdfasdfasdf"
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_005e: stloc.3
-				IL_005f: ldarg.0
-				IL_0060: ldloc.3
-				IL_0061: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0066: ldloc.0
-				IL_0067: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_006c: stloc.2
-				IL_006d: ldloc.2
-				IL_006e: ldc.r8 1
-				IL_0077: add
-				IL_0078: stloc.2
-				IL_0079: ldloc.2
-				IL_007a: box [System.Runtime]System.Double
-				IL_007f: stloc.1
-				IL_0080: ldloc.1
-				IL_0081: stloc.0
-				IL_0082: br IL_000f
+				IL_001d: ldarg.0
+				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+				IL_0023: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0028: ldloc.0
+				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_002e: castclass [System.Runtime]System.String
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0038: stloc.2
+				IL_0039: ldstr "aaaaaaaaaa"
+				IL_003e: ldstr "g"
+				IL_0043: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_0048: stloc.3
+				IL_0049: ldloc.2
+				IL_004a: ldstr "replace"
+				IL_004f: ldloc.3
+				IL_0050: ldstr "asdfasdfasdf"
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_005a: stloc.2
+				IL_005b: ldarg.0
+				IL_005c: ldloc.2
+				IL_005d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0062: ldloc.0
+				IL_0063: ldc.r8 1
+				IL_006c: add
+				IL_006d: stloc.0
+				IL_006e: br IL_000a
 			// end loop
 
-			IL_0087: ldnull
-			IL_0088: ret
+			IL_0073: ldnull
+			IL_0074: ret
 		} // end of method FunctionExpression_L376C42::__js_call__
 
 	} // end of class FunctionExpression_L376C42
@@ -6911,7 +6500,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5421
+			// Method begins at RVA 0x5109
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -8898,7 +8487,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x5715
+		// Method begins at RVA 0x53fd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x626c
+				// Method begins at RVA 0x5f8c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6275
+				// Method begins at RVA 0x5f95
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6287
+					// Method begins at RVA 0x5fa7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x627e
+				// Method begins at RVA 0x5f9e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -191,7 +191,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6299
+					// Method begins at RVA 0x5fb9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -209,7 +209,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6290
+				// Method begins at RVA 0x5fb0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -269,7 +269,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x62ab
+					// Method begins at RVA 0x5fcb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -289,7 +289,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x62b4
+					// Method begins at RVA 0x5fd4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -309,7 +309,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x62bd
+					// Method begins at RVA 0x5fdd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -329,7 +329,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x62c6
+					// Method begins at RVA 0x5fe6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -349,7 +349,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x62cf
+					// Method begins at RVA 0x5fef
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -369,7 +369,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x62d8
+					// Method begins at RVA 0x5ff8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -393,7 +393,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x62ea
+						// Method begins at RVA 0x600a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -411,7 +411,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x62e1
+					// Method begins at RVA 0x6001
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -429,7 +429,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x62a2
+				// Method begins at RVA 0x5fc2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -459,25 +459,25 @@
 			)
 			// Method begins at RVA 0x2540
 			// Header size: 12
-			// Code size: 1033 (0x409)
+			// Code size: 816 (0x330)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] object,
-				[4] object,
-				[5] object,
+				[4] float64,
+				[5] float64,
 				[6] object,
 				[7] object,
-				[8] object,
-				[9] object,
-				[10] object,
-				[11] object,
-				[12] object,
-				[13] object,
-				[14] object,
-				[15] object,
+				[8] float64,
+				[9] float64,
+				[10] float64,
+				[11] float64,
+				[12] float64,
+				[13] float64,
+				[14] float64,
+				[15] float64,
 				[16] object,
 				[17] object,
 				[18] float64,
@@ -526,339 +526,272 @@
 			IL_0085: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::abs(float64)
 			IL_008a: stloc.s 19
 			IL_008c: ldloc.s 19
-			IL_008e: box [System.Runtime]System.Double
-			IL_0093: stloc.s 20
-			IL_0095: ldloc.s 20
-			IL_0097: stloc.s 4
-			IL_0099: ldloc.3
-			IL_009a: stloc.s 17
-			IL_009c: ldloc.s 17
-			IL_009e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00a3: stloc.s 19
-			IL_00a5: ldloc.2
-			IL_00a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00ab: stloc.s 18
-			IL_00ad: ldloc.s 19
-			IL_00af: ldloc.s 18
-			IL_00b1: sub
+			IL_008e: stloc.s 4
+			IL_0090: ldloc.3
+			IL_0091: stloc.s 17
+			IL_0093: ldloc.s 17
+			IL_0095: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_009a: stloc.s 19
+			IL_009c: ldloc.2
+			IL_009d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00a2: stloc.s 18
+			IL_00a4: ldloc.s 19
+			IL_00a6: ldloc.s 18
+			IL_00a8: sub
+			IL_00a9: stloc.s 18
+			IL_00ab: ldloc.s 18
+			IL_00ad: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::abs(float64)
 			IL_00b2: stloc.s 18
 			IL_00b4: ldloc.s 18
-			IL_00b6: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::abs(float64)
-			IL_00bb: stloc.s 18
-			IL_00bd: ldloc.s 18
-			IL_00bf: box [System.Runtime]System.Double
-			IL_00c4: stloc.s 20
-			IL_00c6: ldloc.s 20
-			IL_00c8: stloc.s 5
-			IL_00ca: ldloc.0
-			IL_00cb: stloc.s 6
-			IL_00cd: ldloc.2
-			IL_00ce: stloc.s 7
-			IL_00d0: ldnull
-			IL_00d1: stloc.s 8
-			IL_00d3: ldnull
-			IL_00d4: stloc.s 9
-			IL_00d6: ldnull
-			IL_00d7: stloc.s 10
-			IL_00d9: ldnull
-			IL_00da: stloc.s 11
-			IL_00dc: ldnull
-			IL_00dd: stloc.s 12
-			IL_00df: ldnull
-			IL_00e0: stloc.s 13
-			IL_00e2: ldnull
-			IL_00e3: stloc.s 14
-			IL_00e5: ldnull
-			IL_00e6: stloc.s 15
-			IL_00e8: ldloc.1
-			IL_00e9: stloc.s 17
-			IL_00eb: ldloc.s 17
-			IL_00ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00f2: stloc.s 18
-			IL_00f4: ldloc.0
-			IL_00f5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00fa: stloc.s 19
-			IL_00fc: ldloc.s 18
-			IL_00fe: ldloc.s 19
-			IL_0100: clt
-			IL_0102: ldc.i4.0
-			IL_0103: ceq
-			IL_0105: brfalse IL_0137
+			IL_00b6: stloc.s 5
+			IL_00b8: ldloc.0
+			IL_00b9: stloc.s 6
+			IL_00bb: ldloc.2
+			IL_00bc: stloc.s 7
+			IL_00be: nop
+			IL_00bf: nop
+			IL_00c0: nop
+			IL_00c1: nop
+			IL_00c2: nop
+			IL_00c3: nop
+			IL_00c4: ldloc.1
+			IL_00c5: stloc.s 17
+			IL_00c7: ldloc.s 17
+			IL_00c9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00ce: stloc.s 18
+			IL_00d0: ldloc.0
+			IL_00d1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00d6: stloc.s 19
+			IL_00d8: ldloc.s 18
+			IL_00da: ldloc.s 19
+			IL_00dc: clt
+			IL_00de: ldc.i4.0
+			IL_00df: ceq
+			IL_00e1: brfalse IL_0109
 
-			IL_010a: ldc.r8 1
-			IL_0113: box [System.Runtime]System.Double
-			IL_0118: stloc.s 20
-			IL_011a: ldloc.s 20
-			IL_011c: stloc.s 8
-			IL_011e: ldc.r8 1
-			IL_0127: box [System.Runtime]System.Double
-			IL_012c: stloc.s 20
-			IL_012e: ldloc.s 20
-			IL_0130: stloc.s 10
-			IL_0132: br IL_0161
+			IL_00e6: ldc.r8 1
+			IL_00ef: stloc.s 19
+			IL_00f1: ldloc.s 19
+			IL_00f3: stloc.s 8
+			IL_00f5: ldc.r8 1
+			IL_00fe: stloc.s 19
+			IL_0100: ldloc.s 19
+			IL_0102: stloc.s 9
+			IL_0104: br IL_0129
 
-			IL_0137: ldc.r8 1
-			IL_0140: neg
-			IL_0141: box [System.Runtime]System.Double
-			IL_0146: stloc.s 20
-			IL_0148: ldloc.s 20
-			IL_014a: stloc.s 8
-			IL_014c: ldc.r8 1
-			IL_0155: neg
-			IL_0156: box [System.Runtime]System.Double
-			IL_015b: stloc.s 20
-			IL_015d: ldloc.s 20
-			IL_015f: stloc.s 10
+			IL_0109: ldc.r8 1
+			IL_0112: neg
+			IL_0113: stloc.s 19
+			IL_0115: ldloc.s 19
+			IL_0117: stloc.s 8
+			IL_0119: ldc.r8 1
+			IL_0122: neg
+			IL_0123: stloc.s 19
+			IL_0125: ldloc.s 19
+			IL_0127: stloc.s 9
 
-			IL_0161: ldloc.3
-			IL_0162: stloc.s 17
-			IL_0164: ldloc.s 17
-			IL_0166: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_016b: stloc.s 19
-			IL_016d: ldloc.2
-			IL_016e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0173: stloc.s 18
-			IL_0175: ldloc.s 19
-			IL_0177: ldloc.s 18
-			IL_0179: clt
-			IL_017b: ldc.i4.0
-			IL_017c: ceq
-			IL_017e: brfalse IL_01b0
+			IL_0129: ldloc.3
+			IL_012a: stloc.s 17
+			IL_012c: ldloc.s 17
+			IL_012e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0133: stloc.s 19
+			IL_0135: ldloc.2
+			IL_0136: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_013b: stloc.s 18
+			IL_013d: ldloc.s 19
+			IL_013f: ldloc.s 18
+			IL_0141: clt
+			IL_0143: ldc.i4.0
+			IL_0144: ceq
+			IL_0146: brfalse IL_016e
 
-			IL_0183: ldc.r8 1
-			IL_018c: box [System.Runtime]System.Double
-			IL_0191: stloc.s 20
-			IL_0193: ldloc.s 20
-			IL_0195: stloc.s 9
-			IL_0197: ldc.r8 1
-			IL_01a0: box [System.Runtime]System.Double
-			IL_01a5: stloc.s 20
-			IL_01a7: ldloc.s 20
-			IL_01a9: stloc.s 11
-			IL_01ab: br IL_01da
+			IL_014b: ldc.r8 1
+			IL_0154: stloc.s 18
+			IL_0156: ldloc.s 18
+			IL_0158: stloc.s 10
+			IL_015a: ldc.r8 1
+			IL_0163: stloc.s 18
+			IL_0165: ldloc.s 18
+			IL_0167: stloc.s 11
+			IL_0169: br IL_018e
 
-			IL_01b0: ldc.r8 1
-			IL_01b9: neg
-			IL_01ba: box [System.Runtime]System.Double
-			IL_01bf: stloc.s 20
-			IL_01c1: ldloc.s 20
-			IL_01c3: stloc.s 9
-			IL_01c5: ldc.r8 1
-			IL_01ce: neg
-			IL_01cf: box [System.Runtime]System.Double
-			IL_01d4: stloc.s 20
-			IL_01d6: ldloc.s 20
-			IL_01d8: stloc.s 11
+			IL_016e: ldc.r8 1
+			IL_0177: neg
+			IL_0178: stloc.s 18
+			IL_017a: ldloc.s 18
+			IL_017c: stloc.s 10
+			IL_017e: ldc.r8 1
+			IL_0187: neg
+			IL_0188: stloc.s 18
+			IL_018a: ldloc.s 18
+			IL_018c: stloc.s 11
 
-			IL_01da: ldloc.s 4
-			IL_01dc: stloc.s 20
-			IL_01de: ldloc.s 20
-			IL_01e0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01e5: stloc.s 18
-			IL_01e7: ldloc.s 5
-			IL_01e9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01ee: stloc.s 19
-			IL_01f0: ldloc.s 18
-			IL_01f2: ldloc.s 19
-			IL_01f4: clt
-			IL_01f6: ldc.i4.0
-			IL_01f7: ceq
-			IL_01f9: brfalse IL_026b
+			IL_018e: ldloc.s 4
+			IL_0190: stloc.s 18
+			IL_0192: ldloc.s 18
+			IL_0194: ldloc.s 5
+			IL_0196: clt
+			IL_0198: ldc.i4.0
+			IL_0199: ceq
+			IL_019b: brfalse IL_01f1
 
-			IL_01fe: ldc.r8 0.0
-			IL_0207: box [System.Runtime]System.Double
-			IL_020c: stloc.s 20
-			IL_020e: ldloc.s 20
-			IL_0210: stloc.s 8
-			IL_0212: ldc.r8 0.0
-			IL_021b: box [System.Runtime]System.Double
-			IL_0220: stloc.s 20
-			IL_0222: ldloc.s 20
-			IL_0224: stloc.s 11
-			IL_0226: ldloc.s 4
-			IL_0228: stloc.s 20
-			IL_022a: ldloc.s 20
-			IL_022c: stloc.s 12
-			IL_022e: ldloc.s 4
-			IL_0230: stloc.s 20
-			IL_0232: ldloc.s 20
-			IL_0234: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0239: stloc.s 19
-			IL_023b: ldloc.s 19
-			IL_023d: ldc.r8 2
-			IL_0246: div
-			IL_0247: stloc.s 19
-			IL_0249: ldloc.s 19
-			IL_024b: box [System.Runtime]System.Double
-			IL_0250: stloc.s 20
-			IL_0252: ldloc.s 20
-			IL_0254: stloc.s 13
-			IL_0256: ldloc.s 5
-			IL_0258: stloc.s 20
-			IL_025a: ldloc.s 20
-			IL_025c: stloc.s 14
-			IL_025e: ldloc.s 4
-			IL_0260: stloc.s 20
-			IL_0262: ldloc.s 20
-			IL_0264: stloc.s 15
-			IL_0266: br IL_02d3
+			IL_01a0: ldc.r8 0.0
+			IL_01a9: stloc.s 18
+			IL_01ab: ldloc.s 18
+			IL_01ad: stloc.s 8
+			IL_01af: ldc.r8 0.0
+			IL_01b8: stloc.s 18
+			IL_01ba: ldloc.s 18
+			IL_01bc: stloc.s 11
+			IL_01be: ldloc.s 4
+			IL_01c0: stloc.s 18
+			IL_01c2: ldloc.s 18
+			IL_01c4: stloc.s 12
+			IL_01c6: ldloc.s 4
+			IL_01c8: stloc.s 18
+			IL_01ca: ldloc.s 18
+			IL_01cc: ldc.r8 2
+			IL_01d5: div
+			IL_01d6: stloc.s 18
+			IL_01d8: ldloc.s 18
+			IL_01da: stloc.s 13
+			IL_01dc: ldloc.s 5
+			IL_01de: stloc.s 18
+			IL_01e0: ldloc.s 18
+			IL_01e2: stloc.s 14
+			IL_01e4: ldloc.s 4
+			IL_01e6: stloc.s 18
+			IL_01e8: ldloc.s 18
+			IL_01ea: stloc.s 15
+			IL_01ec: br IL_023d
 
-			IL_026b: ldc.r8 0.0
-			IL_0274: box [System.Runtime]System.Double
-			IL_0279: stloc.s 20
-			IL_027b: ldloc.s 20
-			IL_027d: stloc.s 10
-			IL_027f: ldc.r8 0.0
-			IL_0288: box [System.Runtime]System.Double
-			IL_028d: stloc.s 20
-			IL_028f: ldloc.s 20
-			IL_0291: stloc.s 9
-			IL_0293: ldloc.s 5
-			IL_0295: stloc.s 20
-			IL_0297: ldloc.s 20
-			IL_0299: stloc.s 12
-			IL_029b: ldloc.s 5
-			IL_029d: stloc.s 20
-			IL_029f: ldloc.s 20
-			IL_02a1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_02a6: stloc.s 19
-			IL_02a8: ldloc.s 19
-			IL_02aa: ldc.r8 2
-			IL_02b3: div
-			IL_02b4: stloc.s 19
-			IL_02b6: ldloc.s 19
-			IL_02b8: box [System.Runtime]System.Double
-			IL_02bd: stloc.s 20
-			IL_02bf: ldloc.s 20
-			IL_02c1: stloc.s 13
-			IL_02c3: ldloc.s 4
-			IL_02c5: stloc.s 20
-			IL_02c7: ldloc.s 20
-			IL_02c9: stloc.s 14
-			IL_02cb: ldloc.s 5
-			IL_02cd: stloc.s 20
-			IL_02cf: ldloc.s 20
-			IL_02d1: stloc.s 15
+			IL_01f1: ldc.r8 0.0
+			IL_01fa: stloc.s 18
+			IL_01fc: ldloc.s 18
+			IL_01fe: stloc.s 9
+			IL_0200: ldc.r8 0.0
+			IL_0209: stloc.s 18
+			IL_020b: ldloc.s 18
+			IL_020d: stloc.s 10
+			IL_020f: ldloc.s 5
+			IL_0211: stloc.s 18
+			IL_0213: ldloc.s 18
+			IL_0215: stloc.s 12
+			IL_0217: ldloc.s 5
+			IL_0219: stloc.s 18
+			IL_021b: ldloc.s 18
+			IL_021d: ldc.r8 2
+			IL_0226: div
+			IL_0227: stloc.s 18
+			IL_0229: ldloc.s 18
+			IL_022b: stloc.s 13
+			IL_022d: ldloc.s 4
+			IL_022f: stloc.s 18
+			IL_0231: ldloc.s 18
+			IL_0233: stloc.s 14
+			IL_0235: ldloc.s 5
+			IL_0237: stloc.s 18
+			IL_0239: ldloc.s 18
+			IL_023b: stloc.s 15
 
-			IL_02d3: ldarg.0
-			IL_02d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_02d9: ldstr "LastPx"
-			IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02e3: ldloc.s 15
-			IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02ea: stloc.s 21
-			IL_02ec: ldloc.s 21
-			IL_02ee: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(object)
-			IL_02f3: stloc.s 19
-			IL_02f5: ldloc.s 19
-			IL_02f7: box [System.Runtime]System.Double
-			IL_02fc: stloc.s 20
-			IL_02fe: ldloc.s 20
-			IL_0300: stloc.s 15
-			IL_0302: ldarg.0
-			IL_0303: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0308: ldstr "LastPx"
-			IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0312: stloc.s 16
-			// loop start (head: IL_0314)
-				IL_0314: ldloc.s 16
-				IL_0316: stloc.s 17
-				IL_0318: ldloc.s 17
-				IL_031a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_031f: stloc.s 19
-				IL_0321: ldloc.s 15
-				IL_0323: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0328: stloc.s 18
-				IL_032a: ldloc.s 19
-				IL_032c: ldloc.s 18
-				IL_032e: clt
-				IL_0330: brfalse IL_03f3
+			IL_023d: ldarg.0
+			IL_023e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0243: ldstr "LastPx"
+			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_024d: ldloc.s 15
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0254: stloc.s 20
+			IL_0256: ldloc.s 20
+			IL_0258: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(object)
+			IL_025d: stloc.s 18
+			IL_025f: ldloc.s 18
+			IL_0261: stloc.s 15
+			IL_0263: ldarg.0
+			IL_0264: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0269: ldstr "LastPx"
+			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0273: stloc.s 16
+			// loop start (head: IL_0275)
+				IL_0275: ldloc.s 16
+				IL_0277: stloc.s 17
+				IL_0279: ldloc.s 17
+				IL_027b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0280: stloc.s 18
+				IL_0282: ldloc.s 18
+				IL_0284: ldloc.s 15
+				IL_0286: clt
+				IL_0288: brfalse IL_031a
 
-				IL_0335: ldloc.s 13
-				IL_0337: ldloc.s 14
-				IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_033e: stloc.s 21
-				IL_0340: ldloc.s 21
-				IL_0342: stloc.s 13
-				IL_0344: ldloc.s 13
-				IL_0346: stloc.s 21
-				IL_0348: ldloc.s 21
-				IL_034a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_034f: stloc.s 18
-				IL_0351: ldloc.s 12
-				IL_0353: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0358: stloc.s 19
-				IL_035a: ldloc.s 18
-				IL_035c: ldloc.s 19
-				IL_035e: clt
-				IL_0360: ldc.i4.0
-				IL_0361: ceq
-				IL_0363: brfalse IL_03ac
+				IL_028d: ldloc.s 13
+				IL_028f: ldloc.s 14
+				IL_0291: add
+				IL_0292: stloc.s 18
+				IL_0294: ldloc.s 18
+				IL_0296: stloc.s 13
+				IL_0298: ldloc.s 13
+				IL_029a: stloc.s 18
+				IL_029c: ldloc.s 18
+				IL_029e: ldloc.s 12
+				IL_02a0: clt
+				IL_02a2: ldc.i4.0
+				IL_02a3: ceq
+				IL_02a5: brfalse IL_02d3
 
-				IL_0368: ldloc.s 13
-				IL_036a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_036f: stloc.s 19
-				IL_0371: ldloc.s 12
-				IL_0373: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0378: stloc.s 18
-				IL_037a: ldloc.s 19
-				IL_037c: ldloc.s 18
-				IL_037e: sub
-				IL_037f: stloc.s 18
-				IL_0381: ldloc.s 18
-				IL_0383: box [System.Runtime]System.Double
-				IL_0388: stloc.s 20
-				IL_038a: ldloc.s 20
-				IL_038c: stloc.s 13
-				IL_038e: ldloc.s 6
-				IL_0390: ldloc.s 8
-				IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0397: stloc.s 21
-				IL_0399: ldloc.s 21
-				IL_039b: stloc.s 6
-				IL_039d: ldloc.s 7
-				IL_039f: ldloc.s 9
-				IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_03a6: stloc.s 21
-				IL_03a8: ldloc.s 21
-				IL_03aa: stloc.s 7
+				IL_02aa: ldloc.s 13
+				IL_02ac: ldloc.s 12
+				IL_02ae: sub
+				IL_02af: stloc.s 18
+				IL_02b1: ldloc.s 18
+				IL_02b3: stloc.s 13
+				IL_02b5: ldloc.s 6
+				IL_02b7: ldloc.s 8
+				IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_02be: stloc.s 20
+				IL_02c0: ldloc.s 20
+				IL_02c2: stloc.s 6
+				IL_02c4: ldloc.s 7
+				IL_02c6: ldloc.s 10
+				IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_02cd: stloc.s 20
+				IL_02cf: ldloc.s 20
+				IL_02d1: stloc.s 7
 
-				IL_03ac: ldloc.s 6
-				IL_03ae: ldloc.s 10
-				IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_03b5: stloc.s 21
-				IL_03b7: ldloc.s 21
-				IL_03b9: stloc.s 6
-				IL_03bb: ldloc.s 7
-				IL_03bd: ldloc.s 11
-				IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_03c4: stloc.s 21
-				IL_03c6: ldloc.s 21
-				IL_03c8: stloc.s 7
-				IL_03ca: ldloc.s 16
-				IL_03cc: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_03d1: stloc.s 18
-				IL_03d3: ldloc.s 18
-				IL_03d5: ldc.r8 1
-				IL_03de: add
-				IL_03df: stloc.s 18
-				IL_03e1: ldloc.s 18
-				IL_03e3: box [System.Runtime]System.Double
-				IL_03e8: stloc.s 20
-				IL_03ea: ldloc.s 20
-				IL_03ec: stloc.s 16
-				IL_03ee: br IL_0314
+				IL_02d3: ldloc.s 6
+				IL_02d5: ldloc.s 9
+				IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_02dc: stloc.s 20
+				IL_02de: ldloc.s 20
+				IL_02e0: stloc.s 6
+				IL_02e2: ldloc.s 7
+				IL_02e4: ldloc.s 11
+				IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_02eb: stloc.s 20
+				IL_02ed: ldloc.s 20
+				IL_02ef: stloc.s 7
+				IL_02f1: ldloc.s 16
+				IL_02f3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_02f8: stloc.s 18
+				IL_02fa: ldloc.s 18
+				IL_02fc: ldc.r8 1
+				IL_0305: add
+				IL_0306: stloc.s 18
+				IL_0308: ldloc.s 18
+				IL_030a: box [System.Runtime]System.Double
+				IL_030f: stloc.s 21
+				IL_0311: ldloc.s 21
+				IL_0313: stloc.s 16
+				IL_0315: br IL_0275
 			// end loop
 
-			IL_03f3: ldarg.0
-			IL_03f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_03f9: ldstr "LastPx"
-			IL_03fe: ldloc.s 15
-			IL_0400: ldc.i4.1
-			IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0406: pop
-			IL_0407: ldnull
-			IL_0408: ret
+			IL_031a: ldarg.0
+			IL_031b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0320: ldstr "LastPx"
+			IL_0325: ldloc.s 15
+			IL_0327: ldc.i4.1
+			IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_032d: pop
+			IL_032e: ldnull
+			IL_032f: ret
 		} // end of method DrawLine::__js_call__
 
 	} // end of class DrawLine
@@ -874,7 +807,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x62f3
+				// Method begins at RVA 0x6013
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -899,7 +832,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2958
+			// Method begins at RVA 0x287c
 			// Header size: 12
 			// Code size: 369 (0x171)
 			.maxstack 8
@@ -1053,7 +986,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6305
+					// Method begins at RVA 0x6025
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1071,7 +1004,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x62fc
+				// Method begins at RVA 0x601c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1100,20 +1033,19 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2ad8
+			// Method begins at RVA 0x29fc
 			// Header size: 12
-			// Code size: 596 (0x254)
+			// Code size: 479 (0x1df)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
-				[2] object,
-				[3] object,
+				[2] float64,
+				[3] float64,
 				[4] object,
-				[5] object,
-				[6] float64,
-				[7] object,
-				[8] float64
+				[5] float64,
+				[6] object,
+				[7] float64
 			)
 
 			IL_0000: ldc.i4.0
@@ -1129,206 +1061,167 @@
 			IL_001d: ldloc.s 4
 			IL_001f: stloc.1
 			IL_0020: ldc.r8 0.0
-			IL_0029: box [System.Runtime]System.Double
-			IL_002e: stloc.2
-			// loop start (head: IL_002f)
-				IL_002f: ldloc.2
-				IL_0030: stloc.s 5
-				IL_0032: ldloc.s 5
-				IL_0034: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0039: stloc.s 6
-				IL_003b: ldloc.s 6
-				IL_003d: ldc.r8 3
-				IL_0046: clt
-				IL_0048: brfalse IL_00db
+			IL_0029: stloc.2
+			// loop start (head: IL_002a)
+				IL_002a: ldloc.2
+				IL_002b: stloc.s 5
+				IL_002d: ldloc.s 5
+				IL_002f: ldc.r8 3
+				IL_0038: clt
+				IL_003a: brfalse IL_00ad
 
-				IL_004d: ldarg.2
-				IL_004e: ldloc.2
-				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0054: stloc.s 4
-				IL_0056: ldarg.3
-				IL_0057: ldloc.2
-				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_005d: stloc.s 7
-				IL_005f: ldloc.s 4
-				IL_0061: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0066: stloc.s 6
-				IL_0068: ldloc.0
-				IL_0069: ldloc.2
-				IL_006a: ldloc.s 6
-				IL_006c: ldloc.s 7
-				IL_006e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0073: sub
-				IL_0074: box [System.Runtime]System.Double
-				IL_0079: ldc.i4.1
-				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_007f: pop
-				IL_0080: ldarg.s V2
-				IL_0082: ldloc.2
-				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0088: stloc.s 7
-				IL_008a: ldarg.3
-				IL_008b: ldloc.2
-				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0091: stloc.s 4
-				IL_0093: ldloc.s 7
-				IL_0095: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_009a: stloc.s 6
-				IL_009c: ldloc.1
-				IL_009d: ldloc.2
-				IL_009e: ldloc.s 6
-				IL_00a0: ldloc.s 4
-				IL_00a2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00a7: sub
-				IL_00a8: box [System.Runtime]System.Double
-				IL_00ad: ldc.i4.1
-				IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_00b3: pop
-				IL_00b4: ldloc.2
-				IL_00b5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ba: stloc.s 6
-				IL_00bc: ldloc.s 6
-				IL_00be: ldc.r8 1
-				IL_00c7: add
-				IL_00c8: stloc.s 6
-				IL_00ca: ldloc.s 6
-				IL_00cc: box [System.Runtime]System.Double
-				IL_00d1: stloc.s 5
-				IL_00d3: ldloc.s 5
-				IL_00d5: stloc.2
-				IL_00d6: br IL_002f
+				IL_003f: ldarg.2
+				IL_0040: ldloc.2
+				IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0046: stloc.s 4
+				IL_0048: ldarg.3
+				IL_0049: ldloc.2
+				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_004f: stloc.s 6
+				IL_0051: ldloc.s 4
+				IL_0053: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0058: stloc.s 5
+				IL_005a: ldloc.0
+				IL_005b: ldloc.2
+				IL_005c: ldloc.s 5
+				IL_005e: ldloc.s 6
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: sub
+				IL_0066: ldc.i4.1
+				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+				IL_006c: pop
+				IL_006d: ldarg.s V2
+				IL_006f: ldloc.2
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0075: stloc.s 6
+				IL_0077: ldarg.3
+				IL_0078: ldloc.2
+				IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_007e: stloc.s 4
+				IL_0080: ldloc.s 6
+				IL_0082: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0087: stloc.s 5
+				IL_0089: ldloc.1
+				IL_008a: ldloc.2
+				IL_008b: ldloc.s 5
+				IL_008d: ldloc.s 4
+				IL_008f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0094: sub
+				IL_0095: ldc.i4.1
+				IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+				IL_009b: pop
+				IL_009c: ldloc.2
+				IL_009d: ldc.r8 1
+				IL_00a6: add
+				IL_00a7: stloc.2
+				IL_00a8: br IL_002a
 			// end loop
 
-			IL_00db: ldarg.0
-			IL_00dc: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcCross
-			IL_00e1: ldc.i4.1
-			IL_00e2: newarr [System.Runtime]System.Object
-			IL_00e7: dup
-			IL_00e8: ldc.i4.0
-			IL_00e9: ldarg.0
-			IL_00ea: stelem.ref
-			IL_00eb: ldloc.0
-			IL_00ec: ldloc.1
-			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_00f2: stloc.s 4
-			IL_00f4: ldloc.s 4
-			IL_00f6: stloc.0
-			IL_00f7: ldloc.0
-			IL_00f8: ldc.r8 0.0
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0106: stloc.s 4
-			IL_0108: ldloc.0
-			IL_0109: ldc.r8 0.0
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0117: stloc.s 7
-			IL_0119: ldloc.s 4
-			IL_011b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0120: stloc.s 6
+			IL_00ad: ldarg.0
+			IL_00ae: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcCross
+			IL_00b3: ldc.i4.1
+			IL_00b4: newarr [System.Runtime]System.Object
+			IL_00b9: dup
+			IL_00ba: ldc.i4.0
+			IL_00bb: ldarg.0
+			IL_00bc: stelem.ref
+			IL_00bd: ldloc.0
+			IL_00be: ldloc.1
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_00c4: stloc.s 4
+			IL_00c6: ldloc.s 4
+			IL_00c8: stloc.0
+			IL_00c9: ldloc.0
+			IL_00ca: ldc.r8 0.0
+			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00d8: stloc.s 4
+			IL_00da: ldloc.0
+			IL_00db: ldc.r8 0.0
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00e9: stloc.s 6
+			IL_00eb: ldloc.s 4
+			IL_00ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00f2: stloc.s 5
+			IL_00f4: ldloc.s 5
+			IL_00f6: ldloc.s 6
+			IL_00f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00fd: mul
+			IL_00fe: stloc.s 5
+			IL_0100: ldloc.0
+			IL_0101: ldc.r8 1
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_010f: stloc.s 6
+			IL_0111: ldloc.0
+			IL_0112: ldc.r8 1
+			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0120: stloc.s 4
 			IL_0122: ldloc.s 6
-			IL_0124: ldloc.s 7
-			IL_0126: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_012b: mul
-			IL_012c: stloc.s 6
-			IL_012e: ldloc.0
-			IL_012f: ldc.r8 1
-			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_013d: stloc.s 7
-			IL_013f: ldloc.0
-			IL_0140: ldc.r8 1
-			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_014e: stloc.s 4
-			IL_0150: ldloc.s 7
-			IL_0152: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0157: stloc.s 8
-			IL_0159: ldloc.s 6
-			IL_015b: ldloc.s 8
-			IL_015d: ldloc.s 4
-			IL_015f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0164: mul
-			IL_0165: add
-			IL_0166: stloc.s 6
-			IL_0168: ldloc.0
-			IL_0169: ldc.r8 2
-			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0177: stloc.s 4
-			IL_0179: ldloc.0
-			IL_017a: ldc.r8 2
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0188: stloc.s 7
-			IL_018a: ldloc.s 4
-			IL_018c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0191: stloc.s 8
-			IL_0193: ldloc.s 6
-			IL_0195: ldloc.s 8
-			IL_0197: ldloc.s 7
-			IL_0199: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_019e: mul
-			IL_019f: add
-			IL_01a0: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sqrt(float64)
-			IL_01a5: stloc.s 6
-			IL_01a7: ldloc.s 6
-			IL_01a9: box [System.Runtime]System.Double
-			IL_01ae: stloc.s 5
-			IL_01b0: ldloc.s 5
-			IL_01b2: stloc.3
-			IL_01b3: ldc.r8 0.0
-			IL_01bc: box [System.Runtime]System.Double
-			IL_01c1: stloc.2
-			// loop start (head: IL_01c2)
-				IL_01c2: ldloc.2
-				IL_01c3: stloc.s 5
-				IL_01c5: ldloc.s 5
-				IL_01c7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01cc: stloc.s 6
-				IL_01ce: ldloc.s 6
-				IL_01d0: ldc.r8 3
-				IL_01d9: clt
-				IL_01db: brfalse IL_0233
+			IL_0124: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0129: stloc.s 7
+			IL_012b: ldloc.s 5
+			IL_012d: ldloc.s 7
+			IL_012f: ldloc.s 4
+			IL_0131: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0136: mul
+			IL_0137: add
+			IL_0138: stloc.s 5
+			IL_013a: ldloc.0
+			IL_013b: ldc.r8 2
+			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0149: stloc.s 4
+			IL_014b: ldloc.0
+			IL_014c: ldc.r8 2
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_015a: stloc.s 6
+			IL_015c: ldloc.s 4
+			IL_015e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0163: stloc.s 7
+			IL_0165: ldloc.s 5
+			IL_0167: ldloc.s 7
+			IL_0169: ldloc.s 6
+			IL_016b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0170: mul
+			IL_0171: add
+			IL_0172: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sqrt(float64)
+			IL_0177: stloc.s 5
+			IL_0179: ldloc.s 5
+			IL_017b: stloc.3
+			IL_017c: ldc.r8 0.0
+			IL_0185: stloc.2
+			// loop start (head: IL_0186)
+				IL_0186: ldloc.2
+				IL_0187: stloc.s 5
+				IL_0189: ldloc.s 5
+				IL_018b: ldc.r8 3
+				IL_0194: clt
+				IL_0196: brfalse IL_01be
 
-				IL_01e0: ldloc.0
-				IL_01e1: ldloc.2
-				IL_01e2: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_01e7: stloc.s 6
-				IL_01e9: ldloc.3
-				IL_01ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01ef: stloc.s 8
-				IL_01f1: ldloc.s 6
-				IL_01f3: ldloc.s 8
-				IL_01f5: div
-				IL_01f6: stloc.s 8
-				IL_01f8: ldloc.s 8
-				IL_01fa: box [System.Runtime]System.Double
-				IL_01ff: stloc.s 5
-				IL_0201: ldloc.0
-				IL_0202: ldloc.2
-				IL_0203: ldloc.s 5
-				IL_0205: ldc.i4.1
-				IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_020b: pop
-				IL_020c: ldloc.2
-				IL_020d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0212: stloc.s 8
-				IL_0214: ldloc.s 8
-				IL_0216: ldc.r8 1
-				IL_021f: add
-				IL_0220: stloc.s 8
-				IL_0222: ldloc.s 8
-				IL_0224: box [System.Runtime]System.Double
-				IL_0229: stloc.s 5
-				IL_022b: ldloc.s 5
-				IL_022d: stloc.2
-				IL_022e: br IL_01c2
+				IL_019b: ldloc.0
+				IL_019c: ldloc.2
+				IL_019d: ldloc.0
+				IL_019e: ldloc.2
+				IL_019f: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, float64)
+				IL_01a4: ldloc.3
+				IL_01a5: div
+				IL_01a6: ldc.i4.1
+				IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+				IL_01ac: pop
+				IL_01ad: ldloc.2
+				IL_01ae: ldc.r8 1
+				IL_01b7: add
+				IL_01b8: stloc.2
+				IL_01b9: br IL_0186
 			// end loop
 
-			IL_0233: ldloc.0
-			IL_0234: ldc.r8 3
-			IL_023d: ldc.r8 1
-			IL_0246: ldc.i4.1
-			IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-			IL_024c: pop
-			IL_024d: ldloc.0
-			IL_024e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0253: ret
+			IL_01be: ldloc.0
+			IL_01bf: ldc.r8 3
+			IL_01c8: ldc.r8 1
+			IL_01d1: ldc.i4.1
+			IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+			IL_01d7: pop
+			IL_01d8: ldloc.0
+			IL_01d9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01de: ret
 		} // end of method CalcNormal::__js_call__
 
 	} // end of class CalcNormal
@@ -1344,7 +1237,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x630e
+				// Method begins at RVA 0x602e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1370,7 +1263,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d38
+			// Method begins at RVA 0x2be8
 			// Header size: 12
 			// Code size: 83 (0x53)
 			.maxstack 8
@@ -1424,7 +1317,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6320
+					// Method begins at RVA 0x6040
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1442,7 +1335,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6317
+				// Method begins at RVA 0x6037
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1467,22 +1360,21 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d98
+			// Method begins at RVA 0x2c48
 			// Header size: 12
-			// Code size: 549 (0x225)
+			// Code size: 467 (0x1d3)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object,
-				[2] object,
+				[1] float64,
+				[2] float64,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[5] object,
-				[6] float64,
+				[5] float64,
+				[6] object,
 				[7] object,
 				[8] object,
-				[9] object,
-				[10] float64
+				[9] float64
 			)
 
 			IL_0000: ldc.i4.0
@@ -1509,165 +1401,139 @@
 			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_003c: stloc.0
 			IL_003d: ldc.r8 0.0
-			IL_0046: box [System.Runtime]System.Double
-			IL_004b: stloc.1
-			IL_004c: ldc.r8 0.0
-			IL_0055: box [System.Runtime]System.Double
-			IL_005a: stloc.2
-			// loop start (head: IL_005b)
-				IL_005b: ldloc.1
-				IL_005c: stloc.s 5
-				IL_005e: ldloc.s 5
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: stloc.s 6
-				IL_0067: ldloc.s 6
-				IL_0069: ldc.r8 4
-				IL_0072: clt
-				IL_0074: brfalse IL_0223
+			IL_0046: stloc.1
+			IL_0047: ldc.r8 0.0
+			IL_0050: stloc.2
+			// loop start (head: IL_0051)
+				IL_0051: ldloc.1
+				IL_0052: stloc.s 5
+				IL_0054: ldloc.s 5
+				IL_0056: ldc.r8 4
+				IL_005f: clt
+				IL_0061: brfalse IL_01d1
 
-				IL_0079: ldc.r8 0.0
-				IL_0082: box [System.Runtime]System.Double
-				IL_0087: stloc.s 5
-				IL_0089: ldloc.s 5
-				IL_008b: stloc.2
-				// loop start (head: IL_008c)
-					IL_008c: ldloc.2
-					IL_008d: stloc.s 5
-					IL_008f: ldloc.s 5
-					IL_0091: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0096: stloc.s 6
-					IL_0098: ldloc.s 6
-					IL_009a: ldc.r8 4
-					IL_00a3: clt
-					IL_00a5: brfalse IL_01fc
+				IL_0066: ldc.r8 0.0
+				IL_006f: stloc.s 5
+				IL_0071: ldloc.s 5
+				IL_0073: stloc.2
+				// loop start (head: IL_0074)
+					IL_0074: ldloc.2
+					IL_0075: stloc.s 5
+					IL_0077: ldloc.s 5
+					IL_0079: ldc.r8 4
+					IL_0082: clt
+					IL_0084: brfalse IL_01c0
 
-					IL_00aa: ldloc.0
-					IL_00ab: ldloc.1
-					IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_00b1: stloc.s 7
-					IL_00b3: ldarg.1
-					IL_00b4: ldloc.1
-					IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_00ba: ldc.r8 0.0
-					IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-					IL_00c8: stloc.s 8
-					IL_00ca: ldarg.2
-					IL_00cb: ldc.r8 0.0
-					IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-					IL_00d9: ldloc.2
-					IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_00df: stloc.s 9
-					IL_00e1: ldloc.s 8
-					IL_00e3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_00e8: stloc.s 6
-					IL_00ea: ldloc.s 6
-					IL_00ec: ldloc.s 9
-					IL_00ee: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_00f3: mul
-					IL_00f4: stloc.s 6
-					IL_00f6: ldarg.1
-					IL_00f7: ldloc.1
-					IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_00fd: ldc.r8 1
-					IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-					IL_010b: stloc.s 9
-					IL_010d: ldarg.2
-					IL_010e: ldc.r8 1
-					IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-					IL_011c: ldloc.2
-					IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_0122: stloc.s 8
-					IL_0124: ldloc.s 9
-					IL_0126: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_012b: stloc.s 10
-					IL_012d: ldloc.s 6
-					IL_012f: ldloc.s 10
-					IL_0131: ldloc.s 8
-					IL_0133: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0138: mul
-					IL_0139: add
-					IL_013a: stloc.s 6
-					IL_013c: ldarg.1
-					IL_013d: ldloc.1
-					IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_0143: ldc.r8 2
-					IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-					IL_0151: stloc.s 8
-					IL_0153: ldarg.2
-					IL_0154: ldc.r8 2
-					IL_015d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-					IL_0162: ldloc.2
-					IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_0168: stloc.s 9
-					IL_016a: ldloc.s 8
-					IL_016c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0171: stloc.s 10
-					IL_0173: ldloc.s 6
-					IL_0175: ldloc.s 10
-					IL_0177: ldloc.s 9
-					IL_0179: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_017e: mul
-					IL_017f: add
-					IL_0180: stloc.s 6
-					IL_0182: ldarg.1
-					IL_0183: ldloc.1
-					IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_0189: ldc.r8 3
-					IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-					IL_0197: stloc.s 9
-					IL_0199: ldarg.2
-					IL_019a: ldc.r8 3
-					IL_01a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-					IL_01a8: ldloc.2
-					IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_01ae: stloc.s 8
-					IL_01b0: ldloc.s 9
-					IL_01b2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01b7: stloc.s 10
-					IL_01b9: ldloc.s 7
-					IL_01bb: ldloc.2
-					IL_01bc: ldloc.s 6
-					IL_01be: ldloc.s 10
-					IL_01c0: ldloc.s 8
-					IL_01c2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01c7: mul
-					IL_01c8: add
-					IL_01c9: box [System.Runtime]System.Double
-					IL_01ce: ldc.i4.1
-					IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-					IL_01d4: pop
-					IL_01d5: ldloc.2
-					IL_01d6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01db: stloc.s 6
-					IL_01dd: ldloc.s 6
-					IL_01df: ldc.r8 1
-					IL_01e8: add
-					IL_01e9: stloc.s 6
-					IL_01eb: ldloc.s 6
-					IL_01ed: box [System.Runtime]System.Double
-					IL_01f2: stloc.s 5
-					IL_01f4: ldloc.s 5
-					IL_01f6: stloc.2
-					IL_01f7: br IL_008c
+					IL_0089: ldloc.0
+					IL_008a: ldloc.1
+					IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+					IL_0090: stloc.s 6
+					IL_0092: ldarg.1
+					IL_0093: ldloc.1
+					IL_0094: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+					IL_0099: ldc.r8 0.0
+					IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_00a7: stloc.s 7
+					IL_00a9: ldarg.2
+					IL_00aa: ldc.r8 0.0
+					IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+					IL_00b8: ldloc.2
+					IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_00be: stloc.s 8
+					IL_00c0: ldloc.s 7
+					IL_00c2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_00c7: stloc.s 5
+					IL_00c9: ldloc.s 5
+					IL_00cb: ldloc.s 8
+					IL_00cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_00d2: mul
+					IL_00d3: stloc.s 5
+					IL_00d5: ldarg.1
+					IL_00d6: ldloc.1
+					IL_00d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+					IL_00dc: ldc.r8 1
+					IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_00ea: stloc.s 8
+					IL_00ec: ldarg.2
+					IL_00ed: ldc.r8 1
+					IL_00f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+					IL_00fb: ldloc.2
+					IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_0101: stloc.s 7
+					IL_0103: ldloc.s 8
+					IL_0105: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_010a: stloc.s 9
+					IL_010c: ldloc.s 5
+					IL_010e: ldloc.s 9
+					IL_0110: ldloc.s 7
+					IL_0112: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0117: mul
+					IL_0118: add
+					IL_0119: stloc.s 5
+					IL_011b: ldarg.1
+					IL_011c: ldloc.1
+					IL_011d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+					IL_0122: ldc.r8 2
+					IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_0130: stloc.s 7
+					IL_0132: ldarg.2
+					IL_0133: ldc.r8 2
+					IL_013c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+					IL_0141: ldloc.2
+					IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_0147: stloc.s 8
+					IL_0149: ldloc.s 7
+					IL_014b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0150: stloc.s 9
+					IL_0152: ldloc.s 5
+					IL_0154: ldloc.s 9
+					IL_0156: ldloc.s 8
+					IL_0158: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_015d: mul
+					IL_015e: add
+					IL_015f: stloc.s 5
+					IL_0161: ldarg.1
+					IL_0162: ldloc.1
+					IL_0163: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+					IL_0168: ldc.r8 3
+					IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_0176: stloc.s 8
+					IL_0178: ldarg.2
+					IL_0179: ldc.r8 3
+					IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+					IL_0187: ldloc.2
+					IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_018d: stloc.s 7
+					IL_018f: ldloc.s 8
+					IL_0191: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0196: stloc.s 9
+					IL_0198: ldloc.s 6
+					IL_019a: ldloc.2
+					IL_019b: ldloc.s 5
+					IL_019d: ldloc.s 9
+					IL_019f: ldloc.s 7
+					IL_01a1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_01a6: mul
+					IL_01a7: add
+					IL_01a8: ldc.i4.1
+					IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+					IL_01ae: pop
+					IL_01af: ldloc.2
+					IL_01b0: ldc.r8 1
+					IL_01b9: add
+					IL_01ba: stloc.2
+					IL_01bb: br IL_0074
 				// end loop
 
-				IL_01fc: ldloc.1
-				IL_01fd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0202: stloc.s 6
-				IL_0204: ldloc.s 6
-				IL_0206: ldc.r8 1
-				IL_020f: add
-				IL_0210: stloc.s 6
-				IL_0212: ldloc.s 6
-				IL_0214: box [System.Runtime]System.Double
-				IL_0219: stloc.s 5
-				IL_021b: ldloc.s 5
-				IL_021d: stloc.1
-				IL_021e: br IL_005b
+				IL_01c0: ldloc.1
+				IL_01c1: ldc.r8 1
+				IL_01ca: add
+				IL_01cb: stloc.1
+				IL_01cc: br IL_0051
 			// end loop
 
-			IL_0223: ldloc.0
-			IL_0224: ret
+			IL_01d1: ldloc.0
+			IL_01d2: ret
 		} // end of method MMulti::__js_call__
 
 	} // end of class MMulti
@@ -1683,7 +1549,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6329
+				// Method begins at RVA 0x6049
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1708,18 +1574,17 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fcc
+			// Method begins at RVA 0x2e28
 			// Header size: 12
-			// Code size: 358 (0x166)
+			// Code size: 311 (0x137)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
+				[1] float64,
 				[2] object,
-				[3] object,
-				[4] float64,
-				[5] object,
-				[6] float64
+				[3] float64,
+				[4] object,
+				[5] float64
 			)
 
 			IL_0000: ldc.i4.0
@@ -1729,120 +1594,107 @@
 			IL_000c: ldloc.2
 			IL_000d: stloc.0
 			IL_000e: ldc.r8 0.0
-			IL_0017: box [System.Runtime]System.Double
-			IL_001c: stloc.1
-			// loop start (head: IL_001d)
-				IL_001d: ldloc.1
-				IL_001e: stloc.3
-				IL_001f: ldloc.3
-				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0025: stloc.s 4
-				IL_0027: ldloc.s 4
-				IL_0029: ldc.r8 4
-				IL_0032: clt
-				IL_0034: brfalse IL_015f
+			IL_0017: stloc.1
+			// loop start (head: IL_0018)
+				IL_0018: ldloc.1
+				IL_0019: stloc.3
+				IL_001a: ldloc.3
+				IL_001b: ldc.r8 4
+				IL_0024: clt
+				IL_0026: brfalse IL_0130
 
-				IL_0039: ldarg.1
-				IL_003a: ldloc.1
-				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0040: ldc.r8 0.0
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_004e: stloc.2
-				IL_004f: ldarg.2
-				IL_0050: ldc.r8 0.0
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_005e: stloc.s 5
-				IL_0060: ldloc.2
-				IL_0061: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0066: stloc.s 4
-				IL_0068: ldloc.s 4
-				IL_006a: ldloc.s 5
-				IL_006c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0071: mul
-				IL_0072: stloc.s 4
-				IL_0074: ldarg.1
-				IL_0075: ldloc.1
-				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_002b: ldarg.1
+				IL_002c: ldloc.1
+				IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0032: ldc.r8 0.0
+				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0040: stloc.2
+				IL_0041: ldarg.2
+				IL_0042: ldc.r8 0.0
+				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0050: stloc.s 4
+				IL_0052: ldloc.2
+				IL_0053: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0058: stloc.3
+				IL_0059: ldloc.3
+				IL_005a: ldloc.s 4
+				IL_005c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0061: mul
+				IL_0062: stloc.3
+				IL_0063: ldarg.1
+				IL_0064: ldloc.1
+				IL_0065: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_006a: ldc.r8 1
+				IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0078: stloc.s 4
+				IL_007a: ldarg.2
 				IL_007b: ldc.r8 1
 				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0089: stloc.s 5
-				IL_008b: ldarg.2
-				IL_008c: ldc.r8 1
-				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_009a: stloc.2
-				IL_009b: ldloc.s 5
-				IL_009d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00a2: stloc.s 6
-				IL_00a4: ldloc.s 4
-				IL_00a6: ldloc.s 6
-				IL_00a8: ldloc.2
-				IL_00a9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ae: mul
-				IL_00af: add
-				IL_00b0: stloc.s 4
-				IL_00b2: ldarg.1
-				IL_00b3: ldloc.1
-				IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00b9: ldc.r8 2
-				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00c7: stloc.2
-				IL_00c8: ldarg.2
-				IL_00c9: ldc.r8 2
-				IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00d7: stloc.s 5
-				IL_00d9: ldloc.2
-				IL_00da: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00df: stloc.s 6
-				IL_00e1: ldloc.s 4
-				IL_00e3: ldloc.s 6
-				IL_00e5: ldloc.s 5
-				IL_00e7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ec: mul
-				IL_00ed: add
-				IL_00ee: stloc.s 4
-				IL_00f0: ldarg.1
-				IL_00f1: ldloc.1
-				IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00f7: ldc.r8 3
-				IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0105: stloc.s 5
-				IL_0107: ldarg.2
-				IL_0108: ldc.r8 3
-				IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0116: stloc.2
-				IL_0117: ldloc.s 5
-				IL_0119: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_011e: stloc.s 6
-				IL_0120: ldloc.0
-				IL_0121: ldloc.1
-				IL_0122: ldloc.s 4
-				IL_0124: ldloc.s 6
-				IL_0126: ldloc.2
-				IL_0127: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_012c: mul
-				IL_012d: add
-				IL_012e: box [System.Runtime]System.Double
-				IL_0133: ldc.i4.1
-				IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_0139: pop
-				IL_013a: ldloc.1
-				IL_013b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0140: stloc.s 4
-				IL_0142: ldloc.s 4
-				IL_0144: ldc.r8 1
-				IL_014d: add
-				IL_014e: stloc.s 4
-				IL_0150: ldloc.s 4
-				IL_0152: box [System.Runtime]System.Double
-				IL_0157: stloc.3
-				IL_0158: ldloc.3
-				IL_0159: stloc.1
-				IL_015a: br IL_001d
+				IL_0089: stloc.2
+				IL_008a: ldloc.s 4
+				IL_008c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0091: stloc.s 5
+				IL_0093: ldloc.3
+				IL_0094: ldloc.s 5
+				IL_0096: ldloc.2
+				IL_0097: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_009c: mul
+				IL_009d: add
+				IL_009e: stloc.3
+				IL_009f: ldarg.1
+				IL_00a0: ldloc.1
+				IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_00a6: ldc.r8 2
+				IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00b4: stloc.2
+				IL_00b5: ldarg.2
+				IL_00b6: ldc.r8 2
+				IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00c4: stloc.s 4
+				IL_00c6: ldloc.2
+				IL_00c7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00cc: stloc.s 5
+				IL_00ce: ldloc.3
+				IL_00cf: ldloc.s 5
+				IL_00d1: ldloc.s 4
+				IL_00d3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00d8: mul
+				IL_00d9: add
+				IL_00da: stloc.3
+				IL_00db: ldarg.1
+				IL_00dc: ldloc.1
+				IL_00dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_00e2: ldc.r8 3
+				IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00f0: stloc.s 4
+				IL_00f2: ldarg.2
+				IL_00f3: ldc.r8 3
+				IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0101: stloc.2
+				IL_0102: ldloc.s 4
+				IL_0104: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0109: stloc.s 5
+				IL_010b: ldloc.0
+				IL_010c: ldloc.1
+				IL_010d: ldloc.3
+				IL_010e: ldloc.s 5
+				IL_0110: ldloc.2
+				IL_0111: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0116: mul
+				IL_0117: add
+				IL_0118: ldc.i4.1
+				IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+				IL_011e: pop
+				IL_011f: ldloc.1
+				IL_0120: ldc.r8 1
+				IL_0129: add
+				IL_012a: stloc.1
+				IL_012b: br IL_0018
 			// end loop
 
-			IL_015f: ldloc.0
-			IL_0160: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0165: ret
+			IL_0130: ldloc.0
+			IL_0131: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0136: ret
 		} // end of method VMulti::__js_call__
 
 	} // end of class VMulti
@@ -1858,7 +1710,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6332
+				// Method begins at RVA 0x6052
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1883,18 +1735,17 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3140
+			// Method begins at RVA 0x2f6c
 			// Header size: 12
-			// Code size: 296 (0x128)
+			// Code size: 251 (0xfb)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
+				[1] float64,
 				[2] object,
-				[3] object,
-				[4] float64,
-				[5] object,
-				[6] float64
+				[3] float64,
+				[4] object,
+				[5] float64
 			)
 
 			IL_0000: ldc.i4.0
@@ -1904,100 +1755,87 @@
 			IL_000c: ldloc.2
 			IL_000d: stloc.0
 			IL_000e: ldc.r8 0.0
-			IL_0017: box [System.Runtime]System.Double
-			IL_001c: stloc.1
-			// loop start (head: IL_001d)
-				IL_001d: ldloc.1
-				IL_001e: stloc.3
-				IL_001f: ldloc.3
-				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0025: stloc.s 4
-				IL_0027: ldloc.s 4
-				IL_0029: ldc.r8 3
-				IL_0032: clt
-				IL_0034: brfalse IL_0121
+			IL_0017: stloc.1
+			// loop start (head: IL_0018)
+				IL_0018: ldloc.1
+				IL_0019: stloc.3
+				IL_001a: ldloc.3
+				IL_001b: ldc.r8 3
+				IL_0024: clt
+				IL_0026: brfalse IL_00f4
 
-				IL_0039: ldarg.1
-				IL_003a: ldloc.1
-				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0040: ldc.r8 0.0
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_004e: stloc.2
-				IL_004f: ldarg.2
-				IL_0050: ldc.r8 0.0
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_005e: stloc.s 5
-				IL_0060: ldloc.2
-				IL_0061: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0066: stloc.s 4
-				IL_0068: ldloc.s 4
-				IL_006a: ldloc.s 5
-				IL_006c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0071: mul
-				IL_0072: stloc.s 4
-				IL_0074: ldarg.1
-				IL_0075: ldloc.1
-				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_002b: ldarg.1
+				IL_002c: ldloc.1
+				IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0032: ldc.r8 0.0
+				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0040: stloc.2
+				IL_0041: ldarg.2
+				IL_0042: ldc.r8 0.0
+				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0050: stloc.s 4
+				IL_0052: ldloc.2
+				IL_0053: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0058: stloc.3
+				IL_0059: ldloc.3
+				IL_005a: ldloc.s 4
+				IL_005c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0061: mul
+				IL_0062: stloc.3
+				IL_0063: ldarg.1
+				IL_0064: ldloc.1
+				IL_0065: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_006a: ldc.r8 1
+				IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0078: stloc.s 4
+				IL_007a: ldarg.2
 				IL_007b: ldc.r8 1
 				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0089: stloc.s 5
-				IL_008b: ldarg.2
-				IL_008c: ldc.r8 1
-				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_009a: stloc.2
-				IL_009b: ldloc.s 5
-				IL_009d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00a2: stloc.s 6
-				IL_00a4: ldloc.s 4
-				IL_00a6: ldloc.s 6
-				IL_00a8: ldloc.2
-				IL_00a9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ae: mul
-				IL_00af: add
-				IL_00b0: stloc.s 4
-				IL_00b2: ldarg.1
-				IL_00b3: ldloc.1
-				IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00b9: ldc.r8 2
-				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00c7: stloc.2
-				IL_00c8: ldarg.2
-				IL_00c9: ldc.r8 2
-				IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00d7: stloc.s 5
-				IL_00d9: ldloc.2
-				IL_00da: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00df: stloc.s 6
-				IL_00e1: ldloc.0
-				IL_00e2: ldloc.1
-				IL_00e3: ldloc.s 4
-				IL_00e5: ldloc.s 6
-				IL_00e7: ldloc.s 5
-				IL_00e9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ee: mul
-				IL_00ef: add
-				IL_00f0: box [System.Runtime]System.Double
-				IL_00f5: ldc.i4.1
-				IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_00fb: pop
-				IL_00fc: ldloc.1
-				IL_00fd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0102: stloc.s 4
-				IL_0104: ldloc.s 4
-				IL_0106: ldc.r8 1
-				IL_010f: add
-				IL_0110: stloc.s 4
-				IL_0112: ldloc.s 4
-				IL_0114: box [System.Runtime]System.Double
-				IL_0119: stloc.3
-				IL_011a: ldloc.3
-				IL_011b: stloc.1
-				IL_011c: br IL_001d
+				IL_0089: stloc.2
+				IL_008a: ldloc.s 4
+				IL_008c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0091: stloc.s 5
+				IL_0093: ldloc.3
+				IL_0094: ldloc.s 5
+				IL_0096: ldloc.2
+				IL_0097: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_009c: mul
+				IL_009d: add
+				IL_009e: stloc.3
+				IL_009f: ldarg.1
+				IL_00a0: ldloc.1
+				IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_00a6: ldc.r8 2
+				IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00b4: stloc.2
+				IL_00b5: ldarg.2
+				IL_00b6: ldc.r8 2
+				IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00c4: stloc.s 4
+				IL_00c6: ldloc.2
+				IL_00c7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00cc: stloc.s 5
+				IL_00ce: ldloc.0
+				IL_00cf: ldloc.1
+				IL_00d0: ldloc.3
+				IL_00d1: ldloc.s 5
+				IL_00d3: ldloc.s 4
+				IL_00d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00da: mul
+				IL_00db: add
+				IL_00dc: ldc.i4.1
+				IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+				IL_00e2: pop
+				IL_00e3: ldloc.1
+				IL_00e4: ldc.r8 1
+				IL_00ed: add
+				IL_00ee: stloc.1
+				IL_00ef: br IL_0018
 			// end loop
 
-			IL_0121: ldloc.0
-			IL_0122: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0127: ret
+			IL_00f4: ldloc.0
+			IL_00f5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00fa: ret
 		} // end of method VMulti2::__js_call__
 
 	} // end of class VMulti2
@@ -2017,7 +1855,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6344
+					// Method begins at RVA 0x6064
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2035,7 +1873,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x633b
+				// Method begins at RVA 0x605b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2060,21 +1898,20 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3274
+			// Method begins at RVA 0x3074
 			// Header size: 12
-			// Code size: 308 (0x134)
+			// Code size: 236 (0xec)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object,
-				[2] object,
+				[1] float64,
+				[2] float64,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[5] object,
-				[6] float64,
+				[5] float64,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] object
+				[8] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -2101,94 +1938,70 @@
 			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_003c: stloc.0
 			IL_003d: ldc.r8 0.0
-			IL_0046: box [System.Runtime]System.Double
-			IL_004b: stloc.1
-			IL_004c: ldc.r8 0.0
-			IL_0055: box [System.Runtime]System.Double
-			IL_005a: stloc.2
-			// loop start (head: IL_005b)
-				IL_005b: ldloc.1
-				IL_005c: stloc.s 5
-				IL_005e: ldloc.s 5
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: stloc.s 6
-				IL_0067: ldloc.s 6
-				IL_0069: ldc.r8 4
-				IL_0072: clt
-				IL_0074: brfalse IL_0132
+			IL_0046: stloc.1
+			IL_0047: ldc.r8 0.0
+			IL_0050: stloc.2
+			// loop start (head: IL_0051)
+				IL_0051: ldloc.1
+				IL_0052: stloc.s 5
+				IL_0054: ldloc.s 5
+				IL_0056: ldc.r8 4
+				IL_005f: clt
+				IL_0061: brfalse IL_00ea
 
-				IL_0079: ldc.r8 0.0
-				IL_0082: box [System.Runtime]System.Double
-				IL_0087: stloc.s 5
-				IL_0089: ldloc.s 5
-				IL_008b: stloc.2
-				// loop start (head: IL_008c)
-					IL_008c: ldloc.2
-					IL_008d: stloc.s 5
-					IL_008f: ldloc.s 5
-					IL_0091: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0096: stloc.s 6
-					IL_0098: ldloc.s 6
-					IL_009a: ldc.r8 4
-					IL_00a3: clt
-					IL_00a5: brfalse IL_010b
+				IL_0066: ldc.r8 0.0
+				IL_006f: stloc.s 5
+				IL_0071: ldloc.s 5
+				IL_0073: stloc.2
+				// loop start (head: IL_0074)
+					IL_0074: ldloc.2
+					IL_0075: stloc.s 5
+					IL_0077: ldloc.s 5
+					IL_0079: ldc.r8 4
+					IL_0082: clt
+					IL_0084: brfalse IL_00d9
 
-					IL_00aa: ldloc.0
-					IL_00ab: ldloc.1
-					IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_00b1: stloc.s 7
-					IL_00b3: ldarg.1
-					IL_00b4: ldloc.1
-					IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_00ba: ldloc.2
-					IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_00c0: stloc.s 8
-					IL_00c2: ldloc.s 8
-					IL_00c4: ldarg.2
-					IL_00c5: ldloc.1
-					IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_00cb: ldloc.2
-					IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-					IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_00d6: stloc.s 9
-					IL_00d8: ldloc.s 7
-					IL_00da: ldloc.2
-					IL_00db: ldloc.s 9
-					IL_00dd: ldc.i4.1
-					IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-					IL_00e3: pop
-					IL_00e4: ldloc.2
-					IL_00e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_00ea: stloc.s 6
-					IL_00ec: ldloc.s 6
-					IL_00ee: ldc.r8 1
-					IL_00f7: add
-					IL_00f8: stloc.s 6
-					IL_00fa: ldloc.s 6
-					IL_00fc: box [System.Runtime]System.Double
-					IL_0101: stloc.s 5
-					IL_0103: ldloc.s 5
-					IL_0105: stloc.2
-					IL_0106: br IL_008c
+					IL_0089: ldloc.0
+					IL_008a: ldloc.1
+					IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+					IL_0090: stloc.s 6
+					IL_0092: ldarg.1
+					IL_0093: ldloc.1
+					IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_0099: ldloc.2
+					IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_009f: stloc.s 7
+					IL_00a1: ldloc.s 7
+					IL_00a3: ldarg.2
+					IL_00a4: ldloc.1
+					IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_00aa: ldloc.2
+					IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_00b5: stloc.s 8
+					IL_00b7: ldloc.s 6
+					IL_00b9: ldloc.2
+					IL_00ba: box [System.Runtime]System.Double
+					IL_00bf: ldloc.s 8
+					IL_00c1: ldc.i4.1
+					IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+					IL_00c7: pop
+					IL_00c8: ldloc.2
+					IL_00c9: ldc.r8 1
+					IL_00d2: add
+					IL_00d3: stloc.2
+					IL_00d4: br IL_0074
 				// end loop
 
-				IL_010b: ldloc.1
-				IL_010c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0111: stloc.s 6
-				IL_0113: ldloc.s 6
-				IL_0115: ldc.r8 1
-				IL_011e: add
-				IL_011f: stloc.s 6
-				IL_0121: ldloc.s 6
-				IL_0123: box [System.Runtime]System.Double
-				IL_0128: stloc.s 5
-				IL_012a: ldloc.s 5
-				IL_012c: stloc.1
-				IL_012d: br IL_005b
+				IL_00d9: ldloc.1
+				IL_00da: ldc.r8 1
+				IL_00e3: add
+				IL_00e4: stloc.1
+				IL_00e5: br IL_0051
 			// end loop
 
-			IL_0132: ldloc.0
-			IL_0133: ret
+			IL_00ea: ldloc.0
+			IL_00eb: ret
 		} // end of method MAdd::__js_call__
 
 	} // end of class MAdd
@@ -2204,7 +2017,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x634d
+				// Method begins at RVA 0x606d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2234,7 +2047,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x33b4
+			// Method begins at RVA 0x316c
 			// Header size: 12
 			// Code size: 379 (0x17b)
 			.maxstack 8
@@ -2365,7 +2178,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6356
+				// Method begins at RVA 0x6076
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2393,14 +2206,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x353c
+			// Method begins at RVA 0x32f4
 			// Header size: 12
-			// Code size: 474 (0x1da)
+			// Code size: 484 (0x1e4)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] object,
+				[1] float64,
+				[2] float64,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[4] float64,
 				[5] object,
@@ -2431,127 +2244,131 @@
 			IL_002f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::cos(float64)
 			IL_0034: stloc.s 4
 			IL_0036: ldloc.s 4
-			IL_0038: box [System.Runtime]System.Double
-			IL_003d: stloc.s 5
-			IL_003f: ldloc.s 5
-			IL_0041: stloc.1
-			IL_0042: ldloc.0
-			IL_0043: unbox.any [System.Runtime]System.Double
-			IL_0048: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sin(float64)
-			IL_004d: stloc.s 4
-			IL_004f: ldloc.s 4
-			IL_0051: box [System.Runtime]System.Double
-			IL_0056: stloc.s 5
-			IL_0058: ldloc.s 5
-			IL_005a: stloc.2
-			IL_005b: ldc.i4.4
-			IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0061: dup
-			IL_0062: ldc.r8 1
-			IL_006b: box [System.Runtime]System.Double
-			IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0075: dup
-			IL_0076: ldc.r8 0.0
-			IL_007f: box [System.Runtime]System.Double
-			IL_0084: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0089: dup
-			IL_008a: ldc.r8 0.0
-			IL_0093: box [System.Runtime]System.Double
-			IL_0098: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_009d: dup
-			IL_009e: ldc.r8 0.0
-			IL_00a7: box [System.Runtime]System.Double
-			IL_00ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00b1: stloc.s 6
-			IL_00b3: ldloc.2
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-			IL_00b9: stloc.s 7
-			IL_00bb: ldc.i4.4
-			IL_00bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00c1: dup
-			IL_00c2: ldc.r8 0.0
-			IL_00cb: box [System.Runtime]System.Double
-			IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00d5: dup
-			IL_00d6: ldloc.1
+			IL_0038: stloc.1
+			IL_0039: ldloc.0
+			IL_003a: unbox.any [System.Runtime]System.Double
+			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sin(float64)
+			IL_0044: stloc.s 4
+			IL_0046: ldloc.s 4
+			IL_0048: stloc.2
+			IL_0049: ldc.i4.4
+			IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_004f: dup
+			IL_0050: ldc.r8 1
+			IL_0059: box [System.Runtime]System.Double
+			IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0063: dup
+			IL_0064: ldc.r8 0.0
+			IL_006d: box [System.Runtime]System.Double
+			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0077: dup
+			IL_0078: ldc.r8 0.0
+			IL_0081: box [System.Runtime]System.Double
+			IL_0086: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_008b: dup
+			IL_008c: ldc.r8 0.0
+			IL_0095: box [System.Runtime]System.Double
+			IL_009a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_009f: stloc.s 6
+			IL_00a1: ldloc.1
+			IL_00a2: box [System.Runtime]System.Double
+			IL_00a7: stloc.s 5
+			IL_00a9: ldloc.2
+			IL_00aa: neg
+			IL_00ab: box [System.Runtime]System.Double
+			IL_00b0: stloc.s 7
+			IL_00b2: ldc.i4.4
+			IL_00b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00b8: dup
+			IL_00b9: ldc.r8 0.0
+			IL_00c2: box [System.Runtime]System.Double
+			IL_00c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00cc: dup
+			IL_00cd: ldloc.s 5
+			IL_00cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00d4: dup
+			IL_00d5: ldloc.s 7
 			IL_00d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_00dc: dup
-			IL_00dd: ldloc.s 7
-			IL_00df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00e4: dup
-			IL_00e5: ldc.r8 0.0
-			IL_00ee: box [System.Runtime]System.Double
-			IL_00f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00f8: stloc.s 8
-			IL_00fa: ldc.i4.4
-			IL_00fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0100: dup
-			IL_0101: ldc.r8 0.0
-			IL_010a: box [System.Runtime]System.Double
-			IL_010f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0114: dup
-			IL_0115: ldloc.2
-			IL_0116: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_011b: dup
-			IL_011c: ldloc.1
-			IL_011d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0122: dup
-			IL_0123: ldc.r8 0.0
-			IL_012c: box [System.Runtime]System.Double
-			IL_0131: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0136: stloc.s 9
-			IL_0138: ldc.i4.4
-			IL_0139: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_013e: dup
-			IL_013f: ldloc.s 6
-			IL_0141: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0146: dup
-			IL_0147: ldloc.s 8
-			IL_0149: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_014e: dup
-			IL_014f: ldloc.s 9
-			IL_0151: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0156: dup
-			IL_0157: ldc.i4.4
-			IL_0158: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_015d: dup
-			IL_015e: ldc.r8 0.0
-			IL_0167: box [System.Runtime]System.Double
-			IL_016c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0171: dup
-			IL_0172: ldc.r8 0.0
-			IL_017b: box [System.Runtime]System.Double
-			IL_0180: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0185: dup
-			IL_0186: ldc.r8 0.0
-			IL_018f: box [System.Runtime]System.Double
-			IL_0194: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0199: dup
-			IL_019a: ldc.r8 1
-			IL_01a3: box [System.Runtime]System.Double
-			IL_01a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
-			IL_01b6: stloc.3
-			IL_01b7: ldc.i4.1
-			IL_01b8: newarr [System.Runtime]System.Object
-			IL_01bd: dup
-			IL_01be: ldc.i4.0
-			IL_01bf: ldarg.0
-			IL_01c0: stelem.ref
-			IL_01c1: stloc.s 10
-			IL_01c3: ldnull
-			IL_01c4: ldloc.3
-			IL_01c5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01ca: ldarg.2
-			IL_01cb: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01d0: tail.
-			IL_01d2: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-			IL_01d7: ret
+			IL_00dd: ldc.r8 0.0
+			IL_00e6: box [System.Runtime]System.Double
+			IL_00eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00f0: stloc.s 8
+			IL_00f2: ldloc.2
+			IL_00f3: box [System.Runtime]System.Double
+			IL_00f8: stloc.s 7
+			IL_00fa: ldloc.1
+			IL_00fb: box [System.Runtime]System.Double
+			IL_0100: stloc.s 5
+			IL_0102: ldc.i4.4
+			IL_0103: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0108: dup
+			IL_0109: ldc.r8 0.0
+			IL_0112: box [System.Runtime]System.Double
+			IL_0117: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_011c: dup
+			IL_011d: ldloc.s 7
+			IL_011f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0124: dup
+			IL_0125: ldloc.s 5
+			IL_0127: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_012c: dup
+			IL_012d: ldc.r8 0.0
+			IL_0136: box [System.Runtime]System.Double
+			IL_013b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0140: stloc.s 9
+			IL_0142: ldc.i4.4
+			IL_0143: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0148: dup
+			IL_0149: ldloc.s 6
+			IL_014b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0150: dup
+			IL_0151: ldloc.s 8
+			IL_0153: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0158: dup
+			IL_0159: ldloc.s 9
+			IL_015b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0160: dup
+			IL_0161: ldc.i4.4
+			IL_0162: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0167: dup
+			IL_0168: ldc.r8 0.0
+			IL_0171: box [System.Runtime]System.Double
+			IL_0176: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_017b: dup
+			IL_017c: ldc.r8 0.0
+			IL_0185: box [System.Runtime]System.Double
+			IL_018a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_018f: dup
+			IL_0190: ldc.r8 0.0
+			IL_0199: box [System.Runtime]System.Double
+			IL_019e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01a3: dup
+			IL_01a4: ldc.r8 1
+			IL_01ad: box [System.Runtime]System.Double
+			IL_01b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01bc: stloc.s 9
+			IL_01be: ldloc.s 9
+			IL_01c0: stloc.3
+			IL_01c1: ldc.i4.1
+			IL_01c2: newarr [System.Runtime]System.Object
+			IL_01c7: dup
+			IL_01c8: ldc.i4.0
+			IL_01c9: ldarg.0
+			IL_01ca: stelem.ref
+			IL_01cb: stloc.s 10
+			IL_01cd: ldnull
+			IL_01ce: ldloc.3
+			IL_01cf: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01d4: ldarg.2
+			IL_01d5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01da: tail.
+			IL_01dc: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_01e1: ret
 
-			IL_01d8: ldnull
-			IL_01d9: ret
+			IL_01e2: ldnull
+			IL_01e3: ret
 		} // end of method RotateX::__js_call__
 
 	} // end of class RotateX
@@ -2567,7 +2384,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x635f
+				// Method begins at RVA 0x607f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2595,216 +2412,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x3724
+			// Method begins at RVA 0x34e4
 			// Header size: 12
-			// Code size: 474 (0x1da)
+			// Code size: 484 (0x1e4)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[4] float64,
-				[5] object,
-				[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[8] object,
-				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[10] object[]
-			)
-
-			IL_0000: ldarg.3
-			IL_0001: box [System.Runtime]System.Double
-			IL_0006: stloc.0
-			IL_0007: ldloc.0
-			IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_000d: stloc.s 4
-			IL_000f: ldloc.s 4
-			IL_0011: ldc.r8 0.017453292519943295
-			IL_001a: mul
-			IL_001b: stloc.s 4
-			IL_001d: ldloc.s 4
-			IL_001f: box [System.Runtime]System.Double
-			IL_0024: stloc.s 5
-			IL_0026: ldloc.s 5
-			IL_0028: stloc.0
-			IL_0029: ldloc.0
-			IL_002a: unbox.any [System.Runtime]System.Double
-			IL_002f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::cos(float64)
-			IL_0034: stloc.s 4
-			IL_0036: ldloc.s 4
-			IL_0038: box [System.Runtime]System.Double
-			IL_003d: stloc.s 5
-			IL_003f: ldloc.s 5
-			IL_0041: stloc.1
-			IL_0042: ldloc.0
-			IL_0043: unbox.any [System.Runtime]System.Double
-			IL_0048: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sin(float64)
-			IL_004d: stloc.s 4
-			IL_004f: ldloc.s 4
-			IL_0051: box [System.Runtime]System.Double
-			IL_0056: stloc.s 5
-			IL_0058: ldloc.s 5
-			IL_005a: stloc.2
-			IL_005b: ldc.i4.4
-			IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0061: dup
-			IL_0062: ldloc.1
-			IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0068: dup
-			IL_0069: ldc.r8 0.0
-			IL_0072: box [System.Runtime]System.Double
-			IL_0077: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_007c: dup
-			IL_007d: ldloc.2
-			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0083: dup
-			IL_0084: ldc.r8 0.0
-			IL_008d: box [System.Runtime]System.Double
-			IL_0092: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0097: stloc.s 6
-			IL_0099: ldc.i4.4
-			IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_009f: dup
-			IL_00a0: ldc.r8 0.0
-			IL_00a9: box [System.Runtime]System.Double
-			IL_00ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00b3: dup
-			IL_00b4: ldc.r8 1
-			IL_00bd: box [System.Runtime]System.Double
-			IL_00c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00c7: dup
-			IL_00c8: ldc.r8 0.0
-			IL_00d1: box [System.Runtime]System.Double
-			IL_00d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00db: dup
-			IL_00dc: ldc.r8 0.0
-			IL_00e5: box [System.Runtime]System.Double
-			IL_00ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00ef: stloc.s 7
-			IL_00f1: ldloc.2
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-			IL_00f7: stloc.s 8
-			IL_00f9: ldc.i4.4
-			IL_00fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00ff: dup
-			IL_0100: ldloc.s 8
-			IL_0102: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0107: dup
-			IL_0108: ldc.r8 0.0
-			IL_0111: box [System.Runtime]System.Double
-			IL_0116: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_011b: dup
-			IL_011c: ldloc.1
-			IL_011d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0122: dup
-			IL_0123: ldc.r8 0.0
-			IL_012c: box [System.Runtime]System.Double
-			IL_0131: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0136: stloc.s 9
-			IL_0138: ldc.i4.4
-			IL_0139: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_013e: dup
-			IL_013f: ldloc.s 6
-			IL_0141: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0146: dup
-			IL_0147: ldloc.s 7
-			IL_0149: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_014e: dup
-			IL_014f: ldloc.s 9
-			IL_0151: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0156: dup
-			IL_0157: ldc.i4.4
-			IL_0158: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_015d: dup
-			IL_015e: ldc.r8 0.0
-			IL_0167: box [System.Runtime]System.Double
-			IL_016c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0171: dup
-			IL_0172: ldc.r8 0.0
-			IL_017b: box [System.Runtime]System.Double
-			IL_0180: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0185: dup
-			IL_0186: ldc.r8 0.0
-			IL_018f: box [System.Runtime]System.Double
-			IL_0194: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0199: dup
-			IL_019a: ldc.r8 1
-			IL_01a3: box [System.Runtime]System.Double
-			IL_01a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
-			IL_01b6: stloc.3
-			IL_01b7: ldc.i4.1
-			IL_01b8: newarr [System.Runtime]System.Object
-			IL_01bd: dup
-			IL_01be: ldc.i4.0
-			IL_01bf: ldarg.0
-			IL_01c0: stelem.ref
-			IL_01c1: stloc.s 10
-			IL_01c3: ldnull
-			IL_01c4: ldloc.3
-			IL_01c5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01ca: ldarg.2
-			IL_01cb: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01d0: tail.
-			IL_01d2: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-			IL_01d7: ret
-
-			IL_01d8: ldnull
-			IL_01d9: ret
-		} // end of method RotateY::__js_call__
-
-	} // end of class RotateY
-
-	.class nested public auto ansi abstract sealed beforefieldinit RotateZ
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x6368
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			class [JavaScriptRuntime]JavaScriptRuntime.Array __js_call__ (
-				class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope scope,
-				object newTarget,
-				class [JavaScriptRuntime]JavaScriptRuntime.Array M,
-				float64 Phi
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 17 00 00 02
-			)
-			// Method begins at RVA 0x390c
-			// Header size: 12
-			// Code size: 474 (0x1da)
-			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object,
-				[2] object,
+				[1] float64,
+				[2] float64,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[4] float64,
 				[5] object,
@@ -2835,127 +2450,337 @@
 			IL_002f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::cos(float64)
 			IL_0034: stloc.s 4
 			IL_0036: ldloc.s 4
-			IL_0038: box [System.Runtime]System.Double
-			IL_003d: stloc.s 5
-			IL_003f: ldloc.s 5
-			IL_0041: stloc.1
-			IL_0042: ldloc.0
-			IL_0043: unbox.any [System.Runtime]System.Double
-			IL_0048: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sin(float64)
-			IL_004d: stloc.s 4
-			IL_004f: ldloc.s 4
-			IL_0051: box [System.Runtime]System.Double
-			IL_0056: stloc.s 5
-			IL_0058: ldloc.s 5
-			IL_005a: stloc.2
-			IL_005b: ldloc.2
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-			IL_0061: stloc.s 6
-			IL_0063: ldc.i4.4
-			IL_0064: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0069: dup
-			IL_006a: ldloc.1
+			IL_0038: stloc.1
+			IL_0039: ldloc.0
+			IL_003a: unbox.any [System.Runtime]System.Double
+			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sin(float64)
+			IL_0044: stloc.s 4
+			IL_0046: ldloc.s 4
+			IL_0048: stloc.2
+			IL_0049: ldloc.1
+			IL_004a: box [System.Runtime]System.Double
+			IL_004f: stloc.s 5
+			IL_0051: ldloc.2
+			IL_0052: box [System.Runtime]System.Double
+			IL_0057: stloc.s 6
+			IL_0059: ldc.i4.4
+			IL_005a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_005f: dup
+			IL_0060: ldloc.s 5
+			IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0067: dup
+			IL_0068: ldc.r8 0.0
+			IL_0071: box [System.Runtime]System.Double
+			IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_007b: dup
+			IL_007c: ldloc.s 6
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0083: dup
+			IL_0084: ldc.r8 0.0
+			IL_008d: box [System.Runtime]System.Double
+			IL_0092: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0097: stloc.s 7
+			IL_0099: ldc.i4.4
+			IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_009f: dup
+			IL_00a0: ldc.r8 0.0
+			IL_00a9: box [System.Runtime]System.Double
+			IL_00ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00b3: dup
+			IL_00b4: ldc.r8 1
+			IL_00bd: box [System.Runtime]System.Double
+			IL_00c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00c7: dup
+			IL_00c8: ldc.r8 0.0
+			IL_00d1: box [System.Runtime]System.Double
+			IL_00d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00db: dup
+			IL_00dc: ldc.r8 0.0
+			IL_00e5: box [System.Runtime]System.Double
+			IL_00ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00ef: stloc.s 8
+			IL_00f1: ldloc.2
+			IL_00f2: neg
+			IL_00f3: box [System.Runtime]System.Double
+			IL_00f8: stloc.s 6
+			IL_00fa: ldloc.1
+			IL_00fb: box [System.Runtime]System.Double
+			IL_0100: stloc.s 5
+			IL_0102: ldc.i4.4
+			IL_0103: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0108: dup
+			IL_0109: ldloc.s 6
+			IL_010b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0110: dup
+			IL_0111: ldc.r8 0.0
+			IL_011a: box [System.Runtime]System.Double
+			IL_011f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0124: dup
+			IL_0125: ldloc.s 5
+			IL_0127: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_012c: dup
+			IL_012d: ldc.r8 0.0
+			IL_0136: box [System.Runtime]System.Double
+			IL_013b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0140: stloc.s 9
+			IL_0142: ldc.i4.4
+			IL_0143: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0148: dup
+			IL_0149: ldloc.s 7
+			IL_014b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0150: dup
+			IL_0151: ldloc.s 8
+			IL_0153: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0158: dup
+			IL_0159: ldloc.s 9
+			IL_015b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0160: dup
+			IL_0161: ldc.i4.4
+			IL_0162: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0167: dup
+			IL_0168: ldc.r8 0.0
+			IL_0171: box [System.Runtime]System.Double
+			IL_0176: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_017b: dup
+			IL_017c: ldc.r8 0.0
+			IL_0185: box [System.Runtime]System.Double
+			IL_018a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_018f: dup
+			IL_0190: ldc.r8 0.0
+			IL_0199: box [System.Runtime]System.Double
+			IL_019e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01a3: dup
+			IL_01a4: ldc.r8 1
+			IL_01ad: box [System.Runtime]System.Double
+			IL_01b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01bc: stloc.s 9
+			IL_01be: ldloc.s 9
+			IL_01c0: stloc.3
+			IL_01c1: ldc.i4.1
+			IL_01c2: newarr [System.Runtime]System.Object
+			IL_01c7: dup
+			IL_01c8: ldc.i4.0
+			IL_01c9: ldarg.0
+			IL_01ca: stelem.ref
+			IL_01cb: stloc.s 10
+			IL_01cd: ldnull
+			IL_01ce: ldloc.3
+			IL_01cf: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01d4: ldarg.2
+			IL_01d5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01da: tail.
+			IL_01dc: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_01e1: ret
+
+			IL_01e2: ldnull
+			IL_01e3: ret
+		} // end of method RotateY::__js_call__
+
+	} // end of class RotateY
+
+	.class nested public auto ansi abstract sealed beforefieldinit RotateZ
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x6088
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			class [JavaScriptRuntime]JavaScriptRuntime.Array __js_call__ (
+				class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope scope,
+				object newTarget,
+				class [JavaScriptRuntime]JavaScriptRuntime.Array M,
+				float64 Phi
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 17 00 00 02
+			)
+			// Method begins at RVA 0x36d4
+			// Header size: 12
+			// Code size: 484 (0x1e4)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] float64,
+				[2] float64,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[4] float64,
+				[5] object,
+				[6] object,
+				[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[10] object[]
+			)
+
+			IL_0000: ldarg.3
+			IL_0001: box [System.Runtime]System.Double
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000d: stloc.s 4
+			IL_000f: ldloc.s 4
+			IL_0011: ldc.r8 0.017453292519943295
+			IL_001a: mul
+			IL_001b: stloc.s 4
+			IL_001d: ldloc.s 4
+			IL_001f: box [System.Runtime]System.Double
+			IL_0024: stloc.s 5
+			IL_0026: ldloc.s 5
+			IL_0028: stloc.0
+			IL_0029: ldloc.0
+			IL_002a: unbox.any [System.Runtime]System.Double
+			IL_002f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::cos(float64)
+			IL_0034: stloc.s 4
+			IL_0036: ldloc.s 4
+			IL_0038: stloc.1
+			IL_0039: ldloc.0
+			IL_003a: unbox.any [System.Runtime]System.Double
+			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sin(float64)
+			IL_0044: stloc.s 4
+			IL_0046: ldloc.s 4
+			IL_0048: stloc.2
+			IL_0049: ldloc.1
+			IL_004a: box [System.Runtime]System.Double
+			IL_004f: stloc.s 5
+			IL_0051: ldloc.2
+			IL_0052: neg
+			IL_0053: box [System.Runtime]System.Double
+			IL_0058: stloc.s 6
+			IL_005a: ldc.i4.4
+			IL_005b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0060: dup
+			IL_0061: ldloc.s 5
+			IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0068: dup
+			IL_0069: ldloc.s 6
 			IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0070: dup
-			IL_0071: ldloc.s 6
-			IL_0073: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0078: dup
-			IL_0079: ldc.r8 0.0
-			IL_0082: box [System.Runtime]System.Double
-			IL_0087: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_008c: dup
-			IL_008d: ldc.r8 0.0
-			IL_0096: box [System.Runtime]System.Double
-			IL_009b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00a0: stloc.s 7
-			IL_00a2: ldc.i4.4
-			IL_00a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00a8: dup
-			IL_00a9: ldloc.2
-			IL_00aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00af: dup
-			IL_00b0: ldloc.1
-			IL_00b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00b6: dup
-			IL_00b7: ldc.r8 0.0
-			IL_00c0: box [System.Runtime]System.Double
-			IL_00c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00ca: dup
-			IL_00cb: ldc.r8 0.0
-			IL_00d4: box [System.Runtime]System.Double
-			IL_00d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00de: stloc.s 8
-			IL_00e0: ldc.i4.4
-			IL_00e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00e6: dup
-			IL_00e7: ldc.r8 0.0
-			IL_00f0: box [System.Runtime]System.Double
-			IL_00f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00fa: dup
-			IL_00fb: ldc.r8 0.0
-			IL_0104: box [System.Runtime]System.Double
-			IL_0109: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_010e: dup
-			IL_010f: ldc.r8 1
-			IL_0118: box [System.Runtime]System.Double
-			IL_011d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0122: dup
-			IL_0123: ldc.r8 0.0
-			IL_012c: box [System.Runtime]System.Double
-			IL_0131: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0136: stloc.s 9
-			IL_0138: ldc.i4.4
-			IL_0139: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_013e: dup
-			IL_013f: ldloc.s 7
-			IL_0141: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0146: dup
-			IL_0147: ldloc.s 8
-			IL_0149: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_014e: dup
-			IL_014f: ldloc.s 9
-			IL_0151: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0156: dup
-			IL_0157: ldc.i4.4
-			IL_0158: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_015d: dup
-			IL_015e: ldc.r8 0.0
-			IL_0167: box [System.Runtime]System.Double
-			IL_016c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0171: dup
-			IL_0172: ldc.r8 0.0
-			IL_017b: box [System.Runtime]System.Double
-			IL_0180: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0185: dup
-			IL_0186: ldc.r8 0.0
-			IL_018f: box [System.Runtime]System.Double
-			IL_0194: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0199: dup
-			IL_019a: ldc.r8 1
-			IL_01a3: box [System.Runtime]System.Double
-			IL_01a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
-			IL_01b6: stloc.3
-			IL_01b7: ldc.i4.1
-			IL_01b8: newarr [System.Runtime]System.Object
-			IL_01bd: dup
-			IL_01be: ldc.i4.0
-			IL_01bf: ldarg.0
-			IL_01c0: stelem.ref
-			IL_01c1: stloc.s 10
-			IL_01c3: ldnull
-			IL_01c4: ldloc.3
-			IL_01c5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01ca: ldarg.2
-			IL_01cb: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01d0: tail.
-			IL_01d2: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-			IL_01d7: ret
+			IL_0071: ldc.r8 0.0
+			IL_007a: box [System.Runtime]System.Double
+			IL_007f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0084: dup
+			IL_0085: ldc.r8 0.0
+			IL_008e: box [System.Runtime]System.Double
+			IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0098: stloc.s 7
+			IL_009a: ldloc.2
+			IL_009b: box [System.Runtime]System.Double
+			IL_00a0: stloc.s 6
+			IL_00a2: ldloc.1
+			IL_00a3: box [System.Runtime]System.Double
+			IL_00a8: stloc.s 5
+			IL_00aa: ldc.i4.4
+			IL_00ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00b0: dup
+			IL_00b1: ldloc.s 6
+			IL_00b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00b8: dup
+			IL_00b9: ldloc.s 5
+			IL_00bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00c0: dup
+			IL_00c1: ldc.r8 0.0
+			IL_00ca: box [System.Runtime]System.Double
+			IL_00cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00d4: dup
+			IL_00d5: ldc.r8 0.0
+			IL_00de: box [System.Runtime]System.Double
+			IL_00e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00e8: stloc.s 8
+			IL_00ea: ldc.i4.4
+			IL_00eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00f0: dup
+			IL_00f1: ldc.r8 0.0
+			IL_00fa: box [System.Runtime]System.Double
+			IL_00ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0104: dup
+			IL_0105: ldc.r8 0.0
+			IL_010e: box [System.Runtime]System.Double
+			IL_0113: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0118: dup
+			IL_0119: ldc.r8 1
+			IL_0122: box [System.Runtime]System.Double
+			IL_0127: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_012c: dup
+			IL_012d: ldc.r8 0.0
+			IL_0136: box [System.Runtime]System.Double
+			IL_013b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0140: stloc.s 9
+			IL_0142: ldc.i4.4
+			IL_0143: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0148: dup
+			IL_0149: ldloc.s 7
+			IL_014b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0150: dup
+			IL_0151: ldloc.s 8
+			IL_0153: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0158: dup
+			IL_0159: ldloc.s 9
+			IL_015b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0160: dup
+			IL_0161: ldc.i4.4
+			IL_0162: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0167: dup
+			IL_0168: ldc.r8 0.0
+			IL_0171: box [System.Runtime]System.Double
+			IL_0176: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_017b: dup
+			IL_017c: ldc.r8 0.0
+			IL_0185: box [System.Runtime]System.Double
+			IL_018a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_018f: dup
+			IL_0190: ldc.r8 0.0
+			IL_0199: box [System.Runtime]System.Double
+			IL_019e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01a3: dup
+			IL_01a4: ldc.r8 1
+			IL_01ad: box [System.Runtime]System.Double
+			IL_01b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01bc: stloc.s 9
+			IL_01be: ldloc.s 9
+			IL_01c0: stloc.3
+			IL_01c1: ldc.i4.1
+			IL_01c2: newarr [System.Runtime]System.Object
+			IL_01c7: dup
+			IL_01c8: ldc.i4.0
+			IL_01c9: ldarg.0
+			IL_01ca: stelem.ref
+			IL_01cb: stloc.s 10
+			IL_01cd: ldnull
+			IL_01ce: ldloc.3
+			IL_01cf: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01d4: ldarg.2
+			IL_01d5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01da: tail.
+			IL_01dc: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_01e1: ret
 
-			IL_01d8: ldnull
-			IL_01d9: ret
+			IL_01e2: ldnull
+			IL_01e3: ret
 		} // end of method RotateZ::__js_call__
 
 	} // end of class RotateZ
@@ -2979,7 +2804,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6383
+						// Method begins at RVA 0x60a3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2999,7 +2824,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x638c
+						// Method begins at RVA 0x60ac
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3019,7 +2844,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6395
+						// Method begins at RVA 0x60b5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3039,7 +2864,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x639e
+						// Method begins at RVA 0x60be
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3057,7 +2882,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x637a
+					// Method begins at RVA 0x609a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3081,7 +2906,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x63b0
+						// Method begins at RVA 0x60d0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3101,7 +2926,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x63b9
+						// Method begins at RVA 0x60d9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3121,7 +2946,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x63c2
+						// Method begins at RVA 0x60e2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3141,7 +2966,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x63cb
+						// Method begins at RVA 0x60eb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3159,7 +2984,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x63a7
+					// Method begins at RVA 0x60c7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3183,7 +3008,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x63dd
+						// Method begins at RVA 0x60fd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3203,7 +3028,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x63e6
+						// Method begins at RVA 0x6106
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3223,7 +3048,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x63ef
+						// Method begins at RVA 0x610f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3243,7 +3068,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x63f8
+						// Method begins at RVA 0x6118
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3261,7 +3086,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x63d4
+					// Method begins at RVA 0x60f4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3285,7 +3110,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x640a
+						// Method begins at RVA 0x612a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3305,7 +3130,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6413
+						// Method begins at RVA 0x6133
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3325,7 +3150,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x641c
+						// Method begins at RVA 0x613c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3345,7 +3170,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6425
+						// Method begins at RVA 0x6145
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3363,7 +3188,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6401
+					// Method begins at RVA 0x6121
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3387,7 +3212,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6437
+						// Method begins at RVA 0x6157
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3407,7 +3232,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6440
+						// Method begins at RVA 0x6160
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3427,7 +3252,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6449
+						// Method begins at RVA 0x6169
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3447,7 +3272,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6452
+						// Method begins at RVA 0x6172
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3465,7 +3290,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x642e
+					// Method begins at RVA 0x614e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3489,7 +3314,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6464
+						// Method begins at RVA 0x6184
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3509,7 +3334,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x646d
+						// Method begins at RVA 0x618d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3529,7 +3354,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6476
+						// Method begins at RVA 0x6196
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3549,7 +3374,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x647f
+						// Method begins at RVA 0x619f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3567,7 +3392,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x645b
+					// Method begins at RVA 0x617b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3585,7 +3410,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6371
+				// Method begins at RVA 0x6091
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3611,21 +3436,19 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x3af4
+			// Method begins at RVA 0x38c4
 			// Header size: 12
-			// Code size: 4832 (0x12e0)
+			// Code size: 4799 (0x12bf)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
+				[1] float64,
 				[2] object,
-				[3] object,
-				[4] float64,
-				[5] float64,
-				[6] object[],
-				[7] object,
-				[8] bool,
-				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[3] float64,
+				[4] object[],
+				[5] object,
+				[6] bool,
+				[7] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldc.i4.0
@@ -3635,1427 +3458,1414 @@
 			IL_000c: ldloc.2
 			IL_000d: stloc.0
 			IL_000e: ldc.r8 5
-			IL_0017: box [System.Runtime]System.Double
-			IL_001c: stloc.1
-			IL_001d: ldarg.0
-			IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0023: ldstr "LastPx"
-			IL_0028: ldc.r8 0.0
-			IL_0031: ldc.i4.1
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0037: pop
-			// loop start (head: IL_0038)
-				IL_0038: ldloc.1
-				IL_0039: stloc.3
-				IL_003a: ldc.r8 1
-				IL_0043: neg
-				IL_0044: stloc.s 4
-				IL_0046: ldloc.3
-				IL_0047: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_004c: stloc.s 5
-				IL_004e: ldloc.s 5
-				IL_0050: ldloc.s 4
-				IL_0052: cgt
-				IL_0054: brfalse IL_00c6
+			IL_0017: stloc.1
+			IL_0018: ldarg.0
+			IL_0019: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_001e: ldstr "LastPx"
+			IL_0023: ldc.r8 0.0
+			IL_002c: ldc.i4.1
+			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0032: pop
+			// loop start (head: IL_0033)
+				IL_0033: ldloc.1
+				IL_0034: stloc.3
+				IL_0035: ldloc.3
+				IL_0036: ldc.r8 1
+				IL_003f: neg
+				IL_0040: cgt
+				IL_0042: brfalse IL_00a5
 
-				IL_0059: ldarg.0
-				IL_005a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti2
-				IL_005f: stloc.2
-				IL_0060: ldc.i4.1
-				IL_0061: newarr [System.Runtime]System.Object
-				IL_0066: dup
-				IL_0067: ldc.i4.0
-				IL_0068: ldarg.0
-				IL_0069: stelem.ref
-				IL_006a: stloc.s 6
-				IL_006c: ldarg.0
-				IL_006d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-				IL_0072: stloc.s 7
-				IL_0074: ldloc.2
-				IL_0075: ldloc.s 6
-				IL_0077: ldloc.s 7
-				IL_0079: ldarg.0
-				IL_007a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_007f: ldstr "Normal"
-				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0089: ldloc.1
-				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_0094: stloc.s 7
-				IL_0096: ldloc.0
-				IL_0097: ldloc.1
-				IL_0098: ldloc.s 7
-				IL_009a: ldc.i4.1
-				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_00a0: pop
-				IL_00a1: ldloc.1
-				IL_00a2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00a7: stloc.s 4
-				IL_00a9: ldloc.s 4
-				IL_00ab: ldc.r8 1
-				IL_00b4: sub
-				IL_00b5: stloc.s 4
-				IL_00b7: ldloc.s 4
-				IL_00b9: box [System.Runtime]System.Double
-				IL_00be: stloc.3
-				IL_00bf: ldloc.3
-				IL_00c0: stloc.1
-				IL_00c1: br IL_0038
+				IL_0047: ldarg.0
+				IL_0048: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti2
+				IL_004d: stloc.2
+				IL_004e: ldc.i4.1
+				IL_004f: newarr [System.Runtime]System.Object
+				IL_0054: dup
+				IL_0055: ldc.i4.0
+				IL_0056: ldarg.0
+				IL_0057: stelem.ref
+				IL_0058: stloc.s 4
+				IL_005a: ldarg.0
+				IL_005b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+				IL_0060: stloc.s 5
+				IL_0062: ldloc.2
+				IL_0063: ldloc.s 4
+				IL_0065: ldloc.s 5
+				IL_0067: ldarg.0
+				IL_0068: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_006d: ldstr "Normal"
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0077: ldloc.1
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_0082: stloc.s 5
+				IL_0084: ldloc.0
+				IL_0085: ldloc.1
+				IL_0086: box [System.Runtime]System.Double
+				IL_008b: ldloc.s 5
+				IL_008d: ldc.i4.1
+				IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_0093: pop
+				IL_0094: ldloc.1
+				IL_0095: ldc.r8 1
+				IL_009e: sub
+				IL_009f: stloc.1
+				IL_00a0: br IL_0033
 			// end loop
 
-			IL_00c6: ldloc.0
+			IL_00a5: ldloc.0
+			IL_00a6: ldc.r8 0.0
+			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00b4: ldc.r8 2
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00c2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_00c7: ldc.r8 0.0
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00d5: ldc.r8 2
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00e3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00e8: ldc.r8 0.0
-			IL_00f1: clt
-			IL_00f3: brfalse IL_03a8
+			IL_00d0: clt
+			IL_00d2: brfalse IL_0387
 
-			IL_00f8: ldarg.0
-			IL_00f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_00fe: ldstr "Line"
-			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0108: ldc.r8 0.0
-			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0116: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_011b: ldc.i4.0
-			IL_011c: ceq
-			IL_011e: stloc.s 8
-			IL_0120: ldloc.s 8
-			IL_0122: brfalse IL_01a4
+			IL_00d7: ldarg.0
+			IL_00d8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_00dd: ldstr "Line"
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e7: ldc.r8 0.0
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00fa: ldc.i4.0
+			IL_00fb: ceq
+			IL_00fd: stloc.s 6
+			IL_00ff: ldloc.s 6
+			IL_0101: brfalse IL_0183
 
-			IL_0127: ldarg.0
-			IL_0128: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_012d: stloc.s 7
-			IL_012f: ldc.i4.1
-			IL_0130: newarr [System.Runtime]System.Object
-			IL_0135: dup
-			IL_0136: ldc.i4.0
-			IL_0137: ldarg.0
-			IL_0138: stelem.ref
-			IL_0139: stloc.s 6
-			IL_013b: ldarg.0
-			IL_013c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0141: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0146: ldc.r8 0.0
-			IL_014f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0154: stloc.2
-			IL_0155: ldloc.s 7
-			IL_0157: ldloc.s 6
-			IL_0159: ldloc.2
-			IL_015a: ldarg.0
-			IL_015b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0160: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0165: ldc.r8 1
-			IL_016e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0178: pop
-			IL_0179: ldarg.0
-			IL_017a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_017f: ldstr "Line"
-			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0189: ldc.r8 0.0
-			IL_0192: box [System.Runtime]System.Double
-			IL_0197: ldc.i4.1
-			IL_0198: box [System.Runtime]System.Boolean
-			IL_019d: ldc.i4.1
-			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_01a3: pop
+			IL_0106: ldarg.0
+			IL_0107: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_010c: stloc.s 5
+			IL_010e: ldc.i4.1
+			IL_010f: newarr [System.Runtime]System.Object
+			IL_0114: dup
+			IL_0115: ldc.i4.0
+			IL_0116: ldarg.0
+			IL_0117: stelem.ref
+			IL_0118: stloc.s 4
+			IL_011a: ldarg.0
+			IL_011b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0120: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0125: ldc.r8 0.0
+			IL_012e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0133: stloc.2
+			IL_0134: ldloc.s 5
+			IL_0136: ldloc.s 4
+			IL_0138: ldloc.2
+			IL_0139: ldarg.0
+			IL_013a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_013f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0144: ldc.r8 1
+			IL_014d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0157: pop
+			IL_0158: ldarg.0
+			IL_0159: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_015e: ldstr "Line"
+			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0168: ldc.r8 0.0
+			IL_0171: box [System.Runtime]System.Double
+			IL_0176: ldc.i4.1
+			IL_0177: box [System.Runtime]System.Boolean
+			IL_017c: ldc.i4.1
+			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0182: pop
 
-			IL_01a4: ldarg.0
-			IL_01a5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_01aa: ldstr "Line"
-			IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01b4: ldc.r8 1
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01c2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01c7: ldc.i4.0
-			IL_01c8: ceq
-			IL_01ca: stloc.s 8
-			IL_01cc: ldloc.s 8
-			IL_01ce: brfalse IL_0250
+			IL_0183: ldarg.0
+			IL_0184: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0189: ldstr "Line"
+			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0193: ldc.r8 1
+			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01a1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01a6: ldc.i4.0
+			IL_01a7: ceq
+			IL_01a9: stloc.s 6
+			IL_01ab: ldloc.s 6
+			IL_01ad: brfalse IL_022f
 
-			IL_01d3: ldarg.0
-			IL_01d4: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_01d9: stloc.2
-			IL_01da: ldc.i4.1
-			IL_01db: newarr [System.Runtime]System.Object
-			IL_01e0: dup
-			IL_01e1: ldc.i4.0
-			IL_01e2: ldarg.0
-			IL_01e3: stelem.ref
-			IL_01e4: stloc.s 6
-			IL_01e6: ldarg.0
-			IL_01e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_01ec: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01f1: ldc.r8 1
-			IL_01fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_01ff: stloc.s 7
-			IL_0201: ldloc.2
-			IL_0202: ldloc.s 6
-			IL_0204: ldloc.s 7
-			IL_0206: ldarg.0
-			IL_0207: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_020c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0211: ldc.r8 2
-			IL_021a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0224: pop
-			IL_0225: ldarg.0
-			IL_0226: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_022b: ldstr "Line"
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0235: ldc.r8 1
-			IL_023e: box [System.Runtime]System.Double
-			IL_0243: ldc.i4.1
-			IL_0244: box [System.Runtime]System.Boolean
-			IL_0249: ldc.i4.1
-			IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_024f: pop
+			IL_01b2: ldarg.0
+			IL_01b3: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_01b8: stloc.2
+			IL_01b9: ldc.i4.1
+			IL_01ba: newarr [System.Runtime]System.Object
+			IL_01bf: dup
+			IL_01c0: ldc.i4.0
+			IL_01c1: ldarg.0
+			IL_01c2: stelem.ref
+			IL_01c3: stloc.s 4
+			IL_01c5: ldarg.0
+			IL_01c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_01cb: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01d0: ldc.r8 1
+			IL_01d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_01de: stloc.s 5
+			IL_01e0: ldloc.2
+			IL_01e1: ldloc.s 4
+			IL_01e3: ldloc.s 5
+			IL_01e5: ldarg.0
+			IL_01e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_01eb: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01f0: ldc.r8 2
+			IL_01f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0203: pop
+			IL_0204: ldarg.0
+			IL_0205: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_020a: ldstr "Line"
+			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0214: ldc.r8 1
+			IL_021d: box [System.Runtime]System.Double
+			IL_0222: ldc.i4.1
+			IL_0223: box [System.Runtime]System.Boolean
+			IL_0228: ldc.i4.1
+			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_022e: pop
 
-			IL_0250: ldarg.0
-			IL_0251: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0256: ldstr "Line"
-			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0260: ldc.r8 2
-			IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_026e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0273: ldc.i4.0
-			IL_0274: ceq
-			IL_0276: stloc.s 8
-			IL_0278: ldloc.s 8
-			IL_027a: brfalse IL_02fc
+			IL_022f: ldarg.0
+			IL_0230: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0235: ldstr "Line"
+			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_023f: ldc.r8 2
+			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_024d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0252: ldc.i4.0
+			IL_0253: ceq
+			IL_0255: stloc.s 6
+			IL_0257: ldloc.s 6
+			IL_0259: brfalse IL_02db
 
-			IL_027f: ldarg.0
-			IL_0280: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0285: stloc.s 7
-			IL_0287: ldc.i4.1
-			IL_0288: newarr [System.Runtime]System.Object
-			IL_028d: dup
-			IL_028e: ldc.i4.0
-			IL_028f: ldarg.0
-			IL_0290: stelem.ref
-			IL_0291: stloc.s 6
-			IL_0293: ldarg.0
-			IL_0294: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0299: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_029e: ldc.r8 2
-			IL_02a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_02ac: stloc.2
-			IL_02ad: ldloc.s 7
-			IL_02af: ldloc.s 6
-			IL_02b1: ldloc.2
-			IL_02b2: ldarg.0
-			IL_02b3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_02b8: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_02bd: ldc.r8 3
-			IL_02c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02d0: pop
-			IL_02d1: ldarg.0
-			IL_02d2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_02d7: ldstr "Line"
-			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02e1: ldc.r8 2
-			IL_02ea: box [System.Runtime]System.Double
-			IL_02ef: ldc.i4.1
-			IL_02f0: box [System.Runtime]System.Boolean
-			IL_02f5: ldc.i4.1
-			IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_02fb: pop
+			IL_025e: ldarg.0
+			IL_025f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0264: stloc.s 5
+			IL_0266: ldc.i4.1
+			IL_0267: newarr [System.Runtime]System.Object
+			IL_026c: dup
+			IL_026d: ldc.i4.0
+			IL_026e: ldarg.0
+			IL_026f: stelem.ref
+			IL_0270: stloc.s 4
+			IL_0272: ldarg.0
+			IL_0273: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0278: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_027d: ldc.r8 2
+			IL_0286: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_028b: stloc.2
+			IL_028c: ldloc.s 5
+			IL_028e: ldloc.s 4
+			IL_0290: ldloc.2
+			IL_0291: ldarg.0
+			IL_0292: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0297: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_029c: ldc.r8 3
+			IL_02a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02af: pop
+			IL_02b0: ldarg.0
+			IL_02b1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02b6: ldstr "Line"
+			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c0: ldc.r8 2
+			IL_02c9: box [System.Runtime]System.Double
+			IL_02ce: ldc.i4.1
+			IL_02cf: box [System.Runtime]System.Boolean
+			IL_02d4: ldc.i4.1
+			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_02da: pop
 
-			IL_02fc: ldarg.0
-			IL_02fd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0302: ldstr "Line"
-			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_030c: ldc.r8 3
-			IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_031a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_031f: ldc.i4.0
-			IL_0320: ceq
-			IL_0322: stloc.s 8
-			IL_0324: ldloc.s 8
-			IL_0326: brfalse IL_03a8
+			IL_02db: ldarg.0
+			IL_02dc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02e1: ldstr "Line"
+			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02eb: ldc.r8 3
+			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_02f9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02fe: ldc.i4.0
+			IL_02ff: ceq
+			IL_0301: stloc.s 6
+			IL_0303: ldloc.s 6
+			IL_0305: brfalse IL_0387
 
-			IL_032b: ldarg.0
-			IL_032c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0331: stloc.2
-			IL_0332: ldc.i4.1
-			IL_0333: newarr [System.Runtime]System.Object
-			IL_0338: dup
-			IL_0339: ldc.i4.0
-			IL_033a: ldarg.0
-			IL_033b: stelem.ref
-			IL_033c: stloc.s 6
-			IL_033e: ldarg.0
-			IL_033f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0344: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0349: ldc.r8 3
-			IL_0352: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0357: stloc.s 7
-			IL_0359: ldloc.2
-			IL_035a: ldloc.s 6
-			IL_035c: ldloc.s 7
-			IL_035e: ldarg.0
-			IL_035f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0364: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0369: ldc.r8 0.0
-			IL_0372: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_037c: pop
-			IL_037d: ldarg.0
-			IL_037e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0383: ldstr "Line"
-			IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_038d: ldc.r8 3
-			IL_0396: box [System.Runtime]System.Double
-			IL_039b: ldc.i4.1
-			IL_039c: box [System.Runtime]System.Boolean
-			IL_03a1: ldc.i4.1
-			IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_03a7: pop
+			IL_030a: ldarg.0
+			IL_030b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0310: stloc.2
+			IL_0311: ldc.i4.1
+			IL_0312: newarr [System.Runtime]System.Object
+			IL_0317: dup
+			IL_0318: ldc.i4.0
+			IL_0319: ldarg.0
+			IL_031a: stelem.ref
+			IL_031b: stloc.s 4
+			IL_031d: ldarg.0
+			IL_031e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0323: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0328: ldc.r8 3
+			IL_0331: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0336: stloc.s 5
+			IL_0338: ldloc.2
+			IL_0339: ldloc.s 4
+			IL_033b: ldloc.s 5
+			IL_033d: ldarg.0
+			IL_033e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0343: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0348: ldc.r8 0.0
+			IL_0351: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_035b: pop
+			IL_035c: ldarg.0
+			IL_035d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0362: ldstr "Line"
+			IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_036c: ldc.r8 3
+			IL_0375: box [System.Runtime]System.Double
+			IL_037a: ldc.i4.1
+			IL_037b: box [System.Runtime]System.Boolean
+			IL_0380: ldc.i4.1
+			IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0386: pop
 
-			IL_03a8: ldloc.0
-			IL_03a9: ldc.r8 1
-			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03b7: ldc.r8 2
-			IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03c5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_03ca: ldc.r8 0.0
-			IL_03d3: clt
-			IL_03d5: brfalse IL_068a
+			IL_0387: ldloc.0
+			IL_0388: ldc.r8 1
+			IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0396: ldc.r8 2
+			IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_03a4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_03a9: ldc.r8 0.0
+			IL_03b2: clt
+			IL_03b4: brfalse IL_0669
 
-			IL_03da: ldarg.0
-			IL_03db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_03e0: ldstr "Line"
-			IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ea: ldc.r8 2
-			IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03f8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_03fd: ldc.i4.0
-			IL_03fe: ceq
-			IL_0400: stloc.s 8
-			IL_0402: ldloc.s 8
-			IL_0404: brfalse IL_0486
+			IL_03b9: ldarg.0
+			IL_03ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_03bf: ldstr "Line"
+			IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c9: ldc.r8 2
+			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_03d7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03dc: ldc.i4.0
+			IL_03dd: ceq
+			IL_03df: stloc.s 6
+			IL_03e1: ldloc.s 6
+			IL_03e3: brfalse IL_0465
 
-			IL_0409: ldarg.0
-			IL_040a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_040f: stloc.s 7
-			IL_0411: ldc.i4.1
-			IL_0412: newarr [System.Runtime]System.Object
-			IL_0417: dup
-			IL_0418: ldc.i4.0
-			IL_0419: ldarg.0
-			IL_041a: stelem.ref
-			IL_041b: stloc.s 6
-			IL_041d: ldarg.0
-			IL_041e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0423: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0428: ldc.r8 3
-			IL_0431: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0436: stloc.2
-			IL_0437: ldloc.s 7
-			IL_0439: ldloc.s 6
-			IL_043b: ldloc.2
-			IL_043c: ldarg.0
-			IL_043d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0442: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0447: ldc.r8 2
-			IL_0450: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_045a: pop
-			IL_045b: ldarg.0
-			IL_045c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0461: ldstr "Line"
-			IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_046b: ldc.r8 2
-			IL_0474: box [System.Runtime]System.Double
-			IL_0479: ldc.i4.1
-			IL_047a: box [System.Runtime]System.Boolean
-			IL_047f: ldc.i4.1
-			IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0485: pop
+			IL_03e8: ldarg.0
+			IL_03e9: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_03ee: stloc.s 5
+			IL_03f0: ldc.i4.1
+			IL_03f1: newarr [System.Runtime]System.Object
+			IL_03f6: dup
+			IL_03f7: ldc.i4.0
+			IL_03f8: ldarg.0
+			IL_03f9: stelem.ref
+			IL_03fa: stloc.s 4
+			IL_03fc: ldarg.0
+			IL_03fd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0402: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0407: ldc.r8 3
+			IL_0410: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0415: stloc.2
+			IL_0416: ldloc.s 5
+			IL_0418: ldloc.s 4
+			IL_041a: ldloc.2
+			IL_041b: ldarg.0
+			IL_041c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0421: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0426: ldc.r8 2
+			IL_042f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0439: pop
+			IL_043a: ldarg.0
+			IL_043b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0440: ldstr "Line"
+			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_044a: ldc.r8 2
+			IL_0453: box [System.Runtime]System.Double
+			IL_0458: ldc.i4.1
+			IL_0459: box [System.Runtime]System.Boolean
+			IL_045e: ldc.i4.1
+			IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0464: pop
 
-			IL_0486: ldarg.0
-			IL_0487: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_048c: ldstr "Line"
-			IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0496: ldc.r8 9
-			IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_04a4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_04a9: ldc.i4.0
-			IL_04aa: ceq
-			IL_04ac: stloc.s 8
-			IL_04ae: ldloc.s 8
-			IL_04b0: brfalse IL_0532
+			IL_0465: ldarg.0
+			IL_0466: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_046b: ldstr "Line"
+			IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0475: ldc.r8 9
+			IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0483: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0488: ldc.i4.0
+			IL_0489: ceq
+			IL_048b: stloc.s 6
+			IL_048d: ldloc.s 6
+			IL_048f: brfalse IL_0511
 
-			IL_04b5: ldarg.0
-			IL_04b6: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_04bb: stloc.2
-			IL_04bc: ldc.i4.1
-			IL_04bd: newarr [System.Runtime]System.Object
-			IL_04c2: dup
-			IL_04c3: ldc.i4.0
-			IL_04c4: ldarg.0
-			IL_04c5: stelem.ref
-			IL_04c6: stloc.s 6
-			IL_04c8: ldarg.0
-			IL_04c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_04ce: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_04d3: ldc.r8 2
-			IL_04dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_04e1: stloc.s 7
-			IL_04e3: ldloc.2
-			IL_04e4: ldloc.s 6
-			IL_04e6: ldloc.s 7
-			IL_04e8: ldarg.0
-			IL_04e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_04ee: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_04f3: ldc.r8 6
-			IL_04fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0501: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0506: pop
-			IL_0507: ldarg.0
-			IL_0508: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_050d: ldstr "Line"
-			IL_0512: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0517: ldc.r8 9
-			IL_0520: box [System.Runtime]System.Double
-			IL_0525: ldc.i4.1
-			IL_0526: box [System.Runtime]System.Boolean
-			IL_052b: ldc.i4.1
-			IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0531: pop
+			IL_0494: ldarg.0
+			IL_0495: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_049a: stloc.2
+			IL_049b: ldc.i4.1
+			IL_049c: newarr [System.Runtime]System.Object
+			IL_04a1: dup
+			IL_04a2: ldc.i4.0
+			IL_04a3: ldarg.0
+			IL_04a4: stelem.ref
+			IL_04a5: stloc.s 4
+			IL_04a7: ldarg.0
+			IL_04a8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_04ad: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_04b2: ldc.r8 2
+			IL_04bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_04c0: stloc.s 5
+			IL_04c2: ldloc.2
+			IL_04c3: ldloc.s 4
+			IL_04c5: ldloc.s 5
+			IL_04c7: ldarg.0
+			IL_04c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_04cd: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_04d2: ldc.r8 6
+			IL_04db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_04e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04e5: pop
+			IL_04e6: ldarg.0
+			IL_04e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_04ec: ldstr "Line"
+			IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04f6: ldc.r8 9
+			IL_04ff: box [System.Runtime]System.Double
+			IL_0504: ldc.i4.1
+			IL_0505: box [System.Runtime]System.Boolean
+			IL_050a: ldc.i4.1
+			IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0510: pop
 
-			IL_0532: ldarg.0
-			IL_0533: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0538: ldstr "Line"
-			IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0542: ldc.r8 6
-			IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0550: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0555: ldc.i4.0
-			IL_0556: ceq
-			IL_0558: stloc.s 8
-			IL_055a: ldloc.s 8
-			IL_055c: brfalse IL_05de
+			IL_0511: ldarg.0
+			IL_0512: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0517: ldstr "Line"
+			IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0521: ldc.r8 6
+			IL_052a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_052f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0534: ldc.i4.0
+			IL_0535: ceq
+			IL_0537: stloc.s 6
+			IL_0539: ldloc.s 6
+			IL_053b: brfalse IL_05bd
 
-			IL_0561: ldarg.0
-			IL_0562: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0567: stloc.s 7
-			IL_0569: ldc.i4.1
-			IL_056a: newarr [System.Runtime]System.Object
-			IL_056f: dup
-			IL_0570: ldc.i4.0
-			IL_0571: ldarg.0
-			IL_0572: stelem.ref
-			IL_0573: stloc.s 6
-			IL_0575: ldarg.0
-			IL_0576: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_057b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0580: ldc.r8 6
-			IL_0589: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_058e: stloc.2
-			IL_058f: ldloc.s 7
-			IL_0591: ldloc.s 6
-			IL_0593: ldloc.2
-			IL_0594: ldarg.0
-			IL_0595: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_059a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_059f: ldc.r8 7
-			IL_05a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05b2: pop
-			IL_05b3: ldarg.0
-			IL_05b4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_05b9: ldstr "Line"
-			IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05c3: ldc.r8 6
-			IL_05cc: box [System.Runtime]System.Double
-			IL_05d1: ldc.i4.1
-			IL_05d2: box [System.Runtime]System.Boolean
-			IL_05d7: ldc.i4.1
-			IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_05dd: pop
+			IL_0540: ldarg.0
+			IL_0541: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0546: stloc.s 5
+			IL_0548: ldc.i4.1
+			IL_0549: newarr [System.Runtime]System.Object
+			IL_054e: dup
+			IL_054f: ldc.i4.0
+			IL_0550: ldarg.0
+			IL_0551: stelem.ref
+			IL_0552: stloc.s 4
+			IL_0554: ldarg.0
+			IL_0555: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_055a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_055f: ldc.r8 6
+			IL_0568: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_056d: stloc.2
+			IL_056e: ldloc.s 5
+			IL_0570: ldloc.s 4
+			IL_0572: ldloc.2
+			IL_0573: ldarg.0
+			IL_0574: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0579: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_057e: ldc.r8 7
+			IL_0587: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0591: pop
+			IL_0592: ldarg.0
+			IL_0593: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0598: ldstr "Line"
+			IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05a2: ldc.r8 6
+			IL_05ab: box [System.Runtime]System.Double
+			IL_05b0: ldc.i4.1
+			IL_05b1: box [System.Runtime]System.Boolean
+			IL_05b6: ldc.i4.1
+			IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_05bc: pop
 
-			IL_05de: ldarg.0
-			IL_05df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_05e4: ldstr "Line"
-			IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05ee: ldc.r8 10
-			IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_05fc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0601: ldc.i4.0
-			IL_0602: ceq
-			IL_0604: stloc.s 8
-			IL_0606: ldloc.s 8
-			IL_0608: brfalse IL_068a
+			IL_05bd: ldarg.0
+			IL_05be: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_05c3: ldstr "Line"
+			IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05cd: ldc.r8 10
+			IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_05db: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05e0: ldc.i4.0
+			IL_05e1: ceq
+			IL_05e3: stloc.s 6
+			IL_05e5: ldloc.s 6
+			IL_05e7: brfalse IL_0669
 
-			IL_060d: ldarg.0
-			IL_060e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0613: stloc.2
-			IL_0614: ldc.i4.1
-			IL_0615: newarr [System.Runtime]System.Object
-			IL_061a: dup
-			IL_061b: ldc.i4.0
-			IL_061c: ldarg.0
-			IL_061d: stelem.ref
-			IL_061e: stloc.s 6
-			IL_0620: ldarg.0
-			IL_0621: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0626: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_062b: ldc.r8 7
-			IL_0634: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0639: stloc.s 7
-			IL_063b: ldloc.2
-			IL_063c: ldloc.s 6
-			IL_063e: ldloc.s 7
-			IL_0640: ldarg.0
-			IL_0641: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0646: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_064b: ldc.r8 3
-			IL_0654: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_065e: pop
-			IL_065f: ldarg.0
-			IL_0660: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0665: ldstr "Line"
-			IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_066f: ldc.r8 10
-			IL_0678: box [System.Runtime]System.Double
-			IL_067d: ldc.i4.1
-			IL_067e: box [System.Runtime]System.Boolean
-			IL_0683: ldc.i4.1
-			IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0689: pop
+			IL_05ec: ldarg.0
+			IL_05ed: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_05f2: stloc.2
+			IL_05f3: ldc.i4.1
+			IL_05f4: newarr [System.Runtime]System.Object
+			IL_05f9: dup
+			IL_05fa: ldc.i4.0
+			IL_05fb: ldarg.0
+			IL_05fc: stelem.ref
+			IL_05fd: stloc.s 4
+			IL_05ff: ldarg.0
+			IL_0600: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0605: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_060a: ldc.r8 7
+			IL_0613: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0618: stloc.s 5
+			IL_061a: ldloc.2
+			IL_061b: ldloc.s 4
+			IL_061d: ldloc.s 5
+			IL_061f: ldarg.0
+			IL_0620: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0625: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_062a: ldc.r8 3
+			IL_0633: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_063d: pop
+			IL_063e: ldarg.0
+			IL_063f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0644: ldstr "Line"
+			IL_0649: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_064e: ldc.r8 10
+			IL_0657: box [System.Runtime]System.Double
+			IL_065c: ldc.i4.1
+			IL_065d: box [System.Runtime]System.Boolean
+			IL_0662: ldc.i4.1
+			IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0668: pop
 
-			IL_068a: ldloc.0
-			IL_068b: ldc.r8 2
-			IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0699: ldc.r8 2
-			IL_06a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_06a7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_06ac: ldc.r8 0.0
-			IL_06b5: clt
-			IL_06b7: brfalse IL_096c
+			IL_0669: ldloc.0
+			IL_066a: ldc.r8 2
+			IL_0673: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0678: ldc.r8 2
+			IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0686: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_068b: ldc.r8 0.0
+			IL_0694: clt
+			IL_0696: brfalse IL_094b
 
-			IL_06bc: ldarg.0
-			IL_06bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_06c2: ldstr "Line"
-			IL_06c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06cc: ldc.r8 4
-			IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_06da: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_06df: ldc.i4.0
-			IL_06e0: ceq
-			IL_06e2: stloc.s 8
-			IL_06e4: ldloc.s 8
-			IL_06e6: brfalse IL_0768
+			IL_069b: ldarg.0
+			IL_069c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_06a1: ldstr "Line"
+			IL_06a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06ab: ldc.r8 4
+			IL_06b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_06b9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_06be: ldc.i4.0
+			IL_06bf: ceq
+			IL_06c1: stloc.s 6
+			IL_06c3: ldloc.s 6
+			IL_06c5: brfalse IL_0747
 
-			IL_06eb: ldarg.0
-			IL_06ec: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_06f1: stloc.s 7
-			IL_06f3: ldc.i4.1
-			IL_06f4: newarr [System.Runtime]System.Object
-			IL_06f9: dup
-			IL_06fa: ldc.i4.0
-			IL_06fb: ldarg.0
-			IL_06fc: stelem.ref
-			IL_06fd: stloc.s 6
-			IL_06ff: ldarg.0
-			IL_0700: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0705: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_070a: ldc.r8 4
-			IL_0713: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0718: stloc.2
-			IL_0719: ldloc.s 7
-			IL_071b: ldloc.s 6
-			IL_071d: ldloc.2
-			IL_071e: ldarg.0
-			IL_071f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0724: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0729: ldc.r8 5
-			IL_0732: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0737: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_073c: pop
-			IL_073d: ldarg.0
-			IL_073e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0743: ldstr "Line"
-			IL_0748: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_074d: ldc.r8 4
-			IL_0756: box [System.Runtime]System.Double
-			IL_075b: ldc.i4.1
-			IL_075c: box [System.Runtime]System.Boolean
-			IL_0761: ldc.i4.1
-			IL_0762: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0767: pop
+			IL_06ca: ldarg.0
+			IL_06cb: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_06d0: stloc.s 5
+			IL_06d2: ldc.i4.1
+			IL_06d3: newarr [System.Runtime]System.Object
+			IL_06d8: dup
+			IL_06d9: ldc.i4.0
+			IL_06da: ldarg.0
+			IL_06db: stelem.ref
+			IL_06dc: stloc.s 4
+			IL_06de: ldarg.0
+			IL_06df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_06e4: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_06e9: ldc.r8 4
+			IL_06f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_06f7: stloc.2
+			IL_06f8: ldloc.s 5
+			IL_06fa: ldloc.s 4
+			IL_06fc: ldloc.2
+			IL_06fd: ldarg.0
+			IL_06fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0703: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0708: ldc.r8 5
+			IL_0711: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0716: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_071b: pop
+			IL_071c: ldarg.0
+			IL_071d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0722: ldstr "Line"
+			IL_0727: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_072c: ldc.r8 4
+			IL_0735: box [System.Runtime]System.Double
+			IL_073a: ldc.i4.1
+			IL_073b: box [System.Runtime]System.Boolean
+			IL_0740: ldc.i4.1
+			IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0746: pop
 
-			IL_0768: ldarg.0
-			IL_0769: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_076e: ldstr "Line"
-			IL_0773: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0778: ldc.r8 5
-			IL_0781: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0786: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_078b: ldc.i4.0
-			IL_078c: ceq
-			IL_078e: stloc.s 8
-			IL_0790: ldloc.s 8
-			IL_0792: brfalse IL_0814
+			IL_0747: ldarg.0
+			IL_0748: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_074d: ldstr "Line"
+			IL_0752: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0757: ldc.r8 5
+			IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0765: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_076a: ldc.i4.0
+			IL_076b: ceq
+			IL_076d: stloc.s 6
+			IL_076f: ldloc.s 6
+			IL_0771: brfalse IL_07f3
 
-			IL_0797: ldarg.0
-			IL_0798: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_079d: stloc.2
-			IL_079e: ldc.i4.1
-			IL_079f: newarr [System.Runtime]System.Object
-			IL_07a4: dup
-			IL_07a5: ldc.i4.0
-			IL_07a6: ldarg.0
-			IL_07a7: stelem.ref
-			IL_07a8: stloc.s 6
-			IL_07aa: ldarg.0
-			IL_07ab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_07b0: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_07b5: ldc.r8 5
-			IL_07be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_07c3: stloc.s 7
-			IL_07c5: ldloc.2
-			IL_07c6: ldloc.s 6
-			IL_07c8: ldloc.s 7
-			IL_07ca: ldarg.0
-			IL_07cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_07d0: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_07d5: ldc.r8 6
-			IL_07de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_07e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_07e8: pop
-			IL_07e9: ldarg.0
-			IL_07ea: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_07ef: ldstr "Line"
-			IL_07f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07f9: ldc.r8 5
-			IL_0802: box [System.Runtime]System.Double
-			IL_0807: ldc.i4.1
-			IL_0808: box [System.Runtime]System.Boolean
-			IL_080d: ldc.i4.1
-			IL_080e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0813: pop
+			IL_0776: ldarg.0
+			IL_0777: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_077c: stloc.2
+			IL_077d: ldc.i4.1
+			IL_077e: newarr [System.Runtime]System.Object
+			IL_0783: dup
+			IL_0784: ldc.i4.0
+			IL_0785: ldarg.0
+			IL_0786: stelem.ref
+			IL_0787: stloc.s 4
+			IL_0789: ldarg.0
+			IL_078a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_078f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0794: ldc.r8 5
+			IL_079d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_07a2: stloc.s 5
+			IL_07a4: ldloc.2
+			IL_07a5: ldloc.s 4
+			IL_07a7: ldloc.s 5
+			IL_07a9: ldarg.0
+			IL_07aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_07af: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_07b4: ldc.r8 6
+			IL_07bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_07c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_07c7: pop
+			IL_07c8: ldarg.0
+			IL_07c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_07ce: ldstr "Line"
+			IL_07d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07d8: ldc.r8 5
+			IL_07e1: box [System.Runtime]System.Double
+			IL_07e6: ldc.i4.1
+			IL_07e7: box [System.Runtime]System.Boolean
+			IL_07ec: ldc.i4.1
+			IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_07f2: pop
 
-			IL_0814: ldarg.0
-			IL_0815: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_081a: ldstr "Line"
-			IL_081f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0824: ldc.r8 6
-			IL_082d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0832: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0837: ldc.i4.0
-			IL_0838: ceq
-			IL_083a: stloc.s 8
-			IL_083c: ldloc.s 8
-			IL_083e: brfalse IL_08c0
+			IL_07f3: ldarg.0
+			IL_07f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_07f9: ldstr "Line"
+			IL_07fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0803: ldc.r8 6
+			IL_080c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0811: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0816: ldc.i4.0
+			IL_0817: ceq
+			IL_0819: stloc.s 6
+			IL_081b: ldloc.s 6
+			IL_081d: brfalse IL_089f
 
-			IL_0843: ldarg.0
-			IL_0844: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0849: stloc.s 7
-			IL_084b: ldc.i4.1
-			IL_084c: newarr [System.Runtime]System.Object
-			IL_0851: dup
-			IL_0852: ldc.i4.0
-			IL_0853: ldarg.0
-			IL_0854: stelem.ref
-			IL_0855: stloc.s 6
-			IL_0857: ldarg.0
-			IL_0858: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_085d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0862: ldc.r8 6
-			IL_086b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0870: stloc.2
-			IL_0871: ldloc.s 7
-			IL_0873: ldloc.s 6
-			IL_0875: ldloc.2
-			IL_0876: ldarg.0
-			IL_0877: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_087c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0881: ldc.r8 7
-			IL_088a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_088f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0894: pop
-			IL_0895: ldarg.0
-			IL_0896: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_089b: ldstr "Line"
-			IL_08a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08a5: ldc.r8 6
-			IL_08ae: box [System.Runtime]System.Double
-			IL_08b3: ldc.i4.1
-			IL_08b4: box [System.Runtime]System.Boolean
-			IL_08b9: ldc.i4.1
-			IL_08ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_08bf: pop
+			IL_0822: ldarg.0
+			IL_0823: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0828: stloc.s 5
+			IL_082a: ldc.i4.1
+			IL_082b: newarr [System.Runtime]System.Object
+			IL_0830: dup
+			IL_0831: ldc.i4.0
+			IL_0832: ldarg.0
+			IL_0833: stelem.ref
+			IL_0834: stloc.s 4
+			IL_0836: ldarg.0
+			IL_0837: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_083c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0841: ldc.r8 6
+			IL_084a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_084f: stloc.2
+			IL_0850: ldloc.s 5
+			IL_0852: ldloc.s 4
+			IL_0854: ldloc.2
+			IL_0855: ldarg.0
+			IL_0856: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_085b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0860: ldc.r8 7
+			IL_0869: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_086e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0873: pop
+			IL_0874: ldarg.0
+			IL_0875: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_087a: ldstr "Line"
+			IL_087f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0884: ldc.r8 6
+			IL_088d: box [System.Runtime]System.Double
+			IL_0892: ldc.i4.1
+			IL_0893: box [System.Runtime]System.Boolean
+			IL_0898: ldc.i4.1
+			IL_0899: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_089e: pop
 
-			IL_08c0: ldarg.0
-			IL_08c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_08c6: ldstr "Line"
-			IL_08cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08d0: ldc.r8 7
-			IL_08d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_08de: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_08e3: ldc.i4.0
-			IL_08e4: ceq
-			IL_08e6: stloc.s 8
-			IL_08e8: ldloc.s 8
-			IL_08ea: brfalse IL_096c
+			IL_089f: ldarg.0
+			IL_08a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_08a5: ldstr "Line"
+			IL_08aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08af: ldc.r8 7
+			IL_08b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_08bd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08c2: ldc.i4.0
+			IL_08c3: ceq
+			IL_08c5: stloc.s 6
+			IL_08c7: ldloc.s 6
+			IL_08c9: brfalse IL_094b
 
-			IL_08ef: ldarg.0
-			IL_08f0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_08f5: stloc.2
-			IL_08f6: ldc.i4.1
-			IL_08f7: newarr [System.Runtime]System.Object
-			IL_08fc: dup
-			IL_08fd: ldc.i4.0
-			IL_08fe: ldarg.0
-			IL_08ff: stelem.ref
-			IL_0900: stloc.s 6
-			IL_0902: ldarg.0
-			IL_0903: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0908: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_090d: ldc.r8 7
-			IL_0916: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_091b: stloc.s 7
-			IL_091d: ldloc.2
-			IL_091e: ldloc.s 6
-			IL_0920: ldloc.s 7
-			IL_0922: ldarg.0
-			IL_0923: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0928: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_092d: ldc.r8 4
-			IL_0936: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_093b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0940: pop
-			IL_0941: ldarg.0
-			IL_0942: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0947: ldstr "Line"
-			IL_094c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0951: ldc.r8 7
-			IL_095a: box [System.Runtime]System.Double
-			IL_095f: ldc.i4.1
-			IL_0960: box [System.Runtime]System.Boolean
-			IL_0965: ldc.i4.1
-			IL_0966: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_096b: pop
+			IL_08ce: ldarg.0
+			IL_08cf: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_08d4: stloc.2
+			IL_08d5: ldc.i4.1
+			IL_08d6: newarr [System.Runtime]System.Object
+			IL_08db: dup
+			IL_08dc: ldc.i4.0
+			IL_08dd: ldarg.0
+			IL_08de: stelem.ref
+			IL_08df: stloc.s 4
+			IL_08e1: ldarg.0
+			IL_08e2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_08e7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_08ec: ldc.r8 7
+			IL_08f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_08fa: stloc.s 5
+			IL_08fc: ldloc.2
+			IL_08fd: ldloc.s 4
+			IL_08ff: ldloc.s 5
+			IL_0901: ldarg.0
+			IL_0902: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0907: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_090c: ldc.r8 4
+			IL_0915: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_091a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_091f: pop
+			IL_0920: ldarg.0
+			IL_0921: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0926: ldstr "Line"
+			IL_092b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0930: ldc.r8 7
+			IL_0939: box [System.Runtime]System.Double
+			IL_093e: ldc.i4.1
+			IL_093f: box [System.Runtime]System.Boolean
+			IL_0944: ldc.i4.1
+			IL_0945: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_094a: pop
 
-			IL_096c: ldloc.0
-			IL_096d: ldc.r8 3
-			IL_0976: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_097b: ldc.r8 2
-			IL_0984: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0989: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_098e: ldc.r8 0.0
-			IL_0997: clt
-			IL_0999: brfalse IL_0c4e
+			IL_094b: ldloc.0
+			IL_094c: ldc.r8 3
+			IL_0955: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_095a: ldc.r8 2
+			IL_0963: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0968: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_096d: ldc.r8 0.0
+			IL_0976: clt
+			IL_0978: brfalse IL_0c2d
 
-			IL_099e: ldarg.0
-			IL_099f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_09a4: ldstr "Line"
-			IL_09a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09ae: ldc.r8 4
-			IL_09b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_09bc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_09c1: ldc.i4.0
-			IL_09c2: ceq
-			IL_09c4: stloc.s 8
-			IL_09c6: ldloc.s 8
-			IL_09c8: brfalse IL_0a4a
+			IL_097d: ldarg.0
+			IL_097e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0983: ldstr "Line"
+			IL_0988: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_098d: ldc.r8 4
+			IL_0996: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_099b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_09a0: ldc.i4.0
+			IL_09a1: ceq
+			IL_09a3: stloc.s 6
+			IL_09a5: ldloc.s 6
+			IL_09a7: brfalse IL_0a29
 
-			IL_09cd: ldarg.0
-			IL_09ce: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_09d3: stloc.s 7
-			IL_09d5: ldc.i4.1
-			IL_09d6: newarr [System.Runtime]System.Object
-			IL_09db: dup
-			IL_09dc: ldc.i4.0
-			IL_09dd: ldarg.0
-			IL_09de: stelem.ref
-			IL_09df: stloc.s 6
-			IL_09e1: ldarg.0
-			IL_09e2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_09e7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_09ec: ldc.r8 4
-			IL_09f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_09fa: stloc.2
-			IL_09fb: ldloc.s 7
-			IL_09fd: ldloc.s 6
-			IL_09ff: ldloc.2
-			IL_0a00: ldarg.0
-			IL_0a01: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a06: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0a0b: ldc.r8 5
-			IL_0a14: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0a19: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0a1e: pop
-			IL_0a1f: ldarg.0
-			IL_0a20: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a25: ldstr "Line"
-			IL_0a2a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a2f: ldc.r8 4
-			IL_0a38: box [System.Runtime]System.Double
-			IL_0a3d: ldc.i4.1
-			IL_0a3e: box [System.Runtime]System.Boolean
-			IL_0a43: ldc.i4.1
-			IL_0a44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0a49: pop
+			IL_09ac: ldarg.0
+			IL_09ad: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_09b2: stloc.s 5
+			IL_09b4: ldc.i4.1
+			IL_09b5: newarr [System.Runtime]System.Object
+			IL_09ba: dup
+			IL_09bb: ldc.i4.0
+			IL_09bc: ldarg.0
+			IL_09bd: stelem.ref
+			IL_09be: stloc.s 4
+			IL_09c0: ldarg.0
+			IL_09c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_09c6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_09cb: ldc.r8 4
+			IL_09d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_09d9: stloc.2
+			IL_09da: ldloc.s 5
+			IL_09dc: ldloc.s 4
+			IL_09de: ldloc.2
+			IL_09df: ldarg.0
+			IL_09e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_09e5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_09ea: ldc.r8 5
+			IL_09f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_09f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_09fd: pop
+			IL_09fe: ldarg.0
+			IL_09ff: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0a04: ldstr "Line"
+			IL_0a09: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a0e: ldc.r8 4
+			IL_0a17: box [System.Runtime]System.Double
+			IL_0a1c: ldc.i4.1
+			IL_0a1d: box [System.Runtime]System.Boolean
+			IL_0a22: ldc.i4.1
+			IL_0a23: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0a28: pop
 
-			IL_0a4a: ldarg.0
-			IL_0a4b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a50: ldstr "Line"
-			IL_0a55: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a5a: ldc.r8 8
-			IL_0a63: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0a68: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0a6d: ldc.i4.0
-			IL_0a6e: ceq
-			IL_0a70: stloc.s 8
-			IL_0a72: ldloc.s 8
-			IL_0a74: brfalse IL_0af6
+			IL_0a29: ldarg.0
+			IL_0a2a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0a2f: ldstr "Line"
+			IL_0a34: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a39: ldc.r8 8
+			IL_0a42: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0a47: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0a4c: ldc.i4.0
+			IL_0a4d: ceq
+			IL_0a4f: stloc.s 6
+			IL_0a51: ldloc.s 6
+			IL_0a53: brfalse IL_0ad5
 
-			IL_0a79: ldarg.0
-			IL_0a7a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0a7f: stloc.2
-			IL_0a80: ldc.i4.1
-			IL_0a81: newarr [System.Runtime]System.Object
-			IL_0a86: dup
-			IL_0a87: ldc.i4.0
-			IL_0a88: ldarg.0
-			IL_0a89: stelem.ref
-			IL_0a8a: stloc.s 6
-			IL_0a8c: ldarg.0
-			IL_0a8d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a92: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0a97: ldc.r8 5
-			IL_0aa0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0aa5: stloc.s 7
-			IL_0aa7: ldloc.2
-			IL_0aa8: ldloc.s 6
-			IL_0aaa: ldloc.s 7
-			IL_0aac: ldarg.0
-			IL_0aad: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ab2: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0ab7: ldc.r8 1
-			IL_0ac0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0ac5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0aca: pop
-			IL_0acb: ldarg.0
-			IL_0acc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ad1: ldstr "Line"
-			IL_0ad6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0adb: ldc.r8 8
-			IL_0ae4: box [System.Runtime]System.Double
-			IL_0ae9: ldc.i4.1
-			IL_0aea: box [System.Runtime]System.Boolean
-			IL_0aef: ldc.i4.1
-			IL_0af0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0af5: pop
+			IL_0a58: ldarg.0
+			IL_0a59: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0a5e: stloc.2
+			IL_0a5f: ldc.i4.1
+			IL_0a60: newarr [System.Runtime]System.Object
+			IL_0a65: dup
+			IL_0a66: ldc.i4.0
+			IL_0a67: ldarg.0
+			IL_0a68: stelem.ref
+			IL_0a69: stloc.s 4
+			IL_0a6b: ldarg.0
+			IL_0a6c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0a71: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0a76: ldc.r8 5
+			IL_0a7f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0a84: stloc.s 5
+			IL_0a86: ldloc.2
+			IL_0a87: ldloc.s 4
+			IL_0a89: ldloc.s 5
+			IL_0a8b: ldarg.0
+			IL_0a8c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0a91: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0a96: ldc.r8 1
+			IL_0a9f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0aa4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0aa9: pop
+			IL_0aaa: ldarg.0
+			IL_0aab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0ab0: ldstr "Line"
+			IL_0ab5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0aba: ldc.r8 8
+			IL_0ac3: box [System.Runtime]System.Double
+			IL_0ac8: ldc.i4.1
+			IL_0ac9: box [System.Runtime]System.Boolean
+			IL_0ace: ldc.i4.1
+			IL_0acf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0ad4: pop
 
-			IL_0af6: ldarg.0
-			IL_0af7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0afc: ldstr "Line"
-			IL_0b01: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b06: ldc.r8 0.0
-			IL_0b0f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0b14: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0b19: ldc.i4.0
-			IL_0b1a: ceq
-			IL_0b1c: stloc.s 8
-			IL_0b1e: ldloc.s 8
-			IL_0b20: brfalse IL_0ba2
+			IL_0ad5: ldarg.0
+			IL_0ad6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0adb: ldstr "Line"
+			IL_0ae0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ae5: ldc.r8 0.0
+			IL_0aee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0af3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0af8: ldc.i4.0
+			IL_0af9: ceq
+			IL_0afb: stloc.s 6
+			IL_0afd: ldloc.s 6
+			IL_0aff: brfalse IL_0b81
 
-			IL_0b25: ldarg.0
-			IL_0b26: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0b2b: stloc.s 7
-			IL_0b2d: ldc.i4.1
-			IL_0b2e: newarr [System.Runtime]System.Object
-			IL_0b33: dup
-			IL_0b34: ldc.i4.0
-			IL_0b35: ldarg.0
-			IL_0b36: stelem.ref
-			IL_0b37: stloc.s 6
-			IL_0b39: ldarg.0
-			IL_0b3a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0b3f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0b44: ldc.r8 1
-			IL_0b4d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0b52: stloc.2
-			IL_0b53: ldloc.s 7
-			IL_0b55: ldloc.s 6
-			IL_0b57: ldloc.2
-			IL_0b58: ldarg.0
-			IL_0b59: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0b5e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0b63: ldc.r8 0.0
-			IL_0b6c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0b71: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b76: pop
-			IL_0b77: ldarg.0
-			IL_0b78: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0b7d: ldstr "Line"
-			IL_0b82: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b87: ldc.r8 0.0
-			IL_0b90: box [System.Runtime]System.Double
-			IL_0b95: ldc.i4.1
-			IL_0b96: box [System.Runtime]System.Boolean
-			IL_0b9b: ldc.i4.1
-			IL_0b9c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0ba1: pop
+			IL_0b04: ldarg.0
+			IL_0b05: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0b0a: stloc.s 5
+			IL_0b0c: ldc.i4.1
+			IL_0b0d: newarr [System.Runtime]System.Object
+			IL_0b12: dup
+			IL_0b13: ldc.i4.0
+			IL_0b14: ldarg.0
+			IL_0b15: stelem.ref
+			IL_0b16: stloc.s 4
+			IL_0b18: ldarg.0
+			IL_0b19: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b1e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0b23: ldc.r8 1
+			IL_0b2c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0b31: stloc.2
+			IL_0b32: ldloc.s 5
+			IL_0b34: ldloc.s 4
+			IL_0b36: ldloc.2
+			IL_0b37: ldarg.0
+			IL_0b38: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b3d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0b42: ldc.r8 0.0
+			IL_0b4b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0b50: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b55: pop
+			IL_0b56: ldarg.0
+			IL_0b57: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b5c: ldstr "Line"
+			IL_0b61: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b66: ldc.r8 0.0
+			IL_0b6f: box [System.Runtime]System.Double
+			IL_0b74: ldc.i4.1
+			IL_0b75: box [System.Runtime]System.Boolean
+			IL_0b7a: ldc.i4.1
+			IL_0b7b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0b80: pop
 
-			IL_0ba2: ldarg.0
-			IL_0ba3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ba8: ldstr "Line"
-			IL_0bad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bb2: ldc.r8 11
-			IL_0bbb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0bc0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0bc5: ldc.i4.0
-			IL_0bc6: ceq
-			IL_0bc8: stloc.s 8
-			IL_0bca: ldloc.s 8
-			IL_0bcc: brfalse IL_0c4e
+			IL_0b81: ldarg.0
+			IL_0b82: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b87: ldstr "Line"
+			IL_0b8c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b91: ldc.r8 11
+			IL_0b9a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0b9f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0ba4: ldc.i4.0
+			IL_0ba5: ceq
+			IL_0ba7: stloc.s 6
+			IL_0ba9: ldloc.s 6
+			IL_0bab: brfalse IL_0c2d
 
-			IL_0bd1: ldarg.0
-			IL_0bd2: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0bd7: stloc.2
-			IL_0bd8: ldc.i4.1
-			IL_0bd9: newarr [System.Runtime]System.Object
-			IL_0bde: dup
-			IL_0bdf: ldc.i4.0
-			IL_0be0: ldarg.0
-			IL_0be1: stelem.ref
-			IL_0be2: stloc.s 6
-			IL_0be4: ldarg.0
-			IL_0be5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0bea: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0bef: ldc.r8 0.0
-			IL_0bf8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0bfd: stloc.s 7
-			IL_0bff: ldloc.2
-			IL_0c00: ldloc.s 6
-			IL_0c02: ldloc.s 7
-			IL_0c04: ldarg.0
-			IL_0c05: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c0a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0c0f: ldc.r8 4
-			IL_0c18: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0c1d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0c22: pop
-			IL_0c23: ldarg.0
-			IL_0c24: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c29: ldstr "Line"
-			IL_0c2e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c33: ldc.r8 11
-			IL_0c3c: box [System.Runtime]System.Double
-			IL_0c41: ldc.i4.1
-			IL_0c42: box [System.Runtime]System.Boolean
-			IL_0c47: ldc.i4.1
-			IL_0c48: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0c4d: pop
+			IL_0bb0: ldarg.0
+			IL_0bb1: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0bb6: stloc.2
+			IL_0bb7: ldc.i4.1
+			IL_0bb8: newarr [System.Runtime]System.Object
+			IL_0bbd: dup
+			IL_0bbe: ldc.i4.0
+			IL_0bbf: ldarg.0
+			IL_0bc0: stelem.ref
+			IL_0bc1: stloc.s 4
+			IL_0bc3: ldarg.0
+			IL_0bc4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0bc9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0bce: ldc.r8 0.0
+			IL_0bd7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0bdc: stloc.s 5
+			IL_0bde: ldloc.2
+			IL_0bdf: ldloc.s 4
+			IL_0be1: ldloc.s 5
+			IL_0be3: ldarg.0
+			IL_0be4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0be9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0bee: ldc.r8 4
+			IL_0bf7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0bfc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0c01: pop
+			IL_0c02: ldarg.0
+			IL_0c03: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c08: ldstr "Line"
+			IL_0c0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c12: ldc.r8 11
+			IL_0c1b: box [System.Runtime]System.Double
+			IL_0c20: ldc.i4.1
+			IL_0c21: box [System.Runtime]System.Boolean
+			IL_0c26: ldc.i4.1
+			IL_0c27: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0c2c: pop
 
-			IL_0c4e: ldloc.0
-			IL_0c4f: ldc.r8 4
-			IL_0c58: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0c5d: ldc.r8 2
-			IL_0c66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0c6b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0c70: ldc.r8 0.0
-			IL_0c79: clt
-			IL_0c7b: brfalse IL_0f30
+			IL_0c2d: ldloc.0
+			IL_0c2e: ldc.r8 4
+			IL_0c37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0c3c: ldc.r8 2
+			IL_0c45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0c4a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0c4f: ldc.r8 0.0
+			IL_0c58: clt
+			IL_0c5a: brfalse IL_0f0f
 
-			IL_0c80: ldarg.0
-			IL_0c81: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c86: ldstr "Line"
-			IL_0c8b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c90: ldc.r8 11
-			IL_0c99: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0c9e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0ca3: ldc.i4.0
-			IL_0ca4: ceq
-			IL_0ca6: stloc.s 8
-			IL_0ca8: ldloc.s 8
-			IL_0caa: brfalse IL_0d2c
+			IL_0c5f: ldarg.0
+			IL_0c60: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c65: ldstr "Line"
+			IL_0c6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c6f: ldc.r8 11
+			IL_0c78: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0c7d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0c82: ldc.i4.0
+			IL_0c83: ceq
+			IL_0c85: stloc.s 6
+			IL_0c87: ldloc.s 6
+			IL_0c89: brfalse IL_0d0b
 
-			IL_0caf: ldarg.0
-			IL_0cb0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0cb5: stloc.s 7
-			IL_0cb7: ldc.i4.1
-			IL_0cb8: newarr [System.Runtime]System.Object
-			IL_0cbd: dup
-			IL_0cbe: ldc.i4.0
-			IL_0cbf: ldarg.0
-			IL_0cc0: stelem.ref
-			IL_0cc1: stloc.s 6
-			IL_0cc3: ldarg.0
-			IL_0cc4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0cc9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0cce: ldc.r8 4
-			IL_0cd7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0cdc: stloc.2
-			IL_0cdd: ldloc.s 7
-			IL_0cdf: ldloc.s 6
-			IL_0ce1: ldloc.2
-			IL_0ce2: ldarg.0
-			IL_0ce3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ce8: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0ced: ldc.r8 0.0
-			IL_0cf6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0cfb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0d00: pop
-			IL_0d01: ldarg.0
-			IL_0d02: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d07: ldstr "Line"
-			IL_0d0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d11: ldc.r8 11
-			IL_0d1a: box [System.Runtime]System.Double
-			IL_0d1f: ldc.i4.1
-			IL_0d20: box [System.Runtime]System.Boolean
-			IL_0d25: ldc.i4.1
-			IL_0d26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0d2b: pop
+			IL_0c8e: ldarg.0
+			IL_0c8f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0c94: stloc.s 5
+			IL_0c96: ldc.i4.1
+			IL_0c97: newarr [System.Runtime]System.Object
+			IL_0c9c: dup
+			IL_0c9d: ldc.i4.0
+			IL_0c9e: ldarg.0
+			IL_0c9f: stelem.ref
+			IL_0ca0: stloc.s 4
+			IL_0ca2: ldarg.0
+			IL_0ca3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0ca8: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0cad: ldc.r8 4
+			IL_0cb6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0cbb: stloc.2
+			IL_0cbc: ldloc.s 5
+			IL_0cbe: ldloc.s 4
+			IL_0cc0: ldloc.2
+			IL_0cc1: ldarg.0
+			IL_0cc2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0cc7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0ccc: ldc.r8 0.0
+			IL_0cd5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0cda: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0cdf: pop
+			IL_0ce0: ldarg.0
+			IL_0ce1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0ce6: ldstr "Line"
+			IL_0ceb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0cf0: ldc.r8 11
+			IL_0cf9: box [System.Runtime]System.Double
+			IL_0cfe: ldc.i4.1
+			IL_0cff: box [System.Runtime]System.Boolean
+			IL_0d04: ldc.i4.1
+			IL_0d05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0d0a: pop
 
-			IL_0d2c: ldarg.0
-			IL_0d2d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d32: ldstr "Line"
-			IL_0d37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d3c: ldc.r8 3
-			IL_0d45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0d4a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0d4f: ldc.i4.0
-			IL_0d50: ceq
-			IL_0d52: stloc.s 8
-			IL_0d54: ldloc.s 8
-			IL_0d56: brfalse IL_0dd8
+			IL_0d0b: ldarg.0
+			IL_0d0c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0d11: ldstr "Line"
+			IL_0d16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d1b: ldc.r8 3
+			IL_0d24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0d29: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0d2e: ldc.i4.0
+			IL_0d2f: ceq
+			IL_0d31: stloc.s 6
+			IL_0d33: ldloc.s 6
+			IL_0d35: brfalse IL_0db7
 
-			IL_0d5b: ldarg.0
-			IL_0d5c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0d61: stloc.2
-			IL_0d62: ldc.i4.1
-			IL_0d63: newarr [System.Runtime]System.Object
-			IL_0d68: dup
-			IL_0d69: ldc.i4.0
-			IL_0d6a: ldarg.0
-			IL_0d6b: stelem.ref
-			IL_0d6c: stloc.s 6
-			IL_0d6e: ldarg.0
-			IL_0d6f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d74: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0d79: ldc.r8 0.0
-			IL_0d82: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0d87: stloc.s 7
-			IL_0d89: ldloc.2
-			IL_0d8a: ldloc.s 6
-			IL_0d8c: ldloc.s 7
-			IL_0d8e: ldarg.0
-			IL_0d8f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d94: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0d99: ldc.r8 3
-			IL_0da2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0da7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0dac: pop
-			IL_0dad: ldarg.0
-			IL_0dae: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0db3: ldstr "Line"
-			IL_0db8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0dbd: ldc.r8 3
-			IL_0dc6: box [System.Runtime]System.Double
-			IL_0dcb: ldc.i4.1
-			IL_0dcc: box [System.Runtime]System.Boolean
-			IL_0dd1: ldc.i4.1
-			IL_0dd2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0dd7: pop
+			IL_0d3a: ldarg.0
+			IL_0d3b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0d40: stloc.2
+			IL_0d41: ldc.i4.1
+			IL_0d42: newarr [System.Runtime]System.Object
+			IL_0d47: dup
+			IL_0d48: ldc.i4.0
+			IL_0d49: ldarg.0
+			IL_0d4a: stelem.ref
+			IL_0d4b: stloc.s 4
+			IL_0d4d: ldarg.0
+			IL_0d4e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0d53: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0d58: ldc.r8 0.0
+			IL_0d61: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0d66: stloc.s 5
+			IL_0d68: ldloc.2
+			IL_0d69: ldloc.s 4
+			IL_0d6b: ldloc.s 5
+			IL_0d6d: ldarg.0
+			IL_0d6e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0d73: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0d78: ldc.r8 3
+			IL_0d81: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0d86: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0d8b: pop
+			IL_0d8c: ldarg.0
+			IL_0d8d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0d92: ldstr "Line"
+			IL_0d97: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d9c: ldc.r8 3
+			IL_0da5: box [System.Runtime]System.Double
+			IL_0daa: ldc.i4.1
+			IL_0dab: box [System.Runtime]System.Boolean
+			IL_0db0: ldc.i4.1
+			IL_0db1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0db6: pop
 
-			IL_0dd8: ldarg.0
-			IL_0dd9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0dde: ldstr "Line"
-			IL_0de3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0de8: ldc.r8 10
-			IL_0df1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0df6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0dfb: ldc.i4.0
-			IL_0dfc: ceq
-			IL_0dfe: stloc.s 8
-			IL_0e00: ldloc.s 8
-			IL_0e02: brfalse IL_0e84
+			IL_0db7: ldarg.0
+			IL_0db8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0dbd: ldstr "Line"
+			IL_0dc2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dc7: ldc.r8 10
+			IL_0dd0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0dd5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0dda: ldc.i4.0
+			IL_0ddb: ceq
+			IL_0ddd: stloc.s 6
+			IL_0ddf: ldloc.s 6
+			IL_0de1: brfalse IL_0e63
 
-			IL_0e07: ldarg.0
-			IL_0e08: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0e0d: stloc.s 7
-			IL_0e0f: ldc.i4.1
-			IL_0e10: newarr [System.Runtime]System.Object
-			IL_0e15: dup
-			IL_0e16: ldc.i4.0
-			IL_0e17: ldarg.0
-			IL_0e18: stelem.ref
-			IL_0e19: stloc.s 6
-			IL_0e1b: ldarg.0
-			IL_0e1c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e21: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0e26: ldc.r8 3
-			IL_0e2f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0e34: stloc.2
-			IL_0e35: ldloc.s 7
-			IL_0e37: ldloc.s 6
-			IL_0e39: ldloc.2
-			IL_0e3a: ldarg.0
-			IL_0e3b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e40: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0e45: ldc.r8 7
-			IL_0e4e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0e53: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0e58: pop
-			IL_0e59: ldarg.0
-			IL_0e5a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e5f: ldstr "Line"
-			IL_0e64: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e69: ldc.r8 10
-			IL_0e72: box [System.Runtime]System.Double
-			IL_0e77: ldc.i4.1
-			IL_0e78: box [System.Runtime]System.Boolean
-			IL_0e7d: ldc.i4.1
-			IL_0e7e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0e83: pop
+			IL_0de6: ldarg.0
+			IL_0de7: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0dec: stloc.s 5
+			IL_0dee: ldc.i4.1
+			IL_0def: newarr [System.Runtime]System.Object
+			IL_0df4: dup
+			IL_0df5: ldc.i4.0
+			IL_0df6: ldarg.0
+			IL_0df7: stelem.ref
+			IL_0df8: stloc.s 4
+			IL_0dfa: ldarg.0
+			IL_0dfb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e00: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e05: ldc.r8 3
+			IL_0e0e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0e13: stloc.2
+			IL_0e14: ldloc.s 5
+			IL_0e16: ldloc.s 4
+			IL_0e18: ldloc.2
+			IL_0e19: ldarg.0
+			IL_0e1a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e1f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e24: ldc.r8 7
+			IL_0e2d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0e32: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0e37: pop
+			IL_0e38: ldarg.0
+			IL_0e39: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e3e: ldstr "Line"
+			IL_0e43: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e48: ldc.r8 10
+			IL_0e51: box [System.Runtime]System.Double
+			IL_0e56: ldc.i4.1
+			IL_0e57: box [System.Runtime]System.Boolean
+			IL_0e5c: ldc.i4.1
+			IL_0e5d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0e62: pop
 
-			IL_0e84: ldarg.0
-			IL_0e85: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e8a: ldstr "Line"
-			IL_0e8f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e94: ldc.r8 7
-			IL_0e9d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0ea2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0ea7: ldc.i4.0
-			IL_0ea8: ceq
-			IL_0eaa: stloc.s 8
-			IL_0eac: ldloc.s 8
-			IL_0eae: brfalse IL_0f30
+			IL_0e63: ldarg.0
+			IL_0e64: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e69: ldstr "Line"
+			IL_0e6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e73: ldc.r8 7
+			IL_0e7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e81: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0e86: ldc.i4.0
+			IL_0e87: ceq
+			IL_0e89: stloc.s 6
+			IL_0e8b: ldloc.s 6
+			IL_0e8d: brfalse IL_0f0f
 
-			IL_0eb3: ldarg.0
-			IL_0eb4: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0eb9: stloc.2
-			IL_0eba: ldc.i4.1
-			IL_0ebb: newarr [System.Runtime]System.Object
-			IL_0ec0: dup
-			IL_0ec1: ldc.i4.0
-			IL_0ec2: ldarg.0
-			IL_0ec3: stelem.ref
-			IL_0ec4: stloc.s 6
-			IL_0ec6: ldarg.0
-			IL_0ec7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ecc: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0ed1: ldc.r8 7
-			IL_0eda: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0edf: stloc.s 7
-			IL_0ee1: ldloc.2
-			IL_0ee2: ldloc.s 6
-			IL_0ee4: ldloc.s 7
-			IL_0ee6: ldarg.0
-			IL_0ee7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0eec: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0ef1: ldc.r8 4
-			IL_0efa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0eff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0f04: pop
-			IL_0f05: ldarg.0
-			IL_0f06: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f0b: ldstr "Line"
-			IL_0f10: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f15: ldc.r8 7
-			IL_0f1e: box [System.Runtime]System.Double
-			IL_0f23: ldc.i4.1
-			IL_0f24: box [System.Runtime]System.Boolean
-			IL_0f29: ldc.i4.1
-			IL_0f2a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0f2f: pop
+			IL_0e92: ldarg.0
+			IL_0e93: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0e98: stloc.2
+			IL_0e99: ldc.i4.1
+			IL_0e9a: newarr [System.Runtime]System.Object
+			IL_0e9f: dup
+			IL_0ea0: ldc.i4.0
+			IL_0ea1: ldarg.0
+			IL_0ea2: stelem.ref
+			IL_0ea3: stloc.s 4
+			IL_0ea5: ldarg.0
+			IL_0ea6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0eab: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0eb0: ldc.r8 7
+			IL_0eb9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0ebe: stloc.s 5
+			IL_0ec0: ldloc.2
+			IL_0ec1: ldloc.s 4
+			IL_0ec3: ldloc.s 5
+			IL_0ec5: ldarg.0
+			IL_0ec6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0ecb: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0ed0: ldc.r8 4
+			IL_0ed9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0ede: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0ee3: pop
+			IL_0ee4: ldarg.0
+			IL_0ee5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0eea: ldstr "Line"
+			IL_0eef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ef4: ldc.r8 7
+			IL_0efd: box [System.Runtime]System.Double
+			IL_0f02: ldc.i4.1
+			IL_0f03: box [System.Runtime]System.Boolean
+			IL_0f08: ldc.i4.1
+			IL_0f09: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0f0e: pop
 
-			IL_0f30: ldloc.0
-			IL_0f31: ldc.r8 5
-			IL_0f3a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0f3f: ldc.r8 2
-			IL_0f48: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0f4d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0f52: ldc.r8 0.0
-			IL_0f5b: clt
-			IL_0f5d: brfalse IL_1212
+			IL_0f0f: ldloc.0
+			IL_0f10: ldc.r8 5
+			IL_0f19: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0f1e: ldc.r8 2
+			IL_0f27: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0f2c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0f31: ldc.r8 0.0
+			IL_0f3a: clt
+			IL_0f3c: brfalse IL_11f1
 
-			IL_0f62: ldarg.0
-			IL_0f63: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f68: ldstr "Line"
-			IL_0f6d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f72: ldc.r8 8
-			IL_0f7b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0f80: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0f85: ldc.i4.0
-			IL_0f86: ceq
-			IL_0f88: stloc.s 8
-			IL_0f8a: ldloc.s 8
-			IL_0f8c: brfalse IL_100e
+			IL_0f41: ldarg.0
+			IL_0f42: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0f47: ldstr "Line"
+			IL_0f4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f51: ldc.r8 8
+			IL_0f5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0f5f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0f64: ldc.i4.0
+			IL_0f65: ceq
+			IL_0f67: stloc.s 6
+			IL_0f69: ldloc.s 6
+			IL_0f6b: brfalse IL_0fed
 
-			IL_0f91: ldarg.0
-			IL_0f92: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0f97: stloc.s 7
-			IL_0f99: ldc.i4.1
-			IL_0f9a: newarr [System.Runtime]System.Object
-			IL_0f9f: dup
-			IL_0fa0: ldc.i4.0
-			IL_0fa1: ldarg.0
-			IL_0fa2: stelem.ref
-			IL_0fa3: stloc.s 6
-			IL_0fa5: ldarg.0
-			IL_0fa6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0fab: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0fb0: ldc.r8 1
-			IL_0fb9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0fbe: stloc.2
-			IL_0fbf: ldloc.s 7
-			IL_0fc1: ldloc.s 6
-			IL_0fc3: ldloc.2
-			IL_0fc4: ldarg.0
-			IL_0fc5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0fca: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0fcf: ldc.r8 5
-			IL_0fd8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0fdd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0fe2: pop
-			IL_0fe3: ldarg.0
-			IL_0fe4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0fe9: ldstr "Line"
-			IL_0fee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ff3: ldc.r8 8
-			IL_0ffc: box [System.Runtime]System.Double
-			IL_1001: ldc.i4.1
-			IL_1002: box [System.Runtime]System.Boolean
-			IL_1007: ldc.i4.1
-			IL_1008: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_100d: pop
+			IL_0f70: ldarg.0
+			IL_0f71: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0f76: stloc.s 5
+			IL_0f78: ldc.i4.1
+			IL_0f79: newarr [System.Runtime]System.Object
+			IL_0f7e: dup
+			IL_0f7f: ldc.i4.0
+			IL_0f80: ldarg.0
+			IL_0f81: stelem.ref
+			IL_0f82: stloc.s 4
+			IL_0f84: ldarg.0
+			IL_0f85: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0f8a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0f8f: ldc.r8 1
+			IL_0f98: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0f9d: stloc.2
+			IL_0f9e: ldloc.s 5
+			IL_0fa0: ldloc.s 4
+			IL_0fa2: ldloc.2
+			IL_0fa3: ldarg.0
+			IL_0fa4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0fa9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0fae: ldc.r8 5
+			IL_0fb7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0fbc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0fc1: pop
+			IL_0fc2: ldarg.0
+			IL_0fc3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0fc8: ldstr "Line"
+			IL_0fcd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0fd2: ldc.r8 8
+			IL_0fdb: box [System.Runtime]System.Double
+			IL_0fe0: ldc.i4.1
+			IL_0fe1: box [System.Runtime]System.Boolean
+			IL_0fe6: ldc.i4.1
+			IL_0fe7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0fec: pop
 
-			IL_100e: ldarg.0
-			IL_100f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1014: ldstr "Line"
-			IL_1019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_101e: ldc.r8 5
-			IL_1027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_102c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_1031: ldc.i4.0
-			IL_1032: ceq
-			IL_1034: stloc.s 8
-			IL_1036: ldloc.s 8
-			IL_1038: brfalse IL_10ba
+			IL_0fed: ldarg.0
+			IL_0fee: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0ff3: ldstr "Line"
+			IL_0ff8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ffd: ldc.r8 5
+			IL_1006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_100b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_1010: ldc.i4.0
+			IL_1011: ceq
+			IL_1013: stloc.s 6
+			IL_1015: ldloc.s 6
+			IL_1017: brfalse IL_1099
 
-			IL_103d: ldarg.0
-			IL_103e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_1043: stloc.2
-			IL_1044: ldc.i4.1
-			IL_1045: newarr [System.Runtime]System.Object
-			IL_104a: dup
-			IL_104b: ldc.i4.0
-			IL_104c: ldarg.0
-			IL_104d: stelem.ref
-			IL_104e: stloc.s 6
-			IL_1050: ldarg.0
-			IL_1051: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1056: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_105b: ldc.r8 5
-			IL_1064: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_1069: stloc.s 7
-			IL_106b: ldloc.2
-			IL_106c: ldloc.s 6
-			IL_106e: ldloc.s 7
-			IL_1070: ldarg.0
-			IL_1071: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1076: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_107b: ldc.r8 6
-			IL_1084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_1089: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_108e: pop
-			IL_108f: ldarg.0
-			IL_1090: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1095: ldstr "Line"
-			IL_109a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_109f: ldc.r8 5
-			IL_10a8: box [System.Runtime]System.Double
-			IL_10ad: ldc.i4.1
-			IL_10ae: box [System.Runtime]System.Boolean
-			IL_10b3: ldc.i4.1
-			IL_10b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_10b9: pop
+			IL_101c: ldarg.0
+			IL_101d: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_1022: stloc.2
+			IL_1023: ldc.i4.1
+			IL_1024: newarr [System.Runtime]System.Object
+			IL_1029: dup
+			IL_102a: ldc.i4.0
+			IL_102b: ldarg.0
+			IL_102c: stelem.ref
+			IL_102d: stloc.s 4
+			IL_102f: ldarg.0
+			IL_1030: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1035: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_103a: ldc.r8 5
+			IL_1043: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1048: stloc.s 5
+			IL_104a: ldloc.2
+			IL_104b: ldloc.s 4
+			IL_104d: ldloc.s 5
+			IL_104f: ldarg.0
+			IL_1050: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1055: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_105a: ldc.r8 6
+			IL_1063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_106d: pop
+			IL_106e: ldarg.0
+			IL_106f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1074: ldstr "Line"
+			IL_1079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_107e: ldc.r8 5
+			IL_1087: box [System.Runtime]System.Double
+			IL_108c: ldc.i4.1
+			IL_108d: box [System.Runtime]System.Boolean
+			IL_1092: ldc.i4.1
+			IL_1093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_1098: pop
 
-			IL_10ba: ldarg.0
-			IL_10bb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_10c0: ldstr "Line"
-			IL_10c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_10ca: ldc.r8 9
-			IL_10d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_10d8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_10dd: ldc.i4.0
-			IL_10de: ceq
-			IL_10e0: stloc.s 8
-			IL_10e2: ldloc.s 8
-			IL_10e4: brfalse IL_1166
+			IL_1099: ldarg.0
+			IL_109a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_109f: ldstr "Line"
+			IL_10a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_10a9: ldc.r8 9
+			IL_10b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_10b7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_10bc: ldc.i4.0
+			IL_10bd: ceq
+			IL_10bf: stloc.s 6
+			IL_10c1: ldloc.s 6
+			IL_10c3: brfalse IL_1145
 
-			IL_10e9: ldarg.0
-			IL_10ea: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_10ef: stloc.s 7
-			IL_10f1: ldc.i4.1
-			IL_10f2: newarr [System.Runtime]System.Object
-			IL_10f7: dup
-			IL_10f8: ldc.i4.0
-			IL_10f9: ldarg.0
-			IL_10fa: stelem.ref
-			IL_10fb: stloc.s 6
-			IL_10fd: ldarg.0
-			IL_10fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1103: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_1108: ldc.r8 6
-			IL_1111: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_1116: stloc.2
-			IL_1117: ldloc.s 7
-			IL_1119: ldloc.s 6
-			IL_111b: ldloc.2
-			IL_111c: ldarg.0
-			IL_111d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1122: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_1127: ldc.r8 2
-			IL_1130: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_1135: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_113a: pop
-			IL_113b: ldarg.0
-			IL_113c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1141: ldstr "Line"
-			IL_1146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_114b: ldc.r8 9
-			IL_1154: box [System.Runtime]System.Double
-			IL_1159: ldc.i4.1
-			IL_115a: box [System.Runtime]System.Boolean
-			IL_115f: ldc.i4.1
-			IL_1160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_1165: pop
+			IL_10c8: ldarg.0
+			IL_10c9: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_10ce: stloc.s 5
+			IL_10d0: ldc.i4.1
+			IL_10d1: newarr [System.Runtime]System.Object
+			IL_10d6: dup
+			IL_10d7: ldc.i4.0
+			IL_10d8: ldarg.0
+			IL_10d9: stelem.ref
+			IL_10da: stloc.s 4
+			IL_10dc: ldarg.0
+			IL_10dd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_10e2: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_10e7: ldc.r8 6
+			IL_10f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_10f5: stloc.2
+			IL_10f6: ldloc.s 5
+			IL_10f8: ldloc.s 4
+			IL_10fa: ldloc.2
+			IL_10fb: ldarg.0
+			IL_10fc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1101: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1106: ldc.r8 2
+			IL_110f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1114: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_1119: pop
+			IL_111a: ldarg.0
+			IL_111b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1120: ldstr "Line"
+			IL_1125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_112a: ldc.r8 9
+			IL_1133: box [System.Runtime]System.Double
+			IL_1138: ldc.i4.1
+			IL_1139: box [System.Runtime]System.Boolean
+			IL_113e: ldc.i4.1
+			IL_113f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_1144: pop
 
-			IL_1166: ldarg.0
-			IL_1167: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_116c: ldstr "Line"
-			IL_1171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1176: ldc.r8 1
-			IL_117f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1184: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_1189: ldc.i4.0
-			IL_118a: ceq
-			IL_118c: stloc.s 8
-			IL_118e: ldloc.s 8
-			IL_1190: brfalse IL_1212
+			IL_1145: ldarg.0
+			IL_1146: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_114b: ldstr "Line"
+			IL_1150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1155: ldc.r8 1
+			IL_115e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1163: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_1168: ldc.i4.0
+			IL_1169: ceq
+			IL_116b: stloc.s 6
+			IL_116d: ldloc.s 6
+			IL_116f: brfalse IL_11f1
 
-			IL_1195: ldarg.0
-			IL_1196: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_119b: stloc.2
-			IL_119c: ldc.i4.1
-			IL_119d: newarr [System.Runtime]System.Object
-			IL_11a2: dup
-			IL_11a3: ldc.i4.0
-			IL_11a4: ldarg.0
-			IL_11a5: stelem.ref
-			IL_11a6: stloc.s 6
-			IL_11a8: ldarg.0
-			IL_11a9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_11ae: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_11b3: ldc.r8 2
-			IL_11bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_11c1: stloc.s 7
-			IL_11c3: ldloc.2
-			IL_11c4: ldloc.s 6
-			IL_11c6: ldloc.s 7
-			IL_11c8: ldarg.0
-			IL_11c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_11ce: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_11d3: ldc.r8 1
-			IL_11dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_11e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_11e6: pop
-			IL_11e7: ldarg.0
-			IL_11e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_11ed: ldstr "Line"
-			IL_11f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_11f7: ldc.r8 1
-			IL_1200: box [System.Runtime]System.Double
-			IL_1205: ldc.i4.1
-			IL_1206: box [System.Runtime]System.Boolean
-			IL_120b: ldc.i4.1
-			IL_120c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_1211: pop
+			IL_1174: ldarg.0
+			IL_1175: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_117a: stloc.2
+			IL_117b: ldc.i4.1
+			IL_117c: newarr [System.Runtime]System.Object
+			IL_1181: dup
+			IL_1182: ldc.i4.0
+			IL_1183: ldarg.0
+			IL_1184: stelem.ref
+			IL_1185: stloc.s 4
+			IL_1187: ldarg.0
+			IL_1188: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_118d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1192: ldc.r8 2
+			IL_119b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_11a0: stloc.s 5
+			IL_11a2: ldloc.2
+			IL_11a3: ldloc.s 4
+			IL_11a5: ldloc.s 5
+			IL_11a7: ldarg.0
+			IL_11a8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_11ad: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_11b2: ldc.r8 1
+			IL_11bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_11c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_11c5: pop
+			IL_11c6: ldarg.0
+			IL_11c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_11cc: ldstr "Line"
+			IL_11d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_11d6: ldc.r8 1
+			IL_11df: box [System.Runtime]System.Double
+			IL_11e4: ldc.i4.1
+			IL_11e5: box [System.Runtime]System.Boolean
+			IL_11ea: ldc.i4.1
+			IL_11eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_11f0: pop
 
-			IL_1212: ldarg.0
-			IL_1213: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1218: stloc.s 7
-			IL_121a: ldc.i4.s 12
-			IL_121c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_1221: dup
-			IL_1222: ldc.i4.0
-			IL_1223: box [System.Runtime]System.Boolean
-			IL_1228: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_122d: dup
-			IL_122e: ldc.i4.0
-			IL_122f: box [System.Runtime]System.Boolean
-			IL_1234: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1239: dup
-			IL_123a: ldc.i4.0
-			IL_123b: box [System.Runtime]System.Boolean
-			IL_1240: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1245: dup
-			IL_1246: ldc.i4.0
-			IL_1247: box [System.Runtime]System.Boolean
-			IL_124c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1251: dup
-			IL_1252: ldc.i4.0
-			IL_1253: box [System.Runtime]System.Boolean
-			IL_1258: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_125d: dup
-			IL_125e: ldc.i4.0
-			IL_125f: box [System.Runtime]System.Boolean
-			IL_1264: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1269: dup
-			IL_126a: ldc.i4.0
-			IL_126b: box [System.Runtime]System.Boolean
-			IL_1270: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1275: dup
-			IL_1276: ldc.i4.0
-			IL_1277: box [System.Runtime]System.Boolean
-			IL_127c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1281: dup
-			IL_1282: ldc.i4.0
-			IL_1283: box [System.Runtime]System.Boolean
-			IL_1288: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_128d: dup
-			IL_128e: ldc.i4.0
-			IL_128f: box [System.Runtime]System.Boolean
-			IL_1294: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1299: dup
-			IL_129a: ldc.i4.0
-			IL_129b: box [System.Runtime]System.Boolean
-			IL_12a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_12a5: dup
-			IL_12a6: ldc.i4.0
-			IL_12a7: box [System.Runtime]System.Boolean
-			IL_12ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_12b1: stloc.s 9
-			IL_12b3: ldloc.s 7
-			IL_12b5: ldstr "Line"
-			IL_12ba: ldloc.s 9
-			IL_12bc: ldc.i4.1
-			IL_12bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_12c2: pop
-			IL_12c3: ldarg.0
-			IL_12c4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_12c9: ldstr "LastPx"
-			IL_12ce: ldc.r8 0.0
-			IL_12d7: ldc.i4.1
-			IL_12d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_12dd: pop
-			IL_12de: ldnull
-			IL_12df: ret
+			IL_11f1: ldarg.0
+			IL_11f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_11f7: stloc.s 5
+			IL_11f9: ldc.i4.s 12
+			IL_11fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_1200: dup
+			IL_1201: ldc.i4.0
+			IL_1202: box [System.Runtime]System.Boolean
+			IL_1207: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_120c: dup
+			IL_120d: ldc.i4.0
+			IL_120e: box [System.Runtime]System.Boolean
+			IL_1213: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1218: dup
+			IL_1219: ldc.i4.0
+			IL_121a: box [System.Runtime]System.Boolean
+			IL_121f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1224: dup
+			IL_1225: ldc.i4.0
+			IL_1226: box [System.Runtime]System.Boolean
+			IL_122b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1230: dup
+			IL_1231: ldc.i4.0
+			IL_1232: box [System.Runtime]System.Boolean
+			IL_1237: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_123c: dup
+			IL_123d: ldc.i4.0
+			IL_123e: box [System.Runtime]System.Boolean
+			IL_1243: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1248: dup
+			IL_1249: ldc.i4.0
+			IL_124a: box [System.Runtime]System.Boolean
+			IL_124f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1254: dup
+			IL_1255: ldc.i4.0
+			IL_1256: box [System.Runtime]System.Boolean
+			IL_125b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1260: dup
+			IL_1261: ldc.i4.0
+			IL_1262: box [System.Runtime]System.Boolean
+			IL_1267: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_126c: dup
+			IL_126d: ldc.i4.0
+			IL_126e: box [System.Runtime]System.Boolean
+			IL_1273: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1278: dup
+			IL_1279: ldc.i4.0
+			IL_127a: box [System.Runtime]System.Boolean
+			IL_127f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1284: dup
+			IL_1285: ldc.i4.0
+			IL_1286: box [System.Runtime]System.Boolean
+			IL_128b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1290: stloc.s 7
+			IL_1292: ldloc.s 5
+			IL_1294: ldstr "Line"
+			IL_1299: ldloc.s 7
+			IL_129b: ldc.i4.1
+			IL_129c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_12a1: pop
+			IL_12a2: ldarg.0
+			IL_12a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_12a8: ldstr "LastPx"
+			IL_12ad: ldc.r8 0.0
+			IL_12b6: ldc.i4.1
+			IL_12b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_12bc: pop
+			IL_12bd: ldnull
+			IL_12be: ret
 		} // end of method DrawQube::__js_call__
 
 	} // end of class DrawQube
@@ -5075,7 +4885,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6491
+					// Method begins at RVA 0x61b1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5093,7 +4903,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6488
+				// Method begins at RVA 0x61a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5119,13 +4929,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x4de0
+			// Method begins at RVA 0x4b90
 			// Header size: 12
-			// Code size: 1102 (0x44e)
+			// Code size: 1072 (0x430)
 			.maxstack 8
 			.locals init (
 				[0] string,
-				[1] object,
+				[1] float64,
 				[2] object,
 				[3] object,
 				[4] float64,
@@ -5136,9 +4946,7 @@
 				[9] object,
 				[10] object[],
 				[11] object,
-				[12] object,
-				[13] object,
-				[14] float64
+				[12] object
 			)
 
 			IL_0000: ldarg.0
@@ -5424,107 +5232,95 @@
 			IL_0336: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 			IL_033b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
 			IL_0340: ldc.r8 8
-			IL_0349: box [System.Runtime]System.Double
-			IL_034e: stloc.1
-			// loop start (head: IL_034f)
-				IL_034f: ldloc.1
-				IL_0350: stloc.s 13
-				IL_0352: ldc.r8 1
-				IL_035b: neg
-				IL_035c: stloc.s 4
-				IL_035e: ldloc.s 13
-				IL_0360: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0365: stloc.s 14
-				IL_0367: ldloc.s 14
-				IL_0369: ldloc.s 4
-				IL_036b: cgt
-				IL_036d: brfalse IL_03f4
+			IL_0349: stloc.1
+			// loop start (head: IL_034a)
+				IL_034a: ldloc.1
+				IL_034b: stloc.s 4
+				IL_034d: ldloc.s 4
+				IL_034f: ldc.r8 1
+				IL_0358: neg
+				IL_0359: cgt
+				IL_035b: brfalse IL_03d6
 
+				IL_0360: ldarg.0
+				IL_0361: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0366: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_036b: ldloc.1
+				IL_036c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0371: stloc.2
 				IL_0372: ldarg.0
-				IL_0373: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0378: ldloc.1
-				IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_037e: stloc.2
-				IL_037f: ldarg.0
-				IL_0380: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
-				IL_0385: stloc.s 12
-				IL_0387: ldc.i4.1
-				IL_0388: newarr [System.Runtime]System.Object
-				IL_038d: dup
-				IL_038e: ldc.i4.0
-				IL_038f: ldarg.0
-				IL_0390: stelem.ref
-				IL_0391: stloc.s 10
-				IL_0393: ldarg.0
-				IL_0394: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-				IL_0399: stloc.s 11
-				IL_039b: ldloc.s 12
-				IL_039d: ldloc.s 10
-				IL_039f: ldloc.s 11
-				IL_03a1: ldarg.0
-				IL_03a2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_03a7: ldloc.1
-				IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_03ad: ldstr "V"
-				IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_03bc: stloc.s 11
-				IL_03be: ldloc.2
-				IL_03bf: ldstr "V"
-				IL_03c4: ldloc.s 11
-				IL_03c6: ldc.i4.1
-				IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_03cc: pop
-				IL_03cd: ldloc.1
-				IL_03ce: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_03d3: stloc.s 4
-				IL_03d5: ldloc.s 4
-				IL_03d7: ldc.r8 1
-				IL_03e0: sub
-				IL_03e1: stloc.s 4
-				IL_03e3: ldloc.s 4
-				IL_03e5: box [System.Runtime]System.Double
-				IL_03ea: stloc.s 13
-				IL_03ec: ldloc.s 13
-				IL_03ee: stloc.1
-				IL_03ef: br IL_034f
+				IL_0373: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
+				IL_0378: stloc.s 12
+				IL_037a: ldc.i4.1
+				IL_037b: newarr [System.Runtime]System.Object
+				IL_0380: dup
+				IL_0381: ldc.i4.0
+				IL_0382: ldarg.0
+				IL_0383: stelem.ref
+				IL_0384: stloc.s 10
+				IL_0386: ldarg.0
+				IL_0387: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+				IL_038c: stloc.s 11
+				IL_038e: ldloc.s 12
+				IL_0390: ldloc.s 10
+				IL_0392: ldloc.s 11
+				IL_0394: ldarg.0
+				IL_0395: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_039a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_039f: ldloc.1
+				IL_03a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_03a5: ldstr "V"
+				IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_03b4: stloc.s 11
+				IL_03b6: ldloc.2
+				IL_03b7: ldstr "V"
+				IL_03bc: ldloc.s 11
+				IL_03be: ldc.i4.1
+				IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_03c4: pop
+				IL_03c5: ldloc.1
+				IL_03c6: ldc.r8 1
+				IL_03cf: sub
+				IL_03d0: stloc.1
+				IL_03d1: br IL_034a
 			// end loop
 
-			IL_03f4: ldarg.0
-			IL_03f5: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
-			IL_03fa: ldc.i4.1
-			IL_03fb: newarr [System.Runtime]System.Object
-			IL_0400: dup
-			IL_0401: ldc.i4.0
-			IL_0402: ldarg.0
-			IL_0403: stelem.ref
-			IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0409: pop
-			IL_040a: ldarg.0
-			IL_040b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_0410: stloc.s 11
-			IL_0412: ldloc.s 11
-			IL_0414: ldstr "LoopCount"
-			IL_0419: ldloc.s 11
-			IL_041b: ldstr "LoopCount"
-			IL_0420: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_0425: ldc.r8 1
-			IL_042e: add
-			IL_042f: ldc.i4.1
-			IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0435: pop
-			IL_0436: ldarg.0
-			IL_0437: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
-			IL_043c: ldc.i4.1
-			IL_043d: newarr [System.Runtime]System.Object
-			IL_0442: dup
-			IL_0443: ldc.i4.0
-			IL_0444: ldarg.0
-			IL_0445: stelem.ref
-			IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_044b: pop
-			IL_044c: ldnull
-			IL_044d: ret
+			IL_03d6: ldarg.0
+			IL_03d7: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
+			IL_03dc: ldc.i4.1
+			IL_03dd: newarr [System.Runtime]System.Object
+			IL_03e2: dup
+			IL_03e3: ldc.i4.0
+			IL_03e4: ldarg.0
+			IL_03e5: stelem.ref
+			IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_03eb: pop
+			IL_03ec: ldarg.0
+			IL_03ed: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_03f2: stloc.s 11
+			IL_03f4: ldloc.s 11
+			IL_03f6: ldstr "LoopCount"
+			IL_03fb: ldloc.s 11
+			IL_03fd: ldstr "LoopCount"
+			IL_0402: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_0407: ldc.r8 1
+			IL_0410: add
+			IL_0411: ldc.i4.1
+			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0417: pop
+			IL_0418: ldarg.0
+			IL_0419: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
+			IL_041e: ldc.i4.1
+			IL_041f: newarr [System.Runtime]System.Object
+			IL_0424: dup
+			IL_0425: ldc.i4.0
+			IL_0426: ldarg.0
+			IL_0427: stelem.ref
+			IL_0428: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_042d: pop
+			IL_042e: ldnull
+			IL_042f: ret
 		} // end of method Loop::__js_call__
 
 	} // end of class Loop
@@ -5544,7 +5340,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x64a3
+					// Method begins at RVA 0x61c3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5562,7 +5358,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x649a
+				// Method begins at RVA 0x61ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5589,12 +5385,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x523c
+			// Method begins at RVA 0x4fcc
 			// Header size: 12
-			// Code size: 4023 (0xfb7)
+			// Code size: 3912 (0xf48)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] float64,
 				[1] object,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -6423,427 +6219,388 @@
 			IL_0adf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
 			IL_0ae4: pop
 			IL_0ae5: ldc.r8 0.0
-			IL_0aee: box [System.Runtime]System.Double
-			IL_0af3: stloc.0
-			// loop start (head: IL_0af4)
-				IL_0af4: ldloc.0
-				IL_0af5: stloc.s 6
-				IL_0af7: ldarg.0
-				IL_0af8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0afd: ldstr "Edge"
-				IL_0b02: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0b07: ldstr "length"
-				IL_0b0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0b11: stloc.s 5
-				IL_0b13: ldloc.s 6
-				IL_0b15: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0b1a: stloc.s 10
-				IL_0b1c: ldloc.s 10
-				IL_0b1e: ldloc.s 5
-				IL_0b20: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0b25: clt
-				IL_0b27: brfalse IL_0c4d
+			IL_0aee: stloc.0
+			// loop start (head: IL_0aef)
+				IL_0aef: ldloc.0
+				IL_0af0: stloc.s 10
+				IL_0af2: ldloc.s 10
+				IL_0af4: ldarg.0
+				IL_0af5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0afa: ldstr "Edge"
+				IL_0aff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b04: ldstr "length"
+				IL_0b09: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0b0e: clt
+				IL_0b10: brfalse IL_0c25
 
-				IL_0b2c: ldarg.0
-				IL_0b2d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0b32: ldstr "Normal"
-				IL_0b37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0b3c: stloc.s 5
-				IL_0b3e: ldarg.0
-				IL_0b3f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcNormal
-				IL_0b44: stloc.1
-				IL_0b45: ldc.i4.1
-				IL_0b46: newarr [System.Runtime]System.Object
-				IL_0b4b: dup
-				IL_0b4c: ldc.i4.0
-				IL_0b4d: ldarg.0
-				IL_0b4e: stelem.ref
-				IL_0b4f: stloc.s 11
-				IL_0b51: ldarg.0
-				IL_0b52: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0b57: stloc.s 12
-				IL_0b59: ldloc.s 12
-				IL_0b5b: ldarg.0
-				IL_0b5c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0b61: ldstr "Edge"
-				IL_0b66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0b6b: ldloc.0
-				IL_0b6c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0b71: ldc.r8 0.0
-				IL_0b7a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0b7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0b84: ldstr "V"
-				IL_0b89: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0b8e: stloc.s 12
-				IL_0b90: ldarg.0
-				IL_0b91: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0b96: stloc.s 13
-				IL_0b98: ldloc.s 13
-				IL_0b9a: ldarg.0
-				IL_0b9b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0ba0: ldstr "Edge"
-				IL_0ba5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0baa: ldloc.0
-				IL_0bab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0bb0: ldc.r8 1
-				IL_0bb9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0bbe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0bc3: ldstr "V"
-				IL_0bc8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0bcd: stloc.s 13
-				IL_0bcf: ldarg.0
-				IL_0bd0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0bd5: stloc.s 14
-				IL_0bd7: ldloc.1
-				IL_0bd8: ldloc.s 11
-				IL_0bda: ldloc.s 12
-				IL_0bdc: ldloc.s 13
-				IL_0bde: ldloc.s 14
-				IL_0be0: ldarg.0
-				IL_0be1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0be6: ldstr "Edge"
-				IL_0beb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0bf0: ldloc.0
-				IL_0bf1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0bf6: ldc.r8 2
-				IL_0bff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0c04: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0c09: ldstr "V"
-				IL_0c0e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0c13: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_0c18: stloc.s 13
-				IL_0c1a: ldloc.s 5
-				IL_0c1c: ldloc.0
-				IL_0c1d: ldloc.s 13
-				IL_0c1f: ldc.i4.1
-				IL_0c20: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_0c25: pop
-				IL_0c26: ldloc.0
-				IL_0c27: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0c2c: stloc.s 10
-				IL_0c2e: ldloc.s 10
-				IL_0c30: ldc.r8 1
-				IL_0c39: add
-				IL_0c3a: stloc.s 10
-				IL_0c3c: ldloc.s 10
-				IL_0c3e: box [System.Runtime]System.Double
-				IL_0c43: stloc.s 6
-				IL_0c45: ldloc.s 6
-				IL_0c47: stloc.0
-				IL_0c48: br IL_0af4
+				IL_0b15: ldarg.0
+				IL_0b16: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b1b: ldstr "Normal"
+				IL_0b20: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b25: stloc.s 5
+				IL_0b27: ldarg.0
+				IL_0b28: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcNormal
+				IL_0b2d: stloc.1
+				IL_0b2e: ldc.i4.1
+				IL_0b2f: newarr [System.Runtime]System.Object
+				IL_0b34: dup
+				IL_0b35: ldc.i4.0
+				IL_0b36: ldarg.0
+				IL_0b37: stelem.ref
+				IL_0b38: stloc.s 11
+				IL_0b3a: ldarg.0
+				IL_0b3b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b40: stloc.s 12
+				IL_0b42: ldloc.s 12
+				IL_0b44: ldarg.0
+				IL_0b45: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b4a: ldstr "Edge"
+				IL_0b4f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b54: ldloc.0
+				IL_0b55: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0b5a: ldc.r8 0.0
+				IL_0b63: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0b68: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0b6d: ldstr "V"
+				IL_0b72: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b77: stloc.s 12
+				IL_0b79: ldarg.0
+				IL_0b7a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b7f: stloc.s 13
+				IL_0b81: ldloc.s 13
+				IL_0b83: ldarg.0
+				IL_0b84: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b89: ldstr "Edge"
+				IL_0b8e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b93: ldloc.0
+				IL_0b94: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0b99: ldc.r8 1
+				IL_0ba2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0ba7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0bac: ldstr "V"
+				IL_0bb1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0bb6: stloc.s 13
+				IL_0bb8: ldarg.0
+				IL_0bb9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0bbe: stloc.s 14
+				IL_0bc0: ldloc.1
+				IL_0bc1: ldloc.s 11
+				IL_0bc3: ldloc.s 12
+				IL_0bc5: ldloc.s 13
+				IL_0bc7: ldloc.s 14
+				IL_0bc9: ldarg.0
+				IL_0bca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0bcf: ldstr "Edge"
+				IL_0bd4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0bd9: ldloc.0
+				IL_0bda: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0bdf: ldc.r8 2
+				IL_0be8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0bed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0bf2: ldstr "V"
+				IL_0bf7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0bfc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_0c01: stloc.s 13
+				IL_0c03: ldloc.s 5
+				IL_0c05: ldloc.0
+				IL_0c06: box [System.Runtime]System.Double
+				IL_0c0b: ldloc.s 13
+				IL_0c0d: ldc.i4.1
+				IL_0c0e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_0c13: pop
+				IL_0c14: ldloc.0
+				IL_0c15: ldc.r8 1
+				IL_0c1e: add
+				IL_0c1f: stloc.0
+				IL_0c20: br IL_0aef
 			// end loop
 
-			IL_0c4d: ldarg.0
-			IL_0c4e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c53: stloc.s 13
-			IL_0c55: ldc.i4.s 12
-			IL_0c57: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0c5c: dup
-			IL_0c5d: ldc.i4.0
-			IL_0c5e: box [System.Runtime]System.Boolean
-			IL_0c63: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c68: dup
-			IL_0c69: ldc.i4.0
-			IL_0c6a: box [System.Runtime]System.Boolean
-			IL_0c6f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c74: dup
-			IL_0c75: ldc.i4.0
-			IL_0c76: box [System.Runtime]System.Boolean
-			IL_0c7b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c80: dup
-			IL_0c81: ldc.i4.0
-			IL_0c82: box [System.Runtime]System.Boolean
-			IL_0c87: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c8c: dup
-			IL_0c8d: ldc.i4.0
-			IL_0c8e: box [System.Runtime]System.Boolean
-			IL_0c93: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c98: dup
-			IL_0c99: ldc.i4.0
-			IL_0c9a: box [System.Runtime]System.Boolean
-			IL_0c9f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0ca4: dup
-			IL_0ca5: ldc.i4.0
-			IL_0ca6: box [System.Runtime]System.Boolean
-			IL_0cab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0cb0: dup
-			IL_0cb1: ldc.i4.0
-			IL_0cb2: box [System.Runtime]System.Boolean
-			IL_0cb7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0cbc: dup
-			IL_0cbd: ldc.i4.0
-			IL_0cbe: box [System.Runtime]System.Boolean
-			IL_0cc3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0cc8: dup
-			IL_0cc9: ldc.i4.0
-			IL_0cca: box [System.Runtime]System.Boolean
-			IL_0ccf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0cd4: dup
-			IL_0cd5: ldc.i4.0
-			IL_0cd6: box [System.Runtime]System.Boolean
-			IL_0cdb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0ce0: dup
-			IL_0ce1: ldc.i4.0
-			IL_0ce2: box [System.Runtime]System.Boolean
-			IL_0ce7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0cec: stloc.s 9
-			IL_0cee: ldloc.s 13
-			IL_0cf0: ldstr "Line"
-			IL_0cf5: ldloc.s 9
-			IL_0cf7: ldc.i4.1
-			IL_0cf8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0cfd: pop
-			IL_0cfe: ldarg.0
-			IL_0cff: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d04: stloc.s 13
-			IL_0d06: ldc.r8 9
-			IL_0d0f: ldc.r8 2
-			IL_0d18: mul
-			IL_0d19: stloc.s 10
-			IL_0d1b: ldloc.s 10
-			IL_0d1d: ldarg.2
-			IL_0d1e: mul
-			IL_0d1f: stloc.s 10
-			IL_0d21: ldloc.s 13
-			IL_0d23: ldstr "NumPx"
-			IL_0d28: ldloc.s 10
-			IL_0d2a: ldc.i4.1
-			IL_0d2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0d30: pop
-			IL_0d31: ldc.r8 0.0
-			IL_0d3a: box [System.Runtime]System.Double
-			IL_0d3f: stloc.0
-			// loop start (head: IL_0d40)
-				IL_0d40: ldloc.0
-				IL_0d41: stloc.s 6
-				IL_0d43: ldarg.0
-				IL_0d44: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0d49: ldstr "NumPx"
-				IL_0d4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0d53: stloc.s 13
-				IL_0d55: ldloc.s 6
-				IL_0d57: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0d5c: stloc.s 10
-				IL_0d5e: ldloc.s 10
-				IL_0d60: ldloc.s 13
-				IL_0d62: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0d67: clt
-				IL_0d69: brfalse IL_0dde
+			IL_0c25: ldarg.0
+			IL_0c26: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c2b: stloc.s 13
+			IL_0c2d: ldc.i4.s 12
+			IL_0c2f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0c34: dup
+			IL_0c35: ldc.i4.0
+			IL_0c36: box [System.Runtime]System.Boolean
+			IL_0c3b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c40: dup
+			IL_0c41: ldc.i4.0
+			IL_0c42: box [System.Runtime]System.Boolean
+			IL_0c47: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c4c: dup
+			IL_0c4d: ldc.i4.0
+			IL_0c4e: box [System.Runtime]System.Boolean
+			IL_0c53: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c58: dup
+			IL_0c59: ldc.i4.0
+			IL_0c5a: box [System.Runtime]System.Boolean
+			IL_0c5f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c64: dup
+			IL_0c65: ldc.i4.0
+			IL_0c66: box [System.Runtime]System.Boolean
+			IL_0c6b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c70: dup
+			IL_0c71: ldc.i4.0
+			IL_0c72: box [System.Runtime]System.Boolean
+			IL_0c77: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c7c: dup
+			IL_0c7d: ldc.i4.0
+			IL_0c7e: box [System.Runtime]System.Boolean
+			IL_0c83: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c88: dup
+			IL_0c89: ldc.i4.0
+			IL_0c8a: box [System.Runtime]System.Boolean
+			IL_0c8f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c94: dup
+			IL_0c95: ldc.i4.0
+			IL_0c96: box [System.Runtime]System.Boolean
+			IL_0c9b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0ca0: dup
+			IL_0ca1: ldc.i4.0
+			IL_0ca2: box [System.Runtime]System.Boolean
+			IL_0ca7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0cac: dup
+			IL_0cad: ldc.i4.0
+			IL_0cae: box [System.Runtime]System.Boolean
+			IL_0cb3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0cb8: dup
+			IL_0cb9: ldc.i4.0
+			IL_0cba: box [System.Runtime]System.Boolean
+			IL_0cbf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0cc4: stloc.s 9
+			IL_0cc6: ldloc.s 13
+			IL_0cc8: ldstr "Line"
+			IL_0ccd: ldloc.s 9
+			IL_0ccf: ldc.i4.1
+			IL_0cd0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0cd5: pop
+			IL_0cd6: ldarg.0
+			IL_0cd7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0cdc: stloc.s 13
+			IL_0cde: ldc.r8 9
+			IL_0ce7: ldc.r8 2
+			IL_0cf0: mul
+			IL_0cf1: stloc.s 10
+			IL_0cf3: ldloc.s 10
+			IL_0cf5: ldarg.2
+			IL_0cf6: mul
+			IL_0cf7: stloc.s 10
+			IL_0cf9: ldloc.s 13
+			IL_0cfb: ldstr "NumPx"
+			IL_0d00: ldloc.s 10
+			IL_0d02: ldc.i4.1
+			IL_0d03: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0d08: pop
+			IL_0d09: ldc.r8 0.0
+			IL_0d12: stloc.0
+			// loop start (head: IL_0d13)
+				IL_0d13: ldloc.0
+				IL_0d14: stloc.s 10
+				IL_0d16: ldloc.s 10
+				IL_0d18: ldarg.0
+				IL_0d19: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0d1e: ldstr "NumPx"
+				IL_0d23: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0d28: clt
+				IL_0d2a: brfalse IL_0d89
 
-				IL_0d6e: ldarg.0
-				IL_0d6f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-				IL_0d74: stloc.s 13
-				IL_0d76: ldloc.s 13
-				IL_0d78: ldc.i4.3
-				IL_0d79: newarr [System.Runtime]System.Object
-				IL_0d7e: dup
-				IL_0d7f: ldc.i4.0
-				IL_0d80: ldc.r8 0.0
-				IL_0d89: box [System.Runtime]System.Double
-				IL_0d8e: stelem.ref
-				IL_0d8f: dup
-				IL_0d90: ldc.i4.1
-				IL_0d91: ldc.r8 0.0
-				IL_0d9a: box [System.Runtime]System.Double
-				IL_0d9f: stelem.ref
-				IL_0da0: dup
-				IL_0da1: ldc.i4.2
-				IL_0da2: ldc.r8 0.0
-				IL_0dab: box [System.Runtime]System.Double
-				IL_0db0: stelem.ref
-				IL_0db1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-				IL_0db6: pop
-				IL_0db7: ldloc.0
-				IL_0db8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0dbd: stloc.s 10
-				IL_0dbf: ldloc.s 10
-				IL_0dc1: ldc.r8 1
-				IL_0dca: add
-				IL_0dcb: stloc.s 10
-				IL_0dcd: ldloc.s 10
-				IL_0dcf: box [System.Runtime]System.Double
-				IL_0dd4: stloc.s 6
-				IL_0dd6: ldloc.s 6
-				IL_0dd8: stloc.0
-				IL_0dd9: br IL_0d40
+				IL_0d2f: ldarg.0
+				IL_0d30: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+				IL_0d35: stloc.s 13
+				IL_0d37: ldloc.s 13
+				IL_0d39: ldc.i4.3
+				IL_0d3a: newarr [System.Runtime]System.Object
+				IL_0d3f: dup
+				IL_0d40: ldc.i4.0
+				IL_0d41: ldc.r8 0.0
+				IL_0d4a: box [System.Runtime]System.Double
+				IL_0d4f: stelem.ref
+				IL_0d50: dup
+				IL_0d51: ldc.i4.1
+				IL_0d52: ldc.r8 0.0
+				IL_0d5b: box [System.Runtime]System.Double
+				IL_0d60: stelem.ref
+				IL_0d61: dup
+				IL_0d62: ldc.i4.2
+				IL_0d63: ldc.r8 0.0
+				IL_0d6c: box [System.Runtime]System.Double
+				IL_0d71: stelem.ref
+				IL_0d72: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+				IL_0d77: pop
+				IL_0d78: ldloc.0
+				IL_0d79: ldc.r8 1
+				IL_0d82: add
+				IL_0d83: stloc.0
+				IL_0d84: br IL_0d13
 			// end loop
 
-			IL_0dde: ldarg.0
-			IL_0ddf: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
-			IL_0de4: stloc.s 13
-			IL_0de6: ldc.i4.1
-			IL_0de7: newarr [System.Runtime]System.Object
-			IL_0dec: dup
-			IL_0ded: ldc.i4.0
-			IL_0dee: ldarg.0
-			IL_0def: stelem.ref
-			IL_0df0: stloc.s 11
-			IL_0df2: ldarg.0
-			IL_0df3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0df8: stloc.s 5
-			IL_0dfa: ldarg.0
-			IL_0dfb: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_0e00: ldstr "V"
-			IL_0e05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e0a: ldc.r8 0.0
-			IL_0e13: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e18: stloc.s 12
-			IL_0e1a: ldarg.0
-			IL_0e1b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_0e20: ldstr "V"
-			IL_0e25: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e2a: ldc.r8 1
-			IL_0e33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e38: stloc.1
-			IL_0e39: ldloc.s 13
-			IL_0e3b: ldloc.s 11
-			IL_0e3d: ldc.i4.4
-			IL_0e3e: newarr [System.Runtime]System.Object
-			IL_0e43: dup
-			IL_0e44: ldc.i4.0
-			IL_0e45: ldloc.s 5
-			IL_0e47: stelem.ref
-			IL_0e48: dup
-			IL_0e49: ldc.i4.1
-			IL_0e4a: ldloc.s 12
-			IL_0e4c: stelem.ref
-			IL_0e4d: dup
-			IL_0e4e: ldc.i4.2
-			IL_0e4f: ldloc.1
-			IL_0e50: stelem.ref
-			IL_0e51: dup
-			IL_0e52: ldc.i4.3
-			IL_0e53: ldarg.0
-			IL_0e54: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_0e59: ldstr "V"
-			IL_0e5e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e63: ldc.r8 2
-			IL_0e6c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e71: stelem.ref
-			IL_0e72: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0e77: stloc.s 13
-			IL_0e79: ldarg.0
-			IL_0e7a: ldloc.s 13
-			IL_0e7c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0e81: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0e86: ldc.i4.1
-			IL_0e87: newarr [System.Runtime]System.Object
-			IL_0e8c: dup
-			IL_0e8d: ldc.i4.0
-			IL_0e8e: ldarg.0
-			IL_0e8f: stelem.ref
-			IL_0e90: stloc.s 11
-			IL_0e92: ldarg.0
-			IL_0e93: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0e98: stloc.s 13
-			IL_0e9a: ldarg.0
-			IL_0e9b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
-			IL_0ea0: ldloc.s 11
-			IL_0ea2: ldloc.s 13
-			IL_0ea4: ldarg.0
-			IL_0ea5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_0eaa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0eaf: stloc.s 13
-			IL_0eb1: ldarg.0
-			IL_0eb2: ldloc.s 13
-			IL_0eb4: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0eb9: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_0ebe: ldc.r8 0.0
-			IL_0ec7: box [System.Runtime]System.Double
-			IL_0ecc: stloc.0
-			// loop start (head: IL_0ecd)
-				IL_0ecd: ldloc.0
-				IL_0ece: stloc.s 6
-				IL_0ed0: ldloc.s 6
-				IL_0ed2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0ed7: stloc.s 10
-				IL_0ed9: ldloc.s 10
-				IL_0edb: ldc.r8 9
-				IL_0ee4: clt
-				IL_0ee6: brfalse IL_0f6d
+			IL_0d89: ldarg.0
+			IL_0d8a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
+			IL_0d8f: stloc.s 13
+			IL_0d91: ldc.i4.1
+			IL_0d92: newarr [System.Runtime]System.Object
+			IL_0d97: dup
+			IL_0d98: ldc.i4.0
+			IL_0d99: ldarg.0
+			IL_0d9a: stelem.ref
+			IL_0d9b: stloc.s 11
+			IL_0d9d: ldarg.0
+			IL_0d9e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0da3: stloc.s 5
+			IL_0da5: ldarg.0
+			IL_0da6: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0dab: ldstr "V"
+			IL_0db0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0db5: ldc.r8 0.0
+			IL_0dbe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0dc3: stloc.s 12
+			IL_0dc5: ldarg.0
+			IL_0dc6: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0dcb: ldstr "V"
+			IL_0dd0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dd5: ldc.r8 1
+			IL_0dde: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0de3: stloc.1
+			IL_0de4: ldloc.s 13
+			IL_0de6: ldloc.s 11
+			IL_0de8: ldc.i4.4
+			IL_0de9: newarr [System.Runtime]System.Object
+			IL_0dee: dup
+			IL_0def: ldc.i4.0
+			IL_0df0: ldloc.s 5
+			IL_0df2: stelem.ref
+			IL_0df3: dup
+			IL_0df4: ldc.i4.1
+			IL_0df5: ldloc.s 12
+			IL_0df7: stelem.ref
+			IL_0df8: dup
+			IL_0df9: ldc.i4.2
+			IL_0dfa: ldloc.1
+			IL_0dfb: stelem.ref
+			IL_0dfc: dup
+			IL_0dfd: ldc.i4.3
+			IL_0dfe: ldarg.0
+			IL_0dff: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0e04: ldstr "V"
+			IL_0e09: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e0e: ldc.r8 2
+			IL_0e17: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e1c: stelem.ref
+			IL_0e1d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0e22: stloc.s 13
+			IL_0e24: ldarg.0
+			IL_0e25: ldloc.s 13
+			IL_0e27: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e2c: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0e31: ldc.i4.1
+			IL_0e32: newarr [System.Runtime]System.Object
+			IL_0e37: dup
+			IL_0e38: ldc.i4.0
+			IL_0e39: ldarg.0
+			IL_0e3a: stelem.ref
+			IL_0e3b: stloc.s 11
+			IL_0e3d: ldarg.0
+			IL_0e3e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0e43: stloc.s 13
+			IL_0e45: ldarg.0
+			IL_0e46: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
+			IL_0e4b: ldloc.s 11
+			IL_0e4d: ldloc.s 13
+			IL_0e4f: ldarg.0
+			IL_0e50: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0e55: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0e5a: stloc.s 13
+			IL_0e5c: ldarg.0
+			IL_0e5d: ldloc.s 13
+			IL_0e5f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e64: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0e69: ldc.r8 0.0
+			IL_0e72: stloc.0
+			// loop start (head: IL_0e73)
+				IL_0e73: ldloc.0
+				IL_0e74: stloc.s 10
+				IL_0e76: ldloc.s 10
+				IL_0e78: ldc.r8 9
+				IL_0e81: clt
+				IL_0e83: brfalse IL_0efe
 
-				IL_0eeb: ldarg.0
-				IL_0eec: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0ef1: ldloc.0
-				IL_0ef2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0ef7: stloc.s 13
-				IL_0ef9: ldarg.0
-				IL_0efa: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
-				IL_0eff: stloc.1
-				IL_0f00: ldc.i4.1
-				IL_0f01: newarr [System.Runtime]System.Object
-				IL_0f06: dup
-				IL_0f07: ldc.i4.0
-				IL_0f08: ldarg.0
-				IL_0f09: stelem.ref
-				IL_0f0a: stloc.s 11
-				IL_0f0c: ldarg.0
-				IL_0f0d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-				IL_0f12: stloc.s 12
-				IL_0f14: ldloc.1
-				IL_0f15: ldloc.s 11
-				IL_0f17: ldloc.s 12
-				IL_0f19: ldarg.0
-				IL_0f1a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0f1f: ldloc.0
-				IL_0f20: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0f25: ldstr "V"
-				IL_0f2a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0f2f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_0f34: stloc.s 12
-				IL_0f36: ldloc.s 13
-				IL_0f38: ldstr "V"
-				IL_0f3d: ldloc.s 12
-				IL_0f3f: ldc.i4.1
-				IL_0f40: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0f45: pop
-				IL_0f46: ldloc.0
-				IL_0f47: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0f4c: stloc.s 10
-				IL_0f4e: ldloc.s 10
-				IL_0f50: ldc.r8 1
-				IL_0f59: add
-				IL_0f5a: stloc.s 10
-				IL_0f5c: ldloc.s 10
-				IL_0f5e: box [System.Runtime]System.Double
-				IL_0f63: stloc.s 6
-				IL_0f65: ldloc.s 6
-				IL_0f67: stloc.0
-				IL_0f68: br IL_0ecd
+				IL_0e88: ldarg.0
+				IL_0e89: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0e8e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0e93: ldloc.0
+				IL_0e94: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0e99: stloc.s 13
+				IL_0e9b: ldarg.0
+				IL_0e9c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
+				IL_0ea1: stloc.1
+				IL_0ea2: ldc.i4.1
+				IL_0ea3: newarr [System.Runtime]System.Object
+				IL_0ea8: dup
+				IL_0ea9: ldc.i4.0
+				IL_0eaa: ldarg.0
+				IL_0eab: stelem.ref
+				IL_0eac: stloc.s 11
+				IL_0eae: ldarg.0
+				IL_0eaf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+				IL_0eb4: stloc.s 12
+				IL_0eb6: ldloc.1
+				IL_0eb7: ldloc.s 11
+				IL_0eb9: ldloc.s 12
+				IL_0ebb: ldarg.0
+				IL_0ebc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0ec1: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0ec6: ldloc.0
+				IL_0ec7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0ecc: ldstr "V"
+				IL_0ed1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0ed6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_0edb: stloc.s 12
+				IL_0edd: ldloc.s 13
+				IL_0edf: ldstr "V"
+				IL_0ee4: ldloc.s 12
+				IL_0ee6: ldc.i4.1
+				IL_0ee7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0eec: pop
+				IL_0eed: ldloc.0
+				IL_0eee: ldc.r8 1
+				IL_0ef7: add
+				IL_0ef8: stloc.0
+				IL_0ef9: br IL_0e73
 			// end loop
 
-			IL_0f6d: ldarg.0
-			IL_0f6e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
-			IL_0f73: ldc.i4.1
-			IL_0f74: newarr [System.Runtime]System.Object
-			IL_0f79: dup
-			IL_0f7a: ldc.i4.0
-			IL_0f7b: ldarg.0
-			IL_0f7c: stelem.ref
-			IL_0f7d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0f82: pop
-			IL_0f83: ldarg.0
-			IL_0f84: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_0f89: stloc.s 12
-			IL_0f8b: ldloc.s 12
-			IL_0f8d: ldstr "Init"
-			IL_0f92: ldc.i4.1
-			IL_0f93: box [System.Runtime]System.Boolean
-			IL_0f98: ldc.i4.1
-			IL_0f99: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0f9e: pop
-			IL_0f9f: ldarg.0
-			IL_0fa0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
-			IL_0fa5: ldc.i4.1
-			IL_0fa6: newarr [System.Runtime]System.Object
-			IL_0fab: dup
-			IL_0fac: ldc.i4.0
-			IL_0fad: ldarg.0
-			IL_0fae: stelem.ref
-			IL_0faf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0fb4: pop
-			IL_0fb5: ldnull
-			IL_0fb6: ret
+			IL_0efe: ldarg.0
+			IL_0eff: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
+			IL_0f04: ldc.i4.1
+			IL_0f05: newarr [System.Runtime]System.Object
+			IL_0f0a: dup
+			IL_0f0b: ldc.i4.0
+			IL_0f0c: ldarg.0
+			IL_0f0d: stelem.ref
+			IL_0f0e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0f13: pop
+			IL_0f14: ldarg.0
+			IL_0f15: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_0f1a: stloc.s 12
+			IL_0f1c: ldloc.s 12
+			IL_0f1e: ldstr "Init"
+			IL_0f23: ldc.i4.1
+			IL_0f24: box [System.Runtime]System.Boolean
+			IL_0f29: ldc.i4.1
+			IL_0f2a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0f2f: pop
+			IL_0f30: ldarg.0
+			IL_0f31: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
+			IL_0f36: ldc.i4.1
+			IL_0f37: newarr [System.Runtime]System.Object
+			IL_0f3c: dup
+			IL_0f3d: ldc.i4.0
+			IL_0f3e: ldarg.0
+			IL_0f3f: stelem.ref
+			IL_0f40: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0f45: pop
+			IL_0f46: ldnull
+			IL_0f47: ret
 		} // end of method Init::__js_call__
 
 	} // end of class Init
@@ -6859,7 +6616,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64ac
+				// Method begins at RVA 0x61cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6885,7 +6642,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x6200
+			// Method begins at RVA 0x5f20
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -6978,7 +6735,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x6263
+			// Method begins at RVA 0x5f83
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -7483,7 +7240,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x64b5
+		// Method begins at RVA 0x61d5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
+++ b/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
@@ -169,6 +169,146 @@ public class SymbolTableTypeInferenceTests
     }
 
     [Fact]
+    public void SymbolTable_InferTypes_NumericVarLocals_ProvesInitializedAndLoopBindings()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            function calculate(limit) {
+                var total = 0;
+                for (var i = 0; i < limit; i++) {
+                    total += i;
+                }
+
+                var direction;
+                if (total >= 0) {
+                    direction = 1;
+                } else {
+                    direction = -1;
+                }
+
+                return total + direction;
+            }
+            calculate(5);
+        ");
+
+        foreach (var variableName in new[]
+                 {
+                     "calculate/total",
+                     "calculate/i",
+                     "calculate/direction"
+                 })
+        {
+            var binding = symbolTable.GetBindingInfo(variableName);
+            Assert.NotNull(binding);
+            Assert.True(binding.IsStableType, $"Expected {variableName} to be stable.");
+            Assert.Equal(typeof(double), binding.ClrType);
+            Assert.True(binding.CanUseUnboxedLocal, $"Expected {variableName} to use an unboxed local.");
+        }
+    }
+
+    [Theory]
+    [InlineData("console.log(value); value = 1;")]
+    [InlineData("if (flag) value = 1; console.log(value);")]
+    [InlineData("value = 1; if (flag) value = 'text';")]
+    [InlineData("value = 1; var object = { property: (value = 'text') };")]
+    [InlineData("label: { if (flag) break label; value = 1; } console.log(value);")]
+    [InlineData("var callback = null; callback?.(value = 1); console.log(value);")]
+    public void SymbolTable_InferTypes_NumericVarLocal_RejectsUnsafeControlFlow(string statements)
+    {
+        var symbolTable = BuildSymbolTable($@"
+            function calculate(flag) {{
+                var value;
+                {statements}
+            }}
+        ");
+
+        var binding = symbolTable.GetBindingInfo("calculate/value");
+        Assert.NotNull(binding);
+        Assert.False(binding.CanUseUnboxedLocal);
+    }
+
+    [Fact]
+    public void SymbolTable_InferTypes_NumericVarLocal_RejectsHoistedNumericDependency()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            function calculate() {
+                var result = value;
+                var value = 1;
+                return result;
+            }
+        ");
+
+        var resultBinding = symbolTable.GetBindingInfo("calculate/result");
+        var valueBinding = symbolTable.GetBindingInfo("calculate/value");
+        Assert.NotNull(resultBinding);
+        Assert.NotNull(valueBinding);
+        Assert.False(resultBinding.CanUseUnboxedLocal);
+        Assert.False(valueBinding.CanUseUnboxedLocal);
+        Assert.Null(resultBinding.ClrType);
+        var functionScope = FindFirstScope(
+            symbolTable.Root,
+            candidate => candidate.Kind == ScopeKind.Function
+                         && string.Equals(candidate.Name, "calculate", StringComparison.Ordinal));
+        Assert.NotNull(functionScope);
+        Assert.Null(functionScope!.StableReturnClrType);
+    }
+
+    [Fact]
+    public void SymbolTable_InferTypes_NumericVarLocal_RejectsShadowedNonnumericSource()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            function calculate() {
+                var source = 1;
+                var target;
+                {
+                    let source = 'text';
+                    target = source;
+                }
+                return target;
+            }
+        ");
+
+        var targetBinding = symbolTable.GetBindingInfo("calculate/target");
+        Assert.NotNull(targetBinding);
+        Assert.False(targetBinding.CanUseUnboxedLocal);
+        Assert.Null(targetBinding.ClrType);
+    }
+
+    [Fact]
+    public void SymbolTable_InferTypes_NumericVarLocal_RejectsCapturedBinding()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            function calculate() {
+                var value = 1;
+                return function () {
+                    return ++value;
+                };
+            }
+        ");
+
+        var binding = symbolTable.GetBindingInfo("calculate/value");
+        Assert.NotNull(binding);
+        Assert.True(binding.IsCaptured);
+        Assert.False(binding.CanUseUnboxedLocal);
+    }
+
+    [Fact]
+    public void SymbolTable_InferTypes_NumericVarLocalSpecializationFixture_ProvesHotLocals()
+    {
+        const string resourceName = "Jroc.Tests.Variable.JavaScript.Variable_NumericVarLocalSpecialization.js";
+        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream);
+        var symbolTable = BuildSymbolTable(reader.ReadToEnd());
+
+        foreach (var variableName in new[] { "calculate/total", "calculate/i", "calculate/direction" })
+        {
+            var binding = symbolTable.GetBindingInfo(variableName);
+            Assert.NotNull(binding);
+            Assert.True(binding.CanUseUnboxedLocal, $"Expected {variableName} to use an unboxed local.");
+        }
+    }
+
+    [Fact]
     public void SymbolTable_InferTypes_ClassMethod()
     {
         var code = @"

--- a/tests/Jroc.Tests/Variable/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Variable/ExecutionTests.cs
@@ -20,6 +20,7 @@ namespace Jroc.Tests.Variable
         [Fact] public Task Variable_TemporalDeadZoneCapturedRead() { var testName = nameof(Variable_TemporalDeadZoneCapturedRead); return ExecutionTest(testName); }
         [Fact] public Task Variable_TemporalDeadZoneShadowing() { var testName = nameof(Variable_TemporalDeadZoneShadowing); return ExecutionTest(testName); }
         [Fact] public Task Variable_TemporalDeadZoneSwitchScope() { var testName = nameof(Variable_TemporalDeadZoneSwitchScope); return ExecutionTest(testName); }
+        [Fact] public Task Variable_NumericVarLocalSpecialization() { var testName = nameof(Variable_NumericVarLocalSpecialization); return ExecutionTest(testName); }
 
         // Object destructuring tests
         [Fact] public Task Variable_ObjectDestructuring_Basic() { var testName = nameof(Variable_ObjectDestructuring_Basic); return ExecutionTest(testName); }

--- a/tests/Jroc.Tests/Variable/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Variable/GeneratorTests.cs
@@ -20,6 +20,7 @@ namespace Jroc.Tests.Variable
         [Fact] public Task Variable_TemporalDeadZoneCapturedRead() { var testName = nameof(Variable_TemporalDeadZoneCapturedRead); return GenerateTest(testName); }
         [Fact] public Task Variable_TemporalDeadZoneShadowing() { var testName = nameof(Variable_TemporalDeadZoneShadowing); return GenerateTest(testName); }
         [Fact] public Task Variable_TemporalDeadZoneSwitchScope() { var testName = nameof(Variable_TemporalDeadZoneSwitchScope); return GenerateTest(testName); }
+        [Fact] public Task Variable_NumericVarLocalSpecialization() { var testName = nameof(Variable_NumericVarLocalSpecialization); return GenerateTest(testName); }
 
         // Object destructuring generator tests
         [Fact] public Task Variable_ObjectDestructuring_Basic() { var testName = nameof(Variable_ObjectDestructuring_Basic); return GenerateTest(testName); }

--- a/tests/Jroc.Tests/Variable/JavaScript/Variable_NumericVarLocalSpecialization.js
+++ b/tests/Jroc.Tests/Variable/JavaScript/Variable_NumericVarLocalSpecialization.js
@@ -1,0 +1,100 @@
+function calculate(limit) {
+    var total = 0;
+    for (var i = 0; i < limit; i++) {
+        total += i;
+    }
+
+    var direction;
+    if (total >= 0) {
+        direction = 1;
+    } else {
+        direction = -1;
+    }
+
+    return total + direction;
+}
+
+function readBeforeInitialization() {
+    console.log(typeof value);
+    console.log(value === undefined);
+    var value = 2;
+    return value;
+}
+
+function conditionallyInitialized(flag) {
+    var value;
+    if (flag) {
+        value = 3;
+    }
+    return typeof value;
+}
+
+function mixedType(flag) {
+    var value = 1;
+    if (flag) {
+        value = "text";
+    }
+    return value;
+}
+
+function captured() {
+    var value = 1;
+    return function () {
+        return ++value;
+    };
+}
+
+function hoistedDependency() {
+    var result = value;
+    var value = 1;
+    return result;
+}
+
+function objectLiteralWrite() {
+    var value = 1;
+    var object = { property: (value = "text") };
+    return value + object.property;
+}
+
+function labeledBreak(flag) {
+    label: {
+        if (flag) {
+            break label;
+        }
+        value = 1;
+    }
+    return value;
+    var value;
+}
+
+function optionalWrite() {
+    var callback = null;
+    var value;
+    callback?.(value = 1);
+    return value;
+}
+
+function shadowedSource() {
+    var source = 1;
+    var target;
+    {
+        let source = "text";
+        target = source;
+    }
+    return target;
+}
+
+console.log(calculate(5));
+console.log(readBeforeInitialization());
+console.log(conditionallyInitialized(false));
+console.log(mixedType(false));
+console.log(mixedType(true));
+var increment = captured();
+console.log(increment());
+console.log(increment());
+console.log(hoistedDependency());
+console.log(objectLiteralWrite());
+console.log(labeledBreak(true));
+console.log(labeledBreak(false));
+console.log(optionalWrite());
+console.log(shadowedSource());

--- a/tests/Jroc.Tests/Variable/Snapshots/ExecutionTests.Variable_NumericVarLocalSpecialization.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/ExecutionTests.Variable_NumericVarLocalSpecialization.verified.txt
@@ -1,0 +1,15 @@
+11
+undefined
+true
+2
+undefined
+1
+text
+2
+3
+undefined
+texttext
+undefined
+1
+undefined
+text

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericVarLocalSpecialization.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericVarLocalSpecialization.verified.txt
@@ -1,0 +1,1526 @@
+﻿// IL code: Variable_NumericVarLocalSpecialization
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Variable_NumericVarLocalSpecialization
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit calculate
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L3C36
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2768
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L3C36::.ctor
+
+			} // end of class Block_L3C36
+
+			.class nested public auto ansi beforefieldinit Block_L8C20
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2771
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L8C20::.ctor
+
+			} // end of class Block_L8C20
+
+			.class nested public auto ansi beforefieldinit Block_L10C11
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x277a
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L10C11::.ctor
+
+			} // end of class Block_L10C11
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x275f
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				float64 limit
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2444
+			// Header size: 12
+			// Code size: 124 (0x7c)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] float64,
+				[4] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			IL_000a: ldc.r8 0.0
+			IL_0013: stloc.1
+			// loop start (head: IL_0014)
+				IL_0014: ldloc.1
+				IL_0015: stloc.3
+				IL_0016: ldloc.3
+				IL_0017: ldarg.1
+				IL_0018: clt
+				IL_001a: brfalse IL_0036
+
+				IL_001f: ldloc.0
+				IL_0020: ldloc.1
+				IL_0021: add
+				IL_0022: stloc.3
+				IL_0023: ldloc.3
+				IL_0024: stloc.0
+				IL_0025: ldloc.1
+				IL_0026: ldc.r8 1
+				IL_002f: add
+				IL_0030: stloc.1
+				IL_0031: br IL_0014
+			// end loop
+
+			IL_0036: nop
+			IL_0037: ldloc.0
+			IL_0038: stloc.3
+			IL_0039: ldloc.3
+			IL_003a: ldc.r8 0.0
+			IL_0043: clt
+			IL_0045: ldc.i4.0
+			IL_0046: ceq
+			IL_0048: brfalse IL_005e
+
+			IL_004d: ldc.r8 1
+			IL_0056: stloc.3
+			IL_0057: ldloc.3
+			IL_0058: stloc.2
+			IL_0059: br IL_006b
+
+			IL_005e: ldc.r8 1
+			IL_0067: neg
+			IL_0068: stloc.3
+			IL_0069: ldloc.3
+			IL_006a: stloc.2
+
+			IL_006b: ldloc.0
+			IL_006c: stloc.3
+			IL_006d: ldloc.3
+			IL_006e: ldloc.2
+			IL_006f: add
+			IL_0070: stloc.3
+			IL_0071: ldloc.3
+			IL_0072: box [System.Runtime]System.Double
+			IL_0077: stloc.s 4
+			IL_0079: ldloc.s 4
+			IL_007b: ret
+		} // end of method calculate::__js_call__
+
+	} // end of class calculate
+
+	.class nested public auto ansi abstract sealed beforefieldinit readBeforeInitialization
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2783
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			float64 __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x24cc
+			// Header size: 12
+			// Code size: 114 (0x72)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] object,
+				[3] bool,
+				[4] object,
+				[5] float64
+			)
+
+			IL_0000: ldnull
+			IL_0001: stloc.0
+			IL_0002: ldstr "console"
+			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_000c: stloc.1
+			IL_000d: ldloc.1
+			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0013: stloc.1
+			IL_0014: ldloc.1
+			IL_0015: ldstr "log"
+			IL_001a: ldloc.0
+			IL_001b: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0025: pop
+			IL_0026: ldstr "console"
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0030: stloc.1
+			IL_0031: ldloc.1
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0037: stloc.1
+			IL_0038: ldloc.0
+			IL_0039: stloc.2
+			IL_003a: ldloc.2
+			IL_003b: ldnull
+			IL_003c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0041: stloc.3
+			IL_0042: ldloc.3
+			IL_0043: box [System.Runtime]System.Boolean
+			IL_0048: stloc.s 4
+			IL_004a: ldloc.1
+			IL_004b: ldstr "log"
+			IL_0050: ldloc.s 4
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0057: pop
+			IL_0058: ldc.r8 2
+			IL_0061: box [System.Runtime]System.Double
+			IL_0066: stloc.0
+			IL_0067: ldloc.0
+			IL_0068: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_006d: stloc.s 5
+			IL_006f: ldloc.s 5
+			IL_0071: ret
+		} // end of method readBeforeInitialization::__js_call__
+
+	} // end of class readBeforeInitialization
+
+	.class nested public auto ansi abstract sealed beforefieldinit conditionallyInitialized
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L26C14
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2795
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L26C14::.ctor
+
+			} // end of class Block_L26C14
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x278c
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				bool flag
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x254c
+			// Header size: 12
+			// Code size: 32 (0x20)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: stloc.0
+			IL_0002: ldarg.1
+			IL_0003: brfalse IL_0019
+
+			IL_0008: ldc.r8 3
+			IL_0011: box [System.Runtime]System.Double
+			IL_0016: stloc.1
+			IL_0017: ldloc.1
+			IL_0018: stloc.0
+
+			IL_0019: ldloc.0
+			IL_001a: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_001f: ret
+		} // end of method conditionallyInitialized::__js_call__
+
+	} // end of class conditionallyInitialized
+
+	.class nested public auto ansi abstract sealed beforefieldinit mixedType
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L34C14
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x27a7
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L34C14::.ctor
+
+			} // end of class Block_L34C14
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x279e
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				bool flag
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2578
+			// Header size: 12
+			// Code size: 31 (0x1f)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] string
+			)
+
+			IL_0000: ldc.r8 1
+			IL_0009: box [System.Runtime]System.Double
+			IL_000e: stloc.0
+			IL_000f: ldarg.1
+			IL_0010: brfalse IL_001d
+
+			IL_0015: ldstr "text"
+			IL_001a: stloc.1
+			IL_001b: ldloc.1
+			IL_001c: stloc.0
+
+			IL_001d: ldloc.0
+			IL_001e: ret
+		} // end of method mixedType::__js_call__
+
+	} // end of class mixedType
+
+	.class nested public auto ansi abstract sealed beforefieldinit captured
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L42C11
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x27b9
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x2718
+				// Header size: 12
+				// Code size: 50 (0x32)
+				.maxstack 8
+				.locals init (
+					[0] object
+				)
+
+				IL_0000: ldarg.0
+				IL_0001: ldc.i4.1
+				IL_0002: ldelem.ref
+				IL_0003: castclass Modules.Variable_NumericVarLocalSpecialization/captured/Scope
+				IL_0008: ldfld object Modules.Variable_NumericVarLocalSpecialization/captured/Scope::'value'
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: ldc.r8 1
+				IL_001b: add
+				IL_001c: box [System.Runtime]System.Double
+				IL_0021: stloc.0
+				IL_0022: ldarg.0
+				IL_0023: ldc.i4.1
+				IL_0024: ldelem.ref
+				IL_0025: castclass Modules.Variable_NumericVarLocalSpecialization/captured/Scope
+				IL_002a: ldloc.0
+				IL_002b: stfld object Modules.Variable_NumericVarLocalSpecialization/captured/Scope::'value'
+				IL_0030: ldloc.0
+				IL_0031: ret
+			} // end of method FunctionExpression_L42C11::__js_call__
+
+		} // end of class FunctionExpression_L42C11
+
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 13 53 63 6f 70 65 20 76 61 6c 75 65 3d 7b
+				76 61 6c 75 65 7d 00 00
+			)
+			// Fields
+			.field public object 'value'
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27b0
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Variable_NumericVarLocalSpecialization/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0e 00 00 02
+			)
+			// Method begins at RVA 0x25a4
+			// Header size: 12
+			// Code size: 68 (0x44)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Variable_NumericVarLocalSpecialization/captured/Scope,
+				[1] object
+			)
+
+			IL_0000: newobj instance void Modules.Variable_NumericVarLocalSpecialization/captured/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldloc.0
+			IL_0007: ldc.r8 1
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: stfld object Modules.Variable_NumericVarLocalSpecialization/captured/Scope::'value'
+			IL_001a: ldc.i4.2
+			IL_001b: newarr [System.Runtime]System.Object
+			IL_0020: dup
+			IL_0021: ldc.i4.0
+			IL_0022: ldarg.0
+			IL_0023: stelem.ref
+			IL_0024: dup
+			IL_0025: ldc.i4.1
+			IL_0026: ldloc.0
+			IL_0027: stelem.ref
+			IL_0028: ldftn object Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11::__js_call__(object[], object)
+			IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0033: ldc.i4.0
+			IL_0034: conv.r8
+			IL_0035: ldstr ""
+			IL_003a: ldc.i4.0
+			IL_003b: ldc.i4.0
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0041: stloc.1
+			IL_0042: ldloc.1
+			IL_0043: ret
+		} // end of method captured::__js_call__
+
+	} // end of class captured
+
+	.class nested public auto ansi abstract sealed beforefieldinit hoistedDependency
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27c2
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x25f4
+			// Header size: 12
+			// Code size: 21 (0x15)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: stloc.0
+			IL_0002: ldloc.0
+			IL_0003: stloc.1
+			IL_0004: ldc.r8 1
+			IL_000d: box [System.Runtime]System.Double
+			IL_0012: stloc.0
+			IL_0013: ldloc.1
+			IL_0014: ret
+		} // end of method hoistedDependency::__js_call__
+
+	} // end of class hoistedDependency
+
+	.class nested public auto ansi abstract sealed beforefieldinit objectLiteralWrite
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27cb
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Variable_NumericVarLocalSpecialization/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0e 00 00 02
+			)
+			// Method begins at RVA 0x2618
+			// Header size: 12
+			// Code size: 62 (0x3e)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] class Modules.Variable_NumericVarLocalSpecialization/ObjectLiterals/L55C18_object,
+				[2] string,
+				[3] class Modules.Variable_NumericVarLocalSpecialization/ObjectLiterals/L55C18_object,
+				[4] object
+			)
+
+			IL_0000: ldc.r8 1
+			IL_0009: box [System.Runtime]System.Double
+			IL_000e: stloc.0
+			IL_000f: ldstr "text"
+			IL_0014: stloc.2
+			IL_0015: ldloc.2
+			IL_0016: stloc.0
+			IL_0017: newobj instance void Modules.Variable_NumericVarLocalSpecialization/ObjectLiterals/L55C18_object::.ctor()
+			IL_001c: stloc.3
+			IL_001d: ldloc.3
+			IL_001e: ldloc.0
+			IL_001f: callvirt instance void Modules.Variable_NumericVarLocalSpecialization/ObjectLiterals/L55C18_object::set_property(object)
+			IL_0024: ldloc.3
+			IL_0025: stloc.1
+			IL_0026: ldloc.0
+			IL_0027: stloc.2
+			IL_0028: ldloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldstr "property"
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0039: stloc.s 4
+			IL_003b: ldloc.s 4
+			IL_003d: ret
+		} // end of method objectLiteralWrite::__js_call__
+
+	} // end of class objectLiteralWrite
+
+	.class nested public auto ansi abstract sealed beforefieldinit labeledBreak
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L60C11
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested public auto ansi beforefieldinit Block_L61C18
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x27e6
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L61C18::.ctor
+
+				} // end of class Block_L61C18
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x27dd
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L60C11::.ctor
+
+			} // end of class Block_L60C11
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27d4
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				bool flag
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2664
+			// Header size: 12
+			// Code size: 33 (0x21)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object
+			)
+
+			IL_0000: nop
+			IL_0001: ldarg.1
+			IL_0002: brfalse IL_000c
+
+			IL_0007: br IL_001d
+
+			IL_000c: ldc.r8 1
+			IL_0015: box [System.Runtime]System.Double
+			IL_001a: stloc.1
+			IL_001b: ldloc.1
+			IL_001c: stloc.0
+
+			IL_001d: ldloc.0
+			IL_001e: ret
+
+			IL_001f: ldnull
+			IL_0020: ret
+		} // end of method labeledBreak::__js_call__
+
+	} // end of class labeledBreak
+
+	.class nested public auto ansi abstract sealed beforefieldinit optionalWrite
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27ef
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2694
+			// Header size: 12
+			// Code size: 74 (0x4a)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] object,
+				[3] object[]
+			)
+
+			IL_0000: ldc.i4.0
+			IL_0001: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0006: stloc.0
+			IL_0007: ldnull
+			IL_0008: stloc.1
+			IL_0009: ldloc.0
+			IL_000a: brfalse IL_0048
+
+			IL_000f: ldloc.0
+			IL_0010: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0015: brtrue IL_0048
+
+			IL_001a: ldc.r8 1
+			IL_0023: box [System.Runtime]System.Double
+			IL_0028: stloc.2
+			IL_0029: ldloc.2
+			IL_002a: stloc.1
+			IL_002b: ldc.i4.1
+			IL_002c: newarr [System.Runtime]System.Object
+			IL_0031: dup
+			IL_0032: ldc.i4.0
+			IL_0033: ldloc.1
+			IL_0034: stelem.ref
+			IL_0035: stloc.3
+			IL_0036: ldloc.0
+			IL_0037: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_003c: ldloc.3
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0042: pop
+			IL_0043: br IL_0048
+
+			IL_0048: ldloc.1
+			IL_0049: ret
+		} // end of method optionalWrite::__js_call__
+
+	} // end of class optionalWrite
+
+	.class nested public auto ansi abstract sealed beforefieldinit shadowedSource
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L80C4
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2801
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L80C4::.ctor
+
+			} // end of class Block_L80C4
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27f8
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x26ec
+			// Header size: 12
+			// Code size: 32 (0x20)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object,
+				[2] class Modules.Variable_NumericVarLocalSpecialization/shadowedSource/Scope/Block_L80C4,
+				[3] string,
+				[4] string
+			)
+
+			IL_0000: ldc.r8 1
+			IL_0009: stloc.0
+			IL_000a: ldnull
+			IL_000b: stloc.1
+			IL_000c: newobj instance void Modules.Variable_NumericVarLocalSpecialization/shadowedSource/Scope/Block_L80C4::.ctor()
+			IL_0011: stloc.2
+			IL_0012: ldstr "text"
+			IL_0017: stloc.3
+			IL_0018: ldloc.3
+			IL_0019: stloc.s 4
+			IL_001b: ldloc.s 4
+			IL_001d: stloc.1
+			IL_001e: ldloc.1
+			IL_001f: ret
+		} // end of method shadowedSource::__js_call__
+
+	} // end of class shadowedSource
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 81 23 53 63 6f 70 65 20 63 61 6c 63 75 6c
+			61 74 65 3d 7b 63 61 6c 63 75 6c 61 74 65 7d 2c
+			20 72 65 61 64 42 65 66 6f 72 65 49 6e 69 74 69
+			61 6c 69 7a 61 74 69 6f 6e 3d 7b 72 65 61 64 42
+			65 66 6f 72 65 49 6e 69 74 69 61 6c 69 7a 61 74
+			69 6f 6e 7d 2c 20 63 6f 6e 64 69 74 69 6f 6e 61
+			6c 6c 79 49 6e 69 74 69 61 6c 69 7a 65 64 3d 7b
+			63 6f 6e 64 69 74 69 6f 6e 61 6c 6c 79 49 6e 69
+			74 69 61 6c 69 7a 65 64 7d 2c 20 6d 69 78 65 64
+			54 79 70 65 3d 7b 6d 69 78 65 64 54 79 70 65 7d
+			2c 20 63 61 70 74 75 72 65 64 3d 7b 63 61 70 74
+			75 72 65 64 7d 2c 20 68 6f 69 73 74 65 64 44 65
+			70 65 6e 64 65 6e 63 79 3d 7b 68 6f 69 73 74 65
+			64 44 65 70 65 6e 64 65 6e 63 79 7d 2c 20 6f 62
+			6a 65 63 74 4c 69 74 65 72 61 6c 57 72 69 74 65
+			3d 7b 6f 62 6a 65 63 74 4c 69 74 65 72 61 6c 57
+			72 69 74 65 7d 2c 20 6c 61 62 65 6c 65 64 42 72
+			65 61 6b 3d 7b 6c 61 62 65 6c 65 64 42 72 65 61
+			6b 7d 2c 20 e2 80 a6 00 00
+		)
+		// Fields
+		.field public object calculate
+		.field public object readBeforeInitialization
+		.field public object conditionallyInitialized
+		.field public object mixedType
+		.field public object captured
+		.field public object hoistedDependency
+		.field public object objectLiteralWrite
+		.field public object labeledBreak
+		.field public object optionalWrite
+		.field public object shadowedSource
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2756
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit L55C18_object
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _property
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x280a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method L55C18_object::.ctor
+
+			.method public hidebysig 
+				instance object get_property () cil managed 
+			{
+				// Method begins at RVA 0x2812
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object Modules.Variable_NumericVarLocalSpecialization/ObjectLiterals/L55C18_object::_property
+				IL_0006: ret
+			} // end of method L55C18_object::get_property
+
+			.method public hidebysig 
+				instance void set_property (
+					object ''
+				) cil managed 
+			{
+				// Method begins at RVA 0x281a
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Variable_NumericVarLocalSpecialization/ObjectLiterals/L55C18_object::_property
+				IL_0007: ldarg.0
+				IL_0008: ldstr "property"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method L55C18_object::set_property
+
+		} // end of class L55C18_object
+
+
+	} // end of class ObjectLiterals
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 997 (0x3e5)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Variable_NumericVarLocalSpecialization/Scope,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] object,
+			[5] object,
+			[6] object,
+			[7] object,
+			[8] object,
+			[9] object,
+			[10] object,
+			[11] object,
+			[12] object,
+			[13] object,
+			[14] float64,
+			[15] object
+		)
+
+		IL_0000: newobj instance void Modules.Variable_NumericVarLocalSpecialization/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Modules.Variable_NumericVarLocalSpecialization/calculate::__js_call__(object, float64)
+		IL_000d: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
+		IL_0012: ldc.i4.1
+		IL_0013: conv.r8
+		IL_0014: ldstr "calculate"
+		IL_0019: ldc.i4.0
+		IL_001a: ldc.i4.0
+		IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0020: stloc.s 12
+		IL_0022: ldloc.s 12
+		IL_0024: stloc.1
+		IL_0025: ldnull
+		IL_0026: ldftn float64 Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization::__js_call__(object)
+		IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
+		IL_0031: ldc.i4.0
+		IL_0032: conv.r8
+		IL_0033: ldstr "readBeforeInitialization"
+		IL_0038: ldc.i4.0
+		IL_0039: ldc.i4.0
+		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_003f: stloc.s 12
+		IL_0041: ldloc.s 12
+		IL_0043: stloc.2
+		IL_0044: ldnull
+		IL_0045: ldftn object Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
+		IL_004b: newobj instance void class [System.Runtime]System.Func`3<object, bool, object>::.ctor(object, native int)
+		IL_0050: ldc.i4.1
+		IL_0051: conv.r8
+		IL_0052: ldstr "conditionallyInitialized"
+		IL_0057: ldc.i4.0
+		IL_0058: ldc.i4.0
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_005e: stloc.s 12
+		IL_0060: ldloc.s 12
+		IL_0062: stloc.3
+		IL_0063: ldnull
+		IL_0064: ldftn object Modules.Variable_NumericVarLocalSpecialization/mixedType::__js_call__(object, bool)
+		IL_006a: newobj instance void class [System.Runtime]System.Func`3<object, bool, object>::.ctor(object, native int)
+		IL_006f: ldc.i4.1
+		IL_0070: conv.r8
+		IL_0071: ldstr "mixedType"
+		IL_0076: ldc.i4.0
+		IL_0077: ldc.i4.0
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_007d: stloc.s 12
+		IL_007f: ldloc.s 12
+		IL_0081: stloc.s 4
+		IL_0083: ldc.i4.1
+		IL_0084: newarr [System.Runtime]System.Object
+		IL_0089: dup
+		IL_008a: ldc.i4.0
+		IL_008b: ldloc.0
+		IL_008c: stelem.ref
+		IL_008d: ldc.i4.0
+		IL_008e: ldelem.ref
+		IL_008f: castclass Modules.Variable_NumericVarLocalSpecialization/Scope
+		IL_0094: ldftn object Modules.Variable_NumericVarLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
+		IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_009f: ldc.i4.0
+		IL_00a0: conv.r8
+		IL_00a1: ldstr "captured"
+		IL_00a6: ldc.i4.0
+		IL_00a7: ldc.i4.0
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00ad: stloc.s 12
+		IL_00af: ldloc.s 12
+		IL_00b1: stloc.s 5
+		IL_00b3: ldnull
+		IL_00b4: ldftn object Modules.Variable_NumericVarLocalSpecialization/hoistedDependency::__js_call__(object)
+		IL_00ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00bf: ldc.i4.0
+		IL_00c0: conv.r8
+		IL_00c1: ldstr "hoistedDependency"
+		IL_00c6: ldc.i4.0
+		IL_00c7: ldc.i4.0
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00cd: stloc.s 12
+		IL_00cf: ldloc.s 12
+		IL_00d1: stloc.s 6
+		IL_00d3: ldc.i4.1
+		IL_00d4: newarr [System.Runtime]System.Object
+		IL_00d9: dup
+		IL_00da: ldc.i4.0
+		IL_00db: ldloc.0
+		IL_00dc: stelem.ref
+		IL_00dd: ldc.i4.0
+		IL_00de: ldelem.ref
+		IL_00df: castclass Modules.Variable_NumericVarLocalSpecialization/Scope
+		IL_00e4: ldftn object Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
+		IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ef: ldc.i4.0
+		IL_00f0: conv.r8
+		IL_00f1: ldstr "objectLiteralWrite"
+		IL_00f6: ldc.i4.0
+		IL_00f7: ldc.i4.0
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00fd: stloc.s 12
+		IL_00ff: ldloc.s 12
+		IL_0101: stloc.s 7
+		IL_0103: ldnull
+		IL_0104: ldftn object Modules.Variable_NumericVarLocalSpecialization/labeledBreak::__js_call__(object, bool)
+		IL_010a: newobj instance void class [System.Runtime]System.Func`3<object, bool, object>::.ctor(object, native int)
+		IL_010f: ldc.i4.1
+		IL_0110: conv.r8
+		IL_0111: ldstr "labeledBreak"
+		IL_0116: ldc.i4.0
+		IL_0117: ldc.i4.0
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_011d: stloc.s 12
+		IL_011f: ldloc.s 12
+		IL_0121: stloc.s 8
+		IL_0123: ldnull
+		IL_0124: ldftn object Modules.Variable_NumericVarLocalSpecialization/optionalWrite::__js_call__(object)
+		IL_012a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_012f: ldc.i4.0
+		IL_0130: conv.r8
+		IL_0131: ldstr "optionalWrite"
+		IL_0136: ldc.i4.0
+		IL_0137: ldc.i4.0
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_013d: stloc.s 12
+		IL_013f: ldloc.s 12
+		IL_0141: stloc.s 9
+		IL_0143: ldnull
+		IL_0144: ldftn object Modules.Variable_NumericVarLocalSpecialization/shadowedSource::__js_call__(object)
+		IL_014a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_014f: ldc.i4.0
+		IL_0150: conv.r8
+		IL_0151: ldstr "shadowedSource"
+		IL_0156: ldc.i4.0
+		IL_0157: ldc.i4.0
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_015d: stloc.s 12
+		IL_015f: ldloc.s 12
+		IL_0161: stloc.s 10
+		IL_0163: nop
+		IL_0164: nop
+		IL_0165: nop
+		IL_0166: nop
+		IL_0167: nop
+		IL_0168: nop
+		IL_0169: nop
+		IL_016a: nop
+		IL_016b: nop
+		IL_016c: nop
+		IL_016d: ldstr "console"
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0177: stloc.s 12
+		IL_0179: ldloc.s 12
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0180: stloc.s 12
+		IL_0182: ldnull
+		IL_0183: ldc.r8 5
+		IL_018c: call object Modules.Variable_NumericVarLocalSpecialization/calculate::__js_call__(object, float64)
+		IL_0191: stloc.s 13
+		IL_0193: ldloc.s 12
+		IL_0195: ldstr "log"
+		IL_019a: ldloc.s 13
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01a1: pop
+		IL_01a2: ldstr "console"
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ac: stloc.s 13
+		IL_01ae: ldloc.s 13
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b5: stloc.s 13
+		IL_01b7: ldnull
+		IL_01b8: call float64 Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization::__js_call__(object)
+		IL_01bd: stloc.s 14
+		IL_01bf: ldloc.s 14
+		IL_01c1: box [System.Runtime]System.Double
+		IL_01c6: stloc.s 15
+		IL_01c8: ldloc.s 13
+		IL_01ca: ldstr "log"
+		IL_01cf: ldloc.s 15
+		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01d6: pop
+		IL_01d7: ldstr "console"
+		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e1: stloc.s 13
+		IL_01e3: ldloc.s 13
+		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ea: stloc.s 13
+		IL_01ec: ldnull
+		IL_01ed: ldc.i4.0
+		IL_01ee: call object Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
+		IL_01f3: stloc.s 12
+		IL_01f5: ldloc.s 13
+		IL_01f7: ldstr "log"
+		IL_01fc: ldloc.s 12
+		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0203: pop
+		IL_0204: ldstr "console"
+		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_020e: stloc.s 12
+		IL_0210: ldloc.s 12
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0217: stloc.s 12
+		IL_0219: ldnull
+		IL_021a: ldc.i4.0
+		IL_021b: call object Modules.Variable_NumericVarLocalSpecialization/mixedType::__js_call__(object, bool)
+		IL_0220: stloc.s 13
+		IL_0222: ldloc.s 12
+		IL_0224: ldstr "log"
+		IL_0229: ldloc.s 13
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0230: pop
+		IL_0231: ldstr "console"
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_023b: stloc.s 13
+		IL_023d: ldloc.s 13
+		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0244: stloc.s 13
+		IL_0246: ldnull
+		IL_0247: ldc.i4.1
+		IL_0248: call object Modules.Variable_NumericVarLocalSpecialization/mixedType::__js_call__(object, bool)
+		IL_024d: stloc.s 12
+		IL_024f: ldloc.s 13
+		IL_0251: ldstr "log"
+		IL_0256: ldloc.s 12
+		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_025d: pop
+		IL_025e: ldloc.0
+		IL_025f: castclass Modules.Variable_NumericVarLocalSpecialization/Scope
+		IL_0264: ldnull
+		IL_0265: call object Modules.Variable_NumericVarLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
+		IL_026a: stloc.s 12
+		IL_026c: ldloc.s 12
+		IL_026e: stloc.s 11
+		IL_0270: ldstr "console"
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_027a: stloc.s 12
+		IL_027c: ldloc.s 12
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0283: stloc.s 12
+		IL_0285: ldloc.s 11
+		IL_0287: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0291: stloc.s 13
+		IL_0293: ldloc.s 12
+		IL_0295: ldstr "log"
+		IL_029a: ldloc.s 13
+		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02a1: pop
+		IL_02a2: ldstr "console"
+		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ac: stloc.s 13
+		IL_02ae: ldloc.s 13
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b5: stloc.s 13
+		IL_02b7: ldloc.s 11
+		IL_02b9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_02c3: stloc.s 12
+		IL_02c5: ldloc.s 13
+		IL_02c7: ldstr "log"
+		IL_02cc: ldloc.s 12
+		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02d3: pop
+		IL_02d4: ldstr "console"
+		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02de: stloc.s 12
+		IL_02e0: ldloc.s 12
+		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02e7: stloc.s 12
+		IL_02e9: ldnull
+		IL_02ea: call object Modules.Variable_NumericVarLocalSpecialization/hoistedDependency::__js_call__(object)
+		IL_02ef: stloc.s 13
+		IL_02f1: ldloc.s 12
+		IL_02f3: ldstr "log"
+		IL_02f8: ldloc.s 13
+		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02ff: pop
+		IL_0300: ldstr "console"
+		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_030a: stloc.s 13
+		IL_030c: ldloc.s 13
+		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0313: stloc.s 13
+		IL_0315: ldloc.0
+		IL_0316: castclass Modules.Variable_NumericVarLocalSpecialization/Scope
+		IL_031b: ldnull
+		IL_031c: call object Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
+		IL_0321: stloc.s 12
+		IL_0323: ldloc.s 13
+		IL_0325: ldstr "log"
+		IL_032a: ldloc.s 12
+		IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0331: pop
+		IL_0332: ldstr "console"
+		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_033c: stloc.s 12
+		IL_033e: ldloc.s 12
+		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0345: stloc.s 12
+		IL_0347: ldnull
+		IL_0348: ldc.i4.1
+		IL_0349: call object Modules.Variable_NumericVarLocalSpecialization/labeledBreak::__js_call__(object, bool)
+		IL_034e: stloc.s 13
+		IL_0350: ldloc.s 12
+		IL_0352: ldstr "log"
+		IL_0357: ldloc.s 13
+		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_035e: pop
+		IL_035f: ldstr "console"
+		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0369: stloc.s 13
+		IL_036b: ldloc.s 13
+		IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0372: stloc.s 13
+		IL_0374: ldnull
+		IL_0375: ldc.i4.0
+		IL_0376: call object Modules.Variable_NumericVarLocalSpecialization/labeledBreak::__js_call__(object, bool)
+		IL_037b: stloc.s 12
+		IL_037d: ldloc.s 13
+		IL_037f: ldstr "log"
+		IL_0384: ldloc.s 12
+		IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_038b: pop
+		IL_038c: ldstr "console"
+		IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0396: stloc.s 12
+		IL_0398: ldloc.s 12
+		IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_039f: stloc.s 12
+		IL_03a1: ldnull
+		IL_03a2: call object Modules.Variable_NumericVarLocalSpecialization/optionalWrite::__js_call__(object)
+		IL_03a7: stloc.s 13
+		IL_03a9: ldloc.s 12
+		IL_03ab: ldstr "log"
+		IL_03b0: ldloc.s 13
+		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03b7: pop
+		IL_03b8: ldstr "console"
+		IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03c2: stloc.s 13
+		IL_03c4: ldloc.s 13
+		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03cb: stloc.s 13
+		IL_03cd: ldnull
+		IL_03ce: call object Modules.Variable_NumericVarLocalSpecialization/shadowedSource::__js_call__(object)
+		IL_03d3: stloc.s 12
+		IL_03d5: ldloc.s 13
+		IL_03d7: ldstr "log"
+		IL_03dc: ldloc.s 12
+		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03e3: pop
+		IL_03e4: ret
+	} // end of method Variable_NumericVarLocalSpecialization::__js_module_init__
+
+} // end of class Modules.Variable_NumericVarLocalSpecialization
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x282f
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Variable_NumericVarLocalSpecialization::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+


### PR DESCRIPTION
## Summary

- add a separate flow-sensitive proof for numeric function-local `var` bindings
- keep proven declarations, assignments, compound updates, comparisons, and loop induction variables in unboxed `double` locals
- run the proof once after the existing inference passes stabilize
- preserve object storage for hoisted reads, conditional/optional writes, mixed types, captures, shadowed sources, destructuring, and abrupt loop control

## Generated IL

For the legacy `dromaeo-3d-cube` module:

| Operation | `master` | This branch | Reduction |
|---|---:|---:|---:|
| `box System.Double` | 256 | 212 | 44 (17.2%) |
| `TypeUtilities.ToNumber` | 103 | 65 | 38 (36.9%) |
| dynamic `Operators.*` | 13 | 9 | 4 (30.8%) |

`DrawLine` accounts for the intended hot-path change: numeric branch-joined state such as `dx`, `dy`, `IncX*`, `IncY*`, `Den`, `Num`, `NumAdd`, and `NumPix` now uses `float64` locals. Values initialized from dynamic indexed/property reads remain object-backed.

## Same-runner benchmarks

GitHub Actions runner: AMD EPYC 7763, .NET 10.0.10, BenchmarkDotNet 0.15.8.

### Legacy cube

| Metric | `master` | This branch | Change |
|---|---:|---:|---:|
| Precompiled execution | 12.151 ms | 11.593 ms | **-4.6%** |
| Runtime allocation | 5,137.69 KB | 4,850.26 KB | **-5.6%** |
| Compile time | 79.525 ms | 75.792 ms | -4.7% |
| Compiler allocation | 12,596.37 KB | 13,060.09 KB | +3.7% |

### Modern lexical-declaration control

| Metric | `master` | This branch | Change |
|---|---:|---:|---:|
| Precompiled execution | 14.228 ms | 14.753 ms | +3.7% |
| Runtime allocation | 5,290.83 KB | 5,276.04 KB | -0.3% |
| Compile time | 72.190 ms | 72.672 ms | +0.7% |
| Compiler allocation | 14,293.00 KB | 14,290.71 KB | effectively flat |

The modern scenario uses lexical declarations rather than function-local `var`, so it acts as a no-benefit control. Its allocation stayed flat; no modern timing improvement is claimed.

Benchmark runs:

- Legacy: https://github.com/tomacox74/js2il/actions/runs/29375985988
- Modern: https://github.com/tomacox74/js2il/actions/runs/29375985945

## Validation

- 190 focused symbol-table inference, Variable execution/generator, and legacy cube execution/generator tests
- generated-IL snapshots cover the optimized numeric loop and conservative fallback cases
- direct and indirect unsupported `eval` behavior remains covered by the existing validator tests

Closes #1476
Parent: #1322
