### PR TITLE
perf(runtime): avoid synthetic descriptors for value reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-- perf/runtime: separate exotic-object value reads from descriptor introspection. Array `length`, dense indices, and named values now use backing storage without synthesizing `JsPropertyDescriptor` instances, while stored accessors, data overrides, tombstones, and descriptor APIs retain their existing semantics. (#1523)
+- perf/runtime: separate exotic-object value reads from descriptor introspection. Array `length`, dense indices, and named values now use backing storage without synthesizing `JsPropertyDescriptor` instances, while stored accessors, data overrides, tombstones, and descriptor APIs retain their existing semantics. A same-runner `ai-astar` comparison reduced mean execution time from 11.663 s to 8.119 s (30.4%) and allocation from 3326.39 MB to 1172.04 MB (64.8%). (#1523)
 - runtime: centralize `JsObject` own-property reads behind the virtual `TryGetBoxedValue` contract. Descriptor/accessor handling, delete tombstones, lazy class methods, and exotic subclass dispatch now stay within `JsObject`, while `Object.GetProperty` retains proxy, primitive, and prototype traversal. This behavior-preserving refactor prepares per-instance read optimizations without intentionally changing performance. (#1522)
 
 ## v0.11.29 - 2026-07-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf/runtime: separate exotic-object value reads from descriptor introspection. Array `length`, dense indices, and named values now use backing storage without synthesizing `JsPropertyDescriptor` instances, while stored accessors, data overrides, tombstones, and descriptor APIs retain their existing semantics. (#1523)
 - runtime: centralize `JsObject` own-property reads behind the virtual `TryGetBoxedValue` contract. Descriptor/accessor handling, delete tombstones, lazy class methods, and exotic subclass dispatch now stay within `JsObject`, while `Object.GetProperty` retains proxy, primitive, and prototype traversal. This behavior-preserving refactor prepares per-instance read optimizations without intentionally changing performance. (#1522)
 
 ## v0.11.29 - 2026-07-17

--- a/docs/runtime/OrdinaryObjectRepresentation.md
+++ b/docs/runtime/OrdinaryObjectRepresentation.md
@@ -28,11 +28,14 @@ storage. Generic runtime code dispatches through this shared contract instead of
 maintaining a parallel representation switch.
 
 `Object.GetProperty` delegates `JsObject` own reads to `TryGetBoxedValue`.
-`JsObject` keeps descriptor lookup, accessor invocation, delete tombstones, and
-lazy class-method materialization inside that contract, while preserving the
-original receiver for inherited accessors. Exotic subclasses participate
-through the same virtual/internal operations. Proxy traps, primitive behavior,
-and prototype traversal remain the responsibility of the outer object runtime.
+`JsObject` checks stored descriptor overrides, accessors, and delete tombstones
+inside that contract, while preserving the original receiver for inherited
+accessors. When no stored descriptor affects the read, it asks the object's
+backing-value hook directly instead of materializing a descriptor. Full
+descriptor synthesis remains confined to descriptor APIs. Exotic subclasses
+participate through the same virtual/internal operations. Proxy traps,
+primitive behavior, and prototype traversal remain the responsibility of the
+outer object runtime.
 
 `Array : JsObject` is the first exotic subclass. It inherits identity, ordinary
 named and symbol properties, prototype state, and descriptor integration, while
@@ -43,6 +46,11 @@ overriding only behavior that is exotic under ECMA-262:
 - `length` uses `ArraySetLength` semantics
 - indexed definitions and deletions enforce descriptor and integrity invariants
 - own keys merge indices, other strings, and symbols in specification order
+
+Ordinary reads of default `length`, dense indices, and named Array properties
+use their backing storage directly. Stored accessor/data overrides and
+tombstones remain authoritative, while APIs such as
+`Object.getOwnPropertyDescriptor` continue through Array's descriptor hook.
 
 Array literals and compiler-proven numeric index operations still target direct
 array intrinsics. The shared object contract does not replace the specialized

--- a/src/JavaScriptRuntime/Array.cs
+++ b/src/JavaScriptRuntime/Array.cs
@@ -1099,6 +1099,18 @@ namespace JavaScriptRuntime
             return base.TryGetOwnPropertyValue(key, out value);
         }
 
+        internal override bool TryGetInvariantOwnPropertyValue(string key, out object? value)
+        {
+            if (string.Equals(key, "length", StringComparison.Ordinal))
+            {
+                value = length;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
         internal override bool HasOwnPropertyValue(string key)
         {
             var lookup = PropertyDescriptorStore.GetOwnLookupCore(this, key, out _);

--- a/src/JavaScriptRuntime/JsObject.cs
+++ b/src/JavaScriptRuntime/JsObject.cs
@@ -205,6 +205,16 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
     internal virtual bool TryGetOwnPropertyValue(string key, out object? value)
         => TryGetStoredBoxedValue(key, out value);
 
+    /// <summary>
+    /// Reads an own value whose property invariants make descriptor state irrelevant.
+    /// Returning false defers to normal descriptor-aware resolution.
+    /// </summary>
+    internal virtual bool TryGetInvariantOwnPropertyValue(string key, out object? value)
+    {
+        value = null;
+        return false;
+    }
+
     /// <summary>Tests specialized backing storage for an own property without reading its value.</summary>
     internal virtual bool HasOwnPropertyValue(string key)
         => ContainsKey(key);
@@ -337,14 +347,23 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
         object receiverForAccessors,
         out object? value)
     {
-        if (this is not IExoticJsObject
+        var isExotic = this is IExoticJsObject;
+        if (isExotic && TryGetInvariantOwnPropertyValue(key, out value))
+        {
+            return true;
+        }
+
+        if (!isExotic
             && !HasNonDataDescriptors
             && TryGetStoredBoxedValue(key, out value))
         {
             return true;
         }
 
-        var lookup = PropertyDescriptorStore.GetOwnLookup(this, key, out var descriptor);
+        // Value reads need only stored overrides. Calling the semantic descriptor
+        // hook here would force exotic objects to materialize synthetic descriptors
+        // for values that already live in specialized backing storage.
+        var lookup = PropertyDescriptorStore.GetOwnLookupCore(this, key, out var descriptor);
         if (lookup == PropertyDescriptorLookup.Deleted)
         {
             value = null;
@@ -368,6 +387,11 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
             return true;
         }
 
+        if (TryGetOwnPropertyValue(key, out value))
+        {
+            return true;
+        }
+
         if (RuntimeServices.TryEnsureLazyClassMethodDataProperty(
             this,
             key,
@@ -377,7 +401,8 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
             return true;
         }
 
-        return TryGetOwnPropertyValue(key, out value);
+        value = null;
+        return false;
     }
 
     private bool TryGetStoredBoxedValue(string key, out object? value)

--- a/tests/Jroc.Tests/Array/RuntimeJsObjectInheritanceTests.cs
+++ b/tests/Jroc.Tests/Array/RuntimeJsObjectInheritanceTests.cs
@@ -4,6 +4,27 @@ namespace Jroc.Tests.Array;
 
 public sealed class RuntimeJsObjectInheritanceTests
 {
+    private sealed class DescriptorCountingArray : JavaScriptRuntime.Array
+    {
+        public DescriptorCountingArray(object?[] values)
+            : base(values)
+        {
+        }
+
+        public int DescriptorLookupCount { get; private set; }
+
+        public void ResetDescriptorLookupCount()
+            => DescriptorLookupCount = 0;
+
+        internal override PropertyDescriptorLookup GetOwnPropertyDescriptor(
+            string key,
+            out JsPropertyDescriptor descriptor)
+        {
+            DescriptorLookupCount++;
+            return base.GetOwnPropertyDescriptor(key, out descriptor);
+        }
+    }
+
     [Fact]
     public void ArrayPrototypeAndUnscopables_UseJsObjectRepresentation()
     {
@@ -107,6 +128,88 @@ public sealed class RuntimeJsObjectInheritanceTests
             Assert.Null(ObjectRuntime.GetProperty(target, "custom"));
             Assert.Equal(9d, array.length);
             Assert.Equal(5d, array[4]);
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void ValueReads_BypassSyntheticArrayDescriptors()
+    {
+        var runtime = RuntimeServices.BuildServiceProvider();
+        try
+        {
+            GlobalThis.ServiceProvider = runtime;
+            var array = new DescriptorCountingArray(new object?[] { 1d, 2d });
+            array.ResetDescriptorLookupCount();
+
+            Assert.Equal(2d, ObjectRuntime.GetProperty(array, "length"));
+            Assert.Equal(1d, ObjectRuntime.GetProperty(array, "0"));
+            Assert.Equal(0, array.DescriptorLookupCount);
+
+            Func<object[], object?[]?, object?> getter = static (_, _) => "accessor";
+            Assert.True(array.DefineOwnProperty("0", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Accessor,
+                Get = getter,
+                Enumerable = true,
+                Configurable = true
+            }));
+            var descriptorLookupCount = array.DescriptorLookupCount;
+            Assert.Equal("accessor", ObjectRuntime.GetProperty(array, "0"));
+            Assert.Equal(descriptorLookupCount, array.DescriptorLookupCount);
+
+            Assert.True(array.DefineOwnProperty("length", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Value = 2d,
+                Writable = false,
+                Enumerable = false,
+                Configurable = false
+            }));
+            descriptorLookupCount = array.DescriptorLookupCount;
+            Assert.Equal(2d, ObjectRuntime.GetProperty(array, "length"));
+            Assert.Equal(descriptorLookupCount, array.DescriptorLookupCount);
+
+            Assert.True(array.DeleteOwnProperty("0"));
+            descriptorLookupCount = array.DescriptorLookupCount;
+            Assert.Null(ObjectRuntime.GetProperty(array, "0"));
+            Assert.Equal(descriptorLookupCount, array.DescriptorLookupCount);
+
+            Assert.IsType<JsObject>(
+                JavaScriptRuntime.Object.getOwnPropertyDescriptor(array, "length"));
+            Assert.Equal(descriptorLookupCount + 1, array.DescriptorLookupCount);
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void LengthValueReads_AllocateOnlyTheBoxedResult()
+    {
+        var runtime = RuntimeServices.BuildServiceProvider();
+        try
+        {
+            GlobalThis.ServiceProvider = runtime;
+            var array = new JavaScriptRuntime.Array(new object?[] { 1d, 2d, 3d });
+
+            _ = ObjectRuntime.GetProperty(array, "length");
+            const int iterations = 10_000;
+            object? value = null;
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < iterations; i++)
+            {
+                value = ObjectRuntime.GetProperty(array, "length");
+            }
+
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.Equal(3d, value);
+            Assert.InRange(allocated, 0, iterations * 32L);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- separate exotic-object value reads from semantic descriptor materialization
- keep stored data/accessor overrides and delete tombstones authoritative
- add a reusable invariant-value hook for internal-slot properties such as Array `length`
- read default Array length, dense indices, and named values from backing storage
- keep `Object.getOwnPropertyDescriptor` and descriptor mutation on the full descriptor path

## Allocation behavior

Repeated `ObjectRuntime.GetProperty(array, "length")` calls now allocate only the boxed JavaScript value at the object-returning API boundary. A focused regression test caps 10,000 reads at 32 bytes per read; the previous synthetic-descriptor path exceeded that bound.

[`Benchmark branch comparison` run 29626552561](https://github.com/tomacox74/js2il/actions/runs/29626552561) compared `master` with this branch on the same runner using `kracken / ai-astar`.

| JROC metric | master | this branch | change |
| --- | ---: | ---: | ---: |
| Mean | 11.663 s | 8.119 s | **-30.4%** |
| Median | 11.721 s | 8.123 s | **-30.7%** |
| StdDev | 0.258 s | 0.103 s | |
| Allocated | 3326.39 MB | 1172.04 MB | **-2154.35 MB (-64.8%)** |

The resulting allocation is back near the 1169.88 MB level measured before the `Array : JsObject` regression.

## Validation

- focused ordinary/exotic property-read tests
- Array descriptor, dense-fast-path, reflection, and class-method execution tests
- Release build
- PR build, canary, and test262 checks

Closes #1523
