### PR TITLE
perf(benchmarks): add Kraken Jint and YantraJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 ## Unreleased
 
 - modules: add the Node `util/types` / `node:util/types` subpath as an alias of `util.types`, including Undici-required `isUint8Array` and `isArrayBuffer` predicates for Fetch byte validation and WebSocket ArrayBuffer handling. (#1496)
+- perf/benchmarks: add Jint and YantraJS execution measurements to the Kraken 1.1 `ai-astar` suite. The data and test scripts load during benchmark setup, so each runtime measures only the prepared `runTest()` invocation alongside the existing jroc and Okojo cases.
 
 ## v0.11.27 - 2026-07-16
 

--- a/tests/performance/Benchmarks/KrackenBenchmarks.cs
+++ b/tests/performance/Benchmarks/KrackenBenchmarks.cs
@@ -2,6 +2,8 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
 using Jroc;
 using Jroc.Runtime;
+using Jint;
+using YantraJS.Core;
 
 namespace Benchmarks;
 
@@ -27,6 +29,17 @@ public class KrackenBenchmarks
     /// </summary>
     private Okojo.Runtime.JsRealm? _okojoRealm = null;
     private Okojo.JsValue _okojoRunTest;
+
+    /// <summary>
+    /// Jint engine and prepared runTest function.
+    /// </summary>
+    private Engine? _jintEngine = null;
+
+    /// <summary>
+    /// YantraJS context and prepared runTest function.
+    /// </summary>
+    private JSContext? _yantraJsContext;
+    private JSValue? _yantraJsRunTest;
 
     private void SetupJroc(string astarDataScriptContent, string astarTestScriptContent)
     {
@@ -65,6 +78,27 @@ public class KrackenBenchmarks
         this._okojoRunTest = _okojoRealm.Global["runTest"];
     }
 
+    private void SetupJint(string astarDataScriptContent, string astarTestScriptContent)
+    {
+        var runTestContent = @"function runTest() { go(); return 'done';}";
+
+        _jintEngine = new Engine(options => options.Strict());
+        _jintEngine.Execute(astarDataScriptContent, "ai-astar-data.js");
+        _jintEngine.Execute(astarTestScriptContent, "ai-astar.js");
+        _jintEngine.Execute(runTestContent, "kracken-run-test.js");
+    }
+
+    private void SetupYantraJs(string astarDataScriptContent, string astarTestScriptContent)
+    {
+        var runTestContent = @"function runTest() { go(); return 'done';}";
+
+        var context = new JSContext();
+        context.Eval(astarDataScriptContent, "ai-astar-data.js");
+        context.Eval(astarTestScriptContent, "ai-astar.js");
+        _yantraJsRunTest = context.Eval(runTestContent + "\nrunTest;", "kracken-run-test.js");
+        _yantraJsContext = context;
+    }
+
     [ParamsSource(nameof(ScriptNames))]
     public string ScriptName { get; set; } = "";
 
@@ -88,6 +122,8 @@ public class KrackenBenchmarks
 
         SetupJroc(astarDataScriptContent, astarTestScriptContent);
         SetupOkojo(astarDataScriptContent, astarTestScriptContent);
+        SetupJint(astarDataScriptContent, astarTestScriptContent);
+        SetupYantraJs(astarDataScriptContent, astarTestScriptContent);
     }
 
     [Benchmark(Description = "jroc-execute")]
@@ -108,6 +144,27 @@ public class KrackenBenchmarks
         if (result.ToString() != "done")
         {
             throw new InvalidOperationException($"Unexpected result from Okojo test: {result}");
+        }
+    }
+
+    [Benchmark(Description = "jint-execute")]
+    public void RunJintTest()
+    {
+        var result = _jintEngine!.Invoke("runTest");
+        if (result.ToString() != "done")
+        {
+            throw new InvalidOperationException($"Unexpected result from Jint test: {result}");
+        }
+    }
+
+    [Benchmark(Description = "yantrajs-execute")]
+    public void RunYantraJsTest()
+    {
+        var arguments = Arguments.Empty;
+        var result = _yantraJsRunTest!.InvokeFunction(in arguments);
+        if (result.ToString() != "done")
+        {
+            throw new InvalidOperationException($"Unexpected result from YantraJS test: {result}");
         }
     }
 }

--- a/tests/performance/Benchmarks/README.md
+++ b/tests/performance/Benchmarks/README.md
@@ -109,6 +109,13 @@ dotnet run -c Release -- --phased --scenario dromaeo-3d-cube
 
 If any benchmark case fails, the run now exits non-zero and prints the failing benchmark cases instead of silently treating them as successful timings.
 
+#### Kraken Comparison
+Runs the Kraken 1.1 `ai-astar` workload with the test and data scripts loaded during setup, then measures only `runTest()` execution for jroc, Jint, Okojo, and YantraJS:
+
+```powershell
+dotnet run -c Release -- --kracken
+```
+
 #### Branch comparison workflow
 
 Run the manual `Benchmark branch comparison` workflow to compare a scenario from


### PR DESCRIPTION
## Summary
- add setup-prepared Jint execution to the Kraken ai-astar benchmark
- add direct YantraJS function execution and document the Kraken command
- record the additional runtime coverage in CHANGELOG.md

## Validation
- dotnet build tests\\performance\\Benchmarks\\Benchmarks.csproj -c Release --no-restore
- dotnet run --project tests\\performance\\Benchmarks\\Benchmarks.csproj -c Release --no-build -- --kracken --job Dry --filter '*KrackenBenchmarks*'