### PR TITLE
perf(runtime): lazily allocate JsShape transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/runtime: lazily allocate `JsShape` transition dictionaries so leaf shapes and uncached transitions avoid an empty dictionary allocation while cached property sequences still reuse live child shapes. (#1531)
 
 ## v0.11.31 - 2026-07-19
 

--- a/src/JavaScriptRuntime/JsObject.cs
+++ b/src/JavaScriptRuntime/JsObject.cs
@@ -22,7 +22,7 @@ internal sealed class JsShape
 
     private FrozenDictionary<string, int> _slots;
 
-    private Dictionary<string, WeakReference<JsShape>>? _transitions = new Dictionary<string, WeakReference<JsShape>>();
+    private Dictionary<string, WeakReference<JsShape>>? _transitions;
 
     public JsShape()
     {
@@ -43,6 +43,10 @@ internal sealed class JsShape
             return names;
         }
     }
+
+    internal bool HasTransitionCache => _transitions != null;
+
+    internal int TransitionCacheCount => _transitions?.Count ?? 0;
 
     private JsShape(string newPropertyName, JsShape parent, PropertyNameStorage propertyNameStorage)
     {
@@ -73,7 +77,8 @@ internal sealed class JsShape
             return existingShape;
         }
         var newShape = new JsShape(newPropertyName, this, PropertyNameStorage.Interned);
-        _transitions![newPropertyName] = new WeakReference<JsShape>(newShape);
+        var transitions = _transitions ??= new Dictionary<string, WeakReference<JsShape>>();
+        transitions[newPropertyName] = new WeakReference<JsShape>(newShape);
         return newShape;
     }
 

--- a/tests/Jroc.Tests/JsShapeTransitionTests.cs
+++ b/tests/Jroc.Tests/JsShapeTransitionTests.cs
@@ -1,0 +1,43 @@
+using JavaScriptRuntime;
+
+namespace Jroc.Tests;
+
+public sealed class JsShapeTransitionTests
+{
+    [Fact]
+    public void NewShape_DoesNotAllocateTransitionCache()
+    {
+        var shape = new JsShape();
+
+        Assert.False(shape.HasTransitionCache);
+        Assert.Equal(0, shape.TransitionCacheCount);
+    }
+
+    [Fact]
+    public void TransitionTo_AllocatesTransitionCacheOnlyOnParentAndReusesLiveChild()
+    {
+        var parent = new JsShape();
+
+        var first = parent.TransitionTo("value");
+        var second = parent.TransitionTo("value");
+
+        Assert.Same(first, second);
+        Assert.True(parent.HasTransitionCache);
+        Assert.Equal(1, parent.TransitionCacheCount);
+        Assert.False(first.HasTransitionCache);
+        Assert.Equal(0, first.TransitionCacheCount);
+    }
+
+    [Fact]
+    public void TransitionToUncached_DoesNotAllocateTransitionCache()
+    {
+        var parent = new JsShape();
+
+        var child = parent.TransitionToUncached("value");
+
+        Assert.False(parent.HasTransitionCache);
+        Assert.Equal(0, parent.TransitionCacheCount);
+        Assert.False(child.HasTransitionCache);
+        Assert.Equal(0, child.TransitionCacheCount);
+    }
+}


### PR DESCRIPTION
## Summary

- Lazily allocate `JsShape` transition dictionaries only when a cached child shape is published.
- Keep leaf shapes and `TransitionToUncached` shapes free of transition-cache dictionaries.
- Add focused allocation-state coverage for leaf, cached, and uncached shape transitions.

Closes #1531

## Validation

- `dotnet test tests\Jroc.Tests\Jroc.Tests.csproj --filter "FullyQualifiedName~JsShapeTransitionTests|FullyQualifiedName~ObjectRuntimeOrdinaryObjectTests|FullyQualifiedName~NodeUtilityObjectRepresentationTests" --no-restore --verbosity minimal`

## Benchmark branch comparison

Workflow: [Benchmark branch comparison run 29690197011](https://github.com/tomacox74/js2il/actions/runs/29690197011)

Inputs:
- Suite: `kracken`
- Scenario: `ai-astar`
- Baseline: `master`
- Candidate: `issue-1531-lazy-jsshape-transitions`

| Metric | master | PR branch | Delta |
| --- | ---: | ---: | ---: |
| Mean | 8.663 s | 8.273 s | -0.390 s (-4.50%) |
| Allocated | 1,224,609,072 B/op | 1,224,609,072 B/op | 0 B/op (0.00%) |
| Gen0 | 73 | 73 | 0 |
| Gen1 | 12 | 12 | 0 |
