### PR TITLE
fix(benchmarks): target Kraken setup at benchmark methods

### DIFF
--- a/tests/performance/Benchmarks/KrackenBenchmarks.cs
+++ b/tests/performance/Benchmarks/KrackenBenchmarks.cs
@@ -68,7 +68,7 @@ public class KrackenBenchmarks
     private JSContext? _yantraJsContext;
     private JSValue? _yantraJsRunTest;
 
-    [GlobalSetup(Target = nameof(SetupJroc))]
+    [GlobalSetup(Target = nameof(RunJrocTest))]
     public void SetupJroc()
     {
         LoadScriptContents(out var dataScriptContent, out var testScriptContent);
@@ -96,7 +96,7 @@ public class KrackenBenchmarks
         _jrocExports = JsEngine.LoadModule(loadedAssembly.Assembly, artifact.ModuleIds[0]);        
     }
 
-    [GlobalSetup(Target = nameof(SetupOkojo))]
+    [GlobalSetup(Target = nameof(RunOkojoTest))]
     public void SetupOkojo()
     {
         LoadScriptContents(out var dataScriptContent, out var testScriptContent);
@@ -110,7 +110,7 @@ public class KrackenBenchmarks
         this._okojoRunTest = _okojoRealm.Global["runBenchmark"];
     }
 
-    [GlobalSetup(Target = nameof(SetupJint))]
+    [GlobalSetup(Target = nameof(RunJintTest))]
     public void SetupJint()
     {
         LoadScriptContents(out var dataScriptContent, out var testScriptContent);   
@@ -121,7 +121,7 @@ public class KrackenBenchmarks
         _jintEngine.Execute(BenchmarkRunnerScript, "kracken-benchmark-runner.js");
     }
 
-    [GlobalSetup(Target = nameof(SetupYantraJs))]
+    [GlobalSetup(Target = nameof(RunYantraJsTest))]
     public void SetupYantraJs()
     {
         LoadScriptContents(out var dataScriptContent, out var testScriptContent);


### PR DESCRIPTION
## Summary

- target each Kraken `GlobalSetup` at its corresponding benchmark method
- ensure JROC, Okojo, Jint, and YantraJS initialization runs before measurement
- keep the benchmark fix separate from descriptor struct PR #1528

## Validation

- Release build of `Benchmarks.csproj`
- BenchmarkDotNet discovery of the filtered `RunJrocTest` benchmark
- hosted Kraken comparisons using the same setup-target correction
