### PR TITLE
refactor(runtime): add extensible object operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime: add an explicit, opt-in internal object-operation contract for exotic `JsObject` subclasses, covering own descriptors, values, definitions, writes, deletion, and complete ordered keys while preserving direct hot paths for ordinary/generated objects. Descriptor-store reads retain their shared no-clone contract, canonical array-index parsing is centralized, and focused ordinary-object read/write benchmarks plus an exotic-storage test double prepare the runtime for the phased `Array : JsObject` migration. (#1444, parent #1443)
 - modules: add the Node `util/types` / `node:util/types` subpath as an alias of `util.types`, including Undici-required `isUint8Array` and `isArrayBuffer` predicates for Fetch byte validation and WebSocket ArrayBuffer handling. (#1496)
 
 ## v0.11.27 - 2026-07-16

--- a/src/JavaScriptRuntime/CanonicalArrayIndex.cs
+++ b/src/JavaScriptRuntime/CanonicalArrayIndex.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+
+namespace JavaScriptRuntime;
+
+/// <summary>
+/// Allocation-free classification of ECMAScript array-index property keys.
+/// </summary>
+internal static class CanonicalArrayIndex
+{
+    public static bool TryParse(string? key, out uint index)
+    {
+        index = 0;
+        if (string.IsNullOrEmpty(key)
+            || !uint.TryParse(key, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed)
+            || parsed == uint.MaxValue
+            || key != parsed.ToString(CultureInfo.InvariantCulture))
+        {
+            return false;
+        }
+
+        index = parsed;
+        return true;
+    }
+
+    public static bool TryParseInt32(string? key, out int index)
+    {
+        index = 0;
+        if (!TryParse(key, out var arrayIndex) || arrayIndex > int.MaxValue)
+        {
+            return false;
+        }
+
+        index = (int)arrayIndex;
+        return true;
+    }
+}

--- a/src/JavaScriptRuntime/JsObject.cs
+++ b/src/JavaScriptRuntime/JsObject.cs
@@ -95,6 +95,18 @@ internal sealed class JsShape
 }
 
 /// <summary>
+/// Marks a <see cref="JsObject"/> subclass that overrides ECMAScript internal
+/// object operations for specialized storage.
+/// </summary>
+/// <remarks>
+/// Keeping this opt-in explicit lets ordinary and generated JsObject subclasses
+/// retain direct, non-virtual hot paths.
+/// </remarks>
+internal interface IExoticJsObject
+{
+}
+
+/// <summary>
 /// A JavaScript plain object backed by a <see cref="Dictionary{TKey,TValue}"/> of
 /// <see cref="JsValue"/> entries. Numeric and boolean property values are stored
 /// without heap boxing; boxing is deferred until the value is accessed as
@@ -144,6 +156,106 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
     {
         _cacheShapeTransitions = cacheShapeTransitions;
     }
+
+    // -------------------------------------------------------------------------
+    // ECMAScript internal object-operation hooks
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Looks up an own descriptor without cloning it. The returned descriptor is
+    /// shared descriptor-store state and must be cloned before mutation.
+    /// </summary>
+    /// <remarks>
+    /// Exotic subclasses must preserve descriptor-store tombstones and overrides
+    /// before synthesizing descriptors for specialized storage and implement
+    /// <see cref="IExoticJsObject"/> to opt generic dispatch into these hooks.
+    /// </remarks>
+    internal virtual PropertyDescriptorLookup GetOwnPropertyDescriptor(
+        string key,
+        out JsPropertyDescriptor descriptor)
+    {
+        var lookup = PropertyDescriptorStore.GetOwnLookupCore(this, key, out descriptor);
+        if (lookup != PropertyDescriptorLookup.None)
+        {
+            return lookup;
+        }
+
+        if (!TryGetOwnPropertyValue(key, out var value))
+        {
+            descriptor = null!;
+            return PropertyDescriptorLookup.None;
+        }
+
+        descriptor = new JsPropertyDescriptor
+        {
+            Kind = JsPropertyDescriptorKind.Data,
+            Value = value,
+            Writable = true,
+            Enumerable = true,
+            Configurable = true
+        };
+        return PropertyDescriptorLookup.Found;
+    }
+
+    /// <summary>
+    /// Reads an own value from this object's specialized backing storage.
+    /// Keys are canonical runtime property-key strings; symbols remain encoded
+    /// keys and are never converted to display strings by this contract.
+    /// </summary>
+    internal virtual bool TryGetOwnPropertyValue(string key, out object? value)
+        => TryGetBoxedValue(key, out value);
+
+    /// <summary>
+    /// Defines or updates an own property while keeping ordinary backing storage
+    /// and descriptor state synchronized.
+    /// </summary>
+    internal virtual bool DefineOwnProperty(string key, JsPropertyDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        if (!PropertyDescriptorStore.HasIntrinsicProperties(this))
+        {
+            if (!SetOwnPropertyValue(
+                key,
+                descriptor.Kind == JsPropertyDescriptorKind.Accessor ? null : descriptor.Value))
+            {
+                return false;
+            }
+        }
+
+        PropertyDescriptorStore.DefineOrUpdate(this, key, descriptor);
+        return true;
+    }
+
+    /// <summary>Writes an own value to this object's specialized backing storage.</summary>
+    internal virtual bool SetOwnPropertyValue(string key, object? value)
+    {
+        SetBoxedValue(key, value);
+        return true;
+    }
+
+    /// <summary>Deletes an own property from backing and descriptor storage.</summary>
+    internal virtual bool DeleteOwnProperty(string key)
+    {
+        if (!PropertyDescriptorStore.HasIntrinsicProperties(this))
+        {
+            Remove(key);
+        }
+
+        PropertyDescriptorStore.Delete(this, key);
+        return true;
+    }
+
+    /// <summary>
+    /// Returns every own key in ECMAScript encounter order, including keys held
+    /// only in descriptor or specialized storage.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="IExoticJsObject"/> implementations with specialized storage
+    /// must override this method and merge all of their key sources.
+    /// </remarks>
+    internal virtual IEnumerable<string> GetOwnPropertyKeys()
+        => GetOwnPropertyNames();
 
     // -------------------------------------------------------------------------
     // Typed initializer methods used from generated IL (no boxing at call site)

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -485,16 +485,13 @@ namespace JavaScriptRuntime
 
         private static bool TryGetCanonicalArrayIndexKey(string key, out uint index)
         {
-            if (key is null
-                || IsEncodedSymbolKey(key)
-                || !uint.TryParse(key, out index)
-                || index == uint.MaxValue)
+            if (IsEncodedSymbolKey(key))
             {
                 index = 0;
                 return false;
             }
 
-            return key == index.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
+            return CanonicalArrayIndex.TryParse(key, out index);
         }
 
         private static List<string> ReorderOwnKeys(IEnumerable<string> encounteredKeys, bool includeEncodedSymbolKeys)
@@ -549,6 +546,7 @@ namespace JavaScriptRuntime
         {
             var keys = new List<string>();
             var seen = new HashSet<string>(StringComparer.Ordinal);
+            var isExoticObject = ObjectRuntime.IsExoticObject(obj);
 
             static void AddKey(List<string> keys, HashSet<string> seen, string? key)
             {
@@ -563,15 +561,21 @@ namespace JavaScriptRuntime
                 }
             }
 
-            foreach (var key in PropertyDescriptorStore.GetOwnKeys(obj))
+            if (!isExoticObject)
             {
-                AddKey(keys, seen, key);
+                foreach (var key in PropertyDescriptorStore.GetOwnKeys(obj))
+                {
+                    AddKey(keys, seen, key);
+                }
             }
 
             RuntimeServices.EnsureClassConstructorCoreMetadataProperties(obj);
-            foreach (var key in PropertyDescriptorStore.GetOwnKeys(obj))
+            if (!isExoticObject)
             {
-                AddKey(keys, seen, key);
+                foreach (var key in PropertyDescriptorStore.GetOwnKeys(obj))
+                {
+                    AddKey(keys, seen, key);
+                }
             }
 
             foreach (var key in RuntimeServices.GetLazyClassMethodOwnKeys(obj))
@@ -1467,7 +1471,14 @@ namespace JavaScriptRuntime
                 largeArray.EnsureLengthAtLeast((double)largeArrayIndex + 1d);
             }
 
-            if (!PropertyDescriptorStore.HasIntrinsicProperties(obj)
+            if (obj is JsObject jsObject && jsObject is IExoticJsObject)
+            {
+                if (!jsObject.DefineOwnProperty(key, appliedDescriptor))
+                {
+                    throw new TypeError($"Cannot define property: {key}");
+                }
+            }
+            else if (!PropertyDescriptorStore.HasIntrinsicProperties(obj)
                 && ObjectRuntime.IsOrdinaryObject(obj))
             {
                 ObjectRuntime.TrySetOwnValue(
@@ -1490,7 +1501,10 @@ namespace JavaScriptRuntime
                 }
             }
 
-            PropertyDescriptorStore.DefineOrUpdate(obj, key, appliedDescriptor);
+            if (obj is not IExoticJsObject)
+            {
+                PropertyDescriptorStore.DefineOrUpdate(obj, key, appliedDescriptor);
+            }
             return obj;
         }
 
@@ -1694,7 +1708,17 @@ namespace JavaScriptRuntime
 
                 desc = PropertyDescriptorStore.CloneDescriptor(desc);
                 desc.Configurable = false;
-                PropertyDescriptorStore.DefineOrUpdate(obj, key, desc);
+                if (obj is JsObject exoticObject && exoticObject is IExoticJsObject)
+                {
+                    if (!exoticObject.DefineOwnProperty(key, desc))
+                    {
+                        throw new TypeError($"Cannot define property: {key}");
+                    }
+                }
+                else
+                {
+                    PropertyDescriptorStore.DefineOrUpdate(obj, key, desc);
+                }
             }
 
             var state = GetIntegrityState(obj);
@@ -1729,7 +1753,17 @@ namespace JavaScriptRuntime
                 {
                     desc.Writable = false;
                 }
-                PropertyDescriptorStore.DefineOrUpdate(obj, key, desc);
+                if (obj is JsObject exoticObject && exoticObject is IExoticJsObject)
+                {
+                    if (!exoticObject.DefineOwnProperty(key, desc))
+                    {
+                        throw new TypeError($"Cannot define property: {key}");
+                    }
+                }
+                else
+                {
+                    PropertyDescriptorStore.DefineOrUpdate(obj, key, desc);
+                }
             }
 
             var state = GetIntegrityState(obj);
@@ -2017,20 +2051,31 @@ namespace JavaScriptRuntime
                 }
             }
 
-            PropertyDescriptorStore.DefineOrUpdate(target, key, new JsPropertyDescriptor
+            var descriptor = new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Accessor,
                 Enumerable = enumerable,
                 Configurable = configurable,
                 Get = getter,
                 Set = setter
-            });
+            };
 
-            if (target is IDictionary<string, object?> dict
-                && !PropertyDescriptorStore.HasIntrinsicProperties(target)
-                && !dict.ContainsKey(key))
+            if (target is JsObject jsObject && jsObject is IExoticJsObject)
             {
-                dict[key] = null;
+                if (!jsObject.DefineOwnProperty(key, descriptor))
+                {
+                    throw new TypeError($"Cannot define property: {key}");
+                }
+            }
+            else
+            {
+                PropertyDescriptorStore.DefineOrUpdate(target, key, descriptor);
+                if (target is IDictionary<string, object?> dict
+                    && !PropertyDescriptorStore.HasIntrinsicProperties(target)
+                    && !dict.ContainsKey(key))
+                {
+                    dict[key] = null;
+                }
             }
 
             return null;
@@ -2061,20 +2106,31 @@ namespace JavaScriptRuntime
                 }
             }
 
-            PropertyDescriptorStore.DefineOrUpdate(target, key, new JsPropertyDescriptor
+            var descriptor = new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Accessor,
                 Enumerable = enumerable,
                 Configurable = configurable,
                 Get = getter,
                 Set = setter
-            });
+            };
 
-            if (target is IDictionary<string, object?> dict
-                && !PropertyDescriptorStore.HasIntrinsicProperties(target)
-                && !dict.ContainsKey(key))
+            if (target is JsObject jsObject && jsObject is IExoticJsObject)
             {
-                dict[key] = null;
+                if (!jsObject.DefineOwnProperty(key, descriptor))
+                {
+                    throw new TypeError($"Cannot define property: {key}");
+                }
+            }
+            else
+            {
+                PropertyDescriptorStore.DefineOrUpdate(target, key, descriptor);
+                if (target is IDictionary<string, object?> dict
+                    && !PropertyDescriptorStore.HasIntrinsicProperties(target)
+                    && !dict.ContainsKey(key))
+                {
+                    dict[key] = null;
+                }
             }
 
             return null;
@@ -5482,7 +5538,9 @@ namespace JavaScriptRuntime
             // storage without probing the descriptor store (ConditionalWeakTable).
             // Own misses fall through so prototype-chain and special-name
             // semantics are preserved.
-            if (obj is JsObject plainJsObject && !plainJsObject.HasNonDataDescriptors)
+            if (obj is JsObject plainJsObject
+                && plainJsObject is not IExoticJsObject
+                && !plainJsObject.HasNonDataDescriptors)
             {
                 if (plainJsObject.TryGetBoxedValue(name, out var plainValue))
                 {
@@ -5629,7 +5687,7 @@ namespace JavaScriptRuntime
         /// </summary>
         public static void SetPropertyNumber(object? obj, string key, double value)
         {
-            if (obj is JsObject jsObj)
+            if (obj is JsObject jsObj && jsObj is not IExoticJsObject)
             {
                 jsObj.SetNumber(key, value);
                 return;
@@ -5643,7 +5701,7 @@ namespace JavaScriptRuntime
         /// </summary>
         public static void SetPropertyBoolean(object? obj, string key, bool value)
         {
-            if (obj is JsObject jsObj)
+            if (obj is JsObject jsObj && jsObj is not IExoticJsObject)
             {
                 jsObj.SetBoolean(key, value);
                 return;
@@ -5657,7 +5715,7 @@ namespace JavaScriptRuntime
         /// </summary>
         public static void SetPropertyString(object? obj, string key, string? value)
         {
-            if (obj is JsObject jsObj)
+            if (obj is JsObject jsObj && jsObj is not IExoticJsObject)
             {
                 jsObj.SetString(key, value);
                 return;
@@ -5763,24 +5821,66 @@ namespace JavaScriptRuntime
 
                 desc = PropertyDescriptorStore.CloneDescriptor(desc);
                 desc.Value = value;
-                PropertyDescriptorStore.DefineOrUpdate(obj, name, desc);
-                if (!PropertyDescriptorStore.HasIntrinsicProperties(obj)
-                    && ObjectRuntime.IsOrdinaryObject(obj))
+                if (obj is JsObject descriptorObject && descriptorObject is IExoticJsObject)
                 {
-                    ObjectRuntime.TrySetOwnValue(obj, name, value);
+                    if (!descriptorObject.DefineOwnProperty(name, desc))
+                    {
+                        if (!throwOnError)
+                        {
+                            return value;
+                        }
+
+                        throw new TypeError($"Cannot assign to property '{name}' of object");
+                    }
                 }
-                else if (obj is IDictionary<string, object?> dictDesc && !PropertyDescriptorStore.HasIntrinsicProperties(obj))
+                else
                 {
-                    dictDesc[name] = value;
+                    PropertyDescriptorStore.DefineOrUpdate(obj, name, desc);
+                    if (!PropertyDescriptorStore.HasIntrinsicProperties(obj)
+                        && ObjectRuntime.IsOrdinaryObject(obj))
+                    {
+                        ObjectRuntime.TrySetOwnValue(obj, name, value);
+                    }
+                    else if (obj is IDictionary<string, object?> dictDesc && !PropertyDescriptorStore.HasIntrinsicProperties(obj))
+                    {
+                        dictDesc[name] = value;
+                    }
                 }
                 return value;
             }
 
-            // Ordinary objects use direct JsObject storage.
+            // Exotic JsObject subclasses own their specialized property definition.
+            if (obj is JsObject jsObject && jsObject is IExoticJsObject)
+            {
+                if (!ObjectRuntime.HasOwnValue(jsObject, name)
+                    && TrySetPropertyViaPrototypeOrThrow(obj, name, value, throwOnError))
+                {
+                    return value;
+                }
+
+                if (!jsObject.DefineOwnProperty(name, new JsPropertyDescriptor
+                {
+                    Kind = JsPropertyDescriptorKind.Data,
+                    Value = value,
+                    Writable = true,
+                    Enumerable = true,
+                    Configurable = true
+                }))
+                {
+                    if (!throwOnError)
+                    {
+                        return value;
+                    }
+
+                    throw new TypeError($"Cannot add property '{name}' to object");
+                }
+
+                return value;
+            }
+
+            // Ordinary JsObject subclasses retain the direct non-virtual hot path.
             if (ObjectRuntime.IsOrdinaryObject(obj))
             {
-                // Prototype-setter semantics: if no own property exists, and a prototype accessor
-                // defines a setter, route the assignment to that setter.
                 if (!ObjectRuntime.HasOwnValue(obj, name)
                     && TrySetPropertyViaPrototypeOrThrow(obj, name, value, throwOnError))
                 {

--- a/src/JavaScriptRuntime/ObjectRuntime.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.cs
@@ -34,11 +34,16 @@ namespace JavaScriptRuntime
         internal static bool IsOrdinaryObject(object target)
             => target is JsObject;
 
+        internal static bool IsExoticObject(object target)
+            => target is JsObject and IExoticJsObject;
+
         internal static bool TryGetOwnValue(object target, string key, out object? value)
         {
             if (target is JsObject jsObject)
             {
-                return jsObject.TryGetBoxedValue(key, out value);
+                return jsObject is IExoticJsObject
+                    ? jsObject.TryGetOwnPropertyValue(key, out value)
+                    : jsObject.TryGetBoxedValue(key, out value);
             }
 
             value = null;
@@ -49,7 +54,9 @@ namespace JavaScriptRuntime
         {
             if (target is JsObject jsObject)
             {
-                return jsObject.ContainsKey(key);
+                return jsObject is IExoticJsObject
+                    ? jsObject.GetOwnPropertyDescriptor(key, out _) == PropertyDescriptorLookup.Found
+                    : jsObject.ContainsKey(key);
             }
 
             return false;
@@ -59,6 +66,11 @@ namespace JavaScriptRuntime
         {
             if (target is JsObject jsObject)
             {
+                if (jsObject is IExoticJsObject)
+                {
+                    return jsObject.SetOwnPropertyValue(key, value);
+                }
+
                 jsObject.SetBoxedValue(key, value);
                 return true;
             }
@@ -70,6 +82,11 @@ namespace JavaScriptRuntime
         {
             if (target is JsObject jsObject)
             {
+                if (jsObject is IExoticJsObject)
+                {
+                    return jsObject.DeleteOwnProperty(key);
+                }
+
                 jsObject.Remove(key);
                 return true;
             }
@@ -81,7 +98,9 @@ namespace JavaScriptRuntime
         {
             if (target is JsObject jsObject)
             {
-                return jsObject.GetOwnPropertyNames();
+                return jsObject is IExoticJsObject
+                    ? jsObject.GetOwnPropertyKeys()
+                    : jsObject.GetOwnPropertyNames();
             }
 
             return System.Array.Empty<string>();
@@ -333,18 +352,29 @@ namespace JavaScriptRuntime
                 existingSetter = existing.Set;
             }
 
-            PropertyDescriptorStore.DefineOrUpdate(target, key, new JsPropertyDescriptor
+            var descriptor = new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Accessor,
                 Enumerable = enumerable,
                 Configurable = true,
                 Get = getter is null || getter is JsNull ? existingGetter : getter,
                 Set = setter is null || setter is JsNull ? existingSetter : setter
-            });
+            };
 
-            if (createDictionarySlot && target is IDictionary<string, object?> dict && !dict.ContainsKey(key))
+            if (target is JsObject jsObject && jsObject is IExoticJsObject)
             {
-                dict[key] = null;
+                if (!jsObject.DefineOwnProperty(key, descriptor))
+                {
+                    throw new TypeError($"Cannot define property: {key}");
+                }
+            }
+            else
+            {
+                PropertyDescriptorStore.DefineOrUpdate(target, key, descriptor);
+                if (createDictionarySlot && target is IDictionary<string, object?> dict && !dict.ContainsKey(key))
+                {
+                    dict[key] = null;
+                }
             }
 
             return target;
@@ -369,6 +399,24 @@ namespace JavaScriptRuntime
                 return Object.defineProperty(target, key, CreateDataPropertyDescriptor(value, enumerable));
             }
 
+            var descriptor = new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Value = value,
+                Writable = true,
+                Enumerable = enumerable,
+                Configurable = true
+            };
+
+            if (target is JsObject exoticObject && exoticObject is IExoticJsObject)
+            {
+                if (!exoticObject.DefineOwnProperty(key, descriptor))
+                {
+                    throw new TypeError($"Cannot define property: {key}");
+                }
+                return target;
+            }
+
             if (target is JsObject jsObject && !PropertyDescriptorStore.HasIntrinsicProperties(target))
             {
                 setJsObjectValue(jsObject, key, value);
@@ -383,14 +431,7 @@ namespace JavaScriptRuntime
                 dict[key] = value;
             }
 
-            PropertyDescriptorStore.DefineOrUpdate(target, key, new JsPropertyDescriptor
-            {
-                Kind = JsPropertyDescriptorKind.Data,
-                Value = value,
-                Writable = true,
-                Enumerable = enumerable,
-                Configurable = true
-            });
+            PropertyDescriptorStore.DefineOrUpdate(target, key, descriptor);
 
             return target;
         }
@@ -484,6 +525,16 @@ namespace JavaScriptRuntime
 
             if (IsOrdinaryObject(receiver))
             {
+                if (receiver is JsObject exoticObject && exoticObject is IExoticJsObject)
+                {
+                    if (!exoticObject.DeleteOwnProperty(key))
+                    {
+                        throw new JavaScriptRuntime.TypeError($"Cannot delete property '{key}' of object");
+                    }
+
+                    return true;
+                }
+
                 if (!PropertyDescriptorStore.HasIntrinsicProperties(receiver))
                 {
                     TryDeleteOwnValue(receiver, key);
@@ -575,6 +626,11 @@ namespace JavaScriptRuntime
                 return false;
             }
 
+            if (receiver is JsObject exoticObject && exoticObject is IExoticJsObject)
+            {
+                return exoticObject.DeleteOwnProperty(key);
+            }
+
             return DeleteProperty(receiver, key);
         }
 
@@ -637,33 +693,10 @@ namespace JavaScriptRuntime
         }
 
         internal static bool TryParseCanonicalIndexString(string s, out int parsed)
-        {
-            parsed = 0;
-            if (string.IsNullOrEmpty(s)) return false;
-            if (!int.TryParse(s, global::System.Globalization.NumberStyles.None, global::System.Globalization.CultureInfo.InvariantCulture, out parsed))
-            {
-                return false;
-            }
-            if (parsed < 0) return false;
-            return parsed.ToString(global::System.Globalization.CultureInfo.InvariantCulture) == s;
-        }
+            => CanonicalArrayIndex.TryParseInt32(s, out parsed);
 
         internal static bool TryParseCanonicalArrayIndexUInt(string s, out uint parsed)
-        {
-            parsed = 0;
-            if (string.IsNullOrEmpty(s)) return false;
-            if (!uint.TryParse(s, global::System.Globalization.NumberStyles.None, global::System.Globalization.CultureInfo.InvariantCulture, out parsed))
-            {
-                return false;
-            }
-
-            if (parsed >= 4294967295u)
-            {
-                return false;
-            }
-
-            return parsed.ToString(global::System.Globalization.CultureInfo.InvariantCulture) == s;
-        }
+            => CanonicalArrayIndex.TryParse(s, out parsed);
 
         public static object GetItem(object obj, object index)
         {

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -327,7 +327,7 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
     }
 
     public static bool TryGetOwn(object target, string key, out JsPropertyDescriptor descriptor)
-        => CurrentStore.TryGetOwn(target, key, out descriptor);
+        => GetOwnLookup(target, key, out descriptor) == PropertyDescriptorLookup.Found;
 
     /// <summary>
     /// Unified single-probe own lookup (perf #1418). Combines the tombstone check
@@ -336,6 +336,25 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
     /// is shared and must be cloned by callers that mutate it.
     /// </summary>
     internal static PropertyDescriptorLookup GetOwnLookup(object target, string key, out JsPropertyDescriptor descriptor)
+    {
+        if (target is JsObject jsObject && jsObject is IExoticJsObject)
+        {
+            return jsObject.GetOwnPropertyDescriptor(key, out descriptor);
+        }
+
+        return GetOwnLookupCore(target, key, out descriptor);
+    }
+
+    /// <summary>
+    /// Descriptor-store lookup used by the ordinary <see cref="JsObject"/>
+    /// implementation. This deliberately bypasses virtual object operations to
+    /// avoid recursion; exotic subclasses should call it before consulting their
+    /// specialized storage.
+    /// </summary>
+    internal static PropertyDescriptorLookup GetOwnLookupCore(
+        object target,
+        string key,
+        out JsPropertyDescriptor descriptor)
     {
         ValidateTargetAndKey(target, key);
 
@@ -404,7 +423,7 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
         => CurrentStore.Clear(target);
 
     public static bool IsEnumerableOrDefaultTrue(object target, string key)
-        => CurrentStore.IsEnumerableOrDefaultTrue(target, key);
+        => !TryGetOwn(target, key, out var descriptor) || descriptor.Enumerable;
 
     bool IPropertyDescriptorStore.TryGetOwn(object target, string key, out JsPropertyDescriptor descriptor)
     {

--- a/tests/Jroc.Tests/ObjectRuntimeOrdinaryObjectTests.cs
+++ b/tests/Jroc.Tests/ObjectRuntimeOrdinaryObjectTests.cs
@@ -5,6 +5,58 @@ namespace Jroc.Tests;
 
 public sealed class ObjectRuntimeOrdinaryObjectTests
 {
+    private sealed class ExoticObjectForTest : JsObject, IExoticJsObject
+    {
+        private readonly Dictionary<string, object?> _values = new(StringComparer.Ordinal);
+
+        public bool RejectDefinitions { get; set; }
+
+        public bool RejectDeletions { get; set; }
+
+        public void Seed(string key, object? value)
+            => _values[key] = value;
+
+        internal override bool TryGetOwnPropertyValue(string key, out object? value)
+            => _values.TryGetValue(key, out value);
+
+        internal override bool SetOwnPropertyValue(string key, object? value)
+        {
+            _values[key] = value;
+            return true;
+        }
+
+        internal override bool DefineOwnProperty(string key, JsPropertyDescriptor descriptor)
+            => !RejectDefinitions && base.DefineOwnProperty(key, descriptor);
+
+        internal override bool DeleteOwnProperty(string key)
+        {
+            if (RejectDeletions)
+            {
+                return false;
+            }
+
+            _values.Remove(key);
+            PropertyDescriptorStore.Delete(this, key);
+            return true;
+        }
+
+        internal override IEnumerable<string> GetOwnPropertyKeys()
+        {
+            foreach (var key in _values.Keys)
+            {
+                yield return key;
+            }
+
+            foreach (var key in PropertyDescriptorStore.GetOwnKeys(this))
+            {
+                if (!_values.ContainsKey(key))
+                {
+                    yield return key;
+                }
+            }
+        }
+    }
+
     [Fact]
     public void CoreDispatch_PreservesJsObjectBehavior()
     {
@@ -35,6 +87,21 @@ public sealed class ObjectRuntimeOrdinaryObjectTests
             JavaScriptRuntime.Object.freeze(target);
             Assert.True(JavaScriptRuntime.Object.isFrozen(target));
             Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(target, "first", 4d));
+
+            var rejectingTarget = new ExoticObjectForTest { RejectDefinitions = true };
+            Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(rejectingTarget, "rejected", 1d));
+            Assert.Equal(
+                1d,
+                ObjectRuntime.SetProperty(rejectingTarget, "rejected", 1d, throwOnError: false));
+            Assert.False(JavaScriptRuntime.Object.hasOwn(rejectingTarget, "rejected"));
+
+            var deleteRejectingTarget = new ExoticObjectForTest();
+            ObjectRuntime.SetProperty(deleteRejectingTarget, "retained", 1d);
+            deleteRejectingTarget.RejectDeletions = true;
+            Assert.Throws<TypeError>(() =>
+                ObjectRuntime.DeleteProperty(deleteRejectingTarget, "retained"));
+            Assert.False(ObjectRuntime.DeletePropertyNonStrict(deleteRejectingTarget, "retained"));
+            Assert.True(JavaScriptRuntime.Object.hasOwn(deleteRejectingTarget, "retained"));
         }
         finally
         {
@@ -126,5 +193,94 @@ public sealed class ObjectRuntimeOrdinaryObjectTests
         Assert.Equal(42d, ObjectRuntime.GetProperty(hostObject, "value"));
         Assert.True(JavaScriptRuntime.Object.hasOwn(hostObject, "value"));
         Assert.Equal(42d, hostObject["value"]);
+    }
+
+    [Fact]
+    public void ExoticSubclass_UsesInternalOperationsAcrossGenericObjectSemantics()
+    {
+        var runtime = RuntimeServices.BuildServiceProvider();
+        try
+        {
+            GlobalThis.ServiceProvider = runtime;
+            var target = new ExoticObjectForTest();
+            var prototype = new JsObject();
+
+            target.Seed("seed", 0d);
+            ObjectRuntime.SetProperty(target, "second", 2d);
+            ObjectRuntime.SetProperty(target, "1", "index");
+            ObjectRuntime.SetProperty(target, "first", 1d);
+            ObjectRuntime.SetProperty(prototype, "inherited", 3d);
+            JavaScriptRuntime.Object.setPrototypeOf(target, prototype);
+
+            Assert.Equal(2d, ObjectRuntime.GetProperty(target, "second"));
+            Assert.Equal(3d, ObjectRuntime.GetProperty(target, "inherited"));
+            Assert.True(JavaScriptRuntime.Object.hasOwn(target, "first"));
+            Assert.True(Operators.In("inherited", target));
+            Assert.Equal(
+                new object?[] { "1", "seed", "second", "first" },
+                Assert.IsType<JavaScriptRuntime.Array>(
+                    JavaScriptRuntime.Object.getOwnPropertyNames(target)).ToArray());
+
+            var descriptor = Assert.IsType<JsObject>(
+                JavaScriptRuntime.Object.getOwnPropertyDescriptor(target, "first"));
+            Assert.Equal(1d, ObjectRuntime.GetProperty(descriptor, "value"));
+
+            Func<object[], object?[]?, object?> getter = static (_, _) => "accessor";
+            ObjectRuntime.DefineObjectLiteralAccessorProperty(
+                target,
+                "computed",
+                getter,
+                null);
+            Assert.Equal("accessor", ObjectRuntime.GetProperty(target, "computed"));
+
+            ObjectRuntime.DefineObjectLiteralDataProperty(target, "helper", 5d);
+            JavaScriptRuntime.Object.SetPropertyNumber(target, "typed", 6d);
+            Assert.Equal(5d, ObjectRuntime.GetProperty(target, "helper"));
+            Assert.Equal(6d, ObjectRuntime.GetProperty(target, "typed"));
+
+            PropertyDescriptorStore.DefineOrUpdate(target, "descriptorOnly", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Value = 7d,
+                Writable = true,
+                Enumerable = true,
+                Configurable = true
+            });
+            Assert.Contains(
+                "descriptorOnly",
+                Assert.IsType<JavaScriptRuntime.Array>(
+                    JavaScriptRuntime.Object.getOwnPropertyNames(target)).ToArray());
+
+            var proxy = new JavaScriptRuntime.Proxy(target, new JsObject());
+            Assert.Equal(1d, ObjectRuntime.GetProperty(proxy, "first"));
+
+            Assert.True(ObjectRuntime.DeleteProperty(target, "second"));
+            Assert.False(JavaScriptRuntime.Object.hasOwn(target, "second"));
+
+            JavaScriptRuntime.Object.freeze(target);
+            Assert.True(JavaScriptRuntime.Object.isFrozen(target));
+            Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(target, "first", 4d));
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Theory]
+    [InlineData("0", true, 0u)]
+    [InlineData("2147483648", true, 2147483648u)]
+    [InlineData("4294967294", true, 4294967294u)]
+    [InlineData("4294967295", false, 0u)]
+    [InlineData("01", false, 0u)]
+    [InlineData("-0", false, 0u)]
+    [InlineData("1.0", false, 0u)]
+    public void CanonicalArrayIndex_UsesEcma262PropertyKeyRange(
+        string key,
+        bool expected,
+        uint expectedIndex)
+    {
+        Assert.Equal(expected, CanonicalArrayIndex.TryParse(key, out var index));
+        Assert.Equal(expectedIndex, index);
     }
 }

--- a/tests/performance/Benchmarks/ObjectInternalOperationsBenchmarks.cs
+++ b/tests/performance/Benchmarks/ObjectInternalOperationsBenchmarks.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Order;
+
+namespace Benchmarks;
+
+/// <summary>
+/// Tracks the steady-state cost of ordinary-object reads and writes through the
+/// generic runtime dispatch used by extensible JsObject internal operations.
+/// </summary>
+[MemoryDiagnoser]
+[Config(typeof(FullParamsConfig))]
+[ShortRunJob]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[HideColumns("Error", "StdDev")]
+public class ObjectInternalOperationsBenchmarks
+{
+    private readonly JavaScriptRuntime.JsObject _readTarget = new();
+    private readonly JavaScriptRuntime.JsObject _writeTarget = new();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        JavaScriptRuntime.Object.SetProperty(_readTarget, "value", 42d);
+        JavaScriptRuntime.Object.SetProperty(_writeTarget, "value", 0d);
+    }
+
+    [Benchmark(Description = "Ordinary JsObject read")]
+    public object? Read()
+        => JavaScriptRuntime.Object.GetProperty(_readTarget, "value");
+
+    [Benchmark(Description = "Ordinary JsObject write")]
+    public object? Write()
+        => JavaScriptRuntime.Object.SetProperty(_writeTarget, "value", 42d);
+}

--- a/tests/performance/Benchmarks/Program.cs
+++ b/tests/performance/Benchmarks/Program.cs
@@ -20,6 +20,11 @@ else
         var summary = BenchmarkRunner.Run<LateBoundDispatchBenchmarks>(args: programArgs.Skip(1).ToArray());
         SetExitCodeFromSummaries([summary]);
     }
+    else if (programArgs.Length > 0 && programArgs[0] == "--object-operations")
+    {
+        var summary = BenchmarkRunner.Run<ObjectInternalOperationsBenchmarks>(args: programArgs.Skip(1).ToArray());
+        SetExitCodeFromSummaries([summary]);
+    }
     else
     {
         BenchmarkSwitcher switcher;
@@ -76,6 +81,7 @@ Console.WriteLine("Results are saved in BenchmarkDotNet.Artifacts/");
 Console.WriteLine("\nFor more options:");
 Console.WriteLine("  dotnet run -c Release          # Run cross-runtime comparison");
 Console.WriteLine("  dotnet run -c Release --dispatch # Run late-bound dispatch microbenchmarks");
+Console.WriteLine("  dotnet run -c Release --object-operations # Run ordinary-object operation microbenchmarks");
 Console.WriteLine("  dotnet run -c Release --phased # Run jroc phased + Jint prepared + Okojo execute comparison");
 Console.WriteLine("  dotnet run -c Release --all    # Run all benchmarks");
 Console.WriteLine("  dotnet run -c Debug -- --dispatch --debug-benchmarks # Allow debugging benchmark code");


### PR DESCRIPTION
## Summary

- add an explicit `IExoticJsObject` opt-in and virtual `JsObject` internal operations for own descriptors, values, definitions, writes, deletion, and complete ordered keys
- keep ordinary and generated `JsObject` subclasses on their existing direct hot paths while routing generic descriptor, proxy, prototype, integrity, enumeration, and accessor semantics through exotic overrides
- centralize allocation-free canonical array-index parsing for the full ECMA-262 array-index range without migrating `Array`
- add an exotic-storage test double covering descriptors, accessors, proxies, prototypes, integrity operations, key ordering, typed/data helpers, and rejected definitions/deletions
- add focused ordinary-object read/write BenchmarkDotNet coverage and document the change in the changelog

## Validation

- `Jroc.Tests`: 82 focused object, descriptor, proxy, prototype, and generated-subclass tests passed
- `Jroc.Test262.Tests`: 53 focused `Object.defineProperty`, `Object.getOwnPropertyDescriptor`, `Object.freeze`, and Proxy descriptor tests passed
- benchmark project builds with zero warnings

## Performance

Same-machine BenchmarkDotNet `ShortRun` comparison against `master`:

| Operation | master | this branch | Allocation |
|---|---:|---:|---:|
| ordinary `JsObject` read | 59.10 ns | 50.90 ns | 0 B |
| ordinary `JsObject` write | 432.79 ns | 380.22 ns | 432 B (unchanged) |

The short-run measurements show no material ordinary-object regression; override dispatch remains limited to explicitly marked exotic subclasses.

Closes #1444
