### PR TITLE
perf(runtime): reduce JsObject enumeration allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-- perf/runtime: store ordered property names directly on immutable `JsShape` instances so repeated internal enumeration, `GetOwnProperties`, deletion, and public key/value snapshots avoid rebuilding transient property-name arrays. (#1534)
+- perf/runtime: capture ordered shape names once per `GetOwnProperties` and dictionary enumeration, avoiding repeated per-property reconstruction while preserving mutation-safe snapshots. Public value snapshots and property deletion also avoid LINQ iterator allocations. (#1534)
 - perf/runtime: lazily allocate `JsShape` transition dictionaries so leaf shapes and uncached transitions avoid an empty dictionary allocation while cached property sequences still reuse live child shapes. (#1531)
 
 ## v0.11.31 - 2026-07-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf/runtime: store ordered property names directly on immutable `JsShape` instances so repeated internal enumeration, `GetOwnProperties`, deletion, and public key/value snapshots avoid rebuilding transient property-name arrays. (#1534)
 - perf/runtime: lazily allocate `JsShape` transition dictionaries so leaf shapes and uncached transitions avoid an empty dictionary allocation while cached property sequences still reuse live child shapes. (#1531)
 
 ## v0.11.31 - 2026-07-19

--- a/src/JavaScriptRuntime/JsObject.cs
+++ b/src/JavaScriptRuntime/JsObject.cs
@@ -22,26 +22,32 @@ internal sealed class JsShape
 
     private readonly FrozenDictionary<string, int> _slots;
 
-    private readonly string[] _propertyNames;
+    private readonly JsShape? _parent;
+
+    private readonly string? _addedPropertyName;
+
+    private readonly int _propertyCount;
+
+    private string[]? _propertyNamesInSlotOrder;
 
     private Dictionary<string, WeakReference<JsShape>>? _transitions;
 
     public JsShape()
     {
         _slots = new Dictionary<string, int>().ToFrozenDictionary();
-        _propertyNames = System.Array.Empty<string>();
+        _propertyNamesInSlotOrder = System.Array.Empty<string>();
     }
 
-    internal ReadOnlySpan<string> PropertyNamesInSlotOrder => _propertyNames;
+    internal ReadOnlySpan<string> PropertyNamesInSlotOrder => GetOrCreatePropertyNamesInSlotOrder();
 
-    internal int PropertyCount => _propertyNames.Length;
+    internal int PropertyCount => _propertyCount;
 
     internal string GetPropertyNameAtSlot(int slot)
-        => _propertyNames[slot];
+        => GetOrCreatePropertyNamesInSlotOrder()[slot];
 
     internal IEnumerable<string> EnumeratePropertyNamesSnapshot()
     {
-        var propertyNames = _propertyNames;
+        var propertyNames = GetOrCreatePropertyNamesInSlotOrder();
         for (int i = 0; i < propertyNames.Length; i++)
         {
             yield return propertyNames[i];
@@ -58,13 +64,12 @@ internal sealed class JsShape
             ? string.Intern(newPropertyName)
             : newPropertyName;
 
-        var parentPropertyNames = parent._propertyNames;
-        _propertyNames = new string[parentPropertyNames.Length + 1];
-        System.Array.Copy(parentPropertyNames, _propertyNames, parentPropertyNames.Length);
-        _propertyNames[parentPropertyNames.Length] = storedPropertyName;
+        _parent = parent;
+        _addedPropertyName = storedPropertyName;
+        _propertyCount = parent._propertyCount + 1;
 
         var newSlots = parent._slots.ToDictionary();
-        newSlots[storedPropertyName] = parentPropertyNames.Length;
+        newSlots[storedPropertyName] = parent._propertyCount;
         _slots = newSlots.ToFrozenDictionary();
     }
 
@@ -72,20 +77,54 @@ internal sealed class JsShape
     {
         // Rebuild slots in the parent's slot order so surviving properties keep their
         // relative order and stay aligned with the compacted value array.
-        var parentPropertyNames = parent._propertyNames;
-        _propertyNames = new string[parentPropertyNames.Length - 1];
+        var parentPropertyNames = parent.GetOrCreatePropertyNamesInSlotOrder();
+        _propertyCount = parent._propertyCount - 1;
+        var propertyNames = new string[_propertyCount];
+        _propertyNamesInSlotOrder = propertyNames;
         var newSlots = new Dictionary<string, int>();
         var nextSlot = 0;
         foreach (var name in parentPropertyNames)
         {
             if (!string.Equals(name, deadPropertyName, StringComparison.Ordinal))
             {
-                _propertyNames[nextSlot] = name;
+                propertyNames[nextSlot] = name;
                 newSlots[name] = nextSlot;
                 nextSlot++;
             }
         }
         _slots = newSlots.ToFrozenDictionary();
+    }
+
+    private string[] GetOrCreatePropertyNamesInSlotOrder()
+    {
+        var propertyNames = System.Threading.Volatile.Read(ref _propertyNamesInSlotOrder);
+        if (propertyNames != null)
+        {
+            return propertyNames;
+        }
+
+        propertyNames = new string[_propertyCount];
+        var shape = this;
+        var slot = _propertyCount - 1;
+        while (slot >= 0)
+        {
+            var cachedAncestorNames = System.Threading.Volatile.Read(ref shape._propertyNamesInSlotOrder);
+            if (cachedAncestorNames != null)
+            {
+                System.Array.Copy(cachedAncestorNames, propertyNames, cachedAncestorNames.Length);
+                break;
+            }
+
+            propertyNames[slot] = shape._addedPropertyName!;
+            shape = shape._parent!;
+            slot--;
+        }
+
+        var published = System.Threading.Interlocked.CompareExchange(
+            ref _propertyNamesInSlotOrder,
+            propertyNames,
+            null);
+        return published ?? propertyNames;
     }
 
     public JsShape TransitionTo(string newPropertyName)

--- a/src/JavaScriptRuntime/JsObject.cs
+++ b/src/JavaScriptRuntime/JsObject.cs
@@ -20,37 +20,27 @@ internal sealed class JsShape
         get => _empty.Value!;
     }
 
-    private readonly FrozenDictionary<string, int> _slots;
-
-    private readonly JsShape? _parent;
-
-    private readonly string? _addedPropertyName;
-
-    private readonly int _propertyCount;
-
-    private string[]? _propertyNamesInSlotOrder;
+    private FrozenDictionary<string, int> _slots;
 
     private Dictionary<string, WeakReference<JsShape>>? _transitions;
 
     public JsShape()
     {
         _slots = new Dictionary<string, int>().ToFrozenDictionary();
-        _propertyNamesInSlotOrder = System.Array.Empty<string>();
     }
 
-    internal ReadOnlySpan<string> PropertyNamesInSlotOrder => GetOrCreatePropertyNamesInSlotOrder();
-
-    internal int PropertyCount => _propertyCount;
-
-    internal string GetPropertyNameAtSlot(int slot)
-        => GetOrCreatePropertyNamesInSlotOrder()[slot];
-
-    internal IEnumerable<string> EnumeratePropertyNamesSnapshot()
+    public IEnumerable<string> PropertyNames
     {
-        var propertyNames = GetOrCreatePropertyNamesInSlotOrder();
-        for (int i = 0; i < propertyNames.Length; i++)
+        get
         {
-            yield return propertyNames[i];
+            // FrozenDictionary does not guarantee enumeration order; property names
+            // must be reported in slot order to preserve JS insertion-order semantics.
+            var names = new string[_slots.Count];
+            foreach (var kvp in _slots)
+            {
+                names[kvp.Value] = kvp.Key;
+            }
+            return names;
         }
     }
 
@@ -60,16 +50,8 @@ internal sealed class JsShape
 
     private JsShape(string newPropertyName, JsShape parent, PropertyNameStorage propertyNameStorage)
     {
-        var storedPropertyName = propertyNameStorage == PropertyNameStorage.Interned
-            ? string.Intern(newPropertyName)
-            : newPropertyName;
-
-        _parent = parent;
-        _addedPropertyName = storedPropertyName;
-        _propertyCount = parent._propertyCount + 1;
-
         var newSlots = parent._slots.ToDictionary();
-        newSlots[storedPropertyName] = parent._propertyCount;
+        newSlots[propertyNameStorage == PropertyNameStorage.Interned ? string.Intern(newPropertyName) : newPropertyName] = newSlots.Count;
         _slots = newSlots.ToFrozenDictionary();
     }
 
@@ -77,54 +59,15 @@ internal sealed class JsShape
     {
         // Rebuild slots in the parent's slot order so surviving properties keep their
         // relative order and stay aligned with the compacted value array.
-        var parentPropertyNames = parent.GetOrCreatePropertyNamesInSlotOrder();
-        _propertyCount = parent._propertyCount - 1;
-        var propertyNames = new string[_propertyCount];
-        _propertyNamesInSlotOrder = propertyNames;
         var newSlots = new Dictionary<string, int>();
-        var nextSlot = 0;
-        foreach (var name in parentPropertyNames)
+        foreach (var name in parent.PropertyNames)
         {
             if (!string.Equals(name, deadPropertyName, StringComparison.Ordinal))
             {
-                propertyNames[nextSlot] = name;
-                newSlots[name] = nextSlot;
-                nextSlot++;
+                newSlots[name] = newSlots.Count;
             }
         }
         _slots = newSlots.ToFrozenDictionary();
-    }
-
-    private string[] GetOrCreatePropertyNamesInSlotOrder()
-    {
-        var propertyNames = System.Threading.Volatile.Read(ref _propertyNamesInSlotOrder);
-        if (propertyNames != null)
-        {
-            return propertyNames;
-        }
-
-        propertyNames = new string[_propertyCount];
-        var shape = this;
-        var slot = _propertyCount - 1;
-        while (slot >= 0)
-        {
-            var cachedAncestorNames = System.Threading.Volatile.Read(ref shape._propertyNamesInSlotOrder);
-            if (cachedAncestorNames != null)
-            {
-                System.Array.Copy(cachedAncestorNames, propertyNames, cachedAncestorNames.Length);
-                break;
-            }
-
-            propertyNames[slot] = shape._addedPropertyName!;
-            shape = shape._parent!;
-            slot--;
-        }
-
-        var published = System.Threading.Interlocked.CompareExchange(
-            ref _propertyNamesInSlotOrder,
-            propertyNames,
-            null);
-        return published ?? propertyNames;
     }
 
     public JsShape TransitionTo(string newPropertyName)
@@ -482,17 +425,17 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
 
     /// <summary>Returns enumerable sequence of own property names.</summary>
     public IEnumerable<string> GetOwnPropertyNames()
-        => _shape.EnumeratePropertyNamesSnapshot();
+        => _shape.PropertyNames;
 
     /// <summary>Returns own property key-value pairs (values boxed as object).</summary>
     public IEnumerable<KeyValuePair<string, object?>> GetOwnProperties()
     {
-        var shape = _shape;
+        var propertyNames = _shape.PropertyNames;
         var properties = _properties;
-        for (int i = 0; i < shape.PropertyCount; i++)
+        var slot = 0;
+        foreach (var key in propertyNames)
         {
-            var key = shape.GetPropertyNameAtSlot(i);
-            var value = properties[i];
+            var value = properties[slot++];
             yield return new KeyValuePair<string, object?>(key, value.ToObject());
         }
     }
@@ -508,19 +451,7 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
         set => SetValue(key, JsValue.FromObject(value));
     }
 
-    public ICollection<string> Keys
-    {
-        get
-        {
-            var propertyNames = _shape.PropertyNamesInSlotOrder;
-            var keys = new List<string>(propertyNames.Length);
-            foreach (var name in propertyNames)
-            {
-                keys.Add(name);
-            }
-            return keys;
-        }
-    }
+    public ICollection<string> Keys => _shape.PropertyNames.ToList();
 
     public ICollection<object?> Values
     {
@@ -629,13 +560,14 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
 
     public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
     {
-        var shape = _shape;
+        var propertyNames = _shape.PropertyNames;
         var properties = _properties;
-        for (int i = 0; i < shape.PropertyCount; i++)
+        var slot = 0;
+        foreach (var key in propertyNames)
         {
             yield return new KeyValuePair<string, object?>(
-                shape.GetPropertyNameAtSlot(i),
-                properties[i].ToObject());
+                key,
+                properties[slot++].ToObject());
         }
     }
 

--- a/src/JavaScriptRuntime/JsObject.cs
+++ b/src/JavaScriptRuntime/JsObject.cs
@@ -20,27 +20,31 @@ internal sealed class JsShape
         get => _empty.Value!;
     }
 
-    private FrozenDictionary<string, int> _slots;
+    private readonly FrozenDictionary<string, int> _slots;
+
+    private readonly string[] _propertyNames;
 
     private Dictionary<string, WeakReference<JsShape>>? _transitions;
 
     public JsShape()
     {
         _slots = new Dictionary<string, int>().ToFrozenDictionary();
+        _propertyNames = System.Array.Empty<string>();
     }
 
-    public IEnumerable<string> PropertyNames
+    internal ReadOnlySpan<string> PropertyNamesInSlotOrder => _propertyNames;
+
+    internal int PropertyCount => _propertyNames.Length;
+
+    internal string GetPropertyNameAtSlot(int slot)
+        => _propertyNames[slot];
+
+    internal IEnumerable<string> EnumeratePropertyNamesSnapshot()
     {
-        get
+        var propertyNames = _propertyNames;
+        for (int i = 0; i < propertyNames.Length; i++)
         {
-            // FrozenDictionary does not guarantee enumeration order; property names
-            // must be reported in slot order to preserve JS insertion-order semantics.
-            var names = new string[_slots.Count];
-            foreach (var kvp in _slots)
-            {
-                names[kvp.Value] = kvp.Key;
-            }
-            return names;
+            yield return propertyNames[i];
         }
     }
 
@@ -50,8 +54,17 @@ internal sealed class JsShape
 
     private JsShape(string newPropertyName, JsShape parent, PropertyNameStorage propertyNameStorage)
     {
+        var storedPropertyName = propertyNameStorage == PropertyNameStorage.Interned
+            ? string.Intern(newPropertyName)
+            : newPropertyName;
+
+        var parentPropertyNames = parent._propertyNames;
+        _propertyNames = new string[parentPropertyNames.Length + 1];
+        System.Array.Copy(parentPropertyNames, _propertyNames, parentPropertyNames.Length);
+        _propertyNames[parentPropertyNames.Length] = storedPropertyName;
+
         var newSlots = parent._slots.ToDictionary();
-        newSlots[propertyNameStorage == PropertyNameStorage.Interned ? string.Intern(newPropertyName) : newPropertyName] = newSlots.Count;
+        newSlots[storedPropertyName] = parentPropertyNames.Length;
         _slots = newSlots.ToFrozenDictionary();
     }
 
@@ -59,12 +72,17 @@ internal sealed class JsShape
     {
         // Rebuild slots in the parent's slot order so surviving properties keep their
         // relative order and stay aligned with the compacted value array.
+        var parentPropertyNames = parent._propertyNames;
+        _propertyNames = new string[parentPropertyNames.Length - 1];
         var newSlots = new Dictionary<string, int>();
-        foreach (var name in parent.PropertyNames)
+        var nextSlot = 0;
+        foreach (var name in parentPropertyNames)
         {
             if (!string.Equals(name, deadPropertyName, StringComparison.Ordinal))
             {
-                newSlots[name] = newSlots.Count;
+                _propertyNames[nextSlot] = name;
+                newSlots[name] = nextSlot;
+                nextSlot++;
             }
         }
         _slots = newSlots.ToFrozenDictionary();
@@ -425,15 +443,17 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
 
     /// <summary>Returns enumerable sequence of own property names.</summary>
     public IEnumerable<string> GetOwnPropertyNames()
-        => _shape.PropertyNames;
+        => _shape.EnumeratePropertyNamesSnapshot();
 
     /// <summary>Returns own property key-value pairs (values boxed as object).</summary>
     public IEnumerable<KeyValuePair<string, object?>> GetOwnProperties()
     {
-        for (int i = 0; i < _shape.PropertyNames.Count(); i++)
+        var shape = _shape;
+        var properties = _properties;
+        for (int i = 0; i < shape.PropertyCount; i++)
         {
-            var key = _shape.PropertyNames.ElementAt(i);
-            var value = _properties[i];
+            var key = shape.GetPropertyNameAtSlot(i);
+            var value = properties[i];
             yield return new KeyValuePair<string, object?>(key, value.ToObject());
         }
     }
@@ -449,9 +469,32 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
         set => SetValue(key, JsValue.FromObject(value));
     }
 
-    public ICollection<string> Keys => _shape.PropertyNames.ToList();
+    public ICollection<string> Keys
+    {
+        get
+        {
+            var propertyNames = _shape.PropertyNamesInSlotOrder;
+            var keys = new List<string>(propertyNames.Length);
+            foreach (var name in propertyNames)
+            {
+                keys.Add(name);
+            }
+            return keys;
+        }
+    }
 
-    public ICollection<object?> Values => _properties!.Select(v => v.ToObject()).ToList();
+    public ICollection<object?> Values
+    {
+        get
+        {
+            var values = new List<object?>(_properties.Length);
+            foreach (var value in _properties)
+            {
+                values.Add(value.ToObject());
+            }
+            return values;
+        }
+    }
 
     public int Count => _properties!.Length;
 
@@ -479,7 +522,16 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
             return false;
 
         _shape = _shape.TransitionAway(key);
-        _properties = _properties.Where((v, i) => i != slot).ToArray();
+        var newProperties = new JsValue[_properties.Length - 1];
+        if (slot > 0)
+        {
+            System.Array.Copy(_properties, 0, newProperties, 0, slot);
+        }
+        if (slot < newProperties.Length)
+        {
+            System.Array.Copy(_properties, slot + 1, newProperties, slot, newProperties.Length - slot);
+        }
+        _properties = newProperties;
 
         return true;
     }
@@ -538,10 +590,13 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
 
     public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
     {
-        foreach (var key in _shape.PropertyNames)
+        var shape = _shape;
+        var properties = _properties;
+        for (int i = 0; i < shape.PropertyCount; i++)
         {
-            if (TryGetJsValue(key, out var jv))
-                yield return new KeyValuePair<string, object?>(key, jv.ToObject());
+            yield return new KeyValuePair<string, object?>(
+                shape.GetPropertyNameAtSlot(i),
+                properties[i].ToObject());
         }
     }
 

--- a/tests/Jroc.Tests/JsShapePropertyNameTests.cs
+++ b/tests/Jroc.Tests/JsShapePropertyNameTests.cs
@@ -1,0 +1,166 @@
+using JavaScriptRuntime;
+
+namespace Jroc.Tests;
+
+public sealed class JsShapePropertyNameTests
+{
+    private const int PropertyCount = 256;
+
+    private static volatile int _sink;
+
+    [Fact]
+    public void RepeatedInternalPropertyNameEnumeration_DoesNotAllocate()
+    {
+        var shape = CreateShape(PropertyCount);
+
+        var allocated = MeasureAllocatedBytes(() =>
+        {
+            var total = 0;
+            for (var iteration = 0; iteration < 1_000; iteration++)
+            {
+                foreach (var name in shape.PropertyNamesInSlotOrder)
+                {
+                    total += name.Length;
+                }
+            }
+            _sink = total;
+        });
+
+        Assert.Equal(0, allocated);
+    }
+
+    [Fact]
+    public void GetOwnProperties_DoesNotAllocateOrderedNamesPerProperty()
+    {
+        var obj = CreateObject(PropertyCount);
+
+        var allocated = MeasureAllocatedBytes(() =>
+        {
+            var total = 0;
+            foreach (var property in obj.GetOwnProperties())
+            {
+                total += property.Key.Length + ((string)property.Value!).Length;
+            }
+            _sink = total;
+        });
+
+        Assert.InRange(allocated, 0, 4 * 1024);
+    }
+
+    [Fact]
+    public void PublicKeysAndValues_DoNotAllocateShapeNameSnapshots()
+    {
+        var obj = CreateObject(PropertyCount);
+
+        var allocated = MeasureAllocatedBytes(() =>
+        {
+            var total = 0;
+            for (var iteration = 0; iteration < 10; iteration++)
+            {
+                foreach (var key in obj.Keys)
+                {
+                    total += key.Length;
+                }
+
+                foreach (var value in obj.Values)
+                {
+                    total += ((string)value!).Length;
+                }
+            }
+            _sink = total;
+        });
+
+        Assert.InRange(allocated, 0, 128 * 1024);
+    }
+
+    [Fact]
+    public void PublicPropertyNameEnumeration_IsSnapshotSafeAndDoesNotExposeShapeStorage()
+    {
+        var obj = CreateObject(3);
+
+        var names = obj.GetOwnPropertyNames();
+        var keys = obj.Keys;
+        keys.Clear();
+
+        obj.SetString("p3", "v3");
+
+        Assert.Equal(new[] { "p0", "p1", "p2" }, names.ToArray());
+        Assert.Equal(new[] { "p0", "p1", "p2", "p3" }, obj.GetOwnPropertyNames().ToArray());
+    }
+
+    [Fact]
+    public void OwnPropertyEnumeration_RemainsSnapshotSafeWhenObjectMutates()
+    {
+        var obj = CreateObject(3);
+        using var enumerator = obj.GetOwnProperties().GetEnumerator();
+
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal("p0", enumerator.Current.Key);
+
+        Assert.True(obj.Remove("p1"));
+        obj.SetString("p3", "v3");
+
+        var remainingKeys = new List<string>();
+        while (enumerator.MoveNext())
+        {
+            remainingKeys.Add(enumerator.Current.Key);
+        }
+
+        Assert.Equal(new[] { "p1", "p2" }, remainingKeys);
+        Assert.Equal(new[] { "p0", "p2", "p3" }, obj.GetOwnPropertyNames().ToArray());
+    }
+
+    [Fact]
+    public void DeletionPreservesOrderAndAvoidsTransientPropertyNameSnapshot()
+    {
+        var warmup = CreateObject(PropertyCount);
+        Assert.True(warmup.Remove("p128"));
+
+        var obj = CreateObject(PropertyCount);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        Assert.True(obj.Remove("p128"));
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(PropertyCount - 1, obj.Count);
+        Assert.Equal("p127", obj.GetOwnPropertyNames().ElementAt(127));
+        Assert.Equal("p129", obj.GetOwnPropertyNames().ElementAt(128));
+        Assert.InRange(allocated, 0, 256 * 1024);
+    }
+
+    private static JsShape CreateShape(int propertyCount)
+    {
+        var shape = new JsShape();
+        for (var i = 0; i < propertyCount; i++)
+        {
+            shape = shape.TransitionTo($"p{i}");
+        }
+        return shape;
+    }
+
+    private static JsObject CreateObject(int propertyCount)
+    {
+        var obj = new JsObject();
+        for (var i = 0; i < propertyCount; i++)
+        {
+            obj.SetString($"p{i}", $"v{i}");
+        }
+        return obj;
+    }
+
+    private static long MeasureAllocatedBytes(Action action)
+    {
+        action();
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        action();
+        return GC.GetAllocatedBytesForCurrentThread() - before;
+    }
+}

--- a/tests/Jroc.Tests/JsShapePropertyNameTests.cs
+++ b/tests/Jroc.Tests/JsShapePropertyNameTests.cs
@@ -9,27 +9,6 @@ public sealed class JsShapePropertyNameTests
     private static volatile int _sink;
 
     [Fact]
-    public void RepeatedInternalPropertyNameEnumeration_DoesNotAllocate()
-    {
-        var shape = CreateShape(PropertyCount);
-
-        var allocated = MeasureAllocatedBytes(() =>
-        {
-            var total = 0;
-            for (var iteration = 0; iteration < 1_000; iteration++)
-            {
-                foreach (var name in shape.PropertyNamesInSlotOrder)
-                {
-                    total += name.Length;
-                }
-            }
-            _sink = total;
-        });
-
-        Assert.Equal(0, allocated);
-    }
-
-    [Fact]
     public void GetOwnProperties_DoesNotAllocateOrderedNamesPerProperty()
     {
         var obj = CreateObject(PropertyCount);
@@ -45,32 +24,6 @@ public sealed class JsShapePropertyNameTests
         });
 
         Assert.InRange(allocated, 0, 4 * 1024);
-    }
-
-    [Fact]
-    public void PublicKeysAndValues_DoNotAllocateShapeNameSnapshots()
-    {
-        var obj = CreateObject(PropertyCount);
-
-        var allocated = MeasureAllocatedBytes(() =>
-        {
-            var total = 0;
-            for (var iteration = 0; iteration < 10; iteration++)
-            {
-                foreach (var key in obj.Keys)
-                {
-                    total += key.Length;
-                }
-
-                foreach (var value in obj.Values)
-                {
-                    total += ((string)value!).Length;
-                }
-            }
-            _sink = total;
-        });
-
-        Assert.InRange(allocated, 0, 128 * 1024);
     }
 
     [Fact]
@@ -111,35 +64,36 @@ public sealed class JsShapePropertyNameTests
     }
 
     [Fact]
-    public void DeletionPreservesOrderAndAvoidsTransientPropertyNameSnapshot()
+    public void DictionaryEnumeration_RemainsSnapshotSafeWhenObjectMutates()
     {
-        var warmup = CreateObject(PropertyCount);
-        Assert.True(warmup.Remove("p128"));
+        var obj = CreateObject(3);
+        using var enumerator = obj.GetEnumerator();
 
-        var obj = CreateObject(PropertyCount);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal("p0", enumerator.Current.Key);
 
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
+        Assert.True(obj.Remove("p1"));
+        obj.SetString("p3", "v3");
 
-        var before = GC.GetAllocatedBytesForCurrentThread();
-        Assert.True(obj.Remove("p128"));
-        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        var remainingKeys = new List<string>();
+        while (enumerator.MoveNext())
+        {
+            remainingKeys.Add(enumerator.Current.Key);
+        }
 
-        Assert.Equal(PropertyCount - 1, obj.Count);
-        Assert.Equal("p127", obj.GetOwnPropertyNames().ElementAt(127));
-        Assert.Equal("p129", obj.GetOwnPropertyNames().ElementAt(128));
-        Assert.InRange(allocated, 0, 256 * 1024);
+        Assert.Equal(new[] { "p1", "p2" }, remainingKeys);
+        Assert.Equal(new[] { "p0", "p2", "p3" }, obj.GetOwnPropertyNames().ToArray());
     }
 
-    private static JsShape CreateShape(int propertyCount)
+    [Fact]
+    public void DeletionPreservesPropertyAndValueOrder()
     {
-        var shape = new JsShape();
-        for (var i = 0; i < propertyCount; i++)
-        {
-            shape = shape.TransitionTo($"p{i}");
-        }
-        return shape;
+        var obj = CreateObject(4);
+
+        Assert.True(obj.Remove("p1"));
+
+        Assert.Equal(new[] { "p0", "p2", "p3" }, obj.Keys);
+        Assert.Equal(new object?[] { "v0", "v2", "v3" }, obj.Values);
     }
 
     private static JsObject CreateObject(int propertyCount)


### PR DESCRIPTION
## Summary

- Capture ordered shape names once per `GetOwnProperties` enumeration instead of rebuilding them for both `Count()` and `ElementAt()` on every property.
- Capture the property array alongside ordered names so structural mutations do not change an enumeration already in progress.
- Replace LINQ-based value snapshots and deletion compaction with pre-sized loops and `Array.Copy`.
- Remove the proposed retained ordered-name cache and parent chain, leaving `JsShape` at its existing size and retention behavior.

This salvages the caller-side improvements from #1534. Allocation-free repeated shape-name enumeration remains open and should be addressed with the compact canonical representation proposed by #1533.

## Validation

- `dotnet test tests\Jroc.Tests\Jroc.Tests.csproj --filter "FullyQualifiedName~JsShapePropertyNameTests|FullyQualifiedName~JsShapeTransitionTests|FullyQualifiedName~ObjectRuntimeOrdinaryObjectTests|FullyQualifiedName~NodeUtilityObjectRepresentationTests" --no-restore --verbosity minimal`

## Benchmark branch comparison

Workflow: [Benchmark branch comparison run 29697626490](https://github.com/tomacox74/js2il/actions/runs/29697626490)

Inputs:
- Suite: `kracken`
- Scenario: `ai-astar`
- Baseline: `master`
- Candidate: `issue-1534-jsshape-propertynames-cache`

| Metric | master | PR branch | Delta |
| --- | ---: | ---: | ---: |
| Mean | 5.049 s | 4.720 s | -0.329 s (-6.52%) |
| Allocated | 1,224,596,080 B/op | 1,224,596,080 B/op | 0 B/op (0.00%) |
| Gen0 | 14 | 14 | 0 |
| Gen1 | 4 | 4 | 0 |
