### PR TITLE
perf(compiler): infer class fields from parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/compiler: infer class instance field CLR types from stable constructor and method parameter bindings, allowing assignments such as `this.sieveSize = sieveSize` to retain unboxed `double` storage.
 
 ## v0.11.33 - 2026-07-20
 

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
@@ -2134,6 +2134,7 @@ public partial class SymbolTableBuilder
         var proposedClr = new Dictionary<string, Type>(StringComparer.Ordinal);
         var proposedUserClass = new Dictionary<string, string>(StringComparer.Ordinal);
         var conflicted = new HashSet<string>(StringComparer.Ordinal);
+        var nodeScopes = BuildNodeScopeMap(classScope);
 
         void MarkConflict(string name)
         {
@@ -2266,10 +2267,15 @@ public partial class SymbolTableBuilder
                 : null;
         }
 
-        Type? InferClassFieldExpressionClrType(Node expr)
+        Type? InferClassFieldExpressionClrType(Node expr, Scope currentScope)
         {
             switch (expr)
             {
+                case Identifier id:
+                {
+                    var binding = TryResolveBinding(currentScope, id.Name);
+                    return binding?.IsStableType == true ? binding.ClrType : null;
+                }
                 case NumericLiteral:
                     return typeof(double);
                 case StringLiteral:
@@ -2298,8 +2304,8 @@ public partial class SymbolTableBuilder
                 }
                 case NonLogicalBinaryExpression binExpr:
                 {
-                    var leftType = InferClassFieldExpressionClrType(binExpr.Left);
-                    var rightType = InferClassFieldExpressionClrType(binExpr.Right);
+                    var leftType = InferClassFieldExpressionClrType(binExpr.Left, currentScope);
+                    var rightType = InferClassFieldExpressionClrType(binExpr.Right, currentScope);
 
                     switch (binExpr.Operator)
                     {
@@ -2385,9 +2391,13 @@ public partial class SymbolTableBuilder
             }
         }
 
-        void Walk(Node? node)
+        void Walk(Node? node, Scope currentScope)
         {
             if (node == null) return;
+            if (nodeScopes.TryGetValue(node, out var nodeScope))
+            {
+                currentScope = nodeScope;
+            }
 
             // Assignment: this.x = <expr>
             if (node is AssignmentExpression assign
@@ -2412,7 +2422,7 @@ public partial class SymbolTableBuilder
                     else
                     {
                         var intrinsicClr = TryInferNewExpressionIntrinsicClrType(assign.Right);
-                        ProposeClr(propName, intrinsicClr ?? InferClassFieldExpressionClrType(assign.Right));
+                        ProposeClr(propName, intrinsicClr ?? InferClassFieldExpressionClrType(assign.Right, currentScope));
                     }
                 }
             }
@@ -2438,7 +2448,7 @@ public partial class SymbolTableBuilder
 
             foreach (var child in node.ChildNodes)
             {
-                Walk(child);
+                Walk(child, currentScope);
             }
         }
 
@@ -2447,13 +2457,14 @@ public partial class SymbolTableBuilder
         {
             if (method.Value is FunctionExpression fe)
             {
-                Walk(fe.Body);
+                var methodScope = FindScopeByAstNode(classScope, fe) ?? classScope;
+                Walk(fe.Body, methodScope);
             }
             else if (method.Value is not null)
             {
                 // Normal class methods (including getters/setters) are typically FunctionExpression,
                 // but walk any other representation to avoid missing assignments.
-                Walk(method.Value);
+                Walk(method.Value, classScope);
             }
         }
 

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ConstructorAssigned.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ConstructorAssigned.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2236
+				// Method begins at RVA 0x2231
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -34,7 +34,7 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
@@ -48,7 +48,7 @@
 
 			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
 			IL_0005: ldstr "x"
-			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_000a: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, string)
 			IL_000f: ret
 		} // end of method ArrowFunction_L6C21::__js_call__
 
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2224
+				// Method begins at RVA 0x221f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222d
+				// Method begins at RVA 0x2228
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,7 +101,7 @@
 
 		// Fields
 		.field private object[] _scopes
-		.field public object x
+		.field public float64 x
 		.field public object getX
 
 		// Methods
@@ -116,7 +116,7 @@
 			)
 			// Method begins at RVA 0x21b4
 			// Header size: 12
-			// Code size: 91 (0x5b)
+			// Code size: 86 (0x56)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter/Scope_ctor,
@@ -135,33 +135,32 @@
 			IL_0010: stfld object[] Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter::_scopes
 			IL_0015: ldarg.0
 			IL_0016: ldarg.2
-			IL_0017: box [System.Runtime]System.Double
-			IL_001c: stfld object Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter::x
-			IL_0021: ldnull
-			IL_0022: ldftn object Modules.ArrowFunction_LexicalThis_ConstructorAssigned/ArrowFunction_L6C21::__js_call__(object)
-			IL_0028: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_002d: ldc.i4.1
-			IL_002e: newarr [System.Runtime]System.Object
-			IL_0033: dup
-			IL_0034: ldc.i4.0
-			IL_0035: ldarg.1
-			IL_0036: ldc.i4.0
-			IL_0037: ldelem.ref
-			IL_0038: stelem.ref
-			IL_0039: ldarg.0
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_003f: ldc.i4.0
-			IL_0040: conv.r8
-			IL_0041: ldstr ""
-			IL_0046: ldc.i4.0
-			IL_0047: ldc.i4.0
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0052: stloc.2
-			IL_0053: ldarg.0
-			IL_0054: ldloc.2
-			IL_0055: stfld object Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter::getX
-			IL_005a: ret
+			IL_0017: stfld float64 Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter::x
+			IL_001c: ldnull
+			IL_001d: ldftn float64 Modules.ArrowFunction_LexicalThis_ConstructorAssigned/ArrowFunction_L6C21::__js_call__(object)
+			IL_0023: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
+			IL_0028: ldc.i4.1
+			IL_0029: newarr [System.Runtime]System.Object
+			IL_002e: dup
+			IL_002f: ldc.i4.0
+			IL_0030: ldarg.1
+			IL_0031: ldc.i4.0
+			IL_0032: ldelem.ref
+			IL_0033: stelem.ref
+			IL_0034: ldarg.0
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_003a: ldc.i4.0
+			IL_003b: conv.r8
+			IL_003c: ldstr ""
+			IL_0041: ldc.i4.0
+			IL_0042: ldc.i4.0
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_004d: stloc.2
+			IL_004e: ldarg.0
+			IL_004f: ldloc.2
+			IL_0050: stfld object Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter::getX
+			IL_0055: ret
 		} // end of method Counter::.ctor
 
 	} // end of class Counter
@@ -173,7 +172,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x221b
+			// Method begins at RVA 0x2216
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -324,7 +323,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x223f
+		// Method begins at RVA 0x223a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_CreatedInMethod.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_CreatedInMethod.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x223b
+				// Method begins at RVA 0x2237
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -34,7 +34,7 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
@@ -48,7 +48,7 @@
 
 			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
 			IL_0005: ldstr "x"
-			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_000a: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, string)
 			IL_000f: ret
 		} // end of method ArrowFunction_L9C16::__js_call__
 
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2220
+				// Method begins at RVA 0x221c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2229
+				// Method begins at RVA 0x2225
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2232
+				// Method begins at RVA 0x222e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -120,7 +120,7 @@
 
 
 		// Fields
-		.field public object x
+		.field public float64 x
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -133,16 +133,15 @@
 			)
 			// Method begins at RVA 0x21c2
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 14 (0xe)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 			IL_0006: ldarg.0
 			IL_0007: ldarg.1
-			IL_0008: box [System.Runtime]System.Double
-			IL_000d: stfld object Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter::x
-			IL_0012: ret
+			IL_0008: stfld float64 Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter::x
+			IL_000d: ret
 		} // end of method Counter::.ctor
 
 		.method public hidebysig 
@@ -151,7 +150,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21d4
 			// Header size: 12
 			// Code size: 51 (0x33)
 			.maxstack 8
@@ -163,8 +162,8 @@
 			IL_0000: newobj instance void Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter/Scope_makeGetter::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldnull
-			IL_0007: ldftn object Modules.ArrowFunction_LexicalThis_CreatedInMethod/ArrowFunction_L9C16::__js_call__(object)
-			IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0007: ldftn float64 Modules.ArrowFunction_LexicalThis_CreatedInMethod/ArrowFunction_L9C16::__js_call__(object)
+			IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 			IL_0012: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_0017: ldarg.0
 			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
@@ -189,7 +188,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2217
+			// Method begins at RVA 0x2213
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -345,7 +344,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2244
+		// Method begins at RVA 0x2240
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ac
+				// Method begins at RVA 0x23b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a3
+				// Method begins at RVA 0x23a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -122,7 +122,7 @@
 			)
 			// Method begins at RVA 0x21d0
 			// Header size: 12
-			// Code size: 335 (0x14f)
+			// Code size: 345 (0x159)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L9C16/Scope,
@@ -231,30 +231,32 @@
 			IL_00f8: ldstr "After await, this.x:"
 			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
 			IL_0102: ldstr "x"
-			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0111: pop
-			IL_0112: ldloc.0
-			IL_0113: ldc.i4.m1
-			IL_0114: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0119: ldloc.0
-			IL_011a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_011f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0124: ldarg.0
-			IL_0125: ldc.i4.1
-			IL_0126: newarr [System.Runtime]System.Object
-			IL_012b: dup
-			IL_012c: ldc.i4.0
-			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0132: ldstr "x"
-			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_013c: stelem.ref
-			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0142: pop
-			IL_0143: ldloc.0
-			IL_0144: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0149: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_014e: ret
+			IL_0107: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, string)
+			IL_010c: box [System.Runtime]System.Double
+			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0116: pop
+			IL_0117: ldloc.0
+			IL_0118: ldc.i4.m1
+			IL_0119: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_011e: ldloc.0
+			IL_011f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0129: ldarg.0
+			IL_012a: ldc.i4.1
+			IL_012b: newarr [System.Runtime]System.Object
+			IL_0130: dup
+			IL_0131: ldc.i4.0
+			IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0137: ldstr "x"
+			IL_013c: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, string)
+			IL_0141: box [System.Runtime]System.Double
+			IL_0146: stelem.ref
+			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_014c: pop
+			IL_014d: ldloc.0
+			IL_014e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0153: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0158: ret
 		} // end of method ArrowFunction_L9C16::__js_call__
 
 	} // end of class ArrowFunction_L9C16
@@ -270,7 +272,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2388
+				// Method begins at RVA 0x238c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -290,7 +292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2391
+				// Method begins at RVA 0x2395
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -310,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x239a
+				// Method begins at RVA 0x239e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -325,7 +327,7 @@
 
 
 		// Fields
-		.field public object x
+		.field public float64 x
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -336,18 +338,17 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x232b
+			// Method begins at RVA 0x2335
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 14 (0xe)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 			IL_0006: ldarg.0
 			IL_0007: ldarg.1
-			IL_0008: box [System.Runtime]System.Double
-			IL_000d: stfld object Modules.Async_ArrowFunction_LexicalThis/Counter::x
-			IL_0012: ret
+			IL_0008: stfld float64 Modules.Async_ArrowFunction_LexicalThis/Counter::x
+			IL_000d: ret
 		} // end of method Counter::.ctor
 
 		.method public hidebysig 
@@ -356,7 +357,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2340
+			// Method begins at RVA 0x2344
 			// Header size: 12
 			// Code size: 51 (0x33)
 			.maxstack 8
@@ -394,7 +395,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x237f
+			// Method begins at RVA 0x2383
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -546,7 +547,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23b5
+		// Method begins at RVA 0x23b9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d1
+				// Method begins at RVA 0x21cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21da
+				// Method begins at RVA 0x21d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -54,7 +54,7 @@
 
 		// Fields
 		.field private object[] _scopes
-		.field public object 'value'
+		.field public float64 'value'
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -67,7 +67,7 @@
 			)
 			// Method begins at RVA 0x2194
 			// Header size: 12
-			// Code size: 40 (0x28)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			.locals init (
 				[0] object[]
@@ -86,9 +86,8 @@
 			IL_0012: ldelem.ref
 			IL_0013: castclass Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope
 			IL_0018: ldfld float64 Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::GLOBAL_VALUE
-			IL_001d: box [System.Runtime]System.Double
-			IL_0022: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner::'value'
-			IL_0027: ret
+			IL_001d: stfld float64 Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner::'value'
+			IL_0022: ret
 		} // end of method Inner::.ctor
 
 	} // end of class Inner
@@ -104,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e3
+				// Method begins at RVA 0x21de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -124,7 +123,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ec
+				// Method begins at RVA 0x21e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -195,7 +194,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c8
+			// Method begins at RVA 0x21c3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -327,7 +326,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f5
+		// Method begins at RVA 0x21f0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_New_In_ArrowFunction.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_New_In_ArrowFunction.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c3
+				// Method begins at RVA 0x21be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -87,7 +87,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b1
+				// Method begins at RVA 0x21ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -107,7 +107,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ba
+				// Method begins at RVA 0x21b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -122,7 +122,7 @@
 
 
 		// Fields
-		.field public object n
+		.field public float64 n
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -135,16 +135,15 @@
 			)
 			// Method begins at RVA 0x2194
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 14 (0xe)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 			IL_0006: ldarg.0
 			IL_0007: ldarg.1
-			IL_0008: box [System.Runtime]System.Double
-			IL_000d: stfld object Modules.Classes_ClassConstructor_New_In_ArrowFunction/PrimeSieve::n
-			IL_0012: ret
+			IL_0008: stfld float64 Modules.Classes_ClassConstructor_New_In_ArrowFunction/PrimeSieve::n
+			IL_000d: ret
 		} // end of method PrimeSieve::.ctor
 
 	} // end of class PrimeSieve
@@ -164,7 +163,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a8
+			// Method begins at RVA 0x21a3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -290,7 +289,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21cc
+		// Method begins at RVA 0x21c7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_Param_Field_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_Param_Field_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x211b
+				// Method begins at RVA 0x211f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2124
+				// Method begins at RVA 0x2128
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x212d
+				// Method begins at RVA 0x2131
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -73,7 +73,7 @@
 
 
 		// Fields
-		.field public object name
+		.field public string name
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -86,15 +86,16 @@
 			)
 			// Method begins at RVA 0x20cf
 			// Header size: 1
-			// Code size: 14 (0xe)
+			// Code size: 19 (0x13)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 			IL_0006: ldarg.0
 			IL_0007: ldarg.1
-			IL_0008: stfld object Modules.Classes_ClassConstructor_Param_Field_Log/Greeter::name
-			IL_000d: ret
+			IL_0008: castclass [System.Runtime]System.String
+			IL_000d: stfld string Modules.Classes_ClassConstructor_Param_Field_Log/Greeter::name
+			IL_0012: ret
 		} // end of method Greeter::.ctor
 
 		.method public hidebysig 
@@ -103,7 +104,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e0
+			// Method begins at RVA 0x20e4
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -120,7 +121,7 @@
 			IL_0012: ldloc.0
 			IL_0013: ldstr "log"
 			IL_0018: ldarg.0
-			IL_0019: ldfld object Modules.Classes_ClassConstructor_Param_Field_Log/Greeter::name
+			IL_0019: ldfld string Modules.Classes_ClassConstructor_Param_Field_Log/Greeter::name
 			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0023: pop
 			IL_0024: ldnull
@@ -136,7 +137,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2112
+			// Method begins at RVA 0x2116
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -224,7 +225,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2136
+		// Method begins at RVA 0x213a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TypedNestedNew_FieldStore.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TypedNestedNew_FieldStore.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2235
+				// Method begins at RVA 0x2230
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x223e
+				// Method begins at RVA 0x2239
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -53,7 +53,7 @@
 
 
 		// Fields
-		.field public object n
+		.field public float64 n
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -66,16 +66,15 @@
 			)
 			// Method begins at RVA 0x2218
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 14 (0xe)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 			IL_0006: ldarg.0
 			IL_0007: ldarg.1
-			IL_0008: box [System.Runtime]System.Double
-			IL_000d: stfld object Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Bar::n
-			IL_0012: ret
+			IL_0008: stfld float64 Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Bar::n
+			IL_000d: ret
 		} // end of method Bar::.ctor
 
 	} // end of class Bar
@@ -91,7 +90,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2247
+				// Method begins at RVA 0x2242
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,7 +110,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2250
+				// Method begins at RVA 0x224b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -177,7 +176,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x222c
+			// Method begins at RVA 0x2227
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -337,7 +336,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2259
+		// Method begins at RVA 0x2254
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_CallsAnotherMethod.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_CallsAnotherMethod.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2146
+				// Method begins at RVA 0x214a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x214f
+				// Method begins at RVA 0x2153
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2158
+				// Method begins at RVA 0x215c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2161
+				// Method begins at RVA 0x2165
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x216a
+				// Method begins at RVA 0x216e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -113,7 +113,7 @@
 
 
 		// Fields
-		.field public object name
+		.field public string name
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -126,15 +126,16 @@
 			)
 			// Method begins at RVA 0x20cf
 			// Header size: 1
-			// Code size: 14 (0xe)
+			// Code size: 19 (0x13)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 			IL_0006: ldarg.0
 			IL_0007: ldarg.1
-			IL_0008: stfld object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::name
-			IL_000d: ret
+			IL_0008: castclass [System.Runtime]System.String
+			IL_000d: stfld string Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::name
+			IL_0012: ret
 		} // end of method Greeter::.ctor
 
 		.method public hidebysig 
@@ -143,7 +144,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2114
+			// Method begins at RVA 0x2118
 			// Header size: 12
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -157,7 +158,7 @@
 			IL_0006: stloc.0
 			IL_0007: ldloc.0
 			IL_0008: ldarg.0
-			IL_0009: ldfld object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::name
+			IL_0009: ldfld string Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::name
 			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0013: stloc.1
 			IL_0014: ldloc.1
@@ -170,7 +171,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2136
+			// Method begins at RVA 0x213a
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -185,7 +186,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e0
+			// Method begins at RVA 0x20e4
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -221,7 +222,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x213d
+			// Method begins at RVA 0x2141
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -309,7 +310,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2173
+		// Method begins at RVA 0x2177
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ForLoop_CallsAnotherMethod.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ForLoop_CallsAnotherMethod.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2207
+				// Method begins at RVA 0x220c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2210
+				// Method begins at RVA 0x2215
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2219
+				// Method begins at RVA 0x221e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2222
+				// Method begins at RVA 0x2227
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,7 +102,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2234
+					// Method begins at RVA 0x2239
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222b
+				// Method begins at RVA 0x2230
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +140,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x223d
+				// Method begins at RVA 0x2242
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -156,7 +156,7 @@
 
 		// Fields
 		.field private object[] _scopes
-		.field public object total
+		.field public float64 total
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -170,7 +170,7 @@
 			)
 			// Method begins at RVA 0x2138
 			// Header size: 12
-			// Code size: 28 (0x1c)
+			// Code size: 23 (0x17)
 			.maxstack 8
 			.locals init (
 				[0] object[]
@@ -185,9 +185,8 @@
 			IL_000a: stfld object[] Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::_scopes
 			IL_000f: ldarg.0
 			IL_0010: ldarg.2
-			IL_0011: box [System.Runtime]System.Double
-			IL_0016: stfld object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::total
-			IL_001b: ret
+			IL_0011: stfld float64 Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::total
+			IL_0016: ret
 		} // end of method Accumulator::.ctor
 
 		.method public hidebysig 
@@ -198,9 +197,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a4
+			// Method begins at RVA 0x21a0
 			// Header size: 12
-			// Code size: 27 (0x1b)
+			// Code size: 32 (0x20)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -214,9 +213,10 @@
 			IL_0011: stloc.0
 			IL_0012: ldarg.0
 			IL_0013: ldloc.0
-			IL_0014: stfld object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::total
-			IL_0019: ldnull
-			IL_001a: ret
+			IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0019: stfld float64 Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::total
+			IL_001e: ldnull
+			IL_001f: ret
 		} // end of method Accumulator::'add'
 
 		.method public hidebysig 
@@ -227,7 +227,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2160
+			// Method begins at RVA 0x215c
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -272,7 +272,7 @@
 			)
 			// Method begins at RVA 0x21cc
 			// Header size: 12
-			// Code size: 38 (0x26)
+			// Code size: 43 (0x2b)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -287,11 +287,12 @@
 			IL_0012: ldloc.0
 			IL_0013: ldstr "log"
 			IL_0018: ldarg.0
-			IL_0019: ldfld object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::total
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0023: pop
-			IL_0024: ldnull
-			IL_0025: ret
+			IL_0019: ldfld float64 Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::total
+			IL_001e: box [System.Runtime]System.Double
+			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0028: pop
+			IL_0029: ldnull
+			IL_002a: ret
 		} // end of method Accumulator::log
 
 	} // end of class Accumulator
@@ -303,7 +304,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21fe
+			// Method begins at RVA 0x2203
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -423,7 +424,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2246
+		// Method begins at RVA 0x224b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ImplicitlyReturnsThis.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ImplicitlyReturnsThis.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2272
+				// Method begins at RVA 0x226d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x227b
+				// Method begins at RVA 0x2276
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2284
+				// Method begins at RVA 0x227f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228d
+				// Method begins at RVA 0x2288
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -123,7 +123,7 @@
 
 
 		// Fields
-		.field public object sum
+		.field public float64 sum
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -137,7 +137,7 @@
 			)
 			// Method begins at RVA 0x2253
 			// Header size: 1
-			// Code size: 21 (0x15)
+			// Code size: 16 (0x10)
 			.maxstack 8
 
 			IL_0000: ldarg.0
@@ -146,9 +146,8 @@
 			IL_0007: ldarg.1
 			IL_0008: ldarg.2
 			IL_0009: add
-			IL_000a: box [System.Runtime]System.Double
-			IL_000f: stfld object Modules.Classes_Constructor_ImplicitlyReturnsThis/WithParams::sum
-			IL_0014: ret
+			IL_000a: stfld float64 Modules.Classes_Constructor_ImplicitlyReturnsThis/WithParams::sum
+			IL_000f: ret
 		} // end of method WithParams::.ctor
 
 	} // end of class WithParams
@@ -160,7 +159,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2269
+			// Method begins at RVA 0x2264
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -355,7 +354,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2296
+		// Method begins at RVA 0x2291
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Constructor.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Constructor.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2695
+				// Method begins at RVA 0x2682
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26a7
+					// Method begins at RVA 0x2694
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x269e
+				// Method begins at RVA 0x268b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26b0
+				// Method begins at RVA 0x269d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2521
+			// Method begins at RVA 0x251c
 			// Header size: 1
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -143,7 +143,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25e4
+			// Method begins at RVA 0x25d8
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -194,7 +194,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26b9
+				// Method begins at RVA 0x26a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -218,7 +218,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26cb
+					// Method begins at RVA 0x26b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -236,7 +236,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26c2
+				// Method begins at RVA 0x26af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -256,7 +256,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26d4
+				// Method begins at RVA 0x26c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -271,7 +271,7 @@
 
 
 		// Fields
-		.field public object width
+		.field public float64 width
 		.field public object height
 		.field public object depth
 
@@ -288,7 +288,7 @@
 			)
 			// Method begins at RVA 0x24c8
 			// Header size: 12
-			// Code size: 77 (0x4d)
+			// Code size: 72 (0x48)
 			.maxstack 8
 
 			IL_0000: ldarg.0
@@ -309,15 +309,14 @@
 
 			IL_0032: ldarg.0
 			IL_0033: ldarg.1
-			IL_0034: box [System.Runtime]System.Double
-			IL_0039: stfld object Modules.Classes_DefaultParameterValue_Constructor/Box::width
-			IL_003e: ldarg.0
-			IL_003f: ldarg.2
-			IL_0040: stfld object Modules.Classes_DefaultParameterValue_Constructor/Box::height
-			IL_0045: ldarg.0
-			IL_0046: ldarg.3
-			IL_0047: stfld object Modules.Classes_DefaultParameterValue_Constructor/Box::depth
-			IL_004c: ret
+			IL_0034: stfld float64 Modules.Classes_DefaultParameterValue_Constructor/Box::width
+			IL_0039: ldarg.0
+			IL_003a: ldarg.2
+			IL_003b: stfld object Modules.Classes_DefaultParameterValue_Constructor/Box::height
+			IL_0040: ldarg.0
+			IL_0041: ldarg.3
+			IL_0042: stfld object Modules.Classes_DefaultParameterValue_Constructor/Box::depth
+			IL_0047: ret
 		} // end of method Box::.ctor
 
 		.method public hidebysig 
@@ -326,9 +325,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2584
+			// Method begins at RVA 0x257c
 			// Header size: 12
-			// Code size: 84 (0x54)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -344,35 +343,32 @@
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
 			IL_0012: ldarg.0
-			IL_0013: ldfld object Modules.Classes_DefaultParameterValue_Constructor/Box::width
+			IL_0013: ldfld object Modules.Classes_DefaultParameterValue_Constructor/Box::height
 			IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_001d: stloc.1
 			IL_001e: ldarg.0
-			IL_001f: ldfld object Modules.Classes_DefaultParameterValue_Constructor/Box::height
-			IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0029: stloc.2
-			IL_002a: ldloc.1
-			IL_002b: ldloc.2
-			IL_002c: mul
-			IL_002d: stloc.2
-			IL_002e: ldarg.0
-			IL_002f: ldfld object Modules.Classes_DefaultParameterValue_Constructor/Box::depth
-			IL_0034: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0039: stloc.1
-			IL_003a: ldloc.2
-			IL_003b: ldloc.1
-			IL_003c: mul
-			IL_003d: stloc.1
-			IL_003e: ldloc.1
-			IL_003f: box [System.Runtime]System.Double
-			IL_0044: stloc.3
-			IL_0045: ldloc.0
-			IL_0046: ldstr "log"
-			IL_004b: ldloc.3
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0051: pop
-			IL_0052: ldnull
-			IL_0053: ret
+			IL_001f: ldfld float64 Modules.Classes_DefaultParameterValue_Constructor/Box::width
+			IL_0024: ldloc.1
+			IL_0025: mul
+			IL_0026: stloc.1
+			IL_0027: ldarg.0
+			IL_0028: ldfld object Modules.Classes_DefaultParameterValue_Constructor/Box::depth
+			IL_002d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0032: stloc.2
+			IL_0033: ldloc.1
+			IL_0034: ldloc.2
+			IL_0035: mul
+			IL_0036: stloc.2
+			IL_0037: ldloc.2
+			IL_0038: box [System.Runtime]System.Double
+			IL_003d: stloc.3
+			IL_003e: ldloc.0
+			IL_003f: ldstr "log"
+			IL_0044: ldloc.3
+			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_004a: pop
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method Box::volume
 
 	} // end of class Box
@@ -388,7 +384,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26dd
+				// Method begins at RVA 0x26ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -412,7 +408,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26ef
+					// Method begins at RVA 0x26dc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -430,7 +426,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26e6
+				// Method begins at RVA 0x26d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -450,7 +446,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26f8
+				// Method begins at RVA 0x26e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -465,7 +461,7 @@
 
 
 		// Fields
-		.field public object width
+		.field public float64 width
 		.field public object height
 
 		// Methods
@@ -478,9 +474,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x255a
+			// Method begins at RVA 0x2555
 			// Header size: 1
-			// Code size: 40 (0x28)
+			// Code size: 35 (0x23)
 			.maxstack 8
 
 			IL_0000: ldarg.0
@@ -494,12 +490,11 @@
 
 			IL_0014: ldarg.0
 			IL_0015: ldarg.1
-			IL_0016: box [System.Runtime]System.Double
-			IL_001b: stfld object Modules.Classes_DefaultParameterValue_Constructor/Rectangle::width
-			IL_0020: ldarg.0
-			IL_0021: ldarg.2
-			IL_0022: stfld object Modules.Classes_DefaultParameterValue_Constructor/Rectangle::height
-			IL_0027: ret
+			IL_0016: stfld float64 Modules.Classes_DefaultParameterValue_Constructor/Rectangle::width
+			IL_001b: ldarg.0
+			IL_001c: ldarg.2
+			IL_001d: stfld object Modules.Classes_DefaultParameterValue_Constructor/Rectangle::height
+			IL_0022: ret
 		} // end of method Rectangle::.ctor
 
 		.method public hidebysig 
@@ -508,15 +503,14 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x263c
+			// Method begins at RVA 0x2630
 			// Header size: 12
-			// Code size: 68 (0x44)
+			// Code size: 61 (0x3d)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] float64,
-				[2] float64,
-				[3] object
+				[2] object
 			)
 
 			IL_0000: ldstr "console"
@@ -526,27 +520,24 @@
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: stloc.0
 			IL_0012: ldarg.0
-			IL_0013: ldfld object Modules.Classes_DefaultParameterValue_Constructor/Rectangle::width
+			IL_0013: ldfld object Modules.Classes_DefaultParameterValue_Constructor/Rectangle::height
 			IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_001d: stloc.1
 			IL_001e: ldarg.0
-			IL_001f: ldfld object Modules.Classes_DefaultParameterValue_Constructor/Rectangle::height
-			IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0029: stloc.2
-			IL_002a: ldloc.1
-			IL_002b: ldloc.2
-			IL_002c: mul
+			IL_001f: ldfld float64 Modules.Classes_DefaultParameterValue_Constructor/Rectangle::width
+			IL_0024: ldloc.1
+			IL_0025: mul
+			IL_0026: stloc.1
+			IL_0027: ldloc.1
+			IL_0028: box [System.Runtime]System.Double
 			IL_002d: stloc.2
-			IL_002e: ldloc.2
-			IL_002f: box [System.Runtime]System.Double
-			IL_0034: stloc.3
-			IL_0035: ldloc.0
-			IL_0036: ldstr "log"
-			IL_003b: ldloc.3
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0041: pop
-			IL_0042: ldnull
-			IL_0043: ret
+			IL_002e: ldloc.0
+			IL_002f: ldstr "log"
+			IL_0034: ldloc.2
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_003a: pop
+			IL_003b: ldnull
+			IL_003c: ret
 		} // end of method Rectangle::area
 
 	} // end of class Rectangle
@@ -558,7 +549,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x268c
+			// Method begins at RVA 0x2679
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -958,7 +949,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2701
+		// Method begins at RVA 0x26ee
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24bb
+				// Method begins at RVA 0x24b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24c4
+				// Method begins at RVA 0x24bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24cd
+				// Method begins at RVA 0x24c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d6
+				// Method begins at RVA 0x24cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24df
+				// Method begins at RVA 0x24d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24e8
+				// Method begins at RVA 0x24e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 
 
 		// Fields
-		.field public object 'value'
+		.field public float64 'value'
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -144,18 +144,17 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2467
+			// Method begins at RVA 0x246c
 			// Header size: 1
-			// Code size: 19 (0x13)
+			// Code size: 14 (0xe)
 			.maxstack 8
 
 			IL_0000: ldarg.0
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 			IL_0006: ldarg.0
 			IL_0007: ldarg.1
-			IL_0008: box [System.Runtime]System.Double
-			IL_000d: stfld object Modules.Classes_Method_DefaultReturnUndefined/Calculator::'value'
-			IL_0012: ret
+			IL_0008: stfld float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::'value'
+			IL_000d: ret
 		} // end of method Calculator::.ctor
 
 		.method public hidebysig 
@@ -166,7 +165,7 @@
 			)
 			// Method begins at RVA 0x247c
 			// Header size: 12
-			// Code size: 28 (0x1c)
+			// Code size: 21 (0x15)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -174,17 +173,14 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Classes_Method_DefaultReturnUndefined/Calculator::'value'
-			IL_0006: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_000b: stloc.1
-			IL_000c: ldloc.1
-			IL_000d: ldc.r8 2
-			IL_0016: mul
-			IL_0017: stloc.1
-			IL_0018: ldloc.1
-			IL_0019: stloc.0
-			IL_001a: ldnull
-			IL_001b: ret
+			IL_0001: ldfld float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::'value'
+			IL_0006: ldc.r8 2
+			IL_000f: mul
+			IL_0010: stloc.1
+			IL_0011: ldloc.1
+			IL_0012: stloc.0
+			IL_0013: ldnull
+			IL_0014: ret
 		} // end of method Calculator::doNothing
 
 		.method public hidebysig 
@@ -193,7 +189,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24a7
+			// Method begins at RVA 0x24a0
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -203,18 +199,18 @@
 		} // end of method Calculator::returnsUndefined
 
 		.method public hidebysig 
-			instance object returnsValue () cil managed 
+			instance float64 returnsValue () cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24aa
+			// Method begins at RVA 0x24a3
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Classes_Method_DefaultReturnUndefined/Calculator::'value'
+			IL_0001: ldfld float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::'value'
 			IL_0006: ret
 		} // end of method Calculator::returnsValue
 
@@ -224,7 +220,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24a4
+			// Method begins at RVA 0x249d
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -242,7 +238,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24b2
+			// Method begins at RVA 0x24ab
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -268,7 +264,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1035 (0x40b)
+		// Code size: 1040 (0x410)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Method_DefaultReturnUndefined/Scope,
@@ -635,79 +631,80 @@
 		IL_033a: ldloc.s 12
 		IL_033c: isinst Modules.Classes_Method_DefaultReturnUndefined/Calculator
 		IL_0341: dup
-		IL_0342: brfalse IL_0353
+		IL_0342: brfalse IL_0358
 
-		IL_0347: callvirt instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
-		IL_034c: stloc.s 12
-		IL_034e: br IL_0362
+		IL_0347: callvirt instance float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
+		IL_034c: box [System.Runtime]System.Double
+		IL_0351: stloc.s 12
+		IL_0353: br IL_0367
 
-		IL_0353: pop
-		IL_0354: ldloc.s 12
-		IL_0356: ldstr "returnsValue"
-		IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0360: stloc.s 12
+		IL_0358: pop
+		IL_0359: ldloc.s 12
+		IL_035b: ldstr "returnsValue"
+		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0365: stloc.s 12
 
-		IL_0362: ldloc.s 12
-		IL_0364: stloc.s 7
-		IL_0366: ldstr "console"
-		IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0370: stloc.s 12
-		IL_0372: ldloc.s 12
-		IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0379: stloc.s 12
-		IL_037b: ldloc.s 12
-		IL_037d: ldstr "log"
-		IL_0382: ldloc.s 7
-		IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0389: pop
-		IL_038a: ldloc.2
-		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0390: stloc.s 12
-		IL_0392: ldloc.s 12
-		IL_0394: isinst Modules.Classes_Method_DefaultReturnUndefined/Calculator
-		IL_0399: dup
-		IL_039a: brfalse IL_03ab
+		IL_0367: ldloc.s 12
+		IL_0369: stloc.s 7
+		IL_036b: ldstr "console"
+		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0375: stloc.s 12
+		IL_0377: ldloc.s 12
+		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_037e: stloc.s 12
+		IL_0380: ldloc.s 12
+		IL_0382: ldstr "log"
+		IL_0387: ldloc.s 7
+		IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_038e: pop
+		IL_038f: ldloc.2
+		IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0395: stloc.s 12
+		IL_0397: ldloc.s 12
+		IL_0399: isinst Modules.Classes_Method_DefaultReturnUndefined/Calculator
+		IL_039e: dup
+		IL_039f: brfalse IL_03b0
 
-		IL_039f: callvirt instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
-		IL_03a4: stloc.s 12
-		IL_03a6: br IL_03ba
+		IL_03a4: callvirt instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
+		IL_03a9: stloc.s 12
+		IL_03ab: br IL_03bf
 
-		IL_03ab: pop
-		IL_03ac: ldloc.s 12
-		IL_03ae: ldstr "returnsThis"
-		IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_03b8: stloc.s 12
+		IL_03b0: pop
+		IL_03b1: ldloc.s 12
+		IL_03b3: ldstr "returnsThis"
+		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_03bd: stloc.s 12
 
-		IL_03ba: ldloc.s 12
-		IL_03bc: stloc.s 8
-		IL_03be: ldstr "console"
-		IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03c8: stloc.s 12
-		IL_03ca: ldloc.s 12
-		IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d1: stloc.s 12
-		IL_03d3: ldloc.s 8
-		IL_03d5: stloc.s 14
-		IL_03d7: ldloc.s 14
-		IL_03d9: ldloc.2
-		IL_03da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03df: stloc.s 15
-		IL_03e1: ldloc.s 15
-		IL_03e3: brfalse IL_03f4
+		IL_03bf: ldloc.s 12
+		IL_03c1: stloc.s 8
+		IL_03c3: ldstr "console"
+		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03cd: stloc.s 12
+		IL_03cf: ldloc.s 12
+		IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03d6: stloc.s 12
+		IL_03d8: ldloc.s 8
+		IL_03da: stloc.s 14
+		IL_03dc: ldloc.s 14
+		IL_03de: ldloc.2
+		IL_03df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_03e4: stloc.s 15
+		IL_03e6: ldloc.s 15
+		IL_03e8: brfalse IL_03f9
 
-		IL_03e8: ldstr "same instance"
-		IL_03ed: stloc.s 9
-		IL_03ef: br IL_03fb
+		IL_03ed: ldstr "same instance"
+		IL_03f2: stloc.s 9
+		IL_03f4: br IL_0400
 
-		IL_03f4: ldstr "different"
-		IL_03f9: stloc.s 9
+		IL_03f9: ldstr "different"
+		IL_03fe: stloc.s 9
 
-		IL_03fb: ldloc.s 12
-		IL_03fd: ldstr "log"
-		IL_0402: ldloc.s 9
-		IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0409: pop
-		IL_040a: ret
+		IL_0400: ldloc.s 12
+		IL_0402: ldstr "log"
+		IL_0407: ldloc.s 9
+		IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_040e: pop
+		IL_040f: ret
 	} // end of method Classes_Method_DefaultReturnUndefined::__js_module_init__
 
 } // end of class Modules.Classes_Method_DefaultReturnUndefined
@@ -719,7 +716,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24f1
+		// Method begins at RVA 0x24ea
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3324
+						// Method begins at RVA 0x3330
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x331b
+					// Method begins at RVA 0x3327
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3312
+				// Method begins at RVA 0x331e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -266,7 +266,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x332d
+				// Method begins at RVA 0x3339
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -546,7 +546,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3204
+				// Method begins at RVA 0x3210
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -566,7 +566,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x320d
+				// Method begins at RVA 0x3219
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -586,7 +586,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3216
+				// Method begins at RVA 0x3222
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -614,7 +614,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3231
+						// Method begins at RVA 0x323d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -638,7 +638,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3243
+							// Method begins at RVA 0x324f
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x323a
+						// Method begins at RVA 0x3246
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3228
+					// Method begins at RVA 0x3234
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -702,7 +702,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x325e
+							// Method begins at RVA 0x326a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -720,7 +720,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3255
+						// Method begins at RVA 0x3261
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -738,7 +738,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x324c
+					// Method begins at RVA 0x3258
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -762,7 +762,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3270
+						// Method begins at RVA 0x327c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -780,7 +780,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3267
+					// Method begins at RVA 0x3273
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -798,7 +798,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x321f
+				// Method begins at RVA 0x322b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -818,7 +818,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3279
+				// Method begins at RVA 0x3285
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -842,7 +842,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x328b
+					// Method begins at RVA 0x3297
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -860,7 +860,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3282
+				// Method begins at RVA 0x328e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -888,7 +888,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2888
+			// Method begins at RVA 0x2884
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -937,7 +937,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b5c
+			// Method begins at RVA 0x2b58
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -1007,7 +1007,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2920
+			// Method begins at RVA 0x291c
 			// Header size: 12
 			// Code size: 560 (0x230)
 			.maxstack 8
@@ -1310,7 +1310,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bc0
+			// Method begins at RVA 0x2bbc
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1374,7 +1374,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28d8
+			// Method begins at RVA 0x28d4
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -1422,7 +1422,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3294
+				// Method begins at RVA 0x32a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1442,7 +1442,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x329d
+				// Method begins at RVA 0x32a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1466,7 +1466,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32af
+					// Method begins at RVA 0x32bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1484,7 +1484,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32a6
+				// Method begins at RVA 0x32b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1504,7 +1504,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32b8
+				// Method begins at RVA 0x32c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1532,7 +1532,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x32d3
+						// Method begins at RVA 0x32df
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1550,7 +1550,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32ca
+					// Method begins at RVA 0x32d6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1568,7 +1568,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32c1
+				// Method begins at RVA 0x32cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1592,7 +1592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32e5
+					// Method begins at RVA 0x32f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1616,7 +1616,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x32f7
+						// Method begins at RVA 0x3303
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1634,7 +1634,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32ee
+					// Method begins at RVA 0x32fa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1652,7 +1652,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32dc
+				// Method begins at RVA 0x32e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1676,7 +1676,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3309
+					// Method begins at RVA 0x3315
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1694,7 +1694,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3300
+				// Method begins at RVA 0x330c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1710,7 +1710,7 @@
 
 		// Fields
 		.field private object[] _scopes
-		.field public object sieveSize
+		.field public float64 sieveSize
 		.field public float64 sieveSizeInBits
 		.field public class Modules.Compile_Performance_PrimeJavaScript/BitArray bitArray
 
@@ -1726,7 +1726,7 @@
 			)
 			// Method begins at RVA 0x2820
 			// Header size: 12
-			// Code size: 90 (0x5a)
+			// Code size: 85 (0x55)
 			.maxstack 8
 			.locals init (
 				[0] object[],
@@ -1744,35 +1744,34 @@
 			IL_000a: stfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::_scopes
 			IL_000f: ldarg.0
 			IL_0010: ldarg.2
-			IL_0011: box [System.Runtime]System.Double
-			IL_0016: stfld object Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
-			IL_001b: ldarg.2
-			IL_001c: conv.i4
-			IL_001d: conv.u4
-			IL_001e: ldc.r8 1
-			IL_0027: conv.i4
-			IL_0028: shr.un
-			IL_0029: conv.r.un
-			IL_002a: stloc.1
-			IL_002b: ldarg.0
-			IL_002c: ldloc.1
-			IL_002d: stfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
-			IL_0032: ldarg.1
-			IL_0033: stloc.0
-			IL_0034: ldc.r8 1
-			IL_003d: ldarg.0
-			IL_003e: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
-			IL_0043: add
-			IL_0044: stloc.1
-			IL_0045: ldloc.1
-			IL_0046: box [System.Runtime]System.Double
-			IL_004b: stloc.2
-			IL_004c: ldarg.0
-			IL_004d: ldloc.0
-			IL_004e: ldloc.2
-			IL_004f: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray::.ctor(object[], object)
-			IL_0054: stfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
-			IL_0059: ret
+			IL_0011: stfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
+			IL_0016: ldarg.2
+			IL_0017: conv.i4
+			IL_0018: conv.u4
+			IL_0019: ldc.r8 1
+			IL_0022: conv.i4
+			IL_0023: shr.un
+			IL_0024: conv.r.un
+			IL_0025: stloc.1
+			IL_0026: ldarg.0
+			IL_0027: ldloc.1
+			IL_0028: stfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
+			IL_002d: ldarg.1
+			IL_002e: stloc.0
+			IL_002f: ldc.r8 1
+			IL_0038: ldarg.0
+			IL_0039: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
+			IL_003e: add
+			IL_003f: stloc.1
+			IL_0040: ldloc.1
+			IL_0041: box [System.Runtime]System.Double
+			IL_0046: stloc.2
+			IL_0047: ldarg.0
+			IL_0048: ldloc.0
+			IL_0049: ldloc.2
+			IL_004a: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray::.ctor(object[], object)
+			IL_004f: stfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
+			IL_0054: ret
 		} // end of method PrimeSieve::.ctor
 
 		.method public hidebysig 
@@ -1781,7 +1780,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c1c
+			// Method begins at RVA 0x2c18
 			// Header size: 12
 			// Code size: 318 (0x13e)
 			.maxstack 8
@@ -1928,7 +1927,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3038
+			// Method begins at RVA 0x3044
 			// Header size: 12
 			// Code size: 150 (0x96)
 			.maxstack 8
@@ -2011,7 +2010,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30dc
+			// Method begins at RVA 0x30e8
 			// Header size: 12
 			// Code size: 275 (0x113)
 			.maxstack 8
@@ -2138,9 +2137,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d68
+			// Method begins at RVA 0x2d64
 			// Header size: 12
-			// Code size: 706 (0x2c2)
+			// Code size: 721 (0x2d1)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -2213,168 +2212,171 @@
 			IL_00d1: box [System.Runtime]System.Boolean
 			IL_00d6: stloc.s 4
 			IL_00d8: ldarg.0
-			IL_00d9: ldfld object Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
-			IL_00de: ldloc.1
-			IL_00df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-			IL_00e4: stloc.s 10
-			IL_00e6: ldloc.s 10
-			IL_00e8: brfalse IL_01e1
+			IL_00d9: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
+			IL_00de: box [System.Runtime]System.Double
+			IL_00e3: ldloc.1
+			IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+			IL_00e9: stloc.s 10
+			IL_00eb: ldloc.s 10
+			IL_00ed: brfalse IL_01eb
 
-			IL_00ed: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_validatePrimeCount/Block_L187C2::.ctor()
-			IL_00f2: stloc.s 5
-			IL_00f4: ldloc.1
-			IL_00f5: ldarg.0
-			IL_00f6: ldfld object Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
-			IL_0104: stloc.s 6
-			IL_0106: ldloc.s 6
-			IL_0108: stloc.s 9
-			IL_010a: ldloc.2
-			IL_010b: box [System.Runtime]System.Double
-			IL_0110: stloc.s 8
-			IL_0112: ldloc.s 9
-			IL_0114: ldloc.s 8
-			IL_0116: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_011b: stloc.s 10
-			IL_011d: ldloc.s 10
-			IL_011f: box [System.Runtime]System.Boolean
-			IL_0124: stloc.s 11
-			IL_0126: ldloc.s 11
-			IL_0128: stloc.s 4
-			IL_012a: ldloc.s 4
-			IL_012c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0131: ldc.i4.0
-			IL_0132: ceq
-			IL_0134: stloc.s 10
-			IL_0136: ldloc.s 10
-			IL_0138: brfalse IL_01dc
+			IL_00f2: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_validatePrimeCount/Block_L187C2::.ctor()
+			IL_00f7: stloc.s 5
+			IL_00f9: ldloc.1
+			IL_00fa: ldarg.0
+			IL_00fb: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
+			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0105: stloc.s 9
+			IL_0107: ldloc.s 9
+			IL_0109: stloc.s 6
+			IL_010b: ldloc.s 6
+			IL_010d: stloc.s 9
+			IL_010f: ldloc.2
+			IL_0110: box [System.Runtime]System.Double
+			IL_0115: stloc.s 8
+			IL_0117: ldloc.s 9
+			IL_0119: ldloc.s 8
+			IL_011b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+			IL_0120: stloc.s 10
+			IL_0122: ldloc.s 10
+			IL_0124: box [System.Runtime]System.Boolean
+			IL_0129: stloc.s 11
+			IL_012b: ldloc.s 11
+			IL_012d: stloc.s 4
+			IL_012f: ldloc.s 4
+			IL_0131: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0136: ldc.i4.0
+			IL_0137: ceq
+			IL_0139: stloc.s 10
+			IL_013b: ldloc.s 10
+			IL_013d: brfalse IL_01e6
 
-			IL_013d: ldstr "console"
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0147: stloc.s 9
-			IL_0149: ldloc.s 9
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0150: stloc.s 9
-			IL_0152: ldarg.0
-			IL_0153: ldfld object Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
-			IL_0158: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_015d: stloc.s 12
-			IL_015f: ldstr "Limit for "
-			IL_0164: ldloc.s 12
-			IL_0166: call string [System.Runtime]System.String::Concat(string, string)
-			IL_016b: stloc.s 12
-			IL_016d: ldloc.s 12
-			IL_016f: ldstr " should be "
-			IL_0174: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0179: stloc.s 12
-			IL_017b: ldloc.s 6
-			IL_017d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0182: stloc.s 13
-			IL_0184: ldloc.s 12
-			IL_0186: ldloc.s 13
-			IL_0188: call string [System.Runtime]System.String::Concat(string, string)
-			IL_018d: stloc.s 13
-			IL_018f: ldloc.s 13
-			IL_0191: ldstr " "
-			IL_0196: call string [System.Runtime]System.String::Concat(string, string)
-			IL_019b: stloc.s 13
-			IL_019d: ldloc.2
-			IL_019e: box [System.Runtime]System.Double
-			IL_01a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01a8: stloc.s 12
-			IL_01aa: ldstr "but result contains "
-			IL_01af: ldloc.s 12
-			IL_01b1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01b6: stloc.s 12
-			IL_01b8: ldloc.s 12
-			IL_01ba: ldstr " primes"
-			IL_01bf: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01c4: stloc.s 12
-			IL_01c6: ldloc.s 9
-			IL_01c8: ldstr "log"
-			IL_01cd: ldstr "\nError: invalid result."
-			IL_01d2: ldloc.s 13
-			IL_01d4: ldloc.s 12
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_01db: pop
+			IL_0142: ldstr "console"
+			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_014c: stloc.s 9
+			IL_014e: ldloc.s 9
+			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0155: stloc.s 9
+			IL_0157: ldarg.0
+			IL_0158: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
+			IL_015d: box [System.Runtime]System.Double
+			IL_0162: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0167: stloc.s 12
+			IL_0169: ldstr "Limit for "
+			IL_016e: ldloc.s 12
+			IL_0170: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0175: stloc.s 12
+			IL_0177: ldloc.s 12
+			IL_0179: ldstr " should be "
+			IL_017e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0183: stloc.s 12
+			IL_0185: ldloc.s 6
+			IL_0187: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_018c: stloc.s 13
+			IL_018e: ldloc.s 12
+			IL_0190: ldloc.s 13
+			IL_0192: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0197: stloc.s 13
+			IL_0199: ldloc.s 13
+			IL_019b: ldstr " "
+			IL_01a0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01a5: stloc.s 13
+			IL_01a7: ldloc.2
+			IL_01a8: box [System.Runtime]System.Double
+			IL_01ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01b2: stloc.s 12
+			IL_01b4: ldstr "but result contains "
+			IL_01b9: ldloc.s 12
+			IL_01bb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01c0: stloc.s 12
+			IL_01c2: ldloc.s 12
+			IL_01c4: ldstr " primes"
+			IL_01c9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ce: stloc.s 12
+			IL_01d0: ldloc.s 9
+			IL_01d2: ldstr "log"
+			IL_01d7: ldstr "\nError: invalid result."
+			IL_01dc: ldloc.s 13
+			IL_01de: ldloc.s 12
+			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01e5: pop
 
-			IL_01dc: br IL_0259
+			IL_01e6: br IL_0268
 
-			IL_01e1: ldstr "console"
-			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01eb: stloc.s 9
-			IL_01ed: ldloc.s 9
-			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f4: stloc.s 9
-			IL_01f6: ldloc.2
-			IL_01f7: box [System.Runtime]System.Double
-			IL_01fc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0201: stloc.s 12
-			IL_0203: ldstr "Warning: cannot validate result of "
-			IL_0208: ldloc.s 12
-			IL_020a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_020f: stloc.s 12
-			IL_0211: ldloc.s 12
-			IL_0213: ldstr " primes:"
-			IL_0218: call string [System.Runtime]System.String::Concat(string, string)
-			IL_021d: stloc.s 12
-			IL_021f: ldarg.0
-			IL_0220: ldfld object Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
-			IL_0225: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_022a: stloc.s 13
-			IL_022c: ldstr "limit "
-			IL_0231: ldloc.s 13
-			IL_0233: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0238: stloc.s 13
-			IL_023a: ldloc.s 13
-			IL_023c: ldstr " is not in the known list of number of primes!"
-			IL_0241: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0246: stloc.s 13
-			IL_0248: ldloc.s 9
-			IL_024a: ldstr "log"
-			IL_024f: ldloc.s 12
-			IL_0251: ldloc.s 13
-			IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0258: pop
+			IL_01eb: ldstr "console"
+			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01f5: stloc.s 9
+			IL_01f7: ldloc.s 9
+			IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01fe: stloc.s 9
+			IL_0200: ldloc.2
+			IL_0201: box [System.Runtime]System.Double
+			IL_0206: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_020b: stloc.s 12
+			IL_020d: ldstr "Warning: cannot validate result of "
+			IL_0212: ldloc.s 12
+			IL_0214: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0219: stloc.s 12
+			IL_021b: ldloc.s 12
+			IL_021d: ldstr " primes:"
+			IL_0222: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0227: stloc.s 12
+			IL_0229: ldarg.0
+			IL_022a: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
+			IL_022f: box [System.Runtime]System.Double
+			IL_0234: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0239: stloc.s 13
+			IL_023b: ldstr "limit "
+			IL_0240: ldloc.s 13
+			IL_0242: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0247: stloc.s 13
+			IL_0249: ldloc.s 13
+			IL_024b: ldstr " is not in the known list of number of primes!"
+			IL_0250: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0255: stloc.s 13
+			IL_0257: ldloc.s 9
+			IL_0259: ldstr "log"
+			IL_025e: ldloc.s 12
+			IL_0260: ldloc.s 13
+			IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0267: pop
 
-			IL_0259: ldarg.1
-			IL_025a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_025f: stloc.s 10
-			IL_0261: ldloc.s 10
-			IL_0263: brfalse IL_02b6
+			IL_0268: ldarg.1
+			IL_0269: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_026e: stloc.s 10
+			IL_0270: ldloc.s 10
+			IL_0272: brfalse IL_02c5
 
-			IL_0268: ldstr "console"
-			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0272: stloc.s 9
-			IL_0274: ldloc.s 9
-			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027b: stloc.s 9
-			IL_027d: ldloc.0
-			IL_027e: box [System.Runtime]System.Double
-			IL_0283: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0288: stloc.s 13
-			IL_028a: ldstr "\nThe first "
-			IL_028f: ldloc.s 13
-			IL_0291: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0296: stloc.s 13
-			IL_0298: ldloc.s 13
-			IL_029a: ldstr " found primes are:"
-			IL_029f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02a4: stloc.s 13
-			IL_02a6: ldloc.s 9
-			IL_02a8: ldstr "log"
-			IL_02ad: ldloc.s 13
-			IL_02af: ldloc.3
-			IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02b5: pop
+			IL_0277: ldstr "console"
+			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0281: stloc.s 9
+			IL_0283: ldloc.s 9
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_028a: stloc.s 9
+			IL_028c: ldloc.0
+			IL_028d: box [System.Runtime]System.Double
+			IL_0292: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0297: stloc.s 13
+			IL_0299: ldstr "\nThe first "
+			IL_029e: ldloc.s 13
+			IL_02a0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02a5: stloc.s 13
+			IL_02a7: ldloc.s 13
+			IL_02a9: ldstr " found primes are:"
+			IL_02ae: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02b3: stloc.s 13
+			IL_02b5: ldloc.s 9
+			IL_02b7: ldstr "log"
+			IL_02bc: ldloc.s 13
+			IL_02be: ldloc.3
+			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02c4: pop
 
-			IL_02b6: ldloc.s 4
-			IL_02b8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_02bd: stloc.s 10
-			IL_02bf: ldloc.s 10
-			IL_02c1: ret
+			IL_02c5: ldloc.s 4
+			IL_02c7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02cc: stloc.s 10
+			IL_02ce: ldloc.s 10
+			IL_02d0: ret
 		} // end of method PrimeSieve::validatePrimeCount
 
 	} // end of class PrimeSieve
@@ -2408,7 +2410,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x31fb
+			// Method begins at RVA 0x3207
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2438,7 +2440,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3336
+				// Method begins at RVA 0x3342
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2451,7 +2453,7 @@
 			.method public hidebysig 
 				instance float64 get_sieveSize () cil managed 
 			{
-				// Method begins at RVA 0x333e
+				// Method begins at RVA 0x334a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2466,7 +2468,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3346
+				// Method begins at RVA 0x3352
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2484,7 +2486,7 @@
 			.method public hidebysig 
 				instance float64 get_timeLimitSeconds () cil managed 
 			{
-				// Method begins at RVA 0x335b
+				// Method begins at RVA 0x3367
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2499,7 +2501,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3363
+				// Method begins at RVA 0x336f
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2517,7 +2519,7 @@
 			.method public hidebysig 
 				instance object get_verbose () cil managed 
 			{
-				// Method begins at RVA 0x3378
+				// Method begins at RVA 0x3384
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2532,7 +2534,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3380
+				// Method begins at RVA 0x338c
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2550,7 +2552,7 @@
 			.method public hidebysig 
 				instance object get_runtime () cil managed 
 			{
-				// Method begins at RVA 0x3395
+				// Method begins at RVA 0x33a1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2565,7 +2567,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x339d
+				// Method begins at RVA 0x33a9
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3026,7 +3028,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x33b2
+		// Method begins at RVA 0x33be
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
+++ b/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
@@ -1037,6 +1037,8 @@ public class SymbolTableTypeInferenceTests
 
         Assert.NotNull(constructorScope);
         AssertStableParameterTypes(constructorScope!, ("sieveSize", typeof(double)));
+        Assert.True(classScope.StableInstanceFieldClrTypes.TryGetValue("sieveSize", out var fieldType));
+        Assert.Equal(typeof(double), fieldType);
     }
 
     [Fact]
@@ -1065,6 +1067,7 @@ public class SymbolTableTypeInferenceTests
         Assert.NotNull(constructorScope);
         Assert.Empty(constructorScope!.StableParameterClrTypes);
         AssertObjectParameter(constructorScope, "sieveSize");
+        Assert.False(classScope.StableInstanceFieldClrTypes.ContainsKey("sieveSize"));
     }
 
     [Fact]
@@ -1466,6 +1469,8 @@ public class SymbolTableTypeInferenceTests
 
         Assert.NotNull(constructorScope);
         AssertStableParameterTypes(constructorScope!, ("sieveSize", typeof(double)));
+        Assert.True(classScope.StableInstanceFieldClrTypes.TryGetValue("sieveSize", out var fieldType));
+        Assert.Equal(typeof(double), fieldType);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- propagate stable constructor and method parameter binding types into class instance-field inference
- infer `PrimeSieve.sieveSize` as `System.Double` from `this.sieveSize = sieveSize`
- emit the compiled field as `float64`, removing boxing from the constructor field store and enabling typed field reads
- preserve object storage when constructor call-site evidence conflicts

## Validation
- 161 focused SymbolTable, Prime integration, Classes, ArrowFunction, and Async execution/generator tests passed
- `PrimeSieve.sieveSize` is emitted as `.field public float64 sieveSize`
- the constructor now uses `stfld float64` without boxing the `sieveSize` parameter

This PR is intentionally left open and unmerged for review.
