### PR TITLE
perf(runtime): store property descriptors as values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-- perf/runtime: store `JsPropertyDescriptor` as a value type so descriptor snapshots and synthesized descriptors no longer allocate a separate descriptor object. Descriptor reads return independent copies while snapshot publication, accessor identity, and runtime-local overrides preserve existing semantics.
+- perf/runtime: store `JsPropertyDescriptor` as a value type so descriptor snapshots and synthesized descriptors no longer allocate a separate descriptor object. Descriptor reads return independent copies while snapshot publication, accessor identity, and runtime-local overrides preserve existing semantics. Repeated hosted comparisons found no repeatable execution-time regression: `ai-astar` ranged from 3.1% slower to 5.2% faster while consistently allocating 4,361,400 fewer bytes/op (-0.35%), and `array-stress` ran 1.1-3.3% faster while allocating about 5.8 KB more/op (+0.35%).
 
 ## v0.11.30 - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-- perf/runtime: store `JsPropertyDescriptor` as a value type so descriptor snapshots and synthesized descriptors no longer allocate a separate descriptor object. Descriptor reads return independent copies while snapshot publication, accessor identity, and runtime-local overrides preserve existing semantics. Repeated hosted comparisons found no repeatable execution-time regression: `ai-astar` ranged from 3.1% slower to 5.2% faster while consistently allocating 4,361,400 fewer bytes/op (-0.35%), and `array-stress` ran 1.1-3.3% faster while allocating about 5.8 KB more/op (+0.35%).
+- perf/runtime: store `JsPropertyDescriptor` as a value type so descriptor snapshots and synthesized descriptors no longer allocate a separate descriptor object. Descriptor reads return independent copies while snapshot publication, accessor identity, and runtime-local overrides preserve existing semantics. Field ordering keeps the descriptor at 32 bytes on 64-bit runtimes. Repeated hosted comparisons found no repeatable execution-time regression: `ai-astar` consistently allocated 4,361,400 fewer bytes/op (-0.35%), `array-stress` allocated about 5.8 KB more/op (+0.35%), and `audio-beat-detection` allocated 1,008,000 fewer bytes/op (-0.007%). Compact-layout reruns produced the same allocation results as the original 40-byte struct layout.
 
 ## v0.11.30 - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/runtime: store `JsPropertyDescriptor` as a value type so descriptor snapshots and synthesized descriptors no longer allocate a separate descriptor object. Descriptor reads return independent copies while snapshot publication, accessor identity, and runtime-local overrides preserve existing semantics.
 
 ## v0.11.30 - 2026-07-18
 

--- a/docs/runtime/OrdinaryObjectRepresentation.md
+++ b/docs/runtime/OrdinaryObjectRepresentation.md
@@ -29,7 +29,8 @@ maintaining a parallel representation switch.
 
 Descriptor snapshots store `JsPropertyDescriptor` values inline. Reads return
 independent value copies, while writes publish new immutable snapshots; accessor
-getter and setter references retain their JavaScript identity across copies.
+getter and setter references retain their JavaScript identity across copies. Its
+boolean fields precede reference fields so the value occupies 32 bytes on 64-bit runtimes.
 
 `Object.GetProperty` delegates `JsObject` own reads to `TryGetBoxedValue`.
 `JsObject` checks stored descriptor overrides, accessors, and delete tombstones

--- a/docs/runtime/OrdinaryObjectRepresentation.md
+++ b/docs/runtime/OrdinaryObjectRepresentation.md
@@ -27,6 +27,10 @@ Ordinary objects implement these operations with shape/slot and descriptor
 storage. Generic runtime code dispatches through this shared contract instead of
 maintaining a parallel representation switch.
 
+Descriptor snapshots store `JsPropertyDescriptor` values inline. Reads return
+independent value copies, while writes publish new immutable snapshots; accessor
+getter and setter references retain their JavaScript identity across copies.
+
 `Object.GetProperty` delegates `JsObject` own reads to `TryGetBoxedValue`.
 `JsObject` checks stored descriptor overrides, accessors, and delete tombstones
 inside that contract, while preserving the original receiver for inherited

--- a/src/JavaScriptRuntime/Array.cs
+++ b/src/JavaScriptRuntime/Array.cs
@@ -1072,7 +1072,7 @@ namespace JavaScriptRuntime
                 return PropertyDescriptorLookup.Found;
             }
 
-            descriptor = null!;
+            descriptor = default;
             return PropertyDescriptorLookup.None;
         }
 
@@ -1134,8 +1134,6 @@ namespace JavaScriptRuntime
 
         internal override bool DefineOwnProperty(string key, JsPropertyDescriptor descriptor)
         {
-            ArgumentNullException.ThrowIfNull(descriptor);
-
             if (string.Equals(key, "length", StringComparison.Ordinal))
             {
                 return DefineLengthProperty(descriptor);
@@ -1352,7 +1350,7 @@ namespace JavaScriptRuntime
         {
             var lookup = PropertyDescriptorStore.GetOwnLookupCore(this, key, out var storedDescriptor);
             var hasCurrent = lookup == PropertyDescriptorLookup.Found;
-            JsPropertyDescriptor? current = hasCurrent ? storedDescriptor : null;
+            var current = storedDescriptor;
 
             if (!hasCurrent && index <= int.MaxValue && HasDenseIndex((int)index))
             {
@@ -1365,7 +1363,7 @@ namespace JavaScriptRuntime
                 return false;
             }
 
-            if (current != null && !IsCompatibleDescriptor(current, descriptor))
+            if (hasCurrent && !IsCompatibleDescriptor(current, descriptor))
             {
                 return false;
             }

--- a/src/JavaScriptRuntime/Function.cs
+++ b/src/JavaScriptRuntime/Function.cs
@@ -741,11 +741,11 @@ public static class Function
 
             if (IsMetadataPropertyName(propName) && PropertyDescriptorStore.IsDeleted(target, propName))
             {
-                descriptor = null!;
+                descriptor = default;
                 return false;
             }
 
-            if (PropertyDescriptorStore.TryGetOwn(target, propName, out descriptor!))
+            if (PropertyDescriptorStore.TryGetOwn(target, propName, out descriptor))
             {
                 return true;
             }
@@ -778,7 +778,7 @@ public static class Function
                 return true;
             }
 
-            descriptor = null!;
+            descriptor = default;
             return false;
         }
 

--- a/src/JavaScriptRuntime/JsObject.cs
+++ b/src/JavaScriptRuntime/JsObject.cs
@@ -182,7 +182,7 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
 
         if (!TryGetOwnPropertyValue(key, out var value))
         {
-            descriptor = null!;
+            descriptor = default;
             return PropertyDescriptorLookup.None;
         }
 
@@ -225,8 +225,6 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
     /// </summary>
     internal virtual bool DefineOwnProperty(string key, JsPropertyDescriptor descriptor)
     {
-        ArgumentNullException.ThrowIfNull(descriptor);
-
         if (!PropertyDescriptorStore.HasIntrinsicProperties(this))
         {
             if (!SetOwnPropertyValue(

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -3713,7 +3713,7 @@ namespace JavaScriptRuntime
                             }
                         }
 
-                        descriptor = null!;
+                        descriptor = default;
                         return false;
                     }
 
@@ -3749,7 +3749,7 @@ namespace JavaScriptRuntime
 
             if (PropertyDescriptorStore.IsDeleted(target, propName))
             {
-                descriptor = null!;
+                descriptor = default;
                 return false;
             }
 
@@ -3761,14 +3761,14 @@ namespace JavaScriptRuntime
 
             if (GlobalThis.IsArrayConstructorValue(target)
                 && string.Equals(propName, "prototype", StringComparison.Ordinal)
-                && PropertyDescriptorStore.TryGetOwn(target, propName, out descriptor!))
+                && PropertyDescriptorStore.TryGetOwn(target, propName, out descriptor))
             {
                 descriptor = PropertyDescriptorStore.CloneDescriptor(descriptor);
                 descriptor.Value = JavaScriptRuntime.Array.Prototype;
                 return true;
             }
 
-            if (PropertyDescriptorStore.TryGetOwn(target, propName, out descriptor!))
+            if (PropertyDescriptorStore.TryGetOwn(target, propName, out descriptor))
             {
                 return true;
             }
@@ -3788,23 +3788,23 @@ namespace JavaScriptRuntime
                 return true;
             }
 
-            if (target is Delegate del && Function.TryEnsureOwnMetadataPropertyDescriptor(del, propName, out descriptor!))
+            if (target is Delegate del && Function.TryEnsureOwnMetadataPropertyDescriptor(del, propName, out descriptor))
             {
                 return true;
             }
 
             if (target is ClassConstructorValue classConstructorValue
-                && RuntimeServices.TryEnsureClassConstructorMetadataPropertyDescriptor(classConstructorValue, propName, out descriptor!))
+                && RuntimeServices.TryEnsureClassConstructorMetadataPropertyDescriptor(classConstructorValue, propName, out descriptor))
             {
                 return true;
             }
 
-            if (RuntimeServices.TryEnsureLazyClassMethodDataProperty(target, propName, out descriptor!))
+            if (RuntimeServices.TryEnsureLazyClassMethodDataProperty(target, propName, out descriptor))
             {
                 return true;
             }
 
-            if (TryEnsureStaticClassMethodDataProperty(target, propName, out descriptor!))
+            if (TryEnsureStaticClassMethodDataProperty(target, propName, out descriptor))
             {
                 return true;
             }
@@ -3959,7 +3959,7 @@ namespace JavaScriptRuntime
             }
 
             // No implicit descriptor support for arrays/typed arrays/strings here.
-            descriptor = null!;
+            descriptor = default;
             return false;
         }
 
@@ -4020,13 +4020,13 @@ namespace JavaScriptRuntime
         {
             if (PropertyDescriptorStore.IsDeleted(target, propName))
             {
-                descriptor = null!;
+                descriptor = default;
                 return false;
             }
 
             if (!TryGetStaticClassMethodOverloads(target, propName, out var staticClassType, out var methods))
             {
-                descriptor = null!;
+                descriptor = default;
                 return false;
             }
 

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -122,6 +122,11 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
 
     private sealed class PropertyDescriptorOverride
     {
+        public static readonly PropertyDescriptorOverride Deleted = new()
+        {
+            Kind = PropertyDescriptorOverrideKind.Delete
+        };
+
         public required PropertyDescriptorOverrideKind Kind { get; init; }
         public JsPropertyDescriptor Descriptor { get; init; }
     }
@@ -676,10 +681,7 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
             }
 
             var overrides = new Dictionary<string, PropertyDescriptorOverride>(current.Overrides, StringComparer.Ordinal);
-            overrides[key] = new PropertyDescriptorOverride
-            {
-                Kind = PropertyDescriptorOverrideKind.Delete
-            };
+            overrides[key] = PropertyDescriptorOverride.Deleted;
 
             slot.Publish(new OverrideSnapshot(overrides, keyOrder));
 

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -12,7 +12,7 @@ internal enum JsPropertyDescriptorKind
     Accessor
 }
 
-internal sealed class JsPropertyDescriptor
+internal struct JsPropertyDescriptor
 {
     public JsPropertyDescriptorKind Kind { get; set; }
 
@@ -123,7 +123,7 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
     private sealed class PropertyDescriptorOverride
     {
         public required PropertyDescriptorOverrideKind Kind { get; init; }
-        public JsPropertyDescriptor? Descriptor { get; init; }
+        public JsPropertyDescriptor Descriptor { get; init; }
     }
 
     private sealed class IntrinsicPropertyDescriptorStore : IPropertyDescriptorStore
@@ -136,16 +136,12 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
 
             if (_slots.TryGetValue(target, out var slot))
             {
-                // Perf (#1415/#1417): lock-free snapshot read; return the stored
-                // descriptor without cloning. Stored descriptors are never mutated in
-                // place (writes go through DefineOrUpdate, which clones the incoming
-                // descriptor and publishes a new snapshot), so callers that only read
-                // the descriptor can safely share the instance. Callers that mutate
-                // the result must clone it first.
-                return slot.Read().Descriptors.TryGetValue(key, out descriptor!);
+                // Value-type descriptors are returned as copies, so readers cannot
+                // mutate a published snapshot in place.
+                return slot.Read().Descriptors.TryGetValue(key, out descriptor);
             }
 
-            descriptor = null!;
+            descriptor = default;
             return false;
         }
 
@@ -160,7 +156,6 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
         public void DefineOrUpdate(object target, string key, JsPropertyDescriptor descriptor)
         {
             ValidateTargetAndKey(target, key);
-            ArgumentNullException.ThrowIfNull(descriptor);
 
             DefineOrUpdateCore(target, key, descriptor);
 
@@ -319,20 +314,7 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
     }
 
     internal static JsPropertyDescriptor CloneDescriptor(JsPropertyDescriptor descriptor)
-    {
-        ArgumentNullException.ThrowIfNull(descriptor);
-
-        return new JsPropertyDescriptor
-        {
-            Kind = descriptor.Kind,
-            Enumerable = descriptor.Enumerable,
-            Configurable = descriptor.Configurable,
-            Value = descriptor.Value,
-            Writable = descriptor.Writable,
-            Get = descriptor.Get,
-            Set = descriptor.Set
-        };
-    }
+        => descriptor;
 
     public static bool TryGetOwn(object target, string key, out JsPropertyDescriptor descriptor)
         => GetOwnLookup(target, key, out descriptor) == PropertyDescriptorLookup.Found;
@@ -340,8 +322,7 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
     /// <summary>
     /// Unified single-probe own lookup (perf #1418). Combines the tombstone check
     /// (<see cref="IsDeleted"/>) and descriptor fetch (<see cref="TryGetOwn(object, string, out JsPropertyDescriptor)"/>)
-    /// into one descriptor-store probe. Like <c>TryGetOwn</c>, the returned descriptor
-    /// is shared and must be cloned by callers that mutate it.
+    /// into one descriptor-store probe. Value-type descriptors are returned as copies.
     /// </summary>
     internal static PropertyDescriptorLookup GetOwnLookup(object target, string key, out JsPropertyDescriptor descriptor)
     {
@@ -373,11 +354,11 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
             {
                 if (entry.Kind == PropertyDescriptorOverrideKind.Delete)
                 {
-                    descriptor = null!;
+                    descriptor = default;
                     return PropertyDescriptorLookup.Deleted;
                 }
 
-                descriptor = entry.Descriptor!;
+                descriptor = entry.Descriptor;
                 return PropertyDescriptorLookup.Found;
             }
         }
@@ -474,12 +455,11 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
         {
             if (entry.Kind == PropertyDescriptorOverrideKind.Delete)
             {
-                descriptor = null!;
+                descriptor = default;
                 return false;
             }
 
-            // Perf (#1415): no clone on the read path; see IntrinsicPropertyDescriptorStore.TryGetOwn.
-            descriptor = entry.Descriptor!;
+            descriptor = entry.Descriptor;
             return true;
         }
 
@@ -521,7 +501,6 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
     void IPropertyDescriptorStore.DefineOrUpdate(object target, string key, JsPropertyDescriptor descriptor)
     {
         ValidateTargetAndKey(target, key);
-        ArgumentNullException.ThrowIfNull(descriptor);
 
         DefineOrUpdateOverride(target, key, descriptor);
 

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -122,11 +122,6 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
 
     private sealed class PropertyDescriptorOverride
     {
-        public static readonly PropertyDescriptorOverride Deleted = new()
-        {
-            Kind = PropertyDescriptorOverrideKind.Delete
-        };
-
         public required PropertyDescriptorOverrideKind Kind { get; init; }
         public JsPropertyDescriptor Descriptor { get; init; }
     }
@@ -681,7 +676,10 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
             }
 
             var overrides = new Dictionary<string, PropertyDescriptorOverride>(current.Overrides, StringComparer.Ordinal);
-            overrides[key] = PropertyDescriptorOverride.Deleted;
+            overrides[key] = new PropertyDescriptorOverride
+            {
+                Kind = PropertyDescriptorOverrideKind.Delete
+            };
 
             slot.Publish(new OverrideSnapshot(overrides, keyOrder));
 

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -21,8 +21,8 @@ internal struct JsPropertyDescriptor
     public bool Configurable { get; set; }
 
     // Data descriptor
-    public object? Value { get; set; }
     public bool Writable { get; set; }
+    public object? Value { get; set; }
 
     // Accessor descriptor
     public object? Get { get; set; }

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -476,7 +476,7 @@ public class RuntimeServices
         string propName,
         out JsPropertyDescriptor descriptor)
     {
-        if (PropertyDescriptorStore.TryGetOwn(classConstructorValue, propName, out descriptor!))
+        if (PropertyDescriptorStore.TryGetOwn(classConstructorValue, propName, out descriptor))
         {
             return true;
         }
@@ -539,10 +539,10 @@ public class RuntimeServices
                 Value = classConstructorValue
             });
 
-            return PropertyDescriptorStore.TryGetOwn(classConstructorValue, propName, out descriptor!);
+            return PropertyDescriptorStore.TryGetOwn(classConstructorValue, propName, out descriptor);
         }
 
-        descriptor = null!;
+        descriptor = default;
         return false;
     }
 
@@ -562,7 +562,7 @@ public class RuntimeServices
         string propName,
         out JsPropertyDescriptor descriptor)
     {
-        descriptor = null!;
+        descriptor = default;
         if (PropertyDescriptorStore.IsDeleted(target, propName)
             || !TryResolveLazyClassMethodTarget(target, out var ownerType, out var ownerValue, out var isStatic)
             || !_lazyClassMetadata.TryGetValue(ownerType, out var slot))
@@ -596,7 +596,7 @@ public class RuntimeServices
             metadata.IsAsync,
             metadata.Scopes);
 
-        return PropertyDescriptorStore.TryGetOwn(target, propName, out descriptor!);
+        return PropertyDescriptorStore.TryGetOwn(target, propName, out descriptor);
     }
 
     internal static IEnumerable<string> GetLazyClassMethodOwnKeys(object target)

--- a/tests/Jroc.Tests/PropertyDescriptorStoreTests.cs
+++ b/tests/Jroc.Tests/PropertyDescriptorStoreTests.cs
@@ -10,6 +10,12 @@ public class PropertyDescriptorStoreTests
         => Assert.True(typeof(JsPropertyDescriptor).IsValueType);
 
     [Fact]
+    public void Descriptor_UsesCompactFieldLayout()
+        => Assert.Equal(
+            IntPtr.Size == 8 ? 32 : 20,
+            System.Runtime.CompilerServices.Unsafe.SizeOf<JsPropertyDescriptor>());
+
+    [Fact]
     public void RuntimeStore_FallsBackToIntrinsicDescriptor_AndKeepsOverrideIsolated()
     {
         var target = new JsObject();

--- a/tests/Jroc.Tests/PropertyDescriptorStoreTests.cs
+++ b/tests/Jroc.Tests/PropertyDescriptorStoreTests.cs
@@ -6,6 +6,10 @@ namespace Jroc.Tests;
 public class PropertyDescriptorStoreTests
 {
     [Fact]
+    public void Descriptor_IsValueType()
+        => Assert.True(typeof(JsPropertyDescriptor).IsValueType);
+
+    [Fact]
     public void RuntimeStore_FallsBackToIntrinsicDescriptor_AndKeepsOverrideIsolated()
     {
         var target = new JsObject();
@@ -171,7 +175,7 @@ public class PropertyDescriptorStoreTests
     }
 
     [Fact]
-    public void RuntimeStore_WritesCloneIncomingDescriptors()
+    public void RuntimeStore_WritesCopyIncomingDescriptors()
     {
         var target = new JsObject();
         using (PropertyDescriptorStore.BeginIntrinsicInitialization())
@@ -184,7 +188,7 @@ public class PropertyDescriptorStoreTests
         {
             GlobalThis.ServiceProvider = runtime;
 
-            // Writes clone the incoming descriptor, so later caller-side mutation
+            // Writes copy the incoming descriptor, so later caller-side mutation
             // of the written descriptor must not leak into the store.
             var written = DataDescriptor("updated");
             PropertyDescriptorStore.DefineOrUpdate(target, "value", written);
@@ -192,6 +196,43 @@ public class PropertyDescriptorStoreTests
 
             Assert.True(PropertyDescriptorStore.TryGetOwn(target, "value", out var reread));
             Assert.Equal("updated", reread.Value);
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void RuntimeStore_ReadsReturnIndependentDescriptorValues()
+    {
+        var target = new JsObject();
+        Func<object[], object?[]?, object?> getter = static (_, _) => "value";
+        Action<object?> setter = static _ => { };
+        var runtime = RuntimeServices.BuildServiceProvider();
+
+        try
+        {
+            GlobalThis.ServiceProvider = runtime;
+            PropertyDescriptorStore.DefineOrUpdate(target, "value", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Accessor,
+                Get = getter,
+                Set = setter,
+                Enumerable = true,
+                Configurable = true
+            });
+
+            Assert.True(PropertyDescriptorStore.TryGetOwn(target, "value", out var firstRead));
+            Assert.Same(getter, firstRead.Get);
+            Assert.Same(setter, firstRead.Set);
+            firstRead.Get = null;
+            firstRead.Enumerable = false;
+
+            Assert.True(PropertyDescriptorStore.TryGetOwn(target, "value", out var secondRead));
+            Assert.Same(getter, secondRead.Get);
+            Assert.Same(setter, secondRead.Set);
+            Assert.True(secondRead.Enumerable);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- convert internal `JsPropertyDescriptor` storage from reference objects to value-type structs
- return independent descriptor copies from lock-free snapshots
- preserve explicit copy-on-write snapshot publication and runtime-local overrides
- retain getter/setter reference identity across descriptor copies
- replace nullable descriptor payloads with explicit lookup/tombstone state

## Validation

- descriptor-store value/copy/isolation tests
- ordinary and exotic `JsObject` property-read tests
- Array descriptor, Object descriptor/integrity, Proxy validation, and class metadata execution tests
- Release solution build
- PR CI

## Benchmarks

Repeated hosted comparisons used the same runner for `master` and this branch.

### `ai-astar`

| Run | Master mean | Branch mean | Mean delta | Master allocated | Branch allocated | Allocation delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| [29657673533](https://github.com/tomacox74/js2il/actions/runs/29657673533) | 8.129 s | 8.377 s | +3.05% | 1,228,970,472 B | 1,224,609,072 B | -4,361,400 B (-0.35%) |
| [29657969637](https://github.com/tomacox74/js2il/actions/runs/29657969637) | 6.722 s | 6.371 s | -5.23% | 1,228,970,472 B | 1,224,609,072 B | -4,361,400 B (-0.35%) |

The timing direction varied between runs, showing no repeatable execution-time regression. Allocation improved by exactly 4,361,400 bytes/op in both runs.

### `array-stress`

| Run | Master mean | Branch mean | Mean delta | Master allocated | Branch allocated | Allocation delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| [29657508295](https://github.com/tomacox74/js2il/actions/runs/29657508295) | 2.914 ms | 2.817 ms | -3.32% | 1,600,656 B | 1,606,385 B | +5,729 B (+0.36%) |
| [29657706780](https://github.com/tomacox74/js2il/actions/runs/29657706780) | 2.868 ms | 2.835 ms | -1.14% | 1,662,021 B | 1,667,838 B | +5,817 B (+0.35%) |

Execution improved modestly in both runs. Allocation increased by about 5.8 KB/op (0.35%), a small repeatable workload-specific regression.

### `audio-beat-detection`

| Run | Master mean | Branch mean | Mean delta | Master allocated | Branch allocated | Allocation delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| [29658699169](https://github.com/tomacox74/js2il/actions/runs/29658699169) | 6.380 s | 6.304 s | -1.19% | 14,206,210,400 B | 14,205,202,400 B | -1,008,000 B (-0.007%) |

The timing difference is within run variance. Allocation improved slightly in absolute terms but is effectively unchanged relative to the workload's 14.2 GB total.

### Compact 32-byte layout rerun

Reordering the boolean fields ahead of reference fields reduced `JsPropertyDescriptor`
from 40 to 32 bytes on 64-bit runtimes.

| Scenario | Run | Master mean | Branch mean | Mean delta | Master allocated | Branch allocated | Allocation delta |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `ai-astar` | [29659861978](https://github.com/tomacox74/js2il/actions/runs/29659861978) | 8.009 s | 8.150 s | +1.77% | 1,228,970,472 B | 1,224,609,072 B | -4,361,400 B (-0.35%) |
| `array-stress` | [29659862344](https://github.com/tomacox74/js2il/actions/runs/29659862344) | 3.202 ms | 3.179 ms | -0.72% | 1,662,021 B | 1,667,950 B | +5,929 B (+0.36%) |
| `audio-beat-detection` | [29659862361](https://github.com/tomacox74/js2il/actions/runs/29659862361) | 6.006 s | 5.991 s | -0.24% | 14,206,210,400 B | 14,205,202,400 B | -1,008,000 B (-0.007%) |

The smaller layout produced no measurable incremental benchmark benefit: allocation
was effectively identical to the earlier 40-byte struct runs, and timing remained
within the established run-to-run variance.
