### PR TITLE
refactor(runtime): internalize JsObject property reads

### DIFF
--- a/.github/workflows/benchmark-branch-comparison.yml
+++ b/.github/workflows/benchmark-branch-comparison.yml
@@ -82,7 +82,7 @@ jobs:
               benchmark_args=(--phased --filter "*JrocPhasedBenchmarks*" --scenario "$SCENARIO_NAME")
               ;;
             kracken)
-              benchmark_args=(--kracken --filter "*KrackenBenchmarks*" --scenario "$SCENARIO_NAME")
+              benchmark_args=(--kracken --scenario "$SCENARIO_NAME")
               ;;
             *)
               echo "Unsupported benchmark suite: $BENCHMARK_SUITE" >&2
@@ -123,7 +123,7 @@ jobs:
               benchmark_args=(--phased --filter "*JrocPhasedBenchmarks*" --scenario "$SCENARIO_NAME")
               ;;
             kracken)
-              benchmark_args=(--kracken --filter "*KrackenBenchmarks*" --scenario "$SCENARIO_NAME")
+              benchmark_args=(--kracken --scenario "$SCENARIO_NAME")
               ;;
             *)
               echo "Unsupported benchmark suite: $BENCHMARK_SUITE" >&2

--- a/.github/workflows/benchmark-branch-comparison.yml
+++ b/.github/workflows/benchmark-branch-comparison.yml
@@ -82,7 +82,7 @@ jobs:
               benchmark_args=(--phased --filter "*JrocPhasedBenchmarks*" --scenario "$SCENARIO_NAME")
               ;;
             kracken)
-              benchmark_args=(--kracken --scenario "$SCENARIO_NAME")
+              benchmark_args=(--kracken --filter "*KrackenBenchmarks*" --scenario "$SCENARIO_NAME")
               ;;
             *)
               echo "Unsupported benchmark suite: $BENCHMARK_SUITE" >&2
@@ -123,7 +123,7 @@ jobs:
               benchmark_args=(--phased --filter "*JrocPhasedBenchmarks*" --scenario "$SCENARIO_NAME")
               ;;
             kracken)
-              benchmark_args=(--kracken --scenario "$SCENARIO_NAME")
+              benchmark_args=(--kracken --filter "*KrackenBenchmarks*" --scenario "$SCENARIO_NAME")
               ;;
             *)
               echo "Unsupported benchmark suite: $BENCHMARK_SUITE" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 ## Unreleased
 
 - runtime: centralize `JsObject` own-property reads behind the virtual `TryGetBoxedValue` contract. Descriptor/accessor handling, delete tombstones, lazy class methods, and exotic subclass dispatch now stay within `JsObject`, while `Object.GetProperty` retains proxy, primitive, and prototype traversal. This behavior-preserving refactor prepares per-instance read optimizations without intentionally changing performance. (#1522)
+- ci/benchmarks: make the branch-comparison workflow select the Kraken benchmark class explicitly so non-interactive Kraken comparisons produce result artifacts.
 
 ## v0.11.29 - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 ## Unreleased
 
 - runtime: centralize `JsObject` own-property reads behind the virtual `TryGetBoxedValue` contract. Descriptor/accessor handling, delete tombstones, lazy class methods, and exotic subclass dispatch now stay within `JsObject`, while `Object.GetProperty` retains proxy, primitive, and prototype traversal. This behavior-preserving refactor prepares per-instance read optimizations without intentionally changing performance. (#1522)
-- ci/benchmarks: make the branch-comparison workflow select the Kraken benchmark class explicitly so non-interactive Kraken comparisons produce result artifacts.
 
 ## v0.11.29 - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- runtime: centralize `JsObject` own-property reads behind the virtual `TryGetBoxedValue` contract. Descriptor/accessor handling, delete tombstones, lazy class methods, and exotic subclass dispatch now stay within `JsObject`, while `Object.GetProperty` retains proxy, primitive, and prototype traversal. This behavior-preserving refactor prepares per-instance read optimizations without intentionally changing performance. (#1522)
 
 ## v0.11.29 - 2026-07-17
 

--- a/docs/runtime/OrdinaryObjectRepresentation.md
+++ b/docs/runtime/OrdinaryObjectRepresentation.md
@@ -17,7 +17,8 @@ instances; callers must not depend on a CLR dynamic-object implementation.
 The virtual internal-operation hooks on `JsObject` cover:
 
 - own descriptor lookup
-- own value lookup and presence
+- own property-value resolution, including data/accessor descriptors and lazy methods
+- specialized backing-value lookup and presence
 - property definition and assignment
 - deletion
 - complete own-key enumeration
@@ -25,6 +26,13 @@ The virtual internal-operation hooks on `JsObject` cover:
 Ordinary objects implement these operations with shape/slot and descriptor
 storage. Generic runtime code dispatches through this shared contract instead of
 maintaining a parallel representation switch.
+
+`Object.GetProperty` delegates `JsObject` own reads to `TryGetBoxedValue`.
+`JsObject` keeps descriptor lookup, accessor invocation, delete tombstones, and
+lazy class-method materialization inside that contract, while preserving the
+original receiver for inherited accessors. Exotic subclasses participate
+through the same virtual/internal operations. Proxy traps, primitive behavior,
+and prototype traversal remain the responsibility of the outer object runtime.
 
 `Array : JsObject` is the first exotic subclass. It inherits identity, ordinary
 named and symbol properties, prototype state, and descriptor integration, while

--- a/src/JavaScriptRuntime/JsObject.cs
+++ b/src/JavaScriptRuntime/JsObject.cs
@@ -203,7 +203,7 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
     /// keys and are never converted to display strings by this contract.
     /// </summary>
     internal virtual bool TryGetOwnPropertyValue(string key, out object? value)
-        => TryGetBoxedValue(key, out value);
+        => TryGetStoredBoxedValue(key, out value);
 
     /// <summary>Tests specialized backing storage for an own property without reading its value.</summary>
     internal virtual bool HasOwnPropertyValue(string key)
@@ -323,16 +323,71 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
     // -------------------------------------------------------------------------
 
     /// <summary>
-    /// Tries to get the value for <paramref name="key"/> as a boxed CLR object.
-    /// Returns <c>true</c> and sets <paramref name="value"/> when found.
+    /// Tries to read this object's shape/slot storage as a boxed CLR object.
     /// </summary>
     public bool TryGetBoxedValue(string key, out object? value)
+        => TryGetStoredBoxedValue(key, out value);
+
+    /// <summary>
+    /// Resolves an own JavaScript property while keeping descriptor and exotic-object
+    /// semantics internal and preserving the original receiver for inherited accessors.
+    /// </summary>
+    internal virtual bool TryGetBoxedValue(
+        string key,
+        object receiverForAccessors,
+        out object? value)
     {
-        if (TryGetJsValue(key, out var jv))
+        if (this is not IExoticJsObject
+            && !HasNonDataDescriptors
+            && TryGetStoredBoxedValue(key, out value))
         {
-            value = jv.ToObject();
             return true;
         }
+
+        var lookup = PropertyDescriptorStore.GetOwnLookup(this, key, out var descriptor);
+        if (lookup == PropertyDescriptorLookup.Deleted)
+        {
+            value = null;
+            return false;
+        }
+
+        if (lookup == PropertyDescriptorLookup.Found)
+        {
+            if (descriptor.Kind == JsPropertyDescriptorKind.Accessor)
+            {
+                value = descriptor.Get is null || descriptor.Get is JsNull
+                    ? null
+                    : Object.InvokeCallable(
+                        descriptor.Get,
+                        receiverForAccessors,
+                        System.Array.Empty<object>());
+                return true;
+            }
+
+            value = descriptor.Value;
+            return true;
+        }
+
+        if (RuntimeServices.TryEnsureLazyClassMethodDataProperty(
+            this,
+            key,
+            out var lazyClassMethodDescriptor))
+        {
+            value = lazyClassMethodDescriptor.Value;
+            return true;
+        }
+
+        return TryGetOwnPropertyValue(key, out value);
+    }
+
+    private bool TryGetStoredBoxedValue(string key, out object? value)
+    {
+        if (TryGetJsValue(key, out var jsValue))
+        {
+            value = jsValue.ToObject();
+            return true;
+        }
+
         value = null;
         return false;
     }

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -3669,7 +3669,7 @@ namespace JavaScriptRuntime
             return false;
         }
 
-        private static object? InvokeCallable(object? callable, object thisArg, object?[] args)
+        internal static object? InvokeCallable(object? callable, object thisArg, object?[] args)
         {
             if (callable is null || callable is JsNull)
             {
@@ -4170,6 +4170,11 @@ namespace JavaScriptRuntime
             {
                 value = JavaScriptRuntime.Array.Prototype;
                 return true;
+            }
+
+            if (target is JsObject jsObject)
+            {
+                return jsObject.TryGetBoxedValue(propName, receiverForAccessors, out value);
             }
 
             // Perf (#1418): single-probe lookup answering deleted/descriptor/none at once.
@@ -5536,61 +5541,16 @@ namespace JavaScriptRuntime
             // Null/undefined -> undefined (modeled as null)
             if (obj is null) return null;
 
-            // Perf: plain JsObject fast path. While an ordinary object has only
-            // mirrored default data descriptors (no accessors, deletes, or
-            // attribute-bearing descriptors), its property dictionary is fully
-            // authoritative for own reads — answer directly from the shape/slot
-            // storage without probing the descriptor store (ConditionalWeakTable).
-            // Own misses fall through so prototype-chain and special-name
-            // semantics are preserved.
-            if (obj is JsObject plainJsObject
-                && plainJsObject is not IExoticJsObject
-                && !plainJsObject.HasNonDataDescriptors)
-            {
-                if (plainJsObject.TryGetBoxedValue(name, out var plainValue))
-                {
-                    return plainValue;
-                }
-            }
-            // Descriptor-aware fast dispatch for ordinary JsObject receivers. Own
-            // properties on these receivers are authoritatively descriptor-backed
-            // (literal/assignment writes mirror a data descriptor), so a single
-            // descriptor probe resolves the overwhelmingly common case without
-            // walking the full dispatch ladder below. Misses fall through so
-            // rarely-taken paths (lazy class methods, __proto__, inheritance)
-            // keep their existing semantics. Function.Prototype is excluded to
-            // preserve the restricted 'caller'/'arguments' check.
-            else if (ObjectRuntime.IsOrdinaryObject(obj)
-                && !ReferenceEquals(obj, JavaScriptRuntime.Function.Prototype))
-            {
-                var lookup = PropertyDescriptorStore.GetOwnLookup(obj, name, out var fastDesc);
-                if (lookup == PropertyDescriptorLookup.Found)
-                {
-                    if (fastDesc.Kind == JsPropertyDescriptorKind.Data)
-                    {
-                        return fastDesc.Value;
-                    }
-
-                    return fastDesc.Get is null || fastDesc.Get is JsNull
-                        ? null
-                        : InvokeCallable(fastDesc.Get, obj, System.Array.Empty<object>());
-                }
-
-                if (lookup == PropertyDescriptorLookup.None
-                    && ObjectRuntime.TryGetOwnValue(obj, name, out var fastOrdinaryValue))
-                {
-                    // Backing-only entries (no shadowing descriptor) mirror the
-                    // existing TryGetFastDictionaryOwnValue behavior.
-                    return fastOrdinaryValue;
-                }
-
-                // Own miss (or delete tombstone): fall through to the full ladder.
-            }
-
             if (ReferenceEquals(obj, JavaScriptRuntime.Function.Prototype)
                 && (string.Equals(name, "caller", StringComparison.Ordinal) || string.Equals(name, "arguments", StringComparison.Ordinal)))
             {
                 throw new TypeError($"Cannot access restricted function property '{name}'");
+            }
+
+            if (obj is JsObject jsObject
+                && jsObject.TryGetBoxedValue(name, obj, out var jsObjectValue))
+            {
+                return jsObjectValue;
             }
 
             // Proxy get trap
@@ -5619,12 +5579,14 @@ namespace JavaScriptRuntime
                 }
             }
 
-            if (TryGetFastDictionaryOwnValue(obj, name, out var fastOwnValue))
+            if (obj is not JsObject
+                && TryGetFastDictionaryOwnValue(obj, name, out var fastOwnValue))
             {
                 return fastOwnValue;
             }
 
-            if (TryGetOwnPropertyValue(obj, name, out var ownValue))
+            if (obj is not JsObject
+                && TryGetOwnPropertyValue(obj, name, out var ownValue))
             {
                 return ownValue;
             }

--- a/tests/Jroc.Tests/Array/RuntimeJsObjectInheritanceTests.cs
+++ b/tests/Jroc.Tests/Array/RuntimeJsObjectInheritanceTests.cs
@@ -72,9 +72,12 @@ public sealed class RuntimeJsObjectInheritanceTests
             Assert.IsAssignableFrom<JsObject>(array);
             Assert.Equal(3d, ObjectRuntime.GetProperty(target, "custom"));
             Assert.Equal(4d, ObjectRuntime.GetItem(target, "2"));
+            Assert.Equal(3d, ObjectRuntime.GetProperty(target, "length"));
             Assert.Equal(3d, array.length);
 
             var ordinaryStorage = (IDictionary<string, object?>)array;
+            Assert.False(((JsObject)array).TryGetBoxedValue("length", out _));
+            Assert.False(((JsObject)array).TryGetBoxedValue("0", out _));
             Assert.Equal(3d, ordinaryStorage["custom"]);
             Assert.DoesNotContain("0", ((JsObject)array).GetOwnPropertyNames());
             Assert.DoesNotContain("2", ((JsObject)array).GetOwnPropertyNames());

--- a/tests/Jroc.Tests/ObjectRuntimeOrdinaryObjectTests.cs
+++ b/tests/Jroc.Tests/ObjectRuntimeOrdinaryObjectTests.cs
@@ -13,8 +13,19 @@ public sealed class ObjectRuntimeOrdinaryObjectTests
 
         public bool RejectDeletions { get; set; }
 
+        public int PropertyReadCount { get; private set; }
+
         public void Seed(string key, object? value)
             => _values[key] = value;
+
+        internal override bool TryGetBoxedValue(
+            string key,
+            object receiverForAccessors,
+            out object? value)
+        {
+            PropertyReadCount++;
+            return base.TryGetBoxedValue(key, receiverForAccessors, out value);
+        }
 
         internal override bool TryGetOwnPropertyValue(string key, out object? value)
             => _values.TryGetValue(key, out value);
@@ -77,9 +88,20 @@ public sealed class ObjectRuntimeOrdinaryObjectTests
             Assert.Equal(3d, ObjectRuntime.GetProperty(target, "inherited"));
             Assert.True(JavaScriptRuntime.Object.hasOwn(target, "first"));
             Assert.True(Operators.In("inherited", target));
+
             Assert.Equal(
                 new object?[] { "1", "second", "first" },
                 Assert.IsType<JavaScriptRuntime.Array>(JavaScriptRuntime.Object.getOwnPropertyNames(target)).ToArray());
+
+            PropertyDescriptorStore.DefineOrUpdate(target, "descriptorOnly", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Value = 4d,
+                Writable = true,
+                Enumerable = true,
+                Configurable = true
+            });
+            Assert.Equal(4d, ObjectRuntime.GetProperty(target, "descriptorOnly"));
 
             Assert.True(ObjectRuntime.DeleteProperty(target, "second"));
             Assert.False(JavaScriptRuntime.Object.hasOwn(target, "second"));
@@ -102,6 +124,34 @@ public sealed class ObjectRuntimeOrdinaryObjectTests
                 ObjectRuntime.DeleteProperty(deleteRejectingTarget, "retained"));
             Assert.False(ObjectRuntime.DeletePropertyNonStrict(deleteRejectingTarget, "retained"));
             Assert.True(JavaScriptRuntime.Object.hasOwn(deleteRejectingTarget, "retained"));
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void PropertyReadContract_PreservesInheritedAccessorReceiver()
+    {
+        var runtime = RuntimeServices.BuildServiceProvider();
+        try
+        {
+            GlobalThis.ServiceProvider = runtime;
+            var target = new JsObject();
+            var prototype = new JsObject();
+
+            ObjectRuntime.SetProperty(target, "marker", "target");
+            Func<object[], object?[]?, object?> getter = static (_, _) =>
+                ObjectRuntime.GetProperty(RuntimeServices.GetCurrentThis()!, "marker");
+            ObjectRuntime.DefineObjectLiteralAccessorProperty(
+                prototype,
+                "computed",
+                getter,
+                null);
+            JavaScriptRuntime.Object.setPrototypeOf(target, prototype);
+
+            Assert.Equal("target", ObjectRuntime.GetProperty(target, "computed"));
         }
         finally
         {
@@ -214,6 +264,7 @@ public sealed class ObjectRuntimeOrdinaryObjectTests
 
             Assert.Equal(2d, ObjectRuntime.GetProperty(target, "second"));
             Assert.Equal(3d, ObjectRuntime.GetProperty(target, "inherited"));
+            Assert.True(target.PropertyReadCount >= 2);
             Assert.True(JavaScriptRuntime.Object.hasOwn(target, "first"));
             Assert.True(Operators.In("inherited", target));
             Assert.Equal(


### PR DESCRIPTION
## Summary

- internalize ordinary `JsObject` own-property reads behind a receiver-aware virtual contract
- preserve the public raw shape/slot `TryGetBoxedValue` behavior
- keep proxy and prototype traversal in `Object.GetProperty`
- preserve descriptor values, accessors, exotic objects, deletion tombstones, and lazy class methods
- add focused runtime contract coverage and document the new ownership boundary

This is intentionally a behavior-preserving refactor. The follow-up Array `length` fast path remains tracked by #1523.

## Benchmark

[`Benchmark branch comparison` run 29622664600](https://github.com/tomacox74/js2il/actions/runs/29622664600) compared `master` with this branch on the same runner using `kracken / ai-astar`.

| JROC metric | master | this branch | change |
| --- | ---: | ---: | ---: |
| Mean | 11.422 s | 11.599 s | +1.55% |
| Median | 11.467 s | 11.571 s | +0.91% |
| StdDev | 0.251 s | 0.268 s | |
| Allocated | 3329.48 MB | 3326.39 MB | -3.09 MB (-0.093%) |

The small timing difference is within benchmark variability, and allocation is effectively neutral with a slight improvement.

## Validation

- focused property-read, descriptor, Array, lazy class-method, execution, and generator tests
- Release build
- same-runner `ai-astar` branch comparison above

Closes #1522
