### PR TITLE
fix(perf): preserve execution runtime identities

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "perf:phased:cube": "node scripts/runCubePhasedGuardrails.js",
     "perf:compare:dispatch": "node scripts/dispatchBenchmarkBranchComparisonWorkflow.js",
     "perf:profile": "node scripts/profileBenchmarkScenario.js",
+    "test:perf-ingestion": "node --test tests/performance/ingestPerfToSupabase.test.js",
     "perf:phased:cube:dry": "node scripts/runCubePhasedGuardrails.js --dry",
     "perf:phased:cube:dry:il-smells": "node scripts/runCubePhasedGuardrails.js --dry --il-smells",
     "diff:test": "node scripts/differential-test/run.js",

--- a/tests/performance/ingestPerfToSupabase.js
+++ b/tests/performance/ingestPerfToSupabase.js
@@ -65,9 +65,11 @@ function normalizeRuntime(raw) {
     const text = String(raw ?? '').toLowerCase();
     if (text.includes('clearscript')) return 'clearscript';
     if (text.includes('node')) return 'node';
+    if (text.includes('yantra') && text.includes('execute')) return 'yantrajs-execute';
     if (text.includes('yantra')) return 'yantrajs';
     if (text.includes('jint') && text.includes('prepared')) return 'jint-execute-prepared';
     if (text.includes('jint') && text.includes('prepare')) return 'jint-prepare';
+    if (text.includes('jint') && text.includes('execute')) return 'jint-execute';
     if (text.includes('jint')) return 'jint';
     if (text.includes('jroc') && text.includes('execute') && text.includes('pre-compiled')) return 'jroc-execute';
     if (text.includes('jroc') && text.includes('execute') && text.includes('precompiled')) return 'jroc-execute';
@@ -884,7 +886,11 @@ async function main() {
     console.log(`Ingested ${dedupedRows.length} rows to Supabase from '${source}'.`);
 }
 
-main().catch(error => {
-    console.error(error.message);
-    process.exit(1);
-});
+if (require.main === module) {
+    main().catch(error => {
+        console.error(error.message);
+        process.exit(1);
+    });
+}
+
+module.exports = { normalizeRuntime };

--- a/tests/performance/ingestPerfToSupabase.test.js
+++ b/tests/performance/ingestPerfToSupabase.test.js
@@ -1,0 +1,13 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { normalizeRuntime } = require('./ingestPerfToSupabase');
+
+test('preserves execution-phase runtime identities', () => {
+    assert.equal(normalizeRuntime('jint-execute'), 'jint-execute');
+    assert.equal(normalizeRuntime('yantrajs-execute'), 'yantrajs-execute');
+});
+
+test('keeps existing Jint phase distinctions', () => {
+    assert.equal(normalizeRuntime('Jint prepare'), 'jint-prepare');
+    assert.equal(normalizeRuntime('Jint execute (prepared)'), 'jint-execute-prepared');
+});


### PR DESCRIPTION
Preserves jint-execute and yantrajs-execute during Supabase ingestion instead of collapsing them to the generic runtime labels. Adds a focused Node regression test for execution and existing Jint phase normalization.